### PR TITLE
add check for OL layer and source to cluster format

### DIFF
--- a/lib/layer/format/cluster.mjs
+++ b/lib/layer/format/cluster.mjs
@@ -15,7 +15,7 @@ export default layer => {
     const tableZ = layer.tableCurrent()
 
     if (!tableZ) {
-      layer.L.getSource().clear()
+      layer.L?.getSource()?.clear()
       return;
     }
 

--- a/public/workspaces/dev.json
+++ b/public/workspaces/dev.json
@@ -780,6 +780,10 @@
           "format": "cluster",
           "dbs": "DEV",
           "table": "dev.retail_points",
+          "tables": {
+            "6": null,
+            "7": "dev.retail_points"
+          },
           "qID": "id",
           "geom": "geom_p_4326",
           "srid": "4326",


### PR DESCRIPTION
An error would occur previously when the cluster format would try to clear a source of a layer which doesn't exist due to the tables zoom level restriction.