### PR TITLE
control layer container visibility for 3rd party libraries.

### DIFF
--- a/lib/layer/format/mapboxgl.mjs
+++ b/lib/layer/format/mapboxgl.mjs
@@ -41,7 +41,7 @@ export default async layer => {
 
   layer.container = mapp.utils.html.node`<div 
     class="mapboxgl" 
-    style="position: absolute; width: 100%; height: 100%;">`
+    style="visibility: hidden; position: absolute; width: 100%; height: 100%;">`
 
   layer.mapview.Map.getTargetElement().prepend(layer.container)
 
@@ -57,6 +57,8 @@ export default async layer => {
     render: frameState => {
 
       if (!layer.display) return
+
+      layer.container.style.visibility = 'visible';
 
       //adjust view parameters in mapbox
       layer.Map.jumpTo({

--- a/lib/layer/format/maplibre.mjs
+++ b/lib/layer/format/maplibre.mjs
@@ -41,7 +41,7 @@ export default async layer => {
 
   layer.container = mapp.utils.html.node`<div 
     class="maplibre" 
-    style="position: absolute; width: 100%; height: 100%;">`
+    style="visibility: hidden; position: absolute; width: 100%; height: 100%;">`
   
   layer.mapview.Map.getTargetElement().prepend(layer.container)
 
@@ -78,6 +78,8 @@ export default async layer => {
     render: frameState => {
 
       if (!layer.display) return
+
+      layer.container.style.visibility = 'visible';
       
       // adjust view parameters in mapbox
       layer.Map.jumpTo({

--- a/lib/layer/format/mbtiles.mjs
+++ b/lib/layer/format/mbtiles.mjs
@@ -34,7 +34,7 @@ export default async layer => {
 
   layer.container = mapp.utils.html.node`<div 
     class="mbtiles" 
-    style="position: absolute; width: 100%; height: 100%;">`
+    style="visibility: hidden; position: absolute; width: 100%; height: 100%;">`
   
   layer.mapview.Map.getTargetElement().prepend(layer.container)
 
@@ -60,6 +60,8 @@ export default async layer => {
     render: frameState => {
 
       if (!layer.display) return
+
+      layer.container.style.visibility = 'visible';
       
       // adjust view parameters in mapbox
       layer.Map.jumpTo({

--- a/public/views/_default.html
+++ b/public/views/_default.html
@@ -304,9 +304,7 @@
 
   <div id="Map">
     
-    <div id="OL">
-      <div id="GMAP" style="width: 100%; height: 100%; position: absolute;"></div>
-    </div>
+    <div id="OL"></div>
     <div id="Attribution">
       <a class="logo" target="_blank" href="https://geolytix.co.uk">
         <img src="https://geolytix.github.io/public/geolytix_mapp.svg">


### PR DESCRIPTION
The layer container for maplibre, mbtiles, and mapboxgl layers should initially be invisible and turned on when the layer is displayed. Otherwise the render canvas will be visible when no layers are displayed.

The container will not be visible again if the layer is toggled off.

Remove GMAP element from default view which was from a google maps test.