### PR TITLE
Trigger mapchange on remove filter. Create filter object from string …

### DIFF
--- a/lib/ui/layers/panels/filter.mjs
+++ b/lib/ui/layers/panels/filter.mjs
@@ -52,15 +52,23 @@ export default layer => {
 
       if (entry.filter.card) return;
 
-      if ((!(entry.filter instanceof Object)) || (!entry.filter.type)) {
-        throw new TypeError('Filter value must be an object with a "type" key. Eg: {"type": <value_as_string>}')
+      // The filter is defined as a string e.g. "like"
+      if (typeof entry.filter === 'string') {
+
+        // Create filter object with the filter key value as type.
+        entry.filter = { 
+          type: entry.filter,
+          field: entry.field
+        }
       }
-      entry.filter.field = entry.filter.field || entry.field;
 
       entry.filter.remove = () => {
         delete layer.filter.current[entry.filter.field];
         delete entry.filter.card
         layer.reload();
+
+        // The changeEnd event will trigger dataview updates if set.
+        layer.mapview.Map.getTargetElement().dispatchEvent(new Event('changeEnd'))
 
         // enable zoomToExtent button.
         let btn = layer.view.querySelector('[data-id=zoomToExtent]')


### PR DESCRIPTION
Will revert changes from https://github.com/GEOLYTIX/xyz/pull/627

An object with the field should be created if the filter type is defined as string type filter key value.

Also adds mapchange event trigger to remove filter method. This was previously only on applyfilter method.