### PR TITLE
Get cluster feature from features instead of nnearest.

### DIFF
--- a/lib/mapview/interactions/highlight.mjs
+++ b/lib/mapview/interactions/highlight.mjs
@@ -341,6 +341,45 @@ export default function(params){
 
     // Return with a select dialogue for cluster feature.
     if (properties.count > 1) {
+
+      // Get cluster features
+      const features = feature.F.get('features')
+
+      if (Array.isArray(features)) {
+
+        // Get list of cluster feature label and id.
+        let featuresList = features.map(f => {
+          let F = f.getProperties()
+          return {
+            id: F.id,
+            label: F.properties[feature.layer.cluster?.label]
+          }})
+
+        // Create list to get cluster features
+        const list = mapp.utils.html.node`
+        <div style="max-width: 66vw; max-height: 300px; overflow-x: hidden;">
+          <ul>
+          ${featuresList.map(li => mapp.utils.html.node`
+            <li
+              onclick=${e => {
+                mapview.popup(null)
+                mapp.location.get({
+                  layer: feature.layer,
+                  table: feature.layer.table || feature.layer.tableCurrent(),
+                  id: li.id
+                })
+              }}>${li.label || li.id}`)}`;
+
+        // Create popup to select cluster features.
+        mapview.popup({
+          coords: feature.F.getGeometry().getCoordinates(),
+          content: list,
+          autoPan: true,
+        });
+
+        return;
+      }
+
       mapp.location.nnearest({
         mapview: mapview.interaction.mapview,
         layer: feature.layer,


### PR DESCRIPTION
Previously cluster features were queried with the nnearest method applying a layer filter to select the n nearest features that pass the layer filter at the cluster coordinates.

This PR creates a popup with a list of features in a geojson cluster.

This also enabled to define a cluster.label which will displayed instead of the ID if defined and added as property to the layer properties object.

I updated the [geojson_cluster](https://github.com/GEOLYTIX/mapp/commit/2ba75aca70956cf4b44f795613feddca2957fa73) workspace to test this.