### PR TITLE
Add asertation checks on mvt_clone entry

### DIFF
--- a/lib/ui/locations/entries/mvt_clone.mjs
+++ b/lib/ui/locations/entries/mvt_clone.mjs
@@ -34,23 +34,14 @@ export default entry => {
 
       if (entry.view) entry.view.style.display = 'block'
 
-      // Add clone layer to mapview Map.
-      entry.mapview.Map.addLayer(entry.L)
+      try {
+        entry.mapview.Map.addLayer(entry.L)
+      } catch {
+        // Will catch assertation error when layer is already added.
+      }
 
-      // Add clone layer to mvt layer clones.
-      entry.Layer.clones.add(entry.L)
       return;
     }
-
-    // Create clone VectorTile layer.
-    entry.L = new ol.layer.VectorTile({
-      source: entry.Layer.L.getSource(),
-      renderBuffer: 200,
-      zIndex: entry.zIndex,
-
-      // Assign style from entry.style
-      style: mapp.layer.Style(entry)
-    });
 
     // Create the style panel.
     entry.view = mapp.ui.layers.panels.style(entry)
@@ -61,6 +52,16 @@ export default entry => {
 
     // Query the featureLookup.
     entry.featureLookup = await mapp.utils.xhr(`${entry.host || entry.mapview.host}/api/query?${paramString}`)
+
+    // Create clone VectorTile layer.
+    entry.L = new ol.layer.VectorTile({
+      source: entry.Layer.L.getSource(),
+      renderBuffer: 200,
+      zIndex: entry.zIndex,
+
+      // Assign style from entry.style
+      style: mapp.layer.Style(entry)
+    });
 
     // Add the clone layer to the mvt layer clones.
     entry.Layer.clones.add(entry.L)
@@ -112,9 +113,6 @@ export default entry => {
     // The mvt layer can be displayed at all zoom levels.
     if (!entry.Layer.tables) return;
 
-    // Create a set of the layers assigned to the mapview.Map.
-    let mapLayers = new Set(entry.mapview.Map.getAllLayers())
-
     // The clone layer cannot be displayed.
     if (entry.Layer.tableCurrent() === null) {
 
@@ -125,7 +123,7 @@ export default entry => {
       if (entry.view) entry.view.style.display = 'none'
 
       // Remove clone layer if present in set but should not be displayed.
-      !entry.display && mapLayers.has(entry.L) && entry.mapview.Map.removeLayer(entry.L)
+      !entry.display && entry.mapview.Map.removeLayer(entry.L)
 
       return;
     }
@@ -136,8 +134,13 @@ export default entry => {
     // Display style drawer if present.
     if (entry.view) entry.view.style.display = 'block'
     
-    // Add clone layer to map if it should be displayed but not present in set.
-    entry.display && !mapLayers.has(entry.L) && entry.mapview.Map.addLayer(entry.L)
+    // Try to add entry.L to mapview.Map
+    try {
+      entry.display && entry.mapview.Map.addLayer(entry.L)
+    } catch {
+      // Will catch assertation error when layer is already added.
+    }
+
   }
   chkZoom()
 
@@ -147,10 +150,8 @@ export default entry => {
   // Remove zoom level check from mapview changeEnd event.
   entry.location.removeCallbacks.push(()=>{
 
-    let mapLayers = new Set(entry.mapview.Map.getAllLayers())
-
     // Remove layer from map when location is removed.
-    entry.L && !mapLayers.has(entry.L) && entry.mapview.Map.removeLayer(entry.L)
+    entry.mapview.Map.removeLayer(entry.L)
 
     entry.mapview.Map.getTargetElement().removeEventListener('changeEnd', chkZoom)
   })


### PR DESCRIPTION
The OL layer entry.L should only be created after the featureLookup is assigned. Making it impossible to add a clone layer which is not filtered by the featureLookup. This will result in the whole layer showing when quickly zooming after setting the display to true. The zoomCheck will add the layer if it exist and not check whether the featureLookup has already been populated.

Likewise the addLayer method should be try to fail on an assertation check rather than checking whether the layer.L uid is part of the layers on the mapview.Map.