### PR TITLE
Assign table queryparam from layer

### DIFF
--- a/lib/utils/queryParams.mjs
+++ b/lib/utils/queryParams.mjs
@@ -1,10 +1,15 @@
 export default _this => {
-  
+ 
   // Assign empty object if not defined.
   _this.queryparams = _this.queryparams || {}
 
   // The layer queryparam must be true to support viewport params.
   _this.queryparams.layer = _this.queryparams.layer || _this.viewport
+
+  // Assign table name from layer.
+  if (_this.queryparams.table === true) {
+    _this.queryparams.table = _this.layer?.tableCurrent()
+  }
 
   // Assign fieldValues from the location to queryparams.
   if (Array.isArray(_this.queryparams.fieldValues) && _this.location) {


### PR DESCRIPTION
With table queryparam flag set as true, the queryparams module will retrieve the table from the currentTable() method of the layer object assigned to the params _this sent to the module.