### PR TITLE
Create a geojson layer with features array

### DIFF
--- a/lib/layer/format/geojson.mjs
+++ b/lib/layer/format/geojson.mjs
@@ -2,7 +2,11 @@ export default layer => {
 
   layer.format = new ol.format.GeoJSON();
 
-  layer.reload = loader;
+  if (!layer.features) {
+
+    // Only assign the layer reload method if the layer has no features.
+    layer.reload = loader;
+  }
   
   function loader () {
 
@@ -56,6 +60,28 @@ export default layer => {
     zIndex: layer.zIndex || 1,
     style: layer.styleFunction || mapp.layer.Style(layer)
   })
+
+  if (layer.features) {
+
+    // layer.features must be an array.
+    if (!Array.isArray(layer.features)) return;
+
+    // Create featurea from layer.features array.
+    const features = layer.features.map((f) =>
+      new ol.Feature({
+        id: f.id,
+        geometry: layer.format.readGeometry(f.geometry, {
+          dataProjection: 'EPSG:' + layer.srid,
+          featureProjection: 'EPSG:' + layer.mapview.srid,
+        }),
+        properties: f.properties
+      }))
+
+    // Set source with layer.features.
+    layer.L.setSource(new ol.source.Vector({
+      features: features
+    }))
+  }
 
   // Change method for the cluster feature properties and layer stats.
   layer.cluster && layer.L.on('change', e => {


### PR DESCRIPTION
A geojson layer can be added with an array of geojson features instead of a table definition.

The features can be styled with feature properties. It is not possible to highlight or get locations from this layer since it has no source.

It will not be possible to set filters since the features are not gotten from a source.