### PR TITLE
tabulator-bump

### DIFF
--- a/lib/ui/Dataview.mjs
+++ b/lib/ui/Dataview.mjs
@@ -205,7 +205,7 @@ async function Table(_this) {
     Object.assign(
       {
         //renderVertical: 'basic',
-        renderHorizontal: 'virtual',
+        //renderHorizontal: 'virtual',
         selectable: false,
       },
       _this.table

--- a/lib/ui/utils/Tabulator.mjs
+++ b/lib/ui/utils/Tabulator.mjs
@@ -20,12 +20,12 @@ export default async function() {
 
     // Append the tabulator css to the document head.
     document.getElementsByTagName('HEAD')[0].append(mapp.utils.html.node`
-    <link rel="stylesheet" href="https://unpkg.com/tabulator-tables@5.4.2/dist/css/tabulator.min.css"/>`);
+    <link rel="stylesheet" href="https://unpkg.com/tabulator-tables@5.4.3/dist/css/tabulator.min.css"/>`);
 
     // Import Chart and plugins.
     Promise
       .all([
-        import('https://cdn.skypack.dev/pin/tabulator-tables@v5.4.2-4Kc6XrzXUsfkNcGniHXt/mode=imports,min/optimized/tabulator-tables.js')
+        import('https://cdn.skypack.dev/pin/tabulator-tables@v5.4.3-Vy9m0B6vzJzRwJ1amSyz/mode=imports,min/optimized/tabulator-tables.js')
       ])
       .then(imports => {
   

--- a/public/views/_default.html
+++ b/public/views/_default.html
@@ -29,8 +29,8 @@
     <script src="https://unpkg.com/maplibre-gl@1.15.2/dist/maplibre-gl.js"></script> -->
 
   <!-- Tabulator will not be imported from skypack if loaded here.-->
-  <!-- <link rel="stylesheet" href="https://unpkg.com/tabulator-tables@5.4.2/dist/css/tabulator.min.css" /> -->
-  <!-- <script type="text/javascript" src="https://unpkg.com/tabulator-tables@5.4.2/dist/js/tabulator.min.js"></script>  -->
+  <!-- <link rel="stylesheet" href="https://unpkg.com/tabulator-tables@5.4.3/dist/css/tabulator.min.css" />
+  <script type="text/javascript" src="https://unpkg.com/tabulator-tables@5.4.3/dist/js/tabulator.min.js"></script>  -->
 
   <!-- ChartJS will not be imported from skypack if loaded here
     <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>-->


### PR DESCRIPTION
I bumped tabulator import to 5.4.3

I commented the default table render methods. Defaults must be defaults to be overwritten by case if needed.