### PR TITLE
Fix for isoline styles

### DIFF
--- a/lib/ui/locations/entries/isoline.mjs
+++ b/lib/ui/locations/entries/isoline.mjs
@@ -9,10 +9,11 @@ export default entry => {
     && JSON.parse(entry.value)
       || entry.value
 
+
+  // Create OL style object
   // Assign Style if not already assigned.
   entry.Style = entry.Style
-  
-    // Create OL style object fentry.location.update() 'object' && mapp.utils.style(entry.style)
+  || typeof entry.style === 'object' && mapp.utils.style(entry.style)
 
     // Assign style from location.
     || entry.location.Style


### PR DESCRIPTION
Noticed that the entries style creation from the entry was added to a comment.

`// Create OL style object fentry.location.update() 'object' && mapp.utils.style(entry.style)`

I have added back the update method and the style creation.