### PR TITLE
Do not return err object from provider method.

### DIFF
--- a/mod/provider/cloudfront.js
+++ b/mod/provider/cloudfront.js
@@ -45,7 +45,7 @@ module.exports = async ref => {
 
   } catch(err) {
     console.error(err)
-    return err
+    return;
   }
 
 }

--- a/mod/provider/file.js
+++ b/mod/provider/file.js
@@ -18,6 +18,6 @@ module.exports = async ref => {
 
   } catch (err) {
     console.error(err)
-    return err
+    return;
   }
 }

--- a/mod/view.js
+++ b/mod/view.js
@@ -34,7 +34,7 @@ module.exports = async (req, res) => {
     }));
   }
 
-  let template = await templates(
+  const template = await templates(
     'default_view',
     req.params.language || req.params.user?.language,
     params


### PR DESCRIPTION
This is to prevent a stack trace exposure where an error object would be returned to the client.