### PR TITLE
longclick mouse move

### DIFF
--- a/lib/mapview/interactions/highlight.mjs
+++ b/lib/mapview/interactions/highlight.mjs
@@ -75,6 +75,12 @@ export default function(params){
 
   function pointerMove(e) {
 
+    // Reset cursor.
+    _this.mapview.Map.getTargetElement().style.cursor = 'auto'
+
+    // Clear longClick timeout.
+    clearTimeout(_this.longClickTimeout)
+
     // Method should short circuit if still processing.
     if (shortCircuit) return;
 


### PR DESCRIPTION
The longclick event should not happen when using click / mousedown to pan the mapview.