### PR TITLE
Short circuit empty cluster requests

### DIFF
--- a/lib/layer/format/cluster.mjs
+++ b/lib/layer/format/cluster.mjs
@@ -57,6 +57,8 @@ export default layer => {
   
       if (e.target.status !== 200) return;
 
+      if (!e.target.response) return;
+
       layer.max_size = e.target.response.reduce((max_size, f) => Math.max(max_size, f.properties.size || f.properties.count), 0)
         
       const features = e.target.response.map((f,i) => new ol.Feature(Object.assign({

--- a/public/workspaces/dev.json
+++ b/public/workspaces/dev.json
@@ -225,7 +225,7 @@
         "${DIR}/js/plugins/table_entry.js",
         "${DIR}/js/plugins/custom_filter.js",
         "${DIR}/js/plugins/mvt_select_tab.js",
-        "${DIR}/js/plugins/svg_templates.js"
+        "${DIR}/js/plugins/svg_templates.js",
         "${DIR}/js/plugins/update_entry.js"
       ],
       "measure_distance": {


### PR DESCRIPTION
An error is thrown if a cluster request returns an empty array.