### PR TITLE
Added a plugin hooks to fix layer.view

### DIFF
--- a/lib/plugins.mjs
+++ b/lib/plugins.mjs
@@ -17,3 +17,16 @@ export function svg_templates(plugin) {
       })
   })
 }
+
+export function onViewsLoad(hook) {
+  /**
+   * Registers a hook to plugins onViewsLoadHooks array to run after views are loaded
+   * @param {function} hook - Hook to run when vies are loaded
+   */
+
+  if (Array.isArray(this.onViewsLoadHooks)) {
+    this.onViewsLoadHooks.push(hook);
+  } else {
+    this.onViewsLoadHooks = [hook];
+  }
+}

--- a/lib/ui/layers/listview.mjs
+++ b/lib/ui/layers/listview.mjs
@@ -133,4 +133,7 @@ export default function (params){
     }
   
   }
+
+  // Execute plugin onViewsLoad hooks
+  mapp.plugins.onViewsLoadHooks && mapp.plugins.onViewsLoadHooks.forEach(hook => hook());
 }


### PR DESCRIPTION
Added a hooks array to mapp.plugins that gets executed when layer views are fully loaded, solving the issue where the layer.view element in a plugin does not have children nodes available.

Usage: 

```
mapp.ui.layers.panels.someplugin = (layer) => {
        mapp.plugins.onViewsLoad(() => {
            // layer.view is fully rendered
            console.log(layer.view);
        })
}
```