### PR TITLE
Add getLocation to location.get() method; Rename getLocation to getFeature

### DIFF
--- a/lib/location/get.mjs
+++ b/lib/location/get.mjs
@@ -1,5 +1,11 @@
 export default async function (location, list = location.layer.mapview.locations) {
 
+  if (typeof location.layer.mapview.interaction?.getLocation === 'function') {
+
+    location.layer.mapview.interaction?.getLocation(location)
+    return;
+  }
+
   if (!location.layer || !location.id) return;
 
   // Create location hook.

--- a/lib/location/get.mjs
+++ b/lib/location/get.mjs
@@ -1,6 +1,6 @@
 export default async function (location, list = location.layer.mapview.locations) {
 
-  if (typeof location.layer.mapview.interaction?.getLocation === 'function') {
+  if (location.layer.mapview.interaction?.getLocation instanceof Function) {
 
     location.layer.mapview.interaction?.getLocation(location)
     return;

--- a/lib/mapview/interactions/highlight.mjs
+++ b/lib/mapview/interactions/highlight.mjs
@@ -17,7 +17,7 @@ export default function(params){
 
     highlight,
 
-    getLocation,
+    getFeature,
 
     hitTolerance: 5,
 
@@ -179,7 +179,7 @@ export default function(params){
     if (e.originalEvent.pointerType !== 'mouse') {
 
       // Don't get location from touch pan or zoom pinch event.
-      e.type !== 'pointermove' && mapview.interaction.getLocation(mapview.interaction.current)
+      e.type !== 'pointermove' && mapview.interaction.getFeature(mapview.interaction.current)
 
       // Clear touch highlight.
       clear()
@@ -244,7 +244,7 @@ export default function(params){
 
     // Return if there is no current highlight to select.
     if (mapview.interaction.current) {
-      mapview.interaction.getLocation(mapview.interaction.current);
+      mapview.interaction.getFeature(mapview.interaction.current);
       return;
     }
 
@@ -332,7 +332,7 @@ export default function(params){
     delete mapview.interaction.current
   }
 
-  function getLocation(feature) {
+  function getFeature(feature) {
 
     if (!feature.layer.infoj) return;
 


### PR DESCRIPTION
The highlight interaction getLocation method has been renamed to getFeature since the callback does not pass on a location but a feature.

The location.get() method will check for a custom getLocation method assigned to the mapview.interaction and will pass the location to that method if assigned.

This allows to get a location from the highlight method which was previously not possible. It was only possible to get a feature which may be many features for cluster.

Likewise would the popup from the longclick not work with getLocation.

This can be tested with the compare_locations plugin which assigns a custom getLocation method to the highlight interaction.

https://github.com/GEOLYTIX/mapp/blob/main/plugins/compare_locations.js