### PR TITLE
Warning for failed mvt_clone lookup

### DIFF
--- a/lib/ui/locations/entries/mvt_clone.mjs
+++ b/lib/ui/locations/entries/mvt_clone.mjs
@@ -6,6 +6,11 @@ export default entry => {
   // Assign the mvt layer to be cloned from mapview layers.
   entry.Layer = entry.mapview.layers[entry.layer]
 
+  if (!entry.Layer) {
+    console.warn("mvt_clone Layer not found in mapview.layers object.")
+    return;
+  }
+
   // The entry must have a style object.
   entry.style = entry.style || {}
 


### PR DESCRIPTION
Warn and return from mvt_clone entry method if the reference layer is not found in mapview.layers object.