### PR TITLE
assign interaction object to mapview instead of _this

### DIFF
--- a/lib/mapview/interactions/draw.mjs
+++ b/lib/mapview/interactions/draw.mjs
@@ -1,12 +1,12 @@
-let _this;
-
 export default function(params){
 
-  // Finish the current interaction.
-  this.interaction?.finish()
+  const mapview = this;
 
-  // Assign params onto the defaults as _this.
-  _this = Object.assign({
+  // Finish the current interaction.
+  mapview.interaction?.finish()
+
+  // Assign params onto the defaults as mapview.interaction.
+  mapview.interaction = Object.assign({
 
     // Interactions are bound to the mapview as this.
     mapview: this,
@@ -36,22 +36,22 @@ export default function(params){
       if (e.originalEvent.buttons === 2) {
 
         // Remove last vertex.
-        _this.interaction.removeLastPoint()
-        _this.vertices.pop()
+        mapview.interaction.interaction.removeLastPoint()
+        mapview.interaction.vertices.pop()
 
-        const moveEvent = new ol.MapBrowserEvent('pointermove', _this.mapview.Map, e.originalEvent)
-        _this.interaction.handleEvent(moveEvent)
-        _this.interaction.handleEvent(moveEvent)
+        const moveEvent = new ol.MapBrowserEvent('pointermove', mapview.Map, e.originalEvent)
+        mapview.interaction.interaction.handleEvent(moveEvent)
+        mapview.interaction.interaction.handleEvent(moveEvent)
         return false;
       }
 
       // Left click.
       if (e.originalEvent.buttons === 1) {
 
-        _this.vertices.push(e.coordinate);
-        _this.mapview.popup(null);
+        mapview.interaction.vertices.push(e.coordinate);
+        mapview.popup(null);
         
-        _this.conditions?.forEach(fn => typeof fn === 'function' && fn(e))
+        mapview.interaction.conditions?.forEach(fn => typeof fn === 'function' && fn(e))
         return true;
       }
     },
@@ -80,92 +80,105 @@ export default function(params){
     ]
   }, params)
 
-  // Set _this to be the current mapview interaction.
-  _this.mapview.interaction = _this  
+  // Set mapview.interaction to be the current mapview interaction.
+  mapview.interaction = mapview.interaction  
   
   // Change cursor style over mapview element.
-  _this.mapview.Map.getTargetElement().style.cursor = 'crosshair'
+  mapview.Map.getTargetElement().style.cursor = 'crosshair'
 
-  // Set _this.Layer source.
-  _this.Layer.setSource(_this.source)
+  // Set mapview.interaction.Layer source.
+  mapview.interaction.Layer.setSource(mapview.interaction.source)
   
-  // Add _this.Layer to mapview.
-  _this.mapview.Map.addLayer(_this.Layer)
+  // Add mapview.interaction.Layer to mapview.
+  mapview.Map.addLayer(mapview.interaction.Layer)
   
   // Create OL draw interaction.
-  _this.interaction = new ol.interaction.Draw(_this)
+  mapview.interaction.interaction = new ol.interaction.Draw(mapview.interaction)
 
   // Set drawstart event method.
-  _this.interaction.on('drawstart', e => {
+  mapview.interaction.interaction.on('drawstart', e => {
 
     // Get the draw feature geometry.
     const geometry = e.feature.getGeometry()
 
     async function onChange() {
-      _this.mapview.popup({
+      mapview.popup({
         content: mapp.utils.html.node`
-          <div style="padding: 5px">${await mapp.utils.convert(_this.mapview.metrics[_this.tooltip.metric](geometry), _this.tooltip)}`
+          <div style="padding: 5px">${await mapp.utils.convert(mapview.metrics[mapview.interaction.tooltip.metric](geometry), mapview.interaction.tooltip)}`
       })
     }
 
     // Assign an onchange method to the geometry for the tooltip.
-    _this.tooltip && geometry.on('change', _this.tooltip.onChange || onChange)
+    mapview.interaction.tooltip && geometry.on('change', mapview.interaction.tooltip.onChange || onChange)
 
     // Clear the source
-    _this.source.clear()
+    mapview.interaction.source.clear()
 
     // Remove the popup.
-    _this.mapview.popup(null)
+    mapview.popup(null)
   })
   
-  if (typeof _this.drawend === 'function') {
+  if (typeof mapview.interaction.drawend === 'function') {
 
-    _this.interaction.on('drawend', _this.drawend)
+    mapview.interaction.interaction.on('drawend', mapview.interaction.drawend)
   }
   
   // Add OL interaction to mapview.Map
-  _this.mapview.Map.addInteraction(_this.interaction)
+  mapview.Map.addInteraction(mapview.interaction.interaction)
 
-  // Initiate snap for _this interaction.
-  _this.snap && _this.mapview.interactions.snap(_this)
+  // Assign snap interaction.
+  mapview.interactions.snap(mapview)
  
-  // Get first feature from _this.source as GeoJSON.
+  // Get first feature from mapview.interaction.source as GeoJSON.
   function getFeature() {
       
     // Return feature as geojson.
     return JSON.parse(
-      _this.format.writeFeature(
+      mapview.interaction.format.writeFeature(
         // Get first OL feature from source.
-        _this.source.getFeatures()[0],
+        mapview.interaction.source.getFeatures()[0],
         { 
-          // Use _this.srid as dataProjection if defined in params.
-          dataProjection: 'EPSG:' + _this.srid || _this.mapview.srid,
-          featureProjection: 'EPSG:' + _this.mapview.srid
+          // Use mapview.interaction.srid as dataProjection if defined in params.
+          dataProjection: 'EPSG:' + mapview.interaction.srid || mapview.srid,
+          featureProjection: 'EPSG:' + mapview.srid
         })
     )
   }
   
   function finish(feature) {
 
-    // Set the current interaction to null.
-    _this.mapview.interaction = null
+    // Remove snap interaction from mapview.
+    if (mapview.interaction.snap) {
+
+      mapview.Map.removeInteraction(mapview.interaction.snap.interaction)
+
+      // Remove loadend event MVT layer snapSource.
+      if (mapview.interaction.layer.snapSource) {
+        mapview.interaction.layer.snapSource.un('tileloadend', mapview.interaction.snap.tileloadend);
+        mapview.Map.removeLayer(mapview.interaction.snap.vectorTileLayer)
+      }
+    }
+
+    // Execute callback if defined as function.
+    if (typeof mapview.interaction.callback === 'function') {
+
+      // Must be run delayed to prevent a callback
+      const callback = mapview.interaction.callback
+      setTimeout(()=>callback(feature), 400)
+    }
 
     // Reset the cursor style.
-    _this.mapview.Map.getTargetElement().style.cursor = 'default'    
-
-    // Remove snap interaction from mapview.
-    _this.snap && _this.mapview.interactions.snap(null)
-  
-    // Execute callback if defined as function.
-    typeof _this.callback === 'function' && _this.callback(feature)
-  
+    mapview.Map.getTargetElement().style.cursor = 'default'
+    
     // Remove popup from mapview.
-    _this.mapview.popup(null)
+    mapview.popup(null)
     
     // Remove interaction from mapview.Map.
-    _this.mapview.Map.removeInteraction(_this.interaction)
+    mapview.Map.removeInteraction(mapview.interaction.interaction)
   
     // Remove draw Layer from mapview.Map.
-    _this.mapview.Map.removeLayer(_this.Layer)
+    mapview.Map.removeLayer(mapview.interaction.Layer)
+
+    delete mapview.interaction
   }
 }

--- a/lib/mapview/interactions/highlight.mjs
+++ b/lib/mapview/interactions/highlight.mjs
@@ -1,11 +1,11 @@
-let _this;
-
 export default function(params){
 
-  // Finish the current interaction.
-  this.interaction?.finish()  
+  const mapview = this;
 
-  _this = Object.assign({
+  // Finish the current interaction.
+  mapview.interaction?.finish()  
+
+  mapview.interaction = Object.assign({
 
     mapview: this,
 
@@ -39,42 +39,42 @@ export default function(params){
 
   }, params)
 
-  // Set _this to be the current mapview _this.
-  _this.mapview.interaction = _this
+  // Set mapview.interaction to be the current mapview mapview.interaction.
+  mapview.interaction = mapview.interaction
 
   // pointerMove will highlight features.
-  _this.mapview.Map.on('pointermove', pointerMove)
+  mapview.Map.on('pointermove', pointerMove)
 
   // click will select the highlighted feature.
-  _this.mapview.Map.on('click', click)
+  mapview.Map.on('click', click)
 
-  _this.mapview.Map.getTargetElement().addEventListener('mousedown', mouseDown)
+  mapview.Map.getTargetElement().addEventListener('mousedown', mouseDown)
 
-  _this.mapview.Map.getTargetElement().addEventListener('mouseup', mouseUp)
+  mapview.Map.getTargetElement().addEventListener('mouseup', mouseUp)
 
   function mouseDown(){
 
     // Remove longClick flag.
-    delete _this.longClick
+    delete mapview.interaction.longClick
 
     // Clear longClick timeout.
-    clearTimeout(_this.longClickTimeout)
+    clearTimeout(mapview.interaction.longClickTimeout)
 
     // Set longClick timeout.
-    _this.longClickTimeout = setTimeout(
+    mapview.interaction.longClickTimeout = setTimeout(
 
       // Set longClick flag.
       () => {
-        _this.longClick = true
-        _this.mapview.Map.getTargetElement().style.cursor = 'wait'
+        mapview.interaction.longClick = true
+        mapview.Map.getTargetElement().style.cursor = 'wait'
       },
       
       // 1000ms default timeout for longclick.
-      _this.longClickMS)
+      mapview.interaction.longClickMS)
   }
 
   function mouseUp(){
-    _this.mapview.Map.getTargetElement().style.cursor = 'auto'
+    mapview.Map.getTargetElement().style.cursor = 'auto'
   }
 
   let shortCircuit
@@ -82,7 +82,7 @@ export default function(params){
   function pointerMove(e) {
 
     // Clear longClick timeout.
-    clearTimeout(_this.longClickTimeout)
+    clearTimeout(mapview.interaction.longClickTimeout)
 
     // Method should short circuit if still processing.
     if (shortCircuit) return;
@@ -92,7 +92,7 @@ export default function(params){
 
     let candidates = {};
 
-    _this.mapview.Map.forEachFeatureAtPixel(e.pixel,
+    mapview.Map.forEachFeatureAtPixel(e.pixel,
       (F, L) => {
 
         // Create candidate object.
@@ -105,15 +105,15 @@ export default function(params){
         candidates[candidate.key] = candidate
       },
       {
-        layerFilter: _this.layerFilter,
-        hitTolerance: _this.hitTolerance,
+        layerFilter: mapview.interaction.layerFilter,
+        hitTolerance: mapview.interaction.hitTolerance,
       })
 
     // No features at pixel.
     if (!Object.keys(candidates).length) {
 
       // Reset candidateKeys
-      _this.candidateKeys = new Set();
+      mapview.interaction.candidateKeys = new Set();
 
       // Remove shortCircuit flag.
       shortCircuit = false;
@@ -125,8 +125,8 @@ export default function(params){
       return;
     }
 
-    // Check whether set of candidate keys is equal to _this.candidateKeys
-    if (mapp.utils.areSetsEqual(_this.candidateKeys, new Set(Object.keys(candidates)))) {
+    // Check whether set of candidate keys is equal to mapview.interaction.candidateKeys
+    if (mapp.utils.areSetsEqual(mapview.interaction.candidateKeys, new Set(Object.keys(candidates)))) {
 
       // Remove shortCircuit flag
       shortCircuit = false;
@@ -136,21 +136,21 @@ export default function(params){
     }
 
     // Find candidate from key which is not in candidates set.
-    let candidate = candidates[Object.keys(candidates).find(key => !_this.candidateKeys.has(key))]
+    let candidate = candidates[Object.keys(candidates).find(key => !mapview.interaction.candidateKeys.has(key))]
 
     // Assign candidate from first key if candidate is falsy.
     candidate = candidate
-      || _this.current?.key && candidates[_this.current?.key]
+      || mapview.interaction.current?.key && candidates[mapview.interaction.current?.key]
       || candidates[Object.keys(candidates)[0]]
 
-    // Assign new Set of candidate keys to _this.
-    _this.candidateKeys = new Set(Object.keys(candidates))
+    // Assign new Set of candidate keys to mapview.interaction.
+    mapview.interaction.candidateKeys = new Set(Object.keys(candidates))
 
     // Remove shortCircuit flag.
     shortCircuit = false;
 
     // Call highlight method.
-    _this.highlight(candidate, e)
+    mapview.interaction.highlight(candidate, e)
   }
 
   function highlight(feature, e) {
@@ -159,20 +159,20 @@ export default function(params){
     clear()
 
     // Assign the layer and ID to the candidate object.
-    _this.current = Object.assign(feature, {
-      layer: _this.mapview.layers[feature.L.get('key')],
+    mapview.interaction.current = Object.assign(feature, {
+      layer: mapview.layers[feature.L.get('key')],
       id: feature.F.get('id') || feature.F.getId()
     })
 
     // Assign the id to the layer highlight key.
     // Required to determine in the style function whether the current feature should be styled as highlighted.
-    _this.current.layer.highlight = feature.id
+    mapview.interaction.current.layer.highlight = feature.id
 
     // Touch events should not highlight features since there is no cursor.
     if (e.originalEvent.pointerType !== 'mouse') {
 
       // Don't get location from touch pan or zoom pinch event.
-      e.type !== 'pointermove' && _this.getLocation(_this.current)
+      e.type !== 'pointermove' && mapview.interaction.getLocation(mapview.interaction.current)
 
       // Clear touch highlight.
       clear()
@@ -181,22 +181,22 @@ export default function(params){
     }
 
     // Change cursor if the highlight is selectable.
-    if (_this.current.layer.infoj) _this.mapview.Map.getTargetElement().style.cursor = 'pointer'
+    if (mapview.interaction.current.layer.infoj) mapview.Map.getTargetElement().style.cursor = 'pointer'
 
     // Execute any hover method assigned to the current feature layer.
-    typeof _this.current.layer.hover?.show === 'function' && _this.current.layer.hover.show(feature.F)
+    typeof mapview.interaction.current.layer.hover?.show === 'function' && mapview.interaction.current.layer.hover.show(feature.F)
 
     // Style the feature itself if possible.
-    if (_this.current.layer.format !== 'mvt'
-      && typeof _this.current.F.setStyle === 'function') {
+    if (mapview.interaction.current.layer.format !== 'mvt'
+      && typeof mapview.interaction.current.F.setStyle === 'function') {
 
       feature.F.set('highlight', true)
-      _this.current.F.setStyle()
+      mapview.interaction.current.F.setStyle()
 
-    } else if (_this.current.layer.style.highlight) {
+    } else if (mapview.interaction.current.layer.style.highlight) {
 
       // Render unto canvas those things that are canvas'
-      _this.current.layer.L.changed()
+      mapview.interaction.current.layer.L.changed()
     }
   }
 
@@ -206,14 +206,14 @@ export default function(params){
   function click(e) {
 
     // Reset cursor.
-    _this.mapview.Map.getTargetElement().style.cursor = 'auto'
+    mapview.Map.getTargetElement().style.cursor = 'auto'
 
     // Clear longClick timeout.
-    clearTimeout(_this.longClickTimeout)
+    clearTimeout(mapview.interaction.longClickTimeout)
 
-    if (_this.longClick && typeof _this.longClickMethod === 'function') {
+    if (mapview.interaction.longClick && typeof mapview.interaction.longClickMethod === 'function') {
 
-      _this.longClickMethod(e)
+      mapview.interaction.longClickMethod(e)
       return;
     }
 
@@ -226,36 +226,36 @@ export default function(params){
     // Simulate pointermove on the touch click coordinates.
     if (e.originalEvent.pointerType === 'touch') {
 
-      _this.candidateKeys = new Set();
+      mapview.interaction.candidateKeys = new Set();
       e.type = 'touchClick'
       pointerMove(e)
       return
     }
     
     // Remove any existing popup. e.g. Cluster select dialogue.
-    _this.mapview.popup(null)
+    mapview.popup(null)
 
     // Return if there is no current highlight to select.
-    if (_this.current) {
-      _this.getLocation(_this.current);
+    if (mapview.interaction.current) {
+      mapview.interaction.getLocation(mapview.interaction.current);
       return;
     }
 
     // Execute the noLocationClick method
-    if (typeof _this.noLocationClick === 'function') {
-      _this.noLocationClick(e)
+    if (typeof mapview.interaction.noLocationClick === 'function') {
+      mapview.interaction.noLocationClick(e)
     }
   }
 
   function selectAll(e) {
 
     // Remove popup from mapview.
-    _this.mapview.popup(null)
+    mapview.popup(null)
 
     const locations = [];
 
     // Find locations at pixel.
-    _this.mapview.Map.forEachFeatureAtPixel(e.pixel,
+    mapview.Map.forEachFeatureAtPixel(e.pixel,
       (F, L) => {
 
         const properties = F.getProperties()
@@ -267,8 +267,8 @@ export default function(params){
         locations.push(`${L.get('key') || ol.util.getUid(L)}!${F.get('id') || F.getId() || ol.util.getUid(F)}`)
       },
       {
-        layerFilter: _this.layerFilter,
-        hitTolerance: _this.hitTolerance,
+        layerFilter: mapview.interaction.layerFilter,
+        hitTolerance: mapview.interaction.hitTolerance,
       })
 
     // No features at pixel.
@@ -280,15 +280,15 @@ export default function(params){
         ${locations.map(key => mapp.utils.html.node`
           <li onclick=${e => {           
             mapp.location.get({
-              layer: _this.mapview.layers[key.split('!')[0]],
+              layer: mapview.layers[key.split('!')[0]],
               id: key.split('!')[1]
             })
 
-            _this.mapview.popup(null)
+            mapview.popup(null)
           }}
         }}>${key}`)}`;      
 
-    _this.mapview.popup({
+    mapview.popup({
       content,
       autoPan: true,
     });
@@ -297,32 +297,32 @@ export default function(params){
   function clear() {
 
     // Highlight has already been cleared.
-    if (!_this.current) return;
+    if (!mapview.interaction.current) return;
 
     // Remove any infotip.
-    _this.mapview.infotip(null)
+    mapview.infotip(null)
 
     // Reset cursor.
-    _this.mapview.Map.getTargetElement().style.cursor = 'auto'
+    mapview.Map.getTargetElement().style.cursor = 'auto'
 
     // Delete the highlight id from current layer.
-    delete _this.current.layer.highlight
+    delete mapview.interaction.current.layer.highlight
 
     // Style the feature itself if possible.
-    if (_this.current.layer.format !== 'mvt'
-      && typeof _this.current.F.setStyle === 'function') {
+    if (mapview.interaction.current.layer.format !== 'mvt'
+      && typeof mapview.interaction.current.F.setStyle === 'function') {
 
-      _this.current.F.set('highlight', false)
-      _this.current.F.setStyle()
+      mapview.interaction.current.F.set('highlight', false)
+      mapview.interaction.current.F.setStyle()
 
-    } else if (_this.current.layer.style.highlight) {
+    } else if (mapview.interaction.current.layer.style.highlight) {
 
       // Render unto canvas those things that are canvas'
-      _this.current.layer.L.changed()
+      mapview.interaction.current.layer.L.changed()
     }
 
     // Delete the current highlight object.
-    delete _this.current
+    delete mapview.interaction.current
   }
 
   function getLocation(feature) {
@@ -335,7 +335,7 @@ export default function(params){
     // Return with a select dialogue for cluster feature.
     if (properties.count > 1) {
       mapp.location.nnearest({
-        mapview: _this.mapview,
+        mapview: mapview.interaction.mapview,
         layer: feature.layer,
         table: feature.layer.table || feature.layer.tableCurrent(),
         feature: feature.F
@@ -351,21 +351,21 @@ export default function(params){
     })
   }
 
-  // Finished the highlight _this.
+  // Finished the highlight mapview.interaction.
   function finish() {
 
-    // Set the current interaction to null.
-    _this.mapview.interaction = null
-
+    // Clear must be called before interaction is nulled.
     clear()
 
     // Remove popup from mapview.
-    _this.mapview.popup(null)
+    mapview.popup(null)
 
     // Remove event listener from mapview.
-    _this.mapview.Map.un('pointermove', pointerMove)
-    _this.mapview.Map.un('click', click)
-    _this.mapview.Map.getTargetElement().removeEventListener('mousedown', mouseDown)
-    _this.mapview.Map.getTargetElement().removeEventListener('mouseup', mouseUp)
+    mapview.Map.un('pointermove', pointerMove)
+    mapview.Map.un('click', click)
+    mapview.Map.getTargetElement().removeEventListener('mousedown', mouseDown)
+    mapview.Map.getTargetElement().removeEventListener('mouseup', mouseUp)
+
+    delete mapview.interaction
   }
 }

--- a/lib/mapview/interactions/modify.mjs
+++ b/lib/mapview/interactions/modify.mjs
@@ -1,11 +1,11 @@
-let _this;
-
 export default function(params){
+
+  const mapview = this
   
   // Finish the current interaction.
   this.interaction?.finish()
 
-  _this = Object.assign({
+  mapview.interaction = Object.assign({
 
     mapview: this,
 
@@ -60,7 +60,7 @@ export default function(params){
 
       if (e.type === 'singleclick') {
 
-        const geom = _this.Feature.getGeometry()
+        const geom = mapview.interaction.Feature.getGeometry()
 
         const geomType = geom.getType()
 
@@ -75,13 +75,13 @@ export default function(params){
         if (geomType === 'Polygon' && coords[0].length <= 4) return;
      
         // Set popup to remove vertex.
-        _this.mapview.popup({
+        mapview.popup({
           coords: geom.getClosestPoint(e.coordinate),
           content: mapp.utils.html.node`<ul>
             <li
               onclick=${() => {
-              _this.interaction.removePoint()
-              _this.vertices.push(_this.Feature.getGeometry().getClosestPoint(e.coordinate))
+              mapview.interaction.interaction.removePoint()
+              mapview.interaction.vertices.push(mapview.interaction.Feature.getGeometry().getClosestPoint(e.coordinate))
             }}>${mapp.dictionary.delete_vertex}`
         })
       }
@@ -89,75 +89,89 @@ export default function(params){
 
   }, params)
 
-  // Set _this to be the current mapview interaction.
-  _this.mapview.interaction = _this
+  // Set mapview.interaction to be the current mapview interaction.
+  mapview.interaction = mapview.interaction
 
-  _this.mapview.Map.getTargetElement().style.cursor = 'crosshair'
+  mapview.Map.getTargetElement().style.cursor = 'crosshair'
 
-  _this.source.addFeature(_this.Feature)
+  mapview.interaction.source.addFeature(mapview.interaction.Feature)
    
-  // Set _this.Layer source.
-  _this.Layer.setSource(_this.source)
+  // Set mapview.interaction.Layer source.
+  mapview.interaction.Layer.setSource(mapview.interaction.source)
 
-  // Set _this.Layer style
-  _this.Layer.setStyle(_this.Style)
+  // Set mapview.interaction.Layer style
+  mapview.interaction.Layer.setStyle(mapview.interaction.Style)
   
-  // Add _this.Layer to mapview.
-  _this.mapview.Map.addLayer(_this.Layer)
+  // Add mapview.interaction.Layer to mapview.
+  mapview.Map.addLayer(mapview.interaction.Layer)
    
-  _this.interaction = new ol.interaction.Modify(_this)
+  mapview.interaction.interaction = new ol.interaction.Modify(mapview.interaction)
 
   // Will clear remove vertex popup.
-  _this.interaction.on('modifystart', e => {
-    _this.mapview.popup(null)
+  mapview.interaction.interaction.on('modifystart', e => {
+    mapview.popup(null)
   })
 
-  if (typeof _this.modifyend === 'function') {
+  if (typeof mapview.interaction.modifyend === 'function') {
 
-    _this.interaction.on('modifyend', _this.modifyend)
+    mapview.interaction.interaction.on('modifyend', mapview.interaction.modifyend)
   }
 
   // Add OL interaction to mapview.Map
-  _this.mapview.Map.addInteraction(_this.interaction)
+  mapview.Map.addInteraction(mapview.interaction.interaction)
 
-  _this.snap && _this.mapview.interactions.snap(_this)
+  // Assign snap interaction.
+  mapview.interactions.snap(mapview)
  
   function getFeature() {
      
     return JSON.parse(
-      _this.format.writeFeature(
-        _this.Feature,
+      mapview.interaction.format.writeFeature(
+        mapview.interaction.Feature,
         { 
-          dataProjection: 'EPSG:' + _this.srid || _this.mapview.srid,
-          featureProjection: 'EPSG:' + _this.mapview.srid
+          dataProjection: 'EPSG:' + mapview.interaction.srid || mapview.srid,
+          featureProjection: 'EPSG:' + mapview.srid
         })
     )
   }
   
   function finish(feature) {
 
-    // Set the current interaction to null.
-    _this.mapview.interaction = null
+    // Remove snap interaction from mapview.
+    if (mapview.interaction.snap) {
+
+      mapview.Map.removeInteraction(mapview.interaction.snap.interaction)
+
+      // Remove loadend event MVT layer snapSource.
+      if (mapview.interaction.layer.snapSource) {
+        mapview.interaction.layer.snapSource.un('tileloadend', mapview.interaction.snap.tileloadend);
+        mapview.Map.removeLayer(mapview.interaction.snap.vectorTileLayer)
+      }
+    }
+
+    // Execute callback if defined as function.
+    if (typeof mapview.interaction.callback === 'function') {
+
+      // Must be run delayed to prevent a callback
+      const callback = mapview.interaction.callback
+      setTimeout(()=>callback(feature), 400)
+    }
 
     // Reset the cursor style.
-    _this.mapview.Map.getTargetElement().style.cursor = 'default'
-
-    // Remove snap interaction from mapview.
-    _this.snap && _this.mapview.interactions.snap(null)
-  
-    // Execute callback if defined as function.
-    typeof _this.callback === 'function' && _this.callback(feature)
+    mapview.Map.getTargetElement().style.cursor = 'default'
   
     // Remove popup from mapview.
-    _this.mapview.popup(null)
+    mapview.popup(null)
     
     // Remove interaction from mapview.Map.
-    _this.mapview.Map.removeInteraction(_this.interaction)
+    mapview.Map.removeInteraction(mapview.interaction.interaction)
 
     // Clear the modify source.
-    _this.source.clear()
+    mapview.interaction.source.clear()
   
     // Remove draw Layer from mapview.Map.
-    _this.mapview.Map.removeLayer(_this.Layer)
+    mapview.Map.removeLayer(mapview.interaction.Layer)
+
+    delete mapview.interaction
   }
 }

--- a/lib/mapview/interactions/snap.mjs
+++ b/lib/mapview/interactions/snap.mjs
@@ -1,62 +1,49 @@
-let _this;
+export default function(mapview) {
 
-export default function(interaction) {
-
-  // Remove snap interaction if defined.
-  // Called from draw or modify interaction finish method.
-  if (interaction === null) {
-    
-    _this.mapview.Map.removeInteraction(_this.snap.interaction)
-
-    // Remove loadend event MVT layer snapSource.
-    _this.layer.snapSource?.un('tileloadend', tileloadend);
-
-    // Remove vectorTileLayer associated with the MVT layer snapSource.
-    _this.mapview.Map.removeLayer(_this.snap.vectorTileLayer)
-
-    return;
-  }
+  if (!mapview.interaction.snap) return;
 
   // Assign mapview and interaction to be _this.
-  _this = Object.assign(interaction, {
-    snap: {
-      source: new ol.source.Vector()
-    }
-  })
+  mapview.interaction.snap = {
+    source: new ol.source.Vector(),
+    tileloadend: e => {
+
+      // Assign features from tile to the snap source.
+      mapview.interaction.snap.source.addFeatures(e.tile.getFeatures())
+    },
+    // tileloadend: function(e) {
+
+    //   // Assign features from tile to the snap source.
+    //   this.source.addFeatures(e.tile.getFeatures())
+    // }
+  }
 
   // Only MVT layer have a snapSource.
-  if (_this.layer.snapSource) {
+  if (mapview.interaction.layer.snapSource) {
 
     // Assign loadend event to MVT layer snapSource.
-    _this.layer.snapSource.on('tileloadend', tileloadend)
+    mapview.interaction.layer.snapSource.on('tileloadend', mapview.interaction.snap.tileloadend)
 
     // An invisible VectorTile layer is required to trigger the loadend event.
-    _this.snap.vectorTileLayer = new ol.layer.VectorTile({
-      source: _this.layer.snapSource,
+    mapview.interaction.snap.vectorTileLayer = new ol.layer.VectorTile({
+      source: mapview.interaction.layer.snapSource,
       opacity: 0
     })
   
-    _this.mapview.Map.addLayer(_this.snap.vectorTileLayer)
+    mapview.Map.addLayer(mapview.interaction.snap.vectorTileLayer)
 
     // Refresh the snapSource in order to trigger the loadend event.
-    _this.layer.snapSource.refresh()
+    mapview.interaction.layer.snapSource.refresh()
 
   } else {
 
     // Assign snapSource from the snapLayer's OL source.
-    _this.snap.source = _this.layer.L.getSource()
+    mapview.interaction.snap.source = mapview.interaction.layer.L.getSource()
   }
 
   // Create and assign snap interaction.
-  _this.snap.interaction = new ol.interaction.Snap({
-    source: _this.snap.source
+  mapview.interaction.snap.interaction = new ol.interaction.Snap({
+    source: mapview.interaction.snap.source
   })
 
-  _this.mapview.Map.addInteraction(_this.snap.interaction)
-}
-
-function tileloadend(e){
-
-  // Assign features from tile to the snap source.
-  _this.snap.source.addFeatures(e.tile.getFeatures())
+  mapview.Map.addInteraction(mapview.interaction.snap.interaction)
 }

--- a/lib/mapview/interactions/snap.mjs
+++ b/lib/mapview/interactions/snap.mjs
@@ -9,12 +9,7 @@ export default function(mapview) {
 
       // Assign features from tile to the snap source.
       mapview.interaction.snap.source.addFeatures(e.tile.getFeatures())
-    },
-    // tileloadend: function(e) {
-
-    //   // Assign features from tile to the snap source.
-    //   this.source.addFeatures(e.tile.getFeatures())
-    // }
+    }
   }
 
   // Only MVT layer have a snapSource.

--- a/lib/mapview/interactions/zoom.mjs
+++ b/lib/mapview/interactions/zoom.mjs
@@ -4,7 +4,7 @@ export default function(params){
 
   mapview.interaction?.finish()
 
-  const zoom = {
+  mapview.interaction = {
 
     finish: finish,
 
@@ -13,18 +13,16 @@ export default function(params){
     })
   }
 
-  mapview.interaction = zoom
+  mapview.interaction.callback = params.callback
 
-  zoom.callback = params.callback
+  mapview.interaction.Layer.getSource().clear()
 
-  zoom.Layer.getSource().clear()
-
-  mapview.Map.addLayer(zoom.Layer);
+  mapview.Map.addLayer(mapview.interaction.Layer);
 
   mapview.Map.getTargetElement().style.cursor = 'zoom-in';
 
-  zoom.interaction = new ol.interaction.Draw({
-    source: zoom.Layer.getSource(),
+  mapview.interaction.interaction = new ol.interaction.Draw({
+    source: mapview.interaction.Layer.getSource(),
     type: 'Circle',
     geometryFunction: ol.interaction.Draw.createBox(),
     style: new ol.style.Style({
@@ -38,30 +36,33 @@ export default function(params){
     })
   })
 
-  zoom.interaction.on('drawend', e => {
+  mapview.interaction.interaction.on('drawend', e => {
 
     mapview.fitView(e.feature.getGeometry().getExtent())
 
     finish()
   })
 
-  mapview.Map.addInteraction(zoom.interaction)
+  mapview.Map.addInteraction(mapview.interaction.interaction)
 
   function finish() {
 
-    delete mapview.interaction
+    // Execute callback if defined as function.
+    if (typeof mapview.interaction.callback === 'function') {
 
-    if (zoom.callback) {
-      zoom.callback()
-      delete zoom.callback
+      // Must be run delayed to prevent a callback
+      const callback = mapview.interaction.callback
+      setTimeout(()=>callback(), 400)
     }
 
     mapview.Map.getTargetElement().style.cursor = 'auto';
 
-    mapview.Map.removeInteraction(zoom.interaction)
+    mapview.Map.removeInteraction(mapview.interaction.interaction)
 
-    mapview.Map.removeLayer(zoom.Layer)
+    mapview.Map.removeLayer(mapview.interaction.Layer)
 
-    zoom.Layer.getSource().clear()
+    mapview.interaction.Layer.getSource().clear()
+
+    delete mapview.interaction
   }
 }


### PR DESCRIPTION
Assigning the interaction object as _this outside the module closure didn't allow for interactions on multiple mapviews.

The interaction object must be assigned to the mapview itself.

The interaction is now deleted at the end of the finish method instead of nulled.

The callback method execution must be delayed in order to prevent a circular execution where the callback initiated an interaction which would finish this interaction with the callback again.