### PR TITLE
reset longclick cursor on mouseup

### DIFF
--- a/lib/mapview/interactions/highlight.mjs
+++ b/lib/mapview/interactions/highlight.mjs
@@ -50,6 +50,8 @@ export default function(params){
 
   _this.mapview.Map.getTargetElement().addEventListener('mousedown', mouseDown)
 
+  _this.mapview.Map.getTargetElement().addEventListener('mouseup', mouseUp)
+
   function mouseDown(){
 
     // Remove longClick flag.
@@ -71,12 +73,13 @@ export default function(params){
       _this.longClickMS)
   }
 
+  function mouseUp(){
+    _this.mapview.Map.getTargetElement().style.cursor = 'auto'
+  }
+
   let shortCircuit
 
   function pointerMove(e) {
-
-    // Reset cursor.
-    _this.mapview.Map.getTargetElement().style.cursor = 'auto'
 
     // Clear longClick timeout.
     clearTimeout(_this.longClickTimeout)
@@ -363,5 +366,6 @@ export default function(params){
     _this.mapview.Map.un('pointermove', pointerMove)
     _this.mapview.Map.un('click', click)
     _this.mapview.Map.getTargetElement().removeEventListener('mousedown', mouseDown)
+    _this.mapview.Map.getTargetElement().removeEventListener('mouseup', mouseUp)
   }
 }


### PR DESCRIPTION
The click event is not called after longclick triggered by the mousedown event in the highlight interaction.

mousemove cannot reset the cursor to prevent excessive processing during mousemove over the same set of highlight candidates.

A mouseup event will always be called after the click event. The mouseup can reset the cursor to auto.