### PR TITLE
Update to cluster config object

### DIFF
--- a/lib/layer/format/cluster.mjs
+++ b/lib/layer/format/cluster.mjs
@@ -6,12 +6,17 @@ export default layer => {
 
   // Assign legacy cluster properties to cluster config object.
   layer.cluster = Object.assign(layer.cluster || {}, {
-    label: layer.cluster_label,
-    kmeans: layer.cluster_kmeans,
-    dbscan: layer.cluster_dbscan,
-    resolution: layer.cluster_resolution,
-    hexgrid: layer.cluster_hexgrid
+    label: layer.cluster?.label || layer.cluster_label,
+    kmeans: layer.cluster?.kmeans || layer.cluster_kmeans,
+    dbscan: layer.cluster?.dscan || layer.cluster_dbscan,
+    resolution: layer.cluster?.resolution || layer.cluster_resolution,
+    hexgrid: layer.cluster?.hexgrid || layer.cluster_hexgrid
   })
+  
+  // If legacy cluster properties are set, provide warning to update. 
+  if (layer.cluster_label || layer.cluster_kmeans || layer.cluster_dbscan || layer.cluster_resolution || layer.cluster_hexgrid) {
+    console.warn(`Layer ${layer?.name || layer.key} is using legacy cluster properties. Please update to use cluster:{} config object.`)
+  }
 
   function loader () {
 

--- a/mod/workspace/defaults.js
+++ b/mod/workspace/defaults.js
@@ -68,7 +68,9 @@ module.exports = defaults = {
     },
     cluster: {
       srid: '4326',
-      cluster_resolution: 0.1,
+      cluster: {
+        resolution: 0.1
+      },
       style: {       
         default: {
           type: 'dot'


### PR DESCRIPTION
I noticed that the default for the cluster layer is still assigning cluster_resolution not cluster: {resolution} to be in line with the new method of assignment using a cluster object. 

I also added the assignment to first check for a cluster object and use the values from within that, otherwise to use the older legacy method values. 

I added a console warning if the old method is used to tell the developer to update to use cluster:{} 