### PR TITLE
fixed legend flex centered contents class name

### DIFF
--- a/public/css/mapp.css
+++ b/public/css/mapp.css
@@ -174,8 +174,8 @@ a > img {
   flex-basis: 30%;
   flex-shrink: 1;
 }
-.legend > .contents-wrapper.flex .contents.centered,
-.legend > .content > .contents-wrapper.flex .contents.centered {
+.legend > .contents-wrapper.flex .contents.center,
+.legend > .content > .contents-wrapper.flex .contents.center {
   display: flex;
   align-items: center;
   justify-content: center;

--- a/public/css/mapp.scss
+++ b/public/css/mapp.scss
@@ -184,7 +184,7 @@ a > img {
         flex-basis: 30%;
         flex-shrink: 1;
         
-        &.centered {
+        &.center {
           display: flex;
           align-items: center;
           justify-content: center;


### PR DESCRIPTION
Changes to the categorized.mjs led to adding the class "center" instead of "centered" to the contents. Updated css accordingly. 