### PR TITLE
enable offsetY and offsetX in utils.style for label

### DIFF
--- a/lib/utils/style.mjs
+++ b/lib/utils/style.mjs
@@ -67,6 +67,8 @@ export default (style, feature) => {
         font: style.label.font || '12px sans-serif',
         text: String(style.label.text),
         overflow: style.label.overflow,
+        offsetY: style.label.offsetY,
+        offsetX: style.label.offsetX,
         stroke: style.label.strokeColor && new ol.style.Stroke({
           color: style.label.strokeColor,
           width: style.label.strokeWidth || 1


### PR DESCRIPTION
Can be set like so in the label style config.

```
    "label": {
      "font": "bold 12px sans-serif",
      "count": true,
      "field": "stat_name",
      "declutter": true,
      "strokeColor": "#ffffff",
      "strokeWidth": 3,
      "offsetY": -15
    },
```﻿

![image](https://user-images.githubusercontent.com/22201617/212073635-3f73d69c-f597-4b6c-b675-103e5bb34da4.png)

﻿