### PR TITLE
secure inserts and allow for defaults in workspace

### DIFF
--- a/lib/ui/layers/panels/draw.mjs
+++ b/lib/ui/layers/panels/draw.mjs
@@ -84,9 +84,9 @@ function draw(e, options) {
             layer: location.layer.key,
             table: location.layer.tableCurrent()
           }),
-        body: JSON.stringify({
+        body: JSON.stringify(Object.assign({
           [location.layer.geom]: feature.geometry
-        })
+        }, location.layer.edit?.defaults || {}))
       })
     
       options.layer.reload()


### PR DESCRIPTION
Creating an array of values for the location/new insert statement is dangerous. This invites DDL SQL injection as optional value for the location/new call.

All insert values must be provided as val array to be substituted serverside.

Additionally the location/new mapp method should provide the capability to set defaults for other fields together with the JSON geometry value.

The default can be defined in the in the edit config. The key being the field and the value being the default value to be sent in the location/new query.

```js
    "edit": {
      "point": true,
      "delete": true,
      "defaults": {
        "country_mapp": "AUS"
      }
    },
```