### PR TITLE
correction of login form api paths

### DIFF
--- a/public/views/login/_login_de.html
+++ b/public/views/login/_login_de.html
@@ -24,7 +24,7 @@
     <option value="{{dir}}?language=zh&login=true">中文简体</option>
   </select>
 
-  <form action="{{dir}}/public/api/user/login" method="post" autocomplete="off">
+  <form action="{{dir}}/api/user/login" method="post" autocomplete="off">
 
     <input style="display:none;" name="language" required value="de">
 
@@ -46,7 +46,7 @@
 
     <p>Benutzerkontos müssen mit einem Email Link verifiziert und anschließend von einem Administrator genehmigt werden.</p>
 
-    <a class="switch" href="{{dir}}/public/api/user/register?register=true&language=de">Passwort zurücksetzen oder neues Benutzerkonto registrieren.</a>
+    <a class="switch" href="{{dir}}/api/user/register?register=true&language=de">Passwort zurücksetzen oder neues Benutzerkonto registrieren.</a>
 
   </form>
 

--- a/public/views/login/_login_en.html
+++ b/public/views/login/_login_en.html
@@ -24,7 +24,7 @@
     <option value="{{dir}}?language=zh&login=true">中文简体</option>
   </select>
 
-  <form action="{{dir}}/public/api/user/login" method="post" autocomplete="off">
+  <form action="{{dir}}/api/user/login" method="post" autocomplete="off">
     
     <input style="display:none;" name="language" required value="en">
 
@@ -47,7 +47,7 @@
     <p>Your account must be verified by following a verification link sent to the email address and approved by
       an administrator before you are able to log in.</p>
 
-    <a class="switch" href="{{dir}}/public/api/user/register?register=true">Register a new account or reset your password.</a>
+    <a class="switch" href="{{dir}}/api/user/register?register=true">Register a new account or reset your password.</a>
     
   </form>
 

--- a/public/views/login/_login_fr.html
+++ b/public/views/login/_login_fr.html
@@ -24,7 +24,7 @@
     <option value="{{dir}}?language=zh&login=true">中文简体</option>
   </select>
 
-  <form action="{{dir}}/public/api/user/login" method="post" autocomplete="off">
+  <form action="{{dir}}/api/user/login" method="post" autocomplete="off">
 
     <input style="display:none;" name="language" required value="fr">
 
@@ -46,7 +46,7 @@
 
     <p>Son compte doit être vérifié avec un lien de vérification envoyé à l’adresse e-mail et approuvé par
       l'administrateur.</p>
-    <a class="switch" href="{{dir}}/public/api/user/register?register=true&language=fr">Enregistrer un nouveau compte ou
+    <a class="switch" href="{{dir}}/api/user/register?register=true&language=fr">Enregistrer un nouveau compte ou
       réinitialiser son mot de passe.</a>
       
   </form>

--- a/public/views/login/_login_ja.html
+++ b/public/views/login/_login_ja.html
@@ -24,7 +24,7 @@
     <option value="{{dir}}?language=zh&login=true">中文简体</option>
   </select>
 
-  <form action="{{dir}}/public/api/user/login" method="post" autocomplete="off">
+  <form action="{{dir}}/api/user/login" method="post" autocomplete="off">
 
     <input style="display:none;" name="language" required value="ja">
 
@@ -45,7 +45,7 @@
     <button id="btnLogin" type="submit" disabled>ログイン</button>
 
     <p>ログインするにはE-メールアドレス宛に送信された検証リンクに基づくアカウント検証が必要。</p>
-    <a class="switch" href="{{dir}}/public/api/user/register?register=true&language=ja">新規アカウント登録或いはパスワードをリセット</a>
+    <a class="switch" href="{{dir}}/api/user/register?register=true&language=ja">新規アカウント登録或いはパスワードをリセット</a>
     
   </form>
 

--- a/public/views/login/_login_ko.html
+++ b/public/views/login/_login_ko.html
@@ -24,7 +24,7 @@
     <option value="{{dir}}?language=zh&login=true">中文简体</option>
   </select>
 
-  <form action="{{dir}}/public/api/user/login" method="post" autocomplete="off">
+  <form action="{{dir}}/api/user/login" method="post" autocomplete="off">
 
     <input style="display:none;" name="language" required value="ko">
 
@@ -45,7 +45,7 @@
     <button id="btnLogin" type="submit" disabled>로그인</button>
 
     <p>계정은 이메일로 보내드린 검증을 위한 링크에서 확인되어야만 하며 로그인 전에 관리자가 승인하여야 합니다.</p>
-    <a class="switch" href="{{dir}}/public/api/user/register?register=true&language=ko">새로운 계정 등록 또는 비빌번호 재설정</a>
+    <a class="switch" href="{{dir}}/api/user/register?register=true&language=ko">새로운 계정 등록 또는 비빌번호 재설정</a>
     
   </form>
 

--- a/public/views/login/_login_pl.html
+++ b/public/views/login/_login_pl.html
@@ -24,7 +24,7 @@
     <option value="{{dir}}?language=zh&login=true">中文简体</option>
   </select>
 
-  <form action="{{dir}}/public/api/user/login" method="post" autocomplete="off">
+  <form action="{{dir}}/api/user/login" method="post" autocomplete="off">
 
     <input style="display:none;" name="language" required value="pl">
 
@@ -46,7 +46,7 @@
 
     <p>Logowanie jest możliwe po weryfikacji konta za pomocą linku wysłanego we wiadomości e-mail, a następnie
       zatwierdzonego przez administratora.</p>
-    <a class="switch" href="{{dir}}/public/api/user/register?register=true&language=pl">Zarejestruj nowe konto lub zmień hasło.</a>
+    <a class="switch" href="{{dir}}/api/user/register?register=true&language=pl">Zarejestruj nowe konto lub zmień hasło.</a>
     
   </form>
 

--- a/public/views/login/_login_zh.html
+++ b/public/views/login/_login_zh.html
@@ -24,7 +24,7 @@
     <option value="{{dir}}?language=ko&login=true">한국어</option>
   </select>
 
-  <form action="{{dir}}/public/api/user/login" method="post" autocomplete="off">
+  <form action="{{dir}}/api/user/login" method="post" autocomplete="off">
 
     <input style="display:none;" name="language" required value="zh">
 
@@ -51,7 +51,7 @@
     <button id="btnLogin" type="submit" disabled>登录</button>
 
     <p>请通过以下验证链接来验证您的帐户。该链接发送电子邮件并得到管理员的批准之后，您就可以登录了。</p>
-    <a class="switch" href="{{dir}}/public/api/user/register?register=true&language=zh">注册新帐户或重设密码</a>
+    <a class="switch" href="{{dir}}/api/user/register?register=true&language=zh">注册新帐户或重设密码</a>
     
   </form>
 


### PR DESCRIPTION
The api paths for the login form submits where incorrect on the vanilla views.

This has changed from this
```js
action="{{dir}}/public/api/user/login"
```

to this

```js
action="{{dir}}/api/user/login"
```

This has got to do with the removal of public resources changes in the previous release.

https://github.com/GEOLYTIX/xyz/commit/73b574ed49b109169d35c65fd77ad16012c24160

