### PR TITLE
API mod redirect to root instead of stripping logout param from url

### DIFF
--- a/api/api.js
+++ b/api/api.js
@@ -117,7 +117,7 @@ module.exports = async (req, res) => {
     res.setHeader('Set-Cookie', `${process.env.TITLE}=null;HttpOnly;Max-Age=0;Path=${process.env.DIR || '/'}`)
 
     // Remove logout parameter.
-    res.setHeader('location', req.url && decodeURIComponent(req.url).replace(/logout\=true/, ''))
+    res.setHeader('location', '/')
 
     return res.status(302).send()
   }


### PR DESCRIPTION
Redirect should not be from user provided URL param.