### PR TITLE
add csvDownload util for tabulator

### DIFF
--- a/lib/ui/elements/toolbar_el.mjs
+++ b/lib/ui/elements/toolbar_el.mjs
@@ -32,7 +32,31 @@ function download_csv(dataview) {
   return mapp.utils.html`
     <button class="flat"
       onclick=${() => {
+
+        // The data array must have a length
+        if (!dataview.data.length) return;
+
+        // download_csv is an object with 
+        if (dataview.toolbar.download_csv instanceof Object) {
+
+          // Parse data from download_csv.fields
+          const data = dataview.data.map(record => {
+
+            // Check whether string values should be escaped.
+            return dataview.toolbar.download_csv.fields.map(field => (record[field.field] && field.string) ?
+              `"${record[field.field].replace(`"`, `\"`)}"` : record[field.field])
+          })
+
+          // Unshift the header row with either the title or field names.
+          data.unshift(dataview.toolbar.download_csv.fields.map(field => field.title || field.field))
+
+          mapp.utils.csvDownload(data, dataview.toolbar.download_csv)
+          return;
+        }
+        
+        // Use Tabulator download method
         dataview.Tabulator.download('csv', `${dataview.title || 'table'}.csv`)
+
       }}>Download as CSV`
 
 }

--- a/lib/utils/_utils.mjs
+++ b/lib/utils/_utils.mjs
@@ -6,6 +6,8 @@ const areSetsEqual = (a, b) => a.size === b.size && [...a].every(value => b.has(
 // local import
 import clone from './clone.mjs'
 
+import csvDownload from './csvDownload.mjs'
+
 const compose = (...fns) => {
   return arg => fns.reduce((acc, fn) => {
     return fn(acc);
@@ -67,6 +69,7 @@ export default {
   clone,
   compose,
   copyToClipboard,
+  csvDownload,
   dataURLtoBlob,
   getCurrentPosition,
   here,

--- a/lib/utils/csvDownload.mjs
+++ b/lib/utils/csvDownload.mjs
@@ -1,0 +1,24 @@
+export default function csvDownload(arr, params = {}) {
+
+    if (!Array.isArray(arr)) {
+        console.warn('Array argument for csvDownload must be an array')
+        return;
+    }
+
+    const rows = arr.map(record => {
+
+        return Object.values(record).join(',')
+    })
+
+    const blob = new Blob([rows.join('\r\n')], { type: 'text/csv;charset=utf-8;' })
+
+    const link = document.createElement('a')
+
+    link.download = `${params.title || 'file'}.csv`
+    link.href = URL.createObjectURL(blob)
+    link.dataset.downloadurl = ['csv', link.download, link.href].join(':')
+    link.style.display = "none"
+    document.body.append(link)
+    link.click()
+    link.remove()
+}


### PR DESCRIPTION
Provide a csvDownload util which will requires an array as argument to be downloaded as a csv file.

The title for the file can be set in the params argument.

If defined as an object. The fields array can be used to determine which column fields should be exported in which order, with which title.

Using the string flag to escape string value fields.

Quotes need to be escaped in the title.

```js
      "download_csv": {
        "title": "Comparison",
        "fields": [
          {
            "title": "Name",
            "field": "name",
            "string": true
          }, {
            "title": "Hard Pressed Living",
            "field": "hard_pressed_living"
          }, {
            "title": "\" 0-9 (S, U, HPL)\"",
            "field": "pop_0_9_u_s_hpl"
          }
]}
```