### PR TITLE
highlight interaction should support a callback

### DIFF
--- a/lib/mapview/interactions/highlight.mjs
+++ b/lib/mapview/interactions/highlight.mjs
@@ -413,6 +413,14 @@ export default function(params){
     mapview.Map.getTargetElement().removeEventListener('touchstart', touchStart)
     mapview.Map.getTargetElement().removeEventListener('mouseup', mouseUp)
 
+    // Execute callback if defined as function.
+    if (mapview.interaction.callback instanceof Function) {
+
+      // Must be run delayed to prevent a callback loop.
+      const callback = mapview.interaction.callback
+      setTimeout(callback, 400)
+    }
+
     delete mapview.interaction
   }
 }


### PR DESCRIPTION
This is required in order to assign a button reset on a custom highlight interaction.
