### PR TITLE
Bump Openlayers to 7.2.2

### DIFF
--- a/lib/utils/_utils.mjs
+++ b/lib/utils/_utils.mjs
@@ -19,7 +19,7 @@ const olScript = async() => await new Promise(async resolve => {
 
   script.type = 'application/javascript'
 
-  script.src = 'https://cdn.jsdelivr.net/npm/ol@v7.1.0/dist/ol.js'
+  script.src = 'https://cdn.jsdelivr.net/npm/ol@v7.2.2/dist/ol.js'
 
   script.onload = resolve
 

--- a/public/views/_default.html
+++ b/public/views/_default.html
@@ -13,7 +13,7 @@
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   
-  <script src="https://cdn.jsdelivr.net/npm/ol@v7.1.0/dist/ol.js" defer></script>
+  <script src="https://cdn.jsdelivr.net/npm/ol@v7.2.2/dist/ol.js" defer></script>
 
   <!-- Load XYZ / MAPP stylesheet and library. -->
   <link rel="stylesheet" href="{{dir}}/css/mapp.css" />

--- a/public/views/blog.html
+++ b/public/views/blog.html
@@ -9,7 +9,7 @@
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
 
-  <script src="https://cdn.jsdelivr.net/npm/ol@v7.1.0/dist/ol.js" defer></script>
+  <script src="https://cdn.jsdelivr.net/npm/ol@v7.2.2/dist/ol.js" defer></script>
 
   <!-- Load XYZ / MAPP stylesheet and library. -->
   <link rel="stylesheet" href="{{dir}}/css/mapp.css" />

--- a/public/views/embedded.html
+++ b/public/views/embedded.html
@@ -12,7 +12,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
 
   <!-- <script src="{{dir}}/js/ol.js" defer></script> -->
-  <script src="https://cdn.jsdelivr.net/npm/ol@v7.1.0/dist/ol.js" defer></script>
+  <script src="https://cdn.jsdelivr.net/npm/ol@v7.2.2/dist/ol.js" defer></script>
 
 
   <!-- Load XYZ / MAPP stylesheet and library. -->

--- a/public/views/epic.html
+++ b/public/views/epic.html
@@ -12,7 +12,7 @@
     href="https://cdn.jsdelivr.net/gh/openlayers/openlayers.github.io@master/en/v6.4.3/css/ol.css" />
 
   <script src="https://cdn.jsdelivr.net/npm/markdown-it@11.0.0/dist/markdown-it.min.js" defer></script>
-  <script src="https://cdn.jsdelivr.net/npm/ol@v7.1.0/dist/ol.js" defer></script>
+  <script src="https://cdn.jsdelivr.net/npm/ol@v7.2.2/dist/ol.js" defer></script>
 
   <style>
     * {


### PR DESCRIPTION
Please check release notes for relevant changes and fixes.

https://github.com/openlayers/openlayers/releases/tag/v7.2.0