### PR TITLE
add clear table filters to toolbar_el

### DIFF
--- a/lib/ui/elements/toolbar_el.mjs
+++ b/lib/ui/elements/toolbar_el.mjs
@@ -1,14 +1,14 @@
 export default {
   viewport,
   download_json,
-  download_csv
+  download_csv,
+  clear_table_filters
 }
 
 function viewport(dataview) {
 
   return mapp.utils.html`
-    <button
-      class=${`flat ${dataview.viewport && 'active' ||''}`}
+    <button class=${`flat ${dataview.viewport && 'active' ||''}`}
       onclick=${e => {
         e.target.classList.toggle('active')
         dataview.viewport = !dataview.viewport
@@ -20,8 +20,7 @@ function viewport(dataview) {
 function download_json(dataview) {
 
   return mapp.utils.html`
-    <button
-      class="flat"
+    <button class="flat"
       onclick=${() => {
         dataview.Tabulator.download('json', `${dataview.title || 'table'}.json`)
       }}>Export as JSON`
@@ -31,10 +30,19 @@ function download_json(dataview) {
 function download_csv(dataview) {
 
   return mapp.utils.html`
-    <button
-      class="flat"
+    <button class="flat"
       onclick=${() => {
         dataview.Tabulator.download('csv', `${dataview.title || 'table'}.csv`)
       }}>Download as CSV`
+
+}
+
+function clear_table_filters(dataview) {
+
+  return mapp.utils.html`
+    <button class="flat"
+      onclick=${() => {
+        dataview.Tabulator.clearFilter(true);
+      }}>Clear Filters`;
 
 }


### PR DESCRIPTION
The clear_table_filters button will clear any filters set on the tabulator dataview.

```js
"toolbar":{
  "clear_table_filters":true
} 
```