### PR TITLE
update here isoline process

### DIFF
--- a/lib/ui/locations/entries/isoline.mjs
+++ b/lib/ui/locations/entries/isoline.mjs
@@ -171,16 +171,16 @@ function isoline_here(entry) {
         return;
       }
 
-      const _coordinates = mapp.utils.here.decodeIsoline(response.isolines[0].polygons[0].outer)
+      // Decode outer here isoline.
+      const decoded = mapp.utils.here.decodeIsoline(response.isolines[0].polygons[0].outer)
 
-      _coordinates.polyline.forEach(p => p.reverse())
-
-      _coordinates.polyline.push(_coordinates.polyline[0])
+      // Reverse coords in decoded polyline.
+      decoded.polyline.forEach(p => p.reverse())
 
       // Assign feature geometry as new value.
       entry.newValue = {
         type: 'Polygon',
-        coordinates: [_coordinates.polyline]
+        coordinates: [decoded.polyline]
       }
 
       // Update the location in the database.

--- a/lib/utils/here.mjs
+++ b/lib/utils/here.mjs
@@ -227,17 +227,17 @@ function geometryFunction(coordinates, layer, params) {
         return alert('Query failed.')
       }
 
-      const _coordinates = decode(response.isolines[0].polygons[0].outer)
+      // Decode outer here isoline.
+      const decoded = mapp.utils.here.decodeIsoline(response.isolines[0].polygons[0].outer)
 
-      _coordinates.polyline.forEach(p => p.reverse())
-
-      _coordinates.polyline.push(_coordinates.polyline[0])
+      // Reverse coords in decoded polyline.
+      decoded.polyline.forEach(p => p.reverse())
 
       const feature = layer.mapview.interaction.format.readFeature({
         type: 'Feature',
         geometry: {
           type: 'Polygon',
-          coordinates: [_coordinates.polyline]
+          coordinates: [decoded.polyline]
         }
       }, {
         dataProjection: 'EPSG:4326',


### PR DESCRIPTION
The outer object from a here isoline response must be decoded and the coords being reversed in order to create a feature from the polyline coords. This wasn't commented and somewhat awkward.