### PR TITLE
xhr module - promise rejected on status >= 400;

### DIFF
--- a/lib/utils/xhr.mjs
+++ b/lib/utils/xhr.mjs
@@ -25,7 +25,7 @@ export default params => new Promise((resolve, reject) => {
 
   xhr.onload = e => {
 
-    if (e.target.status >= 300) {
+    if (e.target.status >= 400) {
       reject(new Error(e.target.status))
       return;
     }


### PR DESCRIPTION
Until now xhr module has rejected promises which returned status greater or equal to 300.
This isn't great if we expect some updates / pings / status checks which may return 304 - not modified.
I've had valid requests rejected on account of this condition.
Therefore changing the rejection condition to greater or equal to 400;