### PR TITLE
Multiple assignment in geometry entry button method and callback events.

### DIFF
--- a/lib/mapview/interactions/modify.mjs
+++ b/lib/mapview/interactions/modify.mjs
@@ -5,9 +5,6 @@ export default function(params){
   // Finish the current interaction.
   this.interaction?.finish()
 
-  // The callback method from the previous call might have assigned the highlight interaction.
-  this.interaction?.finish()
-
   _this = Object.assign({
 
     mapview: this,

--- a/lib/ui/elements/contextMenu.mjs
+++ b/lib/ui/elements/contextMenu.mjs
@@ -6,9 +6,11 @@ export default {
 mapp.utils.merge(mapp.dictionaries, {
   en: {
     remove_last_vertex: "Remove last vertex",
+    delete_vertex: "Remove vertex"
   },
   de: {
-    remove_last_vertex: "Remove last vertex",
+    remove_last_vertex: "Entferne letzten Scheitelpunkt",
+    delete_vertex: "Entferne Scheitelpunkt"
   },
   cn: {
     remove_last_vertex: "删除最后一个顶点",

--- a/lib/ui/locations/entries/geometry.mjs
+++ b/lib/ui/locations/entries/geometry.mjs
@@ -173,11 +173,10 @@ function draw(e, options) {
 
   // Check whether to cancel interaction.
   if (btn.classList.contains('active')) {
-    btn.classList.remove('active')
 
-    // Begin highlight interaction on mapview.
-    // Cancels current interaction.
-    options.mapview.interactions.highlight()
+    // Finish current interaction.
+    // The callback will begin the highlight interaction.
+    options.mapview.interaction.finish()
     return;
   }
 
@@ -225,11 +224,10 @@ function modify(e, options) {
 
   // Check whether to cancel interaction.
   if (btn.classList.contains('active')) {
-    btn.classList.remove('active')
 
-    // Begin highlight interaction on mapview.
-    // Cancels current interaction.
-    options.mapview.interactions.highlight()
+    // Finish current interaction.
+    // The callback will begin the highlight interaction.
+    options.mapview.interaction.finish()
     return;
   }
 

--- a/public/js/plugins/modify_context_menu.js
+++ b/public/js/plugins/modify_context_menu.js
@@ -1,12 +1,3 @@
-mapp.utils.merge(mapp.dictionaries, {
-  en: {
-    delete_vertex: "Remove vertex"
-  },
-  de: {
-    delete_vertex: "Entferne Scheitelpunkt"
-  }
-})
-
 export default (async function () {
 
   if (!window.turf) {


### PR DESCRIPTION
The active class is removed and the highlight interaction is assigned in the callback as well as the button click event.

Assigning the highlight will finish the current interaction which will trigger the callback and also assign the highlight interaction, as well as remove the active class.

Removing a class twice is not noticeable. But assigning the highlight interaction twice will double assign events.

When next finished only one set of events will be removed and the highlight interaction events remain active.

As a fix the button event should simply finish the current interaction and let the callback take care of all these things.