### PR TITLE
Use hasOwn instead hasOwnProperty

### DIFF
--- a/mod/location/_location.js
+++ b/mod/location/_location.js
@@ -7,7 +7,7 @@ const methods = {
 
 module.exports = async (req, res) => {
 
-  if (!methods.hasOwnProperty(req.params.method)) {
+  if (!Object.hasOwn(methods, req.params.method)) {
     return res.send(`Failed to evaluate 'method' param.<br><br>
     <a href="https://geolytix.github.io/xyz/docs/develop/api/location/">Location API</a>`)
   }


### PR DESCRIPTION
MDN recommends to use hasOwn if available.

https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/hasOwn