### PR TITLE
mvt_clone entry.L must be created prior to calling the style method.

### DIFF
--- a/lib/ui/locations/entries/mvt_clone.mjs
+++ b/lib/ui/locations/entries/mvt_clone.mjs
@@ -43,7 +43,7 @@ export default entry => {
     entry.display = true;
 
     // The OL clone layer already exists.
-    if (entry.L) {
+    if (entry.L && entry.featureLookup) {
 
       if (entry.view) entry.view.style.display = 'block'
 

--- a/lib/ui/locations/entries/mvt_clone.mjs
+++ b/lib/ui/locations/entries/mvt_clone.mjs
@@ -11,6 +11,19 @@ export default entry => {
     return;
   }
 
+  // Create clone VectorTile layer.
+  entry.L = new ol.layer.VectorTile({
+    source: entry.Layer.L.getSource(),
+    renderBuffer: 200,
+    zIndex: entry.zIndex,
+
+    // Assign style from entry.style
+    style: mapp.layer.Style(entry)
+  });
+
+  // Add the clone layer to the mvt layer clones.
+  entry.Layer.clones.add(entry.L)
+
   // The entry must have a style object.
   entry.style = entry.style || {}
 
@@ -52,19 +65,6 @@ export default entry => {
 
     // Query the featureLookup.
     entry.featureLookup = await mapp.utils.xhr(`${entry.host || entry.mapview.host}/api/query?${paramString}`)
-
-    // Create clone VectorTile layer.
-    entry.L = new ol.layer.VectorTile({
-      source: entry.Layer.L.getSource(),
-      renderBuffer: 200,
-      zIndex: entry.zIndex,
-
-      // Assign style from entry.style
-      style: mapp.layer.Style(entry)
-    });
-
-    // Add the clone layer to the mvt layer clones.
-    entry.Layer.clones.add(entry.L)
 
     // Add the clone layer to the mapview.Map.
     entry.mapview.Map.addLayer(entry.L)


### PR DESCRIPTION
Otherwise the style method will fail trying to get the layer L opacity.