### PR TITLE
Prevent mousedown event after touch start

### DIFF
--- a/lib/mapview/interactions/highlight.mjs
+++ b/lib/mapview/interactions/highlight.mjs
@@ -50,7 +50,14 @@ export default function(params){
 
   mapview.Map.getTargetElement().addEventListener('mousedown', mouseDown)
 
+  mapview.Map.getTargetElement().addEventListener('touchstart', touchStart)
+
   mapview.Map.getTargetElement().addEventListener('mouseup', mouseUp)
+
+  // Prevent mouseDown event on touch input.
+  function touchStart(e) {
+    e.preventDefault()
+  }
 
   function mouseDown(){
 
@@ -204,6 +211,8 @@ export default function(params){
 
   // Select the current highlighted feature.
   function click(e) {
+
+    console.log('click')
 
     // Reset cursor.
     mapview.Map.getTargetElement().style.cursor = 'auto'
@@ -364,6 +373,7 @@ export default function(params){
     mapview.Map.un('pointermove', pointerMove)
     mapview.Map.un('click', click)
     mapview.Map.getTargetElement().removeEventListener('mousedown', mouseDown)
+    mapview.Map.getTargetElement().removeEventListener('touchstart', touchStart)
     mapview.Map.getTargetElement().removeEventListener('mouseup', mouseUp)
 
     delete mapview.interaction

--- a/lib/mapview/interactions/highlight.mjs
+++ b/lib/mapview/interactions/highlight.mjs
@@ -212,8 +212,6 @@ export default function(params){
   // Select the current highlighted feature.
   function click(e) {
 
-    console.log('click')
-
     // Reset cursor.
     mapview.Map.getTargetElement().style.cursor = 'auto'
 


### PR DESCRIPTION
The long click drilldown shouldn't happen on touch devices.