### PR TITLE
add longclick event to highlight interaction

### DIFF
--- a/lib/mapview/interactions/highlight.mjs
+++ b/lib/mapview/interactions/highlight.mjs
@@ -27,6 +27,8 @@ export default function(params){
 
     locations: new Set(),
 
+    longClickMethod: selectAll,
+
     // Filter for layers which have a highlight style.
     layerFilter: L => Object.values(this.layers)
 
@@ -43,6 +45,29 @@ export default function(params){
 
   // click will select the highlighted feature.
   _this.mapview.Map.on('click', click)
+
+  _this.mapview.Map.getTargetElement().addEventListener('mousedown', mouseDown)
+
+  function mouseDown(){
+
+    // Remove longClick flag.
+    delete _this.longClick
+
+    // Clear longClick timeout.
+    clearTimeout(_this.longClickTimeout)
+
+    // Set longClick timeout.
+    _this.longClickTimeout = setTimeout(
+
+      // Set longClick flag.
+      () => {
+        _this.longClick = true
+        _this.mapview.Map.getTargetElement().style.cursor = 'wait'
+      },
+      
+      // 1000ms default timeout for longclick.
+      _this.longClickMS || 500)
+  }
 
   let shortCircuit
 
@@ -169,6 +194,18 @@ export default function(params){
   // Select the current highlighted feature.
   function click(e) {
 
+    // Reset cursor.
+    _this.mapview.Map.getTargetElement().style.cursor = 'auto'
+
+    // Clear longClick timeout.
+    clearTimeout(_this.longClickTimeout)
+
+    if (_this.longClick && typeof _this.longClickMethod === 'function') {
+
+      _this.longClickMethod(e)
+      return;
+    }
+
     // Limit click event to 600ms
     if (clicked) return;
 
@@ -197,6 +234,53 @@ export default function(params){
     if (typeof _this.noLocationClick === 'function') {
       _this.noLocationClick(e)
     }
+  }
+
+  function selectAll(e) {
+
+    // Remove popup from mapview.
+    _this.mapview.popup(null)
+
+    const locations = [];
+
+    // Find locations at pixel.
+    _this.mapview.Map.forEachFeatureAtPixel(e.pixel,
+      (F, L) => {
+
+        const properties = F.getProperties()
+
+        // Do not include cluster features.
+        if (properties.count) return;
+
+        // Push location key into locations array.
+        locations.push(`${L.get('key') || ol.util.getUid(L)}!${F.get('id') || F.getId() || ol.util.getUid(F)}`)
+      },
+      {
+        layerFilter: _this.layerFilter,
+        hitTolerance: _this.hitTolerance,
+      })
+
+    // No features at pixel.
+    if (!locations.length) return;
+
+    const content = mapp.utils.html.node`
+      <div style="max-width: 66vw; max-height: 300px; overflow-x: hidden;">
+        <ul>
+        ${locations.map(key => mapp.utils.html.node`
+          <li onclick=${e => {           
+            mapp.location.get({
+              layer: _this.mapview.layers[key.split('!')[0]],
+              id: key.split('!')[1]
+            })
+
+            _this.mapview.popup(null)
+          }}
+        }}>${key}`)}`;      
+
+    _this.mapview.popup({
+      content,
+      autoPan: true,
+    });
   }
 
   function clear() {
@@ -270,5 +354,6 @@ export default function(params){
     // Remove event listener from mapview.
     _this.mapview.Map.un('pointermove', pointerMove)
     _this.mapview.Map.un('click', click)
+    _this.mapview.Map.getTargetElement().removeEventListener('mousedown', mouseDown)
   }
 }

--- a/lib/mapview/interactions/highlight.mjs
+++ b/lib/mapview/interactions/highlight.mjs
@@ -29,6 +29,8 @@ export default function(params){
 
     longClickMethod: selectAll,
 
+    longClickMS: 500,
+
     // Filter for layers which have a highlight style.
     layerFilter: L => Object.values(this.layers)
 
@@ -66,7 +68,7 @@ export default function(params){
       },
       
       // 1000ms default timeout for longclick.
-      _this.longClickMS || 500)
+      _this.longClickMS)
   }
 
   let shortCircuit

--- a/public/workspaces/dev.json
+++ b/public/workspaces/dev.json
@@ -1056,7 +1056,6 @@
           ],
           "style": {
             "label": {
-              "display": true,
               "field": "store_name",
               "template": "retail_points_label",
               "count": true,


### PR DESCRIPTION
I have added longClick to the highlight interaction.

The default longClickMethod will be selectAll.

The method will use the highlight layer filter but not select cluster which are already multiple features and have their own method assigned.

Calling the highlight interaction with longClickMethod: null will disabled the longClick event execution.

A custom method can be assigned which will receive the original event as single argument.

The default timeout for the longclick is 500ms. This is assigning as longClickMS to the highlight interaction.