### PR TITLE
parsefloat on circle draw

### DIFF
--- a/lib/ui/elements/drawing.mjs
+++ b/lib/ui/elements/drawing.mjs
@@ -207,7 +207,7 @@ function circle(_options, draw) {
     max: 1000,
     val: _options.edit.circle.radius,
     callback: e => {
-      _options.edit.circle.radius = parseInt(e.target.value)
+      _options.edit.circle.radius = parseFloat(e.target.value)
     }
   })
 


### PR DESCRIPTION
It is possible to set a float value in the input.

The value is provided as a string in the callback sent to the draw circle method.

The value should be parsed as float.