### PR TITLE
filter fixes and keepPlaceholder

### DIFF
--- a/lib/ui/elements/dropdown.mjs
+++ b/lib/ui/elements/dropdown.mjs
@@ -5,6 +5,12 @@ export default (params) => {
 
   // Create array of li elements for dropdown.
   const ul = params.entries.map((entry) => {
+
+    try {
+      entry.title = decodeURIComponent(entry.title)
+    } catch {
+      // This prevents falling over on % in title.
+    }
     
     // Create li element with click event.
     const li = mapp.utils.html.node`<li onclick=${(e) => {
@@ -15,16 +21,10 @@ export default (params) => {
       // Will collapse the dropdown if current state is 'active'.
       !params.multi && btn.classList.toggle('active')   
 
-      // Will show select background if add to classlist.
-      e.target.classList.toggle('selected')
-
-      try {
-        entry.title = decodeURIComponent(entry.title)
-      } catch {
-        // This prevents falling over on % in title.
-      }
-
       if (params.multi) {
+
+        // Will show select background if add to classlist.
+        e.target.classList.toggle('selected')
 
         // Add or remove title and option value from sets.
         if (e.target.classList.contains('selected')) {
@@ -46,8 +46,11 @@ export default (params) => {
         return;
       }
 
-      // Dropdown is not multi
-      btn.querySelector('[data-id=header-span]').textContent = entry.title;
+      if (!params.keepPlaceholder) {
+        
+        // Dropdown is not multi
+        btn.querySelector('[data-id=header-span]').textContent = entry.title;
+      }
 
       params.callback?.(e, entry);
 

--- a/lib/ui/layers/panels/filter.mjs
+++ b/lib/ui/layers/panels/filter.mjs
@@ -2,10 +2,12 @@ mapp.utils.merge(mapp.dictionaries, {
   en: {
     layer_filter_header: 'Filter',
     layer_filter_select: 'Select filter from list',
+    layer_filter_clear_all: 'Clear all filter'
   },
   de: {
     layer_filter_header: 'Filter',
     layer_filter_select: 'Filter Auswahl',
+    layer_filter_clear_all: 'Entferne alle Filter'
   },
   cn: {
     layer_filter_header: '筛选',
@@ -37,30 +39,38 @@ export default layer => {
     .filter(entry => entry.filter)
     .filter(entry => !layer.filter?.exclude?.includes(entry.field))
     .map(entry => {
-      entry.title = entry.filter.title || entry.title || entry.field
+
+      // The filter is defined as a string e.g. "like"
+      if (typeof entry.filter === 'string') {
+
+        // Create filter object with the filter key value as type.
+        entry.filter = {
+          type: entry.filter,
+          field: entry.field
+        }
+      }
+
+      // Assign entry.title as filter title if not explicit in filter config.
+      entry.filter.title = entry.filter.title || entry.title
+
+      // Assign entry.field as filter field if not explicit in filter config.
+      entry.filter.field = entry.filter.field || entry.field
+
       return entry
     })
 
   const dropdown = mapp.ui.elements.dropdown({
     data_id: `${layer.key}-filter-dropdown`,
     placeholder: mapp.dictionary.layer_filter_select,
+    keepPlaceholder: true,
     entries: layer.filter.list,
     callback: async (e, entry) => {
       
       // Display clear all button.
       layer.filter.view.querySelector('[data-id=clearall]').style.display = 'block';
 
+      // Return if filter card already exists.
       if (entry.filter.card) return;
-
-      // The filter is defined as a string e.g. "like"
-      if (typeof entry.filter === 'string') {
-
-        // Create filter object with the filter key value as type.
-        entry.filter = { 
-          type: entry.filter,
-          field: entry.field
-        }
-      }
 
       entry.filter.remove = () => {
         delete layer.filter.current[entry.filter.field];
@@ -78,15 +88,11 @@ export default layer => {
         layer.filter.view.querySelector('[data-id=clearall]').style.display = layer.filter.view.children.length === 3 ? 'none' : 'block';
       };
 
+      // Return if no interface method for the filter type exists.
       if (!mapp.ui.layers.filters[entry.filter.type]) return;
 
-      // If not implicit in the filter object the field will be assigned from the entry.
-      entry.filter.field = entry.filter.field || entry.field
-
-      let content = await mapp.ui.layers.filters[entry.filter.type](layer, entry);
-
-      // Ensure that input is an array.
-      content = Array.isArray(content) ? content : [content];
+      // Get interface content for filter card.
+      const content = [await mapp.ui.layers.filters[entry.filter.type](layer, entry)].flat()
 
       // Add meta element to beginning of contents array.
       entry.filter.meta && content.unshift(mapp.utils.html.node`<p>${entry.filter.meta}`)
@@ -95,7 +101,7 @@ export default layer => {
         header: entry.filter.title || entry.title,
         close: entry.filter.remove,
         content
-      })).title
+      }))
     }
   })
 
@@ -114,6 +120,7 @@ export default layer => {
 
         // enable zoomToExtent button.
         let btn = layer.view.querySelector('[data-id=zoomToExtent]')
+
         if (btn) btn.disabled = false;
 
         layer.reload()


### PR DESCRIPTION
Decoding of the title should be tried prior to populating the dropdown.

The `selected` class toggle should only apply for multiselect filter.

The callback for the filter interface should shortcircuit if the filter.card exists.

The clearAll button was invisible because of a missing dictionary entry.

`[].flat()` should be used to ensure a value is an array.