### PR TITLE
Encoded in filter values

### DIFF
--- a/lib/ui/elements/dropdown_multi.mjs
+++ b/lib/ui/elements/dropdown_multi.mjs
@@ -29,12 +29,12 @@ export default (params) => {
            
       // Set btn text to reflect selection or show placeholder.
       btn.querySelector("[data-id=header-span]")
-        .textContent = selectedTitles.size && Array.from(selectedTitles).join(', ')
+        .textContent = selectedTitles.size && Array.from(selectedTitles).map(v => decodeURIComponent(v)).join(', ')
         || params.span || params.placeholder
 
       // Execute callback method and pass array of current selection.
       params.callback && params.callback(e, Array.from(selectedOptions));
-    }}>${entry.title}`
+    }}>${decodeURIComponent(entry.title)}`
 
     // The entry is already selected during creation of dropdown.
     if (entry.selected) {

--- a/lib/ui/layers/filters.mjs
+++ b/lib/ui/layers/filters.mjs
@@ -182,6 +182,7 @@ async function filter_in(layer, entry) {
         selected: chkSet.has(val)
       })),
       callback: async (e, options) => {
+
         Object.assign(layer.filter.current, {
           [entry.filter.field]:{
             in: options
@@ -195,7 +196,7 @@ async function filter_in(layer, entry) {
 
   return entry.filter.in.map(val => mapp.ui.elements.chkbox({
     val: val,
-    label: val,
+    label: decodeURIComponent(val),
     checked: chkSet.has(val),
     onchange: (checked, val) => {
   


### PR DESCRIPTION
In filter values as provided in an array should always be encoded.

```
"filter": {
  "type": "in",
  "dropdown": true,
  "in": [
    "A%26B",
    "City Centre",
    "Town Centre",
    "Urban Centre",
    "Parade"
  ]
}
```

The ui layer filter module should decode the values for the checkbox element.

The multi-dropdown element should also decode the values for display in the dropdown and header.