### PR TITLE
assign contextmenu to end events

### DIFF
--- a/lib/mapview/interactions/draw.mjs
+++ b/lib/mapview/interactions/draw.mjs
@@ -28,7 +28,7 @@ export default function(params){
     Layer: new ol.layer.Vector(),
 
     // Bind context menu from mapp ui elements.
-    contextMenu: mapp.ui?.elements.contextMenu.draw.bind(this),
+    drawend: mapp.ui?.elements.contextMenu.draw.bind(this),
 
     vertices: [],
 
@@ -121,21 +121,10 @@ export default function(params){
     _this.mapview.popup(null)
   })
   
-  _this.interaction.on('drawend', e => {
+  if (typeof _this.drawend === 'function') {
 
-    // Return with custom drawend function.
-    if (typeof _this.drawend === 'function') {
-
-      // A drawend method can be assigned to prevent the contextMenu.
-      _this.drawend(e)
-      return;
-    }
-
-    // Call contextMenu if defined as function.
-    if (typeof _this.contextMenu === 'function') {
-      _this.contextMenu(e)
-    }
-  })
+    _this.drawEnd_this.interaction.on('drawend', _this.drawend)
+  }
   
   // Add OL interaction to mapview.Map
   _this.mapview.Map.addInteraction(_this.interaction)

--- a/lib/mapview/interactions/modify.mjs
+++ b/lib/mapview/interactions/modify.mjs
@@ -23,7 +23,7 @@ export default function(params){
   
     vertices: [],
 
-    contextMenu: mapp.ui?.elements.contextMenu.modify.bind(this),
+    modifyend: mapp.ui?.elements.contextMenu.modify.bind(this),
   
     getFeature,
 
@@ -111,17 +111,12 @@ export default function(params){
   _this.interaction.on('modifystart', e => {
     _this.mapview.popup(null)
   })
-  
-  _this.interaction.on('modifyend', e => {
 
-    _this.vertices.push(e.mapBrowserEvent.coordinate);
+  if (typeof _this.modifyend === 'function') {
 
-    // Execute custom modifyend method.
-    if (_this.modifyend) return _this.modifyend(e, modify);
+    _this.interaction.on('modifyend', _this.modifyend)
+  }
 
-    typeof _this.contextMenu === 'function' && setTimeout(_this.contextMenu, 400)
-  })
-  
   // Add OL interaction to mapview.Map
   _this.mapview.Map.addInteraction(_this.interaction)
 

--- a/public/js/plugins/measure_distance.js
+++ b/public/js/plugins/measure_distance.js
@@ -11,7 +11,7 @@ export default (function () {
     }
 
     // Find the btnColumn element.
-    const btnColumn = document.getElementById("mapButton");
+    const btnColumn = document.getElementById('mapButton');
 
     // Append the plugin btn to the btnColumn.
     btnColumn && btnColumn.append(mapp.utils.html.node`
@@ -34,7 +34,7 @@ export default (function () {
         type: 'LineString',
 
         // Prevent contextmenu showing at drawend event.
-        contextMenu: null,
+        drawend: null,
 
         // Tooltip for geometry drawn by interaction.
         tooltip: Object.assign(plugin.tooltip, {
@@ -97,7 +97,7 @@ export default (function () {
           route.waypoints.push(ol.proj.toLonLat([
             e.coordinate[0],
             e.coordinate[1]
-          ], `EPSG:3857`))
+          ], 'EPSG:3857'))
 
           // Redraw route on each waypoint.
           if (route.waypoints.length > 1) {
@@ -125,7 +125,7 @@ export default (function () {
             // Request route info from here API.
             const response = await mapp.utils
               .xhr(`${mapview.host}/api/proxy?url=`
-                + `${encodeURIComponent(`https://router.hereapi.com/v8/routes?`
+                + `${encodeURIComponent('https://router.hereapi.com/v8/routes?'
                   + `${mapp.utils.paramString(params)}&{HERE}`)}`)
 
             if (!response.routes.length) return;
@@ -189,7 +189,7 @@ export default (function () {
           route.waypoints.push(ol.proj.toLonLat([
             e.coordinate[0],
             e.coordinate[1]
-          ], `EPSG:3857`))
+          ], 'EPSG:3857'))
 
           route.profile = route.profile || 'mapbox/driving';
 

--- a/public/js/plugins/polygon_select.js
+++ b/public/js/plugins/polygon_select.js
@@ -19,9 +19,6 @@ export default (function () {
       // Draw polygon.
       type: 'Polygon',
 
-      // Prevent contextmenu showing at drawend event.
-      contextMenu: null,
-
       // Highlight style for intersecting features.
       highlightStyle: new ol.style.Style({
         fill: new ol.style.Fill({


### PR DESCRIPTION
Contextmenu methods should be assigned as drawend or modifyend event to interactions instead of a second method.