### PR TITLE
bump jsonwebtoken to v9

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "@geolytix/saml2-js": "^3.0.5",
     "bcryptjs": "^2.4.3",
     "cloudinary": "^1.24.0",
-    "jsonwebtoken": "^8.5.1",
+    "jsonwebtoken": "^9.0.0",
     "mongodb": "^4.11.0",
     "nanoid": "^3.2.0",
     "node-fetch": "^2.6.7",


### PR DESCRIPTION
Version 8.x has severe (high) vulnerability.