### PR TITLE
Add console warning if pin missing

### DIFF
--- a/lib/ui/locations/entries/streetview.mjs
+++ b/lib/ui/locations/entries/streetview.mjs
@@ -2,7 +2,10 @@ export default entry => {
 
   const pin = entry.location.infoj.find(entry => entry.type === 'pin')
 
-  if (!pin || !pin.value) return;
+   if (!pin || !pin.value) {
+    console.warn('You must provide a pin type entry in the infoj to use streetview') 
+    return;
+  };
 
   const lnglat = ol.proj.toLonLat(
     pin.value,


### PR DESCRIPTION
When using the type:streetview entry. This requires the infoj entry to contain a type:pin entry. 
However, if no type:pin is provided, the streetview plugin will simply return. 
This PR adds a console warning that a type:pin infoj entry must be provided to use streetview - aiding debugging. 
![image](https://user-images.githubusercontent.com/56163132/219383723-1697e81c-f647-4dbc-a9df-c29638dfae2b.png)
