### PR TITLE
increase ctrl width to 350px

### DIFF
--- a/public/views/_default.html
+++ b/public/views/_default.html
@@ -154,7 +154,7 @@
 
       body {
         display: grid;
-        grid-template-columns: 333px 10px auto;
+        grid-template-columns: 350px 10px auto;
       }
 
       body.fullscreen {

--- a/public/views/_default.js
+++ b/public/views/_default.js
@@ -100,7 +100,7 @@ window.onload = async () => {
     resizeEvent: (e) => {
       let pageX = (e.touches && e.touches[0].pageX) || e.pageX;
 
-      if (pageX < 333) return;
+      if (pageX < 350) return;
 
       // Half width snap.
       if (pageX > window.innerWidth / 2) pageX = window.innerWidth / 2;


### PR DESCRIPTION
The default width of 333px is to small for some grid views with min-width elements and a scroll bar.