### PR TITLE
Update Console Warning

### DIFF
--- a/lib/layer/decorate.mjs
+++ b/lib/layer/decorate.mjs
@@ -17,7 +17,7 @@ export default async layer => {
   });
 
   if (layer.edit) {
-    console.warn('layer.edit has been superseeded with layer.draw to be in line with the OL drawing interaction.')
+    console.warn(`Layer: ${layer?.name || layer.key} please update edit:{} to use draw:{} as layer.edit has been superseeded with layer.draw to be in line with the OL drawing interaction.`)
     layer.draw = Object.assign(layer.draw || {}, layer.edit)
   }
 

--- a/lib/layer/decorate.mjs
+++ b/lib/layer/decorate.mjs
@@ -17,7 +17,7 @@ export default async layer => {
   });
 
   if (layer.edit) {
-    console.warn(`Layer: ${layer?.name || layer.key} please update edit:{} to use draw:{} as layer.edit has been superseeded with layer.draw to be in line with the OL drawing interaction.`)
+    console.warn(`Layer: ${layer.key} please update edit:{} to use draw:{} as layer.edit has been superseeded with layer.draw to be in line with the OL drawing interaction.`)
     layer.draw = Object.assign(layer.draw || {}, layer.edit)
   }
 


### PR DESCRIPTION
This PR simply amends the console.warning about layer.edit moving to layer.draw. 

The console warning now provides the name of the layer or the layer key, and tells the developer to update to use draw:{}