### PR TITLE
skip key, field, or query from infoj_skip array

### DIFF
--- a/lib/ui/locations/infoj.mjs
+++ b/lib/ui/locations/infoj.mjs
@@ -33,7 +33,12 @@ export default (location, infoj) => {
       let fieldEntry = entry.location.infoj.find(_entry => _entry.field === entry.objectMergeFromField)
 
       fieldEntry && mapp.utils.merge(entry, fieldEntry.value)
-    }    
+    }
+
+    // Skip entries from infoj_skip array;
+    if (new Set(entry.location.layer?.infoj_skip).has(entry.key || entry.field || entry.query)) {
+      continue;
+    }
 
     // Skip entry.
     if (entry.skipEntry) continue;


### PR DESCRIPTION
The info_skip array allows to define a list of key, field, or query references. If defined on the layer these entries will be skipped.

This allows the composition of templates, or the use of templates with many pre-defined dataview templates but select which ones should be used in the mapp library execution of the infoj method.

e.g. the entry with `query: "uk_postal_area_grocery_summary"` will be skipped.

```json
    "postal_areas": {
      "src": "${TEMPLATES}/templates_v4/uk/postal_area/layer.json",
      "infoj_skip": ["uk_postal_area_grocery_summary"]
    },
```