### PR TITLE
Geojson cluster style and properties

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,7 @@ node_modules/*
 *.crt
 
 public/css/.sass-cache/
+public/workspaces/*
 stats.json
 
 caddy_linux_amd64

--- a/lib/layer/Style.mjs
+++ b/lib/layer/Style.mjs
@@ -23,13 +23,7 @@ export default layer => feature => {
   }
 
   // Assign default style as feature.style.
-  feature.style =  Object.assign({}, layer.style.default, layer.style.theme?.style)
-
-  // Assign properties.count from length of cluster layer features array.
-  if (layer.type === 'cluster') {
-
-    feature.properties.count = feature.get('features').length
-  }
+  feature.style =  Object.assign({}, mapp.utils.clone(layer.style.default), layer.style.theme?.style)
 
   // The featureLookup is an array of features
   if (layer.featureLookup) {
@@ -52,14 +46,16 @@ export default layer => feature => {
     // The style must be cloned as icon if not otherwise defined to prevent circular reference
     feature.style.icon = feature.style.icon || mapp.utils.clone(feature.style)
 
+    // Assign cluster style.
     if (feature.properties.count > 1 && layer.style.cluster) {
 
-      Object.assign(feature.style, layer.style.cluster || {})
+      Object.assign(feature.style, layer.style.cluster)
     }
   }
 
   // Apply theme style to style object.
-  mapp.layer.themes[layer.style.theme?.type] && mapp.layer.themes[layer.style.theme.type](layer.style.theme, feature)
+  mapp.layer.themes[layer.style.theme?.type]?.(layer.style.theme, feature)
+
 
   // Cluster icons will NOT scale different to single locations if the clusterScale is not set in the cluster style.
   if (feature.style.clusterScale) {

--- a/lib/layer/format/geojson.mjs
+++ b/lib/layer/format/geojson.mjs
@@ -75,7 +75,7 @@ export default layer => {
         let fP = features[0].getProperties()
 
         // Set feature properties for for single location cluster.
-        Object.entries(fP.properties).forEach(entry => {
+        Object.entries(fP.properties || {}).forEach(entry => {
           F.set(entry[0], entry[1], true)
         })
 

--- a/lib/layer/format/geojson.mjs
+++ b/lib/layer/format/geojson.mjs
@@ -31,15 +31,17 @@ export default layer => {
             features: features
           })
 
-          if (layer.clusterSource) {
+          // Geojson is a cluster layer.
+          if (layer.cluster) {
 
-            source = new ol.source.Cluster({
-              distance: layer.clusterSource.distance || 50,
+            // Create cluster source.
+            layer.cluster.source = new ol.source.Cluster({
+              distance: layer.cluster.distance || 50,
               source
             })
           }
           
-          layer.L.setSource(source)
+          layer.L.setSource(layer.cluster.source)
 
         })
 
@@ -49,6 +51,44 @@ export default layer => {
     key: layer.key,
     zIndex: layer.zIndex || 1,
     style: layer.styleFunction || mapp.layer.Style(layer)
+  })
+
+  // Change method for the cluster feature properties and layer stats.
+  layer.cluster && layer.L.on('change', e => {
+
+    delete layer.max_size;
+
+    const feature_counts = layer.cluster.source.getFeatures().map(F => {
+
+      const features = F.get('features')
+
+      // Set cluster feature id for highlight interaction.
+      F.set('id', features[0].get('id'), true)
+
+      if (features.length > 1) {
+
+        // Set cluster count.
+        F.set('count', features.length, true)
+
+      } else {
+
+        let fP = features[0].getProperties()
+
+        // Set feature properties for for single location cluster.
+        Object.entries(fP.properties).forEach(entry => {
+          F.set(entry[0], entry[1], true)
+        })
+
+      }
+      
+      // Return length for calculation of max_size.
+      return features.length
+    })
+  
+    if (!feature_counts.length) return;
+
+    // Calculate max_size for cluster size styling.
+    layer.max_size = Math.max(...feature_counts)
   })
 
 }

--- a/lib/layer/hover.mjs
+++ b/lib/layer/hover.mjs
@@ -11,14 +11,14 @@ export default layer => {
       dbs: layer.dbs,
       locale: layer.mapview.locale.key,
       layer: layer.key,
-      filter: layer.filter?.current,
+      filter: feature.properties.count > 1 && layer.filter?.current,
       template: layer.hover.query || 'infotip',
       qID: layer.qID,
-      id: layer.highlight,
+      id: feature.properties.id,
       table: layer.tableCurrent(),
       geom: layer.geom,
       field: layer.hover.field,
-      coords: layer.format === 'cluster'
+      coords: feature.properties.count > 1
         && ol.proj.transform(
           feature.getGeometry().getCoordinates(),
           `EPSG:${layer.mapview.srid}`,

--- a/lib/ui/layers/legends/categorized.mjs
+++ b/lib/ui/layers/legends/categorized.mjs
@@ -4,6 +4,8 @@ export default layer => {
 
   const grid = []
 
+  let timeout;
+
   // Switch all control
   layer.filter && grid.push(mapp.utils.html`
     <div
@@ -13,13 +15,11 @@ export default layer => {
       <button
         class="primary-colour bold"
         onclick=${e => {
-          e.target.closest('.legend').querySelectorAll('.switch').forEach(_switch => _switch.click())
 
-          // theme flag is set in styles or theme.
-          (layer.style.filter || theme.filter)
-            ? layer.L.changed()
-            : layer.reload()
-            
+          let switches = e.target.closest('.legend').querySelectorAll('.switch')
+
+          switches.forEach(_switch => _switch.click())
+
         }}>${mapp.dictionary.layer_style_switch_all}</button>.`)
 
   Object.entries(theme.cat).forEach(cat => {
@@ -106,10 +106,16 @@ export default layer => {
             }
           }
 
-          // theme flag is set in styles or theme.
-          (layer.style.filter || theme.filter)
-            ? layer.L.changed()
-            : layer.reload()
+          if (timeout) clearTimeout(timeout)
+
+          timeout = setTimeout(() => {
+
+            // theme flag is set in styles or theme.
+            (layer.style.filter || theme.filter)
+              ? layer.L.changed()
+              : layer.reload()
+
+          }, 400)
 
         }}>${cat[1].label || cat[0]}`
 


### PR DESCRIPTION
I created a public workspace to compare a grid resolution cluster with openlayers geojson cluster.

https://github.com/GEOLYTIX/mapp/blob/main/workspaces/geojson_cluster.json

The data is GEOLYTIX Retail Points hosted in a public database. https://bit.io/dbauszus/geolytix

https://geojson-cluster.vercel.app/

The geojson layer is defined as cluster with cluster config block. The only supported key is the distance (in pixel) for the cluster source.

```
"cluster": {
 "distance": 50
},
```