### PR TITLE
Query for distinct values in filter doesn't return any values.

### DIFF
--- a/lib/ui/layers/filters.mjs
+++ b/lib/ui/layers/filters.mjs
@@ -159,6 +159,11 @@ async function filter_in(layer, entry) {
         field: entry.field
       }))
 
+    if (!response) {
+      console.warn(`Distinct values query did not return any values for field ${entry.field}`)
+      return;
+    }
+
     entry.filter[entry.filter.type] = [response]
 
       // Flatten response in array to account for the response being a single record and not an array.


### PR DESCRIPTION
The filter card should be shown to be cancelled.

A warning will be printed in the console.

![image](https://user-images.githubusercontent.com/22201617/222138072-47637f3d-6b07-4bd6-93ca-dc04d79d41c9.png)
