### PR TITLE
change format for selectAll highlight popup

### DIFF
--- a/lib/mapview/interactions/highlight.mjs
+++ b/lib/mapview/interactions/highlight.mjs
@@ -286,7 +286,7 @@ export default function(params){
 
             _this.mapview.popup(null)
           }}
-        }}>${key}`)}`;      
+        }}>${key.split('!')[0]} [${key.split('!')[1]}]`)}`;      
 
     _this.mapview.popup({
       content,


### PR DESCRIPTION
Change format of the location key in the selectAll popup.

![image](https://user-images.githubusercontent.com/22201617/211781728-7f17f81f-5daa-4d00-ad96-b98e236715a9.png)
