### PR TITLE
delete feature style icon url in themes

### DIFF
--- a/lib/layer/themes/categorized.mjs
+++ b/lib/layer/themes/categorized.mjs
@@ -10,6 +10,7 @@ export default function (theme, feature) {
 
     // Merge catStyle if icon style is not implicit.
     feature.style.icon = catStyle.icon || Object.assign(feature.style.icon, catStyle)
+    delete feature.style.icon.url;
     return;
   }
 

--- a/lib/layer/themes/graduated.mjs
+++ b/lib/layer/themes/graduated.mjs
@@ -22,6 +22,7 @@ export default function(theme, feature) {
   
       // Merge catStyle if icon style is not implicit.
       feature.style.icon = catStyle.icon || Object.assign(feature.style.icon, catStyle)
+      delete feature.style.icon.url;
       return;
     }
   


### PR DESCRIPTION
The icon url must be deleted from the feature style in the theme methods. MVT feature styles are cached. But the style might change. With an existing URL in the feature style the style method will not recreate the URL.