### PR TITLE
assign empty string in option edit

### DIFF
--- a/lib/ui/locations/entries/text.mjs
+++ b/lib/ui/locations/entries/text.mjs
@@ -55,7 +55,7 @@ function options(entry){
 
   entry.value = chk 
     && typeof chk === 'object' 
-    && Object.keys(chk)[0] || chk || entry.value || ' ';
+    && Object.keys(chk)[0] || chk || entry.value || '';
 
   const entries = entry.edit.options.map(option => ({
     title: typeof option === 'string' && option || Object.keys(option)[0],


### PR DESCRIPTION
as opposed to a 1 space string which will not resolve as falsy with a skipFalsyValue flag on the entry.