### PR TITLE
MVT Clone Issues (Ongoing and need further help)

### DIFF
--- a/lib/ui/locations/entries/mvt_clone.mjs
+++ b/lib/ui/locations/entries/mvt_clone.mjs
@@ -72,7 +72,7 @@ export default entry => {
     // Create a style panel as entry.view and append to entry.node.
     entry.view = mapp.ui.layers.panels.style(entry)
     entry.view && entry.node.append(entry.view)
-
+    
     // Add the clone layer to the mapview.Map.
     entry.mapview.Map.addLayer(entry.L)
 
@@ -120,6 +120,10 @@ export default entry => {
 
     // The mvt layer can be displayed at all zoom levels.
     if (!entry.Layer.tables) return;
+
+    // if the featureLookup is null, the layer cannot be displayed.
+    // This is for when you zoom out beyond the zoom range of the layer, and then zoom back in.
+    if (entry.featureLookup === null) return; 
 
     // The clone layer cannot be displayed.
     if (entry.Layer.tableCurrent() === null) {

--- a/lib/ui/locations/entries/mvt_clone.mjs
+++ b/lib/ui/locations/entries/mvt_clone.mjs
@@ -11,6 +11,9 @@ export default entry => {
     return;
   }
 
+  // The entry must have a style object.
+  entry.style ||= entry.Layer.style
+
   // Create clone VectorTile layer.
   entry.L = new ol.layer.VectorTile({
     source: entry.Layer.L.getSource(),
@@ -18,18 +21,11 @@ export default entry => {
     zIndex: entry.zIndex,
 
     // Assign style from entry.style
-    style: entry.Layer.style
+    style: mapp.layer.Style(entry)
   });
 
   // Add the clone layer to the mvt layer clones.
   entry.Layer.clones.add(entry.L)
-
-  // The entry must have a style object.
-  entry.style = entry.Layer.style || {}
-
-  // The entry style must have a default style.
-  // The entry default style will be assigned to the mvt layer default style.
-  entry.style.default = Object.assign({}, entry.location?.style || {}, entry.style.default || {})
 
   if (entry.style.themes) {
 

--- a/lib/ui/locations/entries/mvt_clone.mjs
+++ b/lib/ui/locations/entries/mvt_clone.mjs
@@ -21,7 +21,6 @@ export default entry => {
     style: entry.Layer.style
   });
 
-  console.log(entry.Layer); 
   // Add the clone layer to the mvt layer clones.
   entry.Layer.clones.add(entry.L)
 
@@ -41,8 +40,6 @@ export default entry => {
   // Assign method to show the clone layer.
   entry.show = async () => {
 
-    console.log(entry);
-
     entry.display = true;
 
     // The OL clone layer already exists.
@@ -52,6 +49,7 @@ export default entry => {
 
       try {
         entry.mapview.Map.addLayer(entry.L)
+
       } catch {
         // Will catch assertation error when layer is already added.
       }
@@ -59,33 +57,25 @@ export default entry => {
       return;
     }
 
-    // Create the style panel.
-    entry.view = mapp.ui.layers.panels.style(entry)
-    entry.view && entry.node.append(entry.view)
-
     // Create query paramString from the entry object.
     const paramString = mapp.utils.paramString(mapp.utils.queryParams(entry))
-    console.log(paramString);
 
     // Query the featureLookup.
     entry.featureLookup = await mapp.utils.xhr(`${entry.host || entry.mapview.host}/api/query?${paramString}`)
 
-    console.log(entry.featureLookup); 
+    // The query does not return a response.
+    if (entry.featureLookup === null) {
 
-    // if the query returns nothing, we should remove the layer from the map and disabled the checkbox.
-    if (entry.featureLookup===null) {
-        // Remove the geometry layer from map.
-    entry.mapview.Map.removeLayer(entry.L)
-    // Disable checkbox.
-    node.querySelector('input').disabled = true
-     // Hide style drawer if present.
-     if (entry.view) entry.view.style.display = 'none'
+      // Disable the chkbox input.
+      node.querySelector('input').disabled = true
 
-     // Remove clone layer if present in set but should not be displayed.
-     !entry.display && entry.mapview.Map.removeLayer(entry.L)
-    // return
-    return;
-    } else {
+      // The entry.view will not be created.
+      return;
+    }
+
+    // Create a style panel as entry.view and append to entry.node.
+    entry.view = mapp.ui.layers.panels.style(entry)
+    entry.view && entry.node.append(entry.view)
 
     // Add the clone layer to the mapview.Map.
     entry.mapview.Map.addLayer(entry.L)
@@ -95,8 +85,8 @@ export default entry => {
       entry.mapview.Map.removeLayer(entry.L)
       entry.Layer.clones.delete(entry.L)
     })
-  }
-};
+
+  };
 
   // Assign method to hide the clone layer.
   entry.hide = async () => {
@@ -123,9 +113,6 @@ export default entry => {
     onchange: (checked) => checked ? entry.show() : entry.hide()
   })
 
-      // If the featureLookup is null, ignore zoom level check.
-      if (entry.featureLookup===null) return;
-      
   // Show geometry if entry is set to display.
   entry.display && entry.show()
 
@@ -158,7 +145,7 @@ export default entry => {
 
     // Display style drawer if present.
     if (entry.view) entry.view.style.display = 'block'
-    
+
     // Try to add entry.L to mapview.Map
     try {
       entry.display && entry.mapview.Map.addLayer(entry.L)
@@ -167,13 +154,14 @@ export default entry => {
     }
 
   }
+
   chkZoom()
 
   // Add zoom level check to mapview changeEnd event.
   entry.mapview.Map.getTargetElement().addEventListener('changeEnd', chkZoom)
 
   // Remove zoom level check from mapview changeEnd event.
-  entry.location.removeCallbacks.push(()=>{
+  entry.location.removeCallbacks.push(() => {
 
     // Remove layer from map when location is removed.
     entry.mapview.Map.removeLayer(entry.L)

--- a/lib/ui/locations/entries/mvt_clone.mjs
+++ b/lib/ui/locations/entries/mvt_clone.mjs
@@ -7,7 +7,7 @@ export default entry => {
   entry.Layer = entry.mapview.layers[entry.layer]
 
   if (!entry.Layer) {
-    console.warn("mvt_clone Layer not found in mapview.layers object.")
+    console.warn('mvt_clone Layer not found in mapview.layers object.')
     return;
   }
 
@@ -18,14 +18,15 @@ export default entry => {
     zIndex: entry.zIndex,
 
     // Assign style from entry.style
-    style: mapp.layer.Style(entry)
+    style: entry.Layer.style
   });
 
+  console.log(entry.Layer); 
   // Add the clone layer to the mvt layer clones.
   entry.Layer.clones.add(entry.L)
 
   // The entry must have a style object.
-  entry.style = entry.style || {}
+  entry.style = entry.Layer.style || {}
 
   // The entry style must have a default style.
   // The entry default style will be assigned to the mvt layer default style.
@@ -39,6 +40,8 @@ export default entry => {
 
   // Assign method to show the clone layer.
   entry.show = async () => {
+
+    console.log(entry);
 
     entry.display = true;
 
@@ -62,9 +65,27 @@ export default entry => {
 
     // Create query paramString from the entry object.
     const paramString = mapp.utils.paramString(mapp.utils.queryParams(entry))
+    console.log(paramString);
 
     // Query the featureLookup.
     entry.featureLookup = await mapp.utils.xhr(`${entry.host || entry.mapview.host}/api/query?${paramString}`)
+
+    console.log(entry.featureLookup); 
+
+    // if the query returns nothing, we should remove the layer from the map and disabled the checkbox.
+    if (entry.featureLookup===null) {
+        // Remove the geometry layer from map.
+    entry.mapview.Map.removeLayer(entry.L)
+    // Disable checkbox.
+    node.querySelector('input').disabled = true
+     // Hide style drawer if present.
+     if (entry.view) entry.view.style.display = 'none'
+
+     // Remove clone layer if present in set but should not be displayed.
+     !entry.display && entry.mapview.Map.removeLayer(entry.L)
+    // return
+    return;
+    } else {
 
     // Add the clone layer to the mapview.Map.
     entry.mapview.Map.addLayer(entry.L)
@@ -75,6 +96,7 @@ export default entry => {
       entry.Layer.clones.delete(entry.L)
     })
   }
+};
 
   // Assign method to hide the clone layer.
   entry.hide = async () => {
@@ -101,6 +123,9 @@ export default entry => {
     onchange: (checked) => checked ? entry.show() : entry.hide()
   })
 
+      // If the featureLookup is null, ignore zoom level check.
+      if (entry.featureLookup===null) return;
+      
   // Show geometry if entry is set to display.
   entry.display && entry.show()
 


### PR DESCRIPTION
1. If the featureLookup queries returns nothing, the whole layer is drawn. In this PR i've got it so it removes the style drawer and then disables the tickboxes. 
2. You should be able to use the layer style, rather than defining the style in the infoj entry too. In this PR, i've got it so that it takes the layer style, but please can we amend this so it takes the entry style if provided, otherwise uses the layer style (to remove duplicated code). 
3. The data isn't drawn to the layer even though information is returned from the featureLookup query. In my PR, i've got it console logging this to test. 