### PR TITLE
Update Geoms warning to Include Layer Name or Key

### DIFF
--- a/mod/workspace/assignDefaults.js
+++ b/mod/workspace/assignDefaults.js
@@ -77,7 +77,7 @@ module.exports = async workspace => {
       // Check for layer geom[s].
       if ((layer.table || layer.tables) && (!layer.geom && !layer.geoms)) {
 
-        console.warn('Layer with a table or tables must have a geom or geoms defined.')
+        console.warn(`Layer ${layer?.name || layer.key} has a table or tables defined, but no geom or geoms.`)
       }
 
       // Assign layer key as name with no existing name on layer object.


### PR DESCRIPTION
I noticed that when you don't provide geom or geoms to the layer - the console warning doesn't specify which layer this is on. 

This is problematic if multiple layers are turned on by default on load, as it's hard to debug. 
This PR adds the layer name is provided, or layer key if not to the console warning - to simply aid debugging as you can quickly locate the layer of issue 