### PR TITLE
escape quote in csv download

### DIFF
--- a/lib/ui/elements/toolbar_el.mjs
+++ b/lib/ui/elements/toolbar_el.mjs
@@ -57,7 +57,7 @@ function download_csv(dataview) {
 
             // Check whether string values should be escaped.
             return dataview.toolbar.download_csv.fields.map(field => (record[field.field] && field.string) ?
-              `"${record[field.field].replace(`"`, `\"`)}"` : record[field.field])
+              `"${record[field.field].replace(`"`, `\\"`)}"` : record[field.field])
           })
 
           // Unshift the header row with either the title or field names.


### PR DESCRIPTION
To prevent the escape character from being swallowed in the tag function a second escape character must be set prior.