### PR TITLE
iterate through tabulator sub columns

### DIFF
--- a/lib/ui/Dataview.mjs
+++ b/lib/ui/Dataview.mjs
@@ -186,8 +186,19 @@ async function Chart(_this) {
 }
 
 async function Table(_this) {
+
   // Check for custom column methods.
-  _this.table.columns.forEach((col) => {
+  _this.table.columns.forEach((col) => chkCol(col));
+
+  function chkCol(col) {
+
+    // Column is an array of sub columns.
+    if (Array.isArray(col.columns)) {
+
+      col.columns.forEach(col => chkCol(col))
+      return;
+    }
+
     // Check for custom headerFilter matched in the ui utils.
     if (
       typeof col.headerFilter === 'string' &&
@@ -206,8 +217,8 @@ async function Table(_this) {
       // Assign custom formatter from ui utils.
       col.formatter =
       mapp.ui.utils.tabulator.formatter[col.formatter](_this);
-    }
-  });
+    }    
+  }
 
   // Await initialisation of Tabulator object.
   _this.Tabulator = await mapp.ui.utils.Tabulator(


### PR DESCRIPTION
The dataview module must iterate through nested columns to assign column methods from the utils.

```
        "columns": [
          {
            "title": "POI",
            "columns": [
              {
                "field": "poi_name",
                "title": "Name",
                "headerFilter":"like"
              },
              {
                "field": "poi_type",
                "title": "Type",
                "headerFilter":"like"
              }
            ]
          },
          {
            "field": "town",
            "title": "Town",
            "headerFilter":"like"
          }
        ]
```