### PR TITLE
Wait for user admin table to be built in promise

### DIFF
--- a/public/views/_user.html
+++ b/public/views/_user.html
@@ -292,7 +292,8 @@
         ]
       });
 
-    
+
+    await new Promise(resolve => userTable.on('tableBuilt', resolve))
 
     let blocked = true
     userTable.setFilter("blocked", "!=", true);


### PR DESCRIPTION
The Tabulator table must be built prior to setting a filter.

Will prevent this warning.

![image](https://user-images.githubusercontent.com/22201617/217600417-68d7894d-1496-4865-baa6-eff743db8cb6.png)
