### PR TITLE
add update entry plugin

### DIFF
--- a/public/js/plugins/update_entry.js
+++ b/public/js/plugins/update_entry.js
@@ -1,0 +1,30 @@
+export default (function(){
+
+  mapp.ui.locations.entries.update_entry = entry => {
+
+    // Check whether the update method is already assigned to the entry.
+    if (entry.update) return;
+
+    // Assign update method to prevent multiple execution.
+    entry.update = update
+
+    function update() {
+
+      // Find entry to update from params.field value.
+      const field_entry = entry.location.infoj.find(_entry => _entry.field === entry.params.field)
+
+      // Check whether field_entry value is already set to prevent multiple execution.
+      if (field_entry.value === (mapp.user?.email || 'anonymous')) return;
+
+      // Assign user email or anonymous if not known as newValue.
+      field_entry.newValue = mapp.user?.email || 'anonymous'
+
+      // Update the location.
+      entry.location.update()
+    }
+
+    // Push update method into location updateCallbacks array.
+    entry.location.updateCallbacks.push(update)
+  }
+
+})()

--- a/public/workspaces/dev.json
+++ b/public/workspaces/dev.json
@@ -224,7 +224,8 @@
         "${DIR}/js/plugins/chart_entry.js",
         "${DIR}/js/plugins/table_entry.js",
         "${DIR}/js/plugins/custom_filter.js",
-        "${DIR}/js/plugins/mvt_select_tab.js"
+        "${DIR}/js/plugins/mvt_select_tab.js",
+        "${DIR}/js/plugins/update_entry.js"
       ],
       "measure_distance": {
         "tooltip": {
@@ -1326,6 +1327,12 @@
               "title": "char_field",
               "field": "char_field_bogus",
               "fieldfx": "char_field"
+            },
+            {
+              "type": "update_entry",
+              "params": {
+                "field": "char_field"
+              }
             },
             {
               "field": "foobar_title",


### PR DESCRIPTION
The update_entry plugin will add a `type:update_entry` to mapp,ui.location.entries.

A field must be defined as params.field in the entry.

The field value will be used to lookup a matching entry.

The user email from the mapp object will be assigned as newValue to the entry and the location will be updated.