### PR TITLE
modify style and remove vertex for multi geom

### DIFF
--- a/lib/mapview/interactions/modify.mjs
+++ b/lib/mapview/interactions/modify.mjs
@@ -75,11 +75,11 @@ export default function(params){
         if (geomType === 'LineString' && coords.length < 3) return;
 
         // Return on polygon with less than 3 vertices.
-        if (coords[0].length <= 4) return;
+        if (geomType === 'Polygon' && coords[0].length <= 4) return;
      
         // Set popup to remove vertex.
         _this.mapview.popup({
-          coords: _this.Feature.getGeometry().getClosestPoint(e.coordinate),
+          coords: geom.getClosestPoint(e.coordinate),
           content: mapp.utils.html.node`<ul>
             <li
               onclick=${() => {
@@ -97,7 +97,7 @@ export default function(params){
 
   _this.mapview.Map.getTargetElement().style.cursor = 'crosshair'
 
-  _this.Feature && _this.source.addFeature(_this.Feature)
+  _this.source.addFeature(_this.Feature)
    
   // Set _this.Layer source.
   _this.Layer.setSource(_this.source)
@@ -161,6 +161,9 @@ export default function(params){
     
     // Remove interaction from mapview.Map.
     _this.mapview.Map.removeInteraction(_this.interaction)
+
+    // Clear the modify source.
+    _this.source.clear()
   
     // Remove draw Layer from mapview.Map.
     _this.mapview.Map.removeLayer(_this.Layer)

--- a/lib/utils/verticeGeoms.mjs
+++ b/lib/utils/verticeGeoms.mjs
@@ -2,19 +2,25 @@ export default feature => {
 
   const geometry = feature.getGeometry()
 
-  const coords = geometry.getCoordinates()
+  if (geometry.getType() === 'Point') return new ol.geom.Point(geometry.getCoordinates())
 
-  const type = geometry.getType()
+  let coords = geometry.getCoordinates()
 
-  if (!coords) return;
+  let depth = getDepth(coords)
 
-  if (type === 'Point') return new ol.geom.Point(geometry.getCoordinates())
+  // Line string will have a depth of 2.
+  if (depth === 2) {
+    return new ol.geom.MultiPoint(coords)
+  }
 
-  if (type === 'LineString') return new ol.geom.MultiPoint(geometry.getCoordinates())
+  // Coords with a depth of more than 3 indicate multi geoms.
+  coords = depth > 3 ? coords.flat(2) : coords[0]
 
-  var coordinates = type === 'MultiPolygon' && geometry.getCoordinates()[0] || geometry.getCoordinates()
+  return new ol.geom.MultiPoint(coords)
+}
 
-  var mp = new ol.geom.MultiPoint(coordinates[0])
-
-  return mp
+function getDepth(arr) {
+  return Array.isArray(arr) ?
+    1 + Math.max(0, ...arr.map(getDepth)) :
+    0;
 }

--- a/public/workspaces/dev.json
+++ b/public/workspaces/dev.json
@@ -1769,6 +1769,32 @@
               "fieldfx": "ARRAY[ST_X(ST_PointOnSurface(geom_3857)),ST_Y(ST_PointOnSurface(geom_3857))]"
             }
           ]
+        },
+        "multigeom": {
+          "format": "geojson",
+          "dbs": "DEV",
+          "table": "dev.multipolygon_features",
+          "srid": "3857",
+          "geom": "geom_3857",
+          "qID": "id",
+          "infoj": [
+            {
+              "type": "geometry",
+              "display": true,
+              "field": "geom_3857",
+              "fieldfx": "ST_asGeoJSON(geom_3857)",
+              "edit": {
+                "geometry": true,
+                "snap": true
+              }
+            },
+            {
+              "type": "pin",
+              "label": "ST_PointOnSurface",
+              "field": "pin",
+              "fieldfx": "ARRAY[ST_X(ST_PointOnSurface(geom_3857)),ST_Y(ST_PointOnSurface(geom_3857))]"
+            }
+          ]
         }
       }
     },


### PR DESCRIPTION
The verticeGeom util which returns a multipoint geometry to style vertices must flatten multigeometries.

The modify click condition which checks whether vertex can be removed should only check whether polygons have 3 or more vertices as otherwise the geometry would be invalid.