### PR TITLE
drawing interaction must provide event e to drawend methods

### DIFF
--- a/lib/mapview/interactions/draw.mjs
+++ b/lib/mapview/interactions/draw.mjs
@@ -121,19 +121,19 @@ export default function(params){
     _this.mapview.popup(null)
   })
   
-  _this.interaction.on('drawend', () => {
+  _this.interaction.on('drawend', e => {
 
     // Return with custom drawend function.
     if (typeof _this.drawend === 'function') {
 
       // A drawend method can be assigned to prevent the contextMenu.
-      _this.drawend()
+      _this.drawend(e)
       return;
     }
 
     // Call contextMenu if defined as function.
     if (typeof _this.contextMenu === 'function') {
-      _this.contextMenu()
+      _this.contextMenu(e)
     }
   })
   


### PR DESCRIPTION
The drawing interaction must pass the event on to methods called from within it's execution.