### PR TITLE
The filter panel should not add filter from skipped entry.

### DIFF
--- a/lib/ui/layers/panels/filter.mjs
+++ b/lib/ui/layers/panels/filter.mjs
@@ -43,6 +43,7 @@ export default layer => {
   layer.filter.list = layer.infoj
     .filter(entry => entry.filter)
     .filter(entry => !layer.filter?.exclude?.includes(entry.field))
+    .filter(entry => !new Set(layer.infoj_skip).has(entry.key || entry.field || entry.query || entry.type || entry.group))
     .map(entry => {
 
       // The filter is defined as a string e.g. "like"


### PR DESCRIPTION
If infoj entries with filter which are skipped because they are in the `layer.infoj_skip[]` should not be added to the filter panel drop down.