### PR TITLE
merge from entry

### DIFF
--- a/lib/ui/locations/infoj.mjs
+++ b/lib/ui/locations/infoj.mjs
@@ -41,6 +41,10 @@ export default (location, infoj) => {
       // Find the entry to merge.
       let fieldEntry = entry.location.infoj.find(_entry => _entry.type === entry.objectMergeFromEntry)
 
+      if (fieldEntry===undefined) {
+        console.warn('The entry you are trying to merge into does not exist. Please check your configuration')
+      };
+
       // Only merge the entry.merge object.
       fieldEntry 
         && fieldEntry.merge instanceof Object 

--- a/lib/ui/locations/infoj.mjs
+++ b/lib/ui/locations/infoj.mjs
@@ -41,10 +41,6 @@ export default (location, infoj) => {
       // Find the entry to merge.
       let fieldEntry = entry.location.infoj.find(_entry => _entry.type === entry.objectMergeFromEntry)
 
-      if (fieldEntry===undefined) {
-        console.warn('The entry you are trying to merge into does not exist. Please check your configuration')
-      };
-
       // Only merge the entry.merge object.
       fieldEntry 
         && fieldEntry.merge instanceof Object 

--- a/lib/ui/locations/infoj.mjs
+++ b/lib/ui/locations/infoj.mjs
@@ -35,6 +35,18 @@ export default (location, infoj) => {
       fieldEntry && mapp.utils.merge(entry, fieldEntry.value)
     }
 
+    // Merge from another entry.
+    if (entry.objectMergeFromEntry) {
+
+      // Find the entry to merge.
+      let fieldEntry = entry.location.infoj.find(_entry => _entry.type === entry.objectMergeFromEntry)
+
+      // Only merge the entry.merge object.
+      fieldEntry 
+        && fieldEntry.merge instanceof Object 
+        && mapp.utils.merge(entry, fieldEntry.merge)
+    }
+
     // Skip entries from infoj_skip array;
     if (new Set(entry.location?.layer?.infoj_skip).has(entry.key || entry.field || entry.query || entry.type || entry.group)) {
       continue;


### PR DESCRIPTION
The `objectMergeFromEntry` key will look up an entry type with the value provided.

```js
        {
          "type":"dataview",
          "label": "Rail Stations",
          "target": "tabview",
          "display": true,
          "query": "query",
          "objectMergeFromEntry": "regions_bus_stop_tableview",
          "queryparams": {
            "id": true,
            "group_field": "stat_type",
            "table": "geodata.uk_glx_geodata_transport_rail_stations a",
            "table_geom": "a.geom_p_4326",
            "boundary_table": "geodata.uk_glx_geodata_metrics_region b",
            "boundary_geom": "b.geom_4326"
          },
          "toolbar": {
            "download_csv": true
          },
          "table": {
            "layout": "fitColumns",
            "selectable": true,
            "columns": [
              {
                "field": "count",
                "title": "Count",
                "hozAlign": "right"
              },
              {
                "field": "value",
                "title": "Category"
              }
            ]
          }
        }
```

The the `entry.merge` object will be merged into the entry object.

```js
        {
          "type": "regions_bus_stop_tableview",
          "merge": {
            "label": "Bus Stops",
            "queryparams": {
              "id": true,
              "group_field": "stoptype",
              "table": "geodata.uk_glx_geodata_transport_bus_stop a",
              "table_geom": "a.geom_p_4326",
              "boundary_table": "geodata.uk_glx_geodata_metrics_region b",
              "boundary_geom": "b.geom_4326"
            }
          }
        }
```