### PR TITLE
style scale for icons

### DIFF
--- a/lib/utils/style.mjs
+++ b/lib/utils/style.mjs
@@ -21,7 +21,7 @@ export default (style, feature) => {
       style.icon.forEach(icon => {
 
         // Calculate scale for icon render.
-        let scale = icon.scale || 1
+        let scale = icon.scale || style.scale || 1
         scale *= style.clusterScale || 1
         scale *= style.zoomInScale || 1
         scale *= style.zoomOutScale || 1


### PR DESCRIPTION
fixes an issue where the default style is not applied to an icon without implicit style.