### PR TITLE
Lookup icon in cat theme for style assignment

### DIFF
--- a/lib/ui/layers/legends/categorized.mjs
+++ b/lib/ui/layers/legends/categorized.mjs
@@ -30,7 +30,7 @@ export default layer => {
       ? cat[1].style
 
       // Assign icon, or style as icon, or cat to the layer style default.
-      : Object.assign({}, layer.style.default, cat[1].style?.icon || cat[1].style || cat[1]);
+      : Object.assign({}, layer.style.default, cat[1].style?.icon || cat[1].icon || cat[1].style || cat[1]);
 
     if (!cat[1].style?.icon) delete cat_style.icon;
 


### PR DESCRIPTION
This is an issue with geojson layer which may consist of icon only and not have the icon in a style block since this is not required for the default (or highlight) style object.