### PR TITLE
Make saml2 dependency optional

### DIFF
--- a/mod/user/saml.js
+++ b/mod/user/saml.js
@@ -1,41 +1,48 @@
-const saml2 = require("@geolytix/saml2-js");
+let acl, sp, idp;
 
-const { join } = require("path");
-
-const { readFileSync } = require("fs");
-
-const logger = require('../utils/logger')
-
-const acl = require('./acl')()
+const logger = require('../utils/logger');
 
 const jwt = require("jsonwebtoken");
 
-const sp = new saml2.ServiceProvider({
-  entity_id: process.env.SAML_ENTITY_ID,
-  private_key:
-    process.env.SAML_SP_CRT &&
-    String(
-      readFileSync(join(__dirname, `../../${process.env.SAML_SP_CRT}.pem`))
-    ),
-  certificate:
-    process.env.SAML_SP_CRT &&
-    String(
-      readFileSync(join(__dirname, `../../${process.env.SAML_SP_CRT}.crt`))
-    ),
-  assert_endpoint: process.env.SAML_ACS,
-  allow_unencrypted_assertion: true,
-});
+try {
+  const saml2 = require("saml2-js");
 
-const idp = new saml2.IdentityProvider({
-  sso_login_url: process.env.SAML_SSO,
-  sso_logout_url: process.env.SAML_SLO,
-  certificates: process.env.SAML_IDP_CRT && [
-    String(
-      readFileSync(join(__dirname, `../../${process.env.SAML_IDP_CRT}.crt`))
-    ),
-  ],
-  sign_get_request: true,
-});
+  const { join } = require("path");
+
+  const { readFileSync } = require("fs");
+
+  acl = require('./acl')();
+
+  sp = new saml2.ServiceProvider({
+    entity_id: process.env.SAML_ENTITY_ID,
+    private_key:
+      process.env.SAML_SP_CRT &&
+      String(
+        readFileSync(join(__dirname, `../../${process.env.SAML_SP_CRT}.pem`))
+      ),
+    certificate:
+      process.env.SAML_SP_CRT &&
+      String(
+        readFileSync(join(__dirname, `../../${process.env.SAML_SP_CRT}.crt`))
+      ),
+    assert_endpoint: process.env.SAML_ACS,
+    allow_unencrypted_assertion: true,
+  });
+
+  idp = new saml2.IdentityProvider({
+    sso_login_url: process.env.SAML_SSO,
+    sso_logout_url: process.env.SAML_SLO,
+    certificates: process.env.SAML_IDP_CRT && [
+      String(
+        readFileSync(join(__dirname, `../../${process.env.SAML_IDP_CRT}.crt`))
+      ),
+    ],
+    sign_get_request: true,
+  });
+
+} catch {
+  console.log('SAML2 module is not available.')
+}
 
 module.exports = (req, res) => {
   

--- a/package.json
+++ b/package.json
@@ -12,7 +12,6 @@
   "license": "MIT",
   "dependencies": {
     "@aws-sdk/cloudfront-signer": "^3.90.0",
-    "@geolytix/saml2-js": "^3.0.5",
     "bcryptjs": "^2.4.3",
     "cloudinary": "^1.24.0",
     "jsonwebtoken": "^9.0.0",


### PR DESCRIPTION
The saml2 library should not be in the package.json.

The package should only be installed if needed.

The latest version of the original []([saml2-js](https://www.npmjs.com/package/saml2-js)) lib should be used, not the fork which was created in response to some dependency vulnerabilities which have since been addressed by the maintainer.

The rewrite for SAML endpoints should only be added when enabled. https://github.com/GEOLYTIX/xyz/wiki/VERCEL#saml

The SAML config notes have been added to the wiki. https://github.com/GEOLYTIX/xyz/wiki/Security#saml-sso