### PR TITLE
Validate the locale and layer request param

### DIFF
--- a/mod/layer/_layer.js
+++ b/mod/layer/_layer.js
@@ -1,4 +1,4 @@
-const _format = {
+const formats = {
   cluster: require('./cluster'),
   mvt: require('./mvt'),
   geojson: require('./geojson'),
@@ -8,24 +8,43 @@ const _format = {
 
 module.exports = async (req, res) => {
 
-  const format = _format[req.params.format]
-
-  if (!format) {
-    return res.send(`Failed to evaluate 'format' param.<br><br>
-    <a href="https://geolytix.github.io/xyz/docs/develop/api/layer/">Layer API</a>`)
-  }
-
-  const locale = req.params.locale && req.params.workspace.locales[req.params.locale]
-
-  const layer = locale && locale.layers[req.params.layer] ||  req.params.workspace.templates[req.params.layer]
-
-  req.params.layer = layer
-
   if (!req.params.layer) {
     return res.send(`Failed to evaluate 'layer' param.<br><br>
     <a href="https://geolytix.github.io/xyz/docs/develop/api/layer/">Layer API</a>`)
   }
 
-  return format(req, res)
+  // The format key must be an own property of the formats object.
+  if (!Object.hasOwn(formats, req.params.format)) {
+    return res.send(`Failed to evaluate 'format' param.<br><br>
+    <a href="https://geolytix.github.io/xyz/docs/develop/api/layer/">Layer API</a>`)
+  }
 
+  if (req.params.locale) {
+    
+    // The locale key must be an own property of the workspace.locales, and must be an object.
+    if (Object.hasOwn(req.params.workspace.locales, req.params.locale)
+      && typeof req.params.workspace.locales[req.params.locale] === 'object') {
+
+        // Assign layer from locale in workspace.
+        req.params.layer = req.params.workspace.locales[req.params.locale].layers[req.params.layer]
+
+    } else {
+
+      // Terminate request if locale is defined but not valid.
+      return res.send(`Failed to evaluate locale param.`)
+    }
+
+  // A layer must be specified in the templates without a locale specifier, and must be an object
+  } else if (Object.hasOwn(req.params.workspace.templates, req.params.layer)
+    && typeof req.params.workspace.templates[req.params.layer] === 'object') {
+
+    // Assign layer object from templates.
+    req.params.layer = req.params.workspace.templates[req.params.layer]
+
+  } else {
+
+    return res.send(`Failed to evaluate layer param.`)
+  }
+    
+  return formats[req.params.format](req, res)
 }

--- a/mod/layer/cluster.js
+++ b/mod/layer/cluster.js
@@ -232,6 +232,8 @@ module.exports = async (req, res) => {
     FROM ${params.cluster_sql}
     GROUP BY ${params.group_by.join(',')};`
 
+  if (!Object.hasOwn(dbs, params.layer.dbs || req.params.workspace.dbs)) return;
+
   const query = dbs[params.layer.dbs || req.params.workspace.dbs];
 
   // Validate query method type.

--- a/mod/workspace/_workspace.js
+++ b/mod/workspace/_workspace.js
@@ -72,7 +72,8 @@ function getLocale(req, res) {
     return res.status(400).send('Locale key missing.')
   }
 
-  if (!req.params.workspace.locales[req.params.locale]) {
+  // The locale object must have an own property for the locales key.
+  if (!Object.hasOwn(req.params.workspace.locales, req.params.locale)) {
     return res.status(404).send('Locale not found.')
   }
 


### PR DESCRIPTION
The locale and layer request parameter were not validated when looked up in the workspace.locales.

At a minimum it must be ensured that the locales and templates object has an own property of the layer / locale key.

Otherwise it might be possible to provide an object prototype key (e.g. `valueOf`, `hasOwnProperty`, or `__defineSetter__`) as layer param with a request.