### PR TITLE
add formatter to tabulatorUtils

### DIFF
--- a/lib/ui/Dataview.mjs
+++ b/lib/ui/Dataview.mjs
@@ -197,6 +197,16 @@ async function Table(_this) {
       col.headerFilter =
         mapp.ui.utils.tabulator.headerFilter[col.headerFilter](_this);
     }
+
+    // Check for custom formatter in the ui utils.
+    if (
+      typeof col.formatter === 'string' &&
+      mapp.ui.utils.tabulator.formatter[col.formatter]
+    ) {
+      // Assign custom formatter from ui utils.
+      col.formatter =
+      mapp.ui.utils.tabulator.formatter[col.formatter](_this);
+    }
   });
 
   // Await initialisation of Tabulator object.

--- a/lib/ui/utils/tabulatorUtils.mjs
+++ b/lib/ui/utils/tabulatorUtils.mjs
@@ -4,6 +4,9 @@ export default {
     numeric,
     set
   },
+  formatter: {
+    toLocalString
+  },
   select
 }
 
@@ -213,6 +216,19 @@ function select(_this, params) {
 
     // Remove selection colour on row element.
     row.deselect();
+  }
+
+}
+
+function toLocalString(_this) {
+
+  return (cell, formatterParams, onRendered) => {
+
+    let val = parseFloat(cell.getValue())
+
+    if (isNaN(val)) return;
+
+    return val.toLocaleString(formatterParams?.locale || 'en-GB', formatterParams?.options)
   }
 
 }

--- a/public/workspaces/dev.json
+++ b/public/workspaces/dev.json
@@ -1348,7 +1348,8 @@
                   {
                     "field": "numeric_field",
                     "title": "Num",
-                    "headerFilter": "numeric"
+                    "headerFilter": "numeric",
+                    "formatter":"toLocalString"
                   }
                 ]
               }


### PR DESCRIPTION
The toLocaleString formatter in the tabulatorUtils will apply the [toLocaleString](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number/toLocaleString) method to the cell value. The locale and options can be defined as formatterParams. `en-GB` is the default locale.

Sample config
```
          {
            "title": "Capacity",
            "field": "capacity",
            "formatter": "toLocalString",
            "formatterParams": {
              "locale": "en-GB",
              "useGrouping": true
            }
          },
          {
            "title": "Actual Members",
            "field": "members",
            "formatter": "toLocalString"
          }
```