### PR TITLE
Validate ownProperty for location methods lookup.

### DIFF
--- a/mod/location/_location.js
+++ b/mod/location/_location.js
@@ -1,13 +1,13 @@
-const methods = {
-  new: require('./new'),
-  get: require('./get'),
-  update: require('./update'),
-  delete: require('./delete'),
-}
+const methods = new Map()
+
+methods.set('new', require('./new'))
+methods.set('get', require('./get'))
+methods.set('update', require('./update'))
+methods.set('delete', require('./delete'))
 
 module.exports = async (req, res) => {
 
-  const method = methods[req.params.method]
+  const method = methods.get(req.params.method)
 
   if (typeof method !== 'function') {
     return res.send(`Failed to evaluate 'method' param.<br><br>

--- a/mod/location/_location.js
+++ b/mod/location/_location.js
@@ -1,19 +1,21 @@
-const methods = new Map()
-
-methods.set('new', require('./new'))
-methods.set('get', require('./get'))
-methods.set('update', require('./update'))
-methods.set('delete', require('./delete'))
+const methods = {
+  new: require('./new'),
+  get: require('./get'),
+  update: require('./update'),
+  delete: require('./delete'),
+}
 
 module.exports = async (req, res) => {
 
-  const method = methods.get(req.params.method)
-
-  if (typeof method !== 'function') {
+  if (!methods.hasOwnProperty(req.params.method)) {
     return res.send(`Failed to evaluate 'method' param.<br><br>
     <a href="https://geolytix.github.io/xyz/docs/develop/api/location/">Location API</a>`)
   }
 
+  const method = methods[req.params.method]
+
+  if (typeof method !== 'function') return;
+  
   const locale = req.params.locale && req.params.workspace.locales[req.params.locale]
 
   const layer = locale && locale.layers[req.params.layer] ||  req.params.workspace.templates[req.params.layer]


### PR DESCRIPTION
Object lookups are not recommended for dynamic method calls.

https://codeql.github.com/codeql-query-help/javascript/js-unvalidated-dynamic-method-call/

This is in response to:

https://github.com/GEOLYTIX/xyz/security/code-scanning/42

