### PR TITLE
Assign style instead of style.icon

### DIFF
--- a/lib/ui/layers/legends/categorized.mjs
+++ b/lib/ui/layers/legends/categorized.mjs
@@ -30,7 +30,9 @@ export default layer => {
       ? cat[1].style
 
       // Assign icon, or style as icon, or cat to the layer style default.
-      : Object.assign({}, layer.style.default, cat[1].style?.icon || cat[1].icon || cat[1].style || cat[1]);
+      : Object.assign({},
+        layer.style.default,
+        cat[1].style || cat[1].icon || cat[1]);
 
     if (!cat[1].style?.icon) delete cat_style.icon;
 

--- a/lib/ui/layers/legends/graduated.mjs
+++ b/lib/ui/layers/legends/graduated.mjs
@@ -6,20 +6,24 @@ export default layer => {
 
   theme.cat_arr.forEach(cat => {
 
-    // Assemble cat_style from defaults and cat style.
-    const cat_style = Object.assign(
-      {},
-      layer.style.default,
-      cat.style?.icon || cat.style || cat)
+    const cat_style = Array.isArray(cat.style?.icon)
 
-    if (!cat.style?.icon) delete cat_style.icon;
+      // Array style icons cannot be assigned to the default.
+      ? cat.style
+
+      // Assign icon, or style as icon, or cat to the layer style default.
+      : Object.assign({},
+        layer.style.default,
+        cat.style || cat.icon || cat);     
+
+    if (!cat.style?.icon) delete cat_style.icon;   
 
     // Cat icon.
     let icon = mapp.utils.html`
       <div
         style="height: 24px; width: 24px; grid-column: 1;">
         ${mapp.ui.elements.legendIcon(
-          Object.assign({ width: 24, height: 24 }, cat_style)
+          Object.assign({ width: 24, height: 24 }, cat_style.icon || cat_style)
         )}`;
 
     // Cat label.


### PR DESCRIPTION
Assigning style.icon instead of style for a theme category style may create an invalid icon style.

Assigning the style.icon to the style.default will not change the default icon. The style itself must be used in the Object assign to overwrite the default icon style with the style from the theme category.

```js
style.default = {
  color: 'red'
  icon: {
    type: 'pill'
    color: 'blue'
  }
}

style.icon = {
  type: 'pill'
  color: 'red'
}
```