### PR TITLE
remove node-fetch

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,8 +46,6 @@ Node.js v12+
 
 [nanoid](https://www.npmjs.com/package/nanoid) - A tiny, secure, URL-friendly, unique string ID generator for JavaScript.
 
-[node-fetch](https://github.com/bitinn/node-fetch) - A light-weight module that brings window.fetch to Node.
-
 [Node-Postgres](https://github.com/brianc/node-postgres) - PostgreSQL client for Node.
 
 [nodemailer](https://github.com/nodemailer/nodemailer) - Send e-mails with Node – easy as cake!

--- a/mod/gazetteer.js
+++ b/mod/gazetteer.js
@@ -1,5 +1,3 @@
-const fetch = require('node-fetch')
-
 const dbs = require('./utils/dbs')()
 
 const sqlFilter = require('./utils/sqlFilter')

--- a/mod/provider/cloudfront.js
+++ b/mod/provider/cloudfront.js
@@ -5,8 +5,6 @@ const httpsAgent = new https.Agent({
   maxSockets: parseInt(process.env.CUSTOM_AGENT) || 1
 })
 
-const fetch = require('node-fetch')
-
 const { readFileSync } = require('fs')
 
 const { join } = require('path')

--- a/mod/templates/_templates.js
+++ b/mod/templates/_templates.js
@@ -10,8 +10,6 @@ const cloudfront = require('../provider/cloudfront')
 
 const file = require('../provider/file')
 
-const fetch = require('node-fetch')
-
 const getFrom = {
   https: async ref => {
 

--- a/mod/utils/logger.js
+++ b/mod/utils/logger.js
@@ -1,5 +1,3 @@
-const fetch = require('node-fetch')
-
 const logs = new Set(process.env.LOGS?.split(',') || [])
 
 const { nanoid } = require('nanoid')

--- a/mod/workspace/httpsAgent.js
+++ b/mod/workspace/httpsAgent.js
@@ -5,8 +5,6 @@ const httpsAgent = new https.Agent({
   maxSockets: parseInt(process.env.CUSTOM_AGENT) || 1
 })
 
-const fetch = require('node-fetch')
-
 module.exports = async ref => {
   try {
 

--- a/package.json
+++ b/package.json
@@ -18,7 +18,6 @@
     "jsonwebtoken": "^9.0.0",
     "mongodb": "^4.11.0",
     "nanoid": "^3.2.0",
-    "node-fetch": "^2.6.7",
     "nodemailer": "^6.6.0",
     "pg": "^8.7.3"
   },

--- a/package.json
+++ b/package.json
@@ -5,6 +5,9 @@
     "type": "git",
     "url": "https://github.com/geolytix/xyz"
   },
+  "engines": {
+    "node": ">=18"
+  },
   "scripts": {
     "test": "web-test-runner \"test/**/*.test.js\" --node-resolve",
     "_build": "npx esbuild ./lib/mapp.mjs ./lib/ui.mjs --bundle --minify --tree-shaking=false --sourcemap --format=iife --outdir=./public/js/lib"

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "url": "https://github.com/geolytix/xyz"
   },
   "engines": {
-    "node": ">=18"
+    "node": "18.x"
   },
   "scripts": {
     "test": "web-test-runner \"test/**/*.test.js\" --node-resolve",


### PR DESCRIPTION
https://github.com/GEOLYTIX/xyz/issues/579

Node 18 (LTS) has native support for the fetch API.

The node-fetch dependency has been removed in favour of the native fetch API support in current Node LTS (18).