### PR TITLE
Send 204 for empty mvt responses.

### DIFF
--- a/mod/layer/mvt.js
+++ b/mod/layer/mvt.js
@@ -19,7 +19,7 @@ module.exports = async (req, res) => {
   }
 
   if (!req.params.table) {
-    return res.send(null)
+    return res.status(204).send(null)
   }
 
   let
@@ -64,6 +64,10 @@ module.exports = async (req, res) => {
   var geom = geoms && z < parseInt(geoms[0]) && Object.values(layer.geoms)[0] || geom
   
   var geom = geoms && z > parseInt(geoms[geoms.length -1]) && Object.values(layer.geoms)[geoms.length -1]  || geom
+
+  if (!geom) {
+    return res.status(204).send(null)
+  }
 
   const tile = `
     SELECT


### PR DESCRIPTION
Empty responses should have a 204 status code.

And empty response should be sent if the geom field cannot be established. This would happen if an mvt_clone attempts to load tiles outside of the zoom range of the original mvt layer.