### PR TITLE
tabulator cross layer selection

### DIFF
--- a/lib/ui/utils/tabulatorUtils.mjs
+++ b/lib/ui/utils/tabulatorUtils.mjs
@@ -205,20 +205,25 @@ function set(_this) {
 
 }
 
-function select(_this, params) {
+function select(_this, params = {}) {
 
   return (e, row) => {
 
     // Get the row data
     const rowData = row.getData();
 
-    // If the layer or qID don't exist, then return
-    if (!_this.layer || !rowData[_this.layer.qID]) return;
+    const layer = _this.layer?.mapview.layers[params.layer] || _this.layer
+
+    // Return without a layer to select from.
+    if (!layer) return;
+
+    // Return without the layer qID in rowData.
+    if (!rowData[layer.qID]) return;
 
     // Get the location using the layer and qID which will select the location in the location panel 
     mapp.location.get({
-      layer: _this.layer,
-      id: rowData[_this.layer.qID],
+      layer: layer,
+      id: rowData[layer.qID],
     })
 
       // Zoom to the location if the params flag is set.


### PR DESCRIPTION
Providing a layer in the event params for the select util will assign this layer to select from on click.

```
              "events": {
                "rowClick": {
                  "util": "select",
                  "layer": "uk_health",
                  "zoomToLocation": true
                }
              },
```