### PR TITLE
Add console warning for draw.delete to layer.deleteLocation

### DIFF
--- a/lib/layer/decorate.mjs
+++ b/lib/layer/decorate.mjs
@@ -23,6 +23,10 @@ export default async layer => {
 
   if (layer.draw) {
 
+    if (layer.draw?.delete) {
+      console.warn(`Layer: ${layer.key} please move draw.delete to use layer.deleteLocation:true.`)
+    }
+    
     // Callback which creates and stores a location from a feature returned by the drawing interaction.
     layer.draw.callback = async (feature, params) => {
  


### PR DESCRIPTION
I noticed that when moving from the old configuration of 

`"edit":{ 
"point": true,
"delete": true
}` 
to 
`"draw":{ 
"point": true,
"delete": true
}` 

The delete method is actually now defined as layer.deleteLocation, so this PR adds a console warning to tell the developer to update from draw.delete to layer.deleteLocation