### PR TITLE
fix for geometry entry modify interaction

### DIFF
--- a/lib/ui/locations/entries/geometry.mjs
+++ b/lib/ui/locations/entries/geometry.mjs
@@ -1,13 +1,16 @@
 export default entry => {
 
-  entry.value = typeof entry.value === 'string' && JSON.parse(entry.value)
-    || entry.value
+  // The geometry value must be JSON.
+  entry.value = typeof entry.value === 'string' && JSON.parse(entry.value) || entry.value
 
   // Turn off display with no geometry to display.
   entry.display = (entry.display && entry.value)
 
-  // Return if entry has no geometry value and is not editable.
-  if (!entry.value && !entry.edit) return;
+  // Return if entry has no geometry value and cannot be drawn in to.
+  if (!entry.value && !entry.draw) return;
+
+  // Assigning the mapview to the entry makes the entry behave like a layer object for draw and modify interactions.
+  entry.mapview = entry.location.layer.mapview
 
   // Assign Style if not already assigned.
   entry.Style = entry.Style
@@ -51,8 +54,6 @@ export default entry => {
   
   if (typeof entry.draw === 'object') {
 
-    entry.mapview = entry.location.layer.mapview
-
     entry.draw.callback = feature => {
 
       if (!feature) return;
@@ -79,7 +80,7 @@ export default entry => {
     let modifyBtn = mapp.utils.html.node`
       <button
         class="flat bold wide primary-colour"
-        onclick=${e=>modify(e, options)}>
+        onclick=${e=>modify(e, entry)}>
         Modify Geometry`
 
     if (entry.edit?.modifyBtnOnly) {
@@ -178,8 +179,8 @@ function show() {
   this.location.Layers.push(this.L)
 }
 
-// Method for button element to call modify interaction with options.
-function modify(e, options) {
+// Method for button element to call modify interaction.
+function modify(e, entry) {
 
   const btn = e.target
 
@@ -188,42 +189,42 @@ function modify(e, options) {
 
     // Finish current interaction.
     // The callback will begin the highlight interaction.
-    options.mapview.interaction.finish()
+    entry.mapview.interaction.finish()
     return;
   }
 
   btn.classList.add('active')
 
   // Tick display checkbox if not already set.
-  !options.entry.display && options.entry.show()
+  !entry.display && entry.show()
 
   // Remove existing entry geometry layer.
-  options.entry.location.layer.mapview.Map.removeLayer(options.entry.L)
+  entry.location.layer.mapview.Map.removeLayer(entry.L)
 
-  const feature = options.entry.L.getSource().getFeatures()[0]
+  const feature = entry.L.getSource().getFeatures()[0]
 
-  options.mapview.interactions.modify({
+  entry.mapview.interactions.modify({
     Feature: feature.clone(),
-    layer: options.entry.location.layer,
-    snap: options.entry.edit.snap,
-    srid: options.entry.srid || options.entry.location.layer.srid,
+    layer: entry.location.layer,
+    snap: entry.edit.snap,
+    srid: entry.srid || entry.location.layer.srid,
     callback: feature => {
 
       // Reset interaction and button
       btn.classList.remove('active')
-      options.mapview.interactions.highlight()
+      entry.mapview.interactions.highlight()
 
       // The callback returns a feature as geojson.
       if (feature) {
 
         // Assign feature geometry as new value.
-        options.entry.newValue = feature.geometry
-        options.entry.location.update()
+        entry.newValue = feature.geometry
+        entry.location.update()
         return;
       }
 
       // Add original layer back with no new feature geometry returned from draw interaction.
-      options.entry.location.layer.mapview.Map.addLayer(options.entry.L)
+      entry.location.layer.mapview.Map.addLayer(entry.L)
     }
   })
 }


### PR DESCRIPTION
The modify method should receive the entry object as a layer like object instead of the options argument.