### PR TITLE
enable placeholder for edit options dropdown

### DIFF
--- a/lib/ui/elements/dropdown.mjs
+++ b/lib/ui/elements/dropdown.mjs
@@ -86,7 +86,19 @@ export default (params) => {
           e.target.parentElement.classList.add('active');
 
         }}>
-        <span data-id=header-span>${params.selectedTitles.size && Array.from(params.selectedTitles).join(', ')|| params.span || params.placeholder || params.entries[0].title}</span>
+        <span data-id=header-span>${
+
+          // join the selected titles if selectTitles set has a size.
+          params.selectedTitles.size && Array.from(params.selectedTitles).join(', ')
+          
+          // header should be the span value.
+          || params.span
+          
+          // use placeholder.
+          || params.placeholder
+          
+          // use first title entry as fallback.
+          || params.entries[0].title}</span>
         <div class="icon"></div>
       </div>
       <ul>${ul}`;

--- a/lib/ui/locations/entries/text.mjs
+++ b/lib/ui/locations/entries/text.mjs
@@ -63,6 +63,7 @@ function options(entry){
   }))
 
   const dropdown = mapp.ui.elements.dropdown({
+    placeholder: entry.edit.placeholder,
     span: entry.value,
     entries: entries,
     callback: (e, _entry) => {


### PR DESCRIPTION
The placeholder should be shown if defined in an entry edit config for the options dropdown.

```
{
 "title": "Optional",
 "field": "option",
 "inline": true,
 "edit": {
  "placeholder": "Select from list",
  "options": [
   "foo",
   "bar"
  ]
 },
}
```