### PR TITLE
Assign template from layer key

### DIFF
--- a/mod/workspace/assignDefaults.js
+++ b/mod/workspace/assignDefaults.js
@@ -20,13 +20,13 @@ module.exports = async workspace => {
 
       layer.key = layer_key
 
-      layer = layer.template && Object.assign({},
+      layer = Object.assign({},
 
-        // Assign layer template.
-        workspace.templates[layer.template] || {},
+        // Assign layer template implicit or from key lookup.
+        workspace.templates[layer.template || layer.key] || {},
 
         // Layer entries must override template entries.
-        layer) || layer
+        layer)
 
       layer = layer.format && Object.assign({},
 


### PR DESCRIPTION
Initial logic had a double check on the layer.template. More importantly this rewarded poor layer keys and or layer template keys.

It shouldn't be necessary to define a layer key and a template of the same name, and then set the template to the same name as the key. This should be obvious.

The workspace method will attempt to find a template from the template key of defined in the layer json. If not template key is defined the method will look for a layer template of the same name as the layer key and assign this template to the layer json.