### PR TITLE
Update infoj_skip to also check on entry Type and entry Group

### DIFF
--- a/lib/ui/locations/infoj.mjs
+++ b/lib/ui/locations/infoj.mjs
@@ -36,7 +36,7 @@ export default (location, infoj) => {
     }
 
     // Skip entries from infoj_skip array;
-    if (new Set(entry.location?.layer?.infoj_skip).has(entry.key || entry.field || entry.query)) {
+    if (new Set(entry.location?.layer?.infoj_skip).has(entry.key || entry.field || entry.query || entry.type || entry.group)) {
       continue;
     }
 


### PR DESCRIPTION
This PR will update the infoj_skip to also check for entry.type and entry.group. 
This is useful as it allows skipping of multiple infoj entries in one go, and also allows for custom types provided via plugins to be skipped too if required.