### PR TITLE
Remove default scale 1 and colour

### DIFF
--- a/mod/workspace/defaults.js
+++ b/mod/workspace/defaults.js
@@ -57,9 +57,7 @@ module.exports = defaults = {
       cluster_resolution: 0.1,
       style: {       
         default: {
-          type: 'dot',
-          fillColor: '#999999',
-          scale: 1,
+          type: 'dot'
         },
         cluster: {
           clusterScale: 2


### PR DESCRIPTION
Icons already have a default scale of 1 which is applied in the style method if no scale is otherwise defined for an icon.

The defaults shouldn't apply a colour to an icon type which has a default.