### PR TITLE
Add tabulator date format and filter.

### DIFF
--- a/lib/ui/utils/tabulatorUtils.mjs
+++ b/lib/ui/utils/tabulatorUtils.mjs
@@ -2,10 +2,12 @@ export default {
   headerFilter: {
     like,
     numeric,
-    set
+    set,
+    date: dateFilter
   },
   formatter: {
-    toLocalString
+    toLocalString,
+    date
   },
   select
 }
@@ -158,6 +160,86 @@ function numeric(_this) {
   }
 }
 
+function dateFilter(_this) {
+
+  return (cell, onRendered, success, cancel, headerFilterParams) => {
+
+    // Select the field
+    const field = cell.getColumn().getField()
+
+    const inputMin = mapp.utils.html`
+    <input
+      type="date"
+      onchange=${minEvent}>`;
+
+    function minEvent(e) {
+
+      const val = new Date(e.target.value).getTime() / 1000
+
+      // Get filter for that field if exists
+      const filter = _this.Tabulator.getFilters().find(f => f.field === field && f.type == '>=')
+
+      // Remove existing filter
+      if (filter) {
+        _this.Tabulator.removeFilter(...Object.values(filter))
+
+        // Remove layer filter
+        headerFilterParams.layerFilter && delete _this.layer.filter.current[field]
+      }
+
+      // Add filter for valid target value.
+      if (val) {
+        _this.Tabulator.addFilter(field, '>=', val)
+
+        // Set layer filter
+        if (headerFilterParams.layerFilter) {
+          _this.layer.filter.current[field] = Object.assign(_this.layer.filter.current[field] || {}, { gte: val })
+          _this.layer.reload();
+          _this.update();  
+        }
+      }
+    }
+
+    const inputMax = mapp.utils.html`
+    <input
+      type="date"
+      onchange=${maxEvent}>`;
+
+    function maxEvent(e) {
+
+      const val = new Date(e.target.value).getTime() / 1000
+
+      // Get filter for that field if exists
+      const filter = _this.Tabulator.getFilters().find(f => f.field === field && f.type == '<=')
+
+      // Remove existing filter
+      if (filter) {
+        _this.Tabulator.removeFilter(...Object.values(filter))
+
+        // Remove layer filter
+        headerFilterParams.layerFilter && delete _this.layer.filter.current[field]
+      }
+
+      // Add filter for valid target value.
+      if (val) {
+        _this.Tabulator.addFilter(field, '<=', val)
+
+        // Set layer filter
+        if (headerFilterParams.layerFilter) {
+          _this.layer.filter.current[field] = Object.assign(_this.layer.filter.current[field] || {}, { lte: val })
+          _this.layer.reload();
+          _this.update();
+        }
+      }
+    }
+
+    // flex container must be encapsulated since tabulator will strip attribute from most senior item returned.
+    return mapp.utils.html.node`
+      <div><div style="display: flex;">${inputMin}${inputMax}`
+
+  }
+}
+
 function set(_this) {
 
   return (cell, onRendered, success, cancel, headerFilterParams) => {
@@ -291,6 +373,21 @@ function toLocalString(_this) {
     if (isNaN(val)) return;
 
     return val.toLocaleString(formatterParams?.locale || 'en-GB', formatterParams?.options)
+  }
+
+}
+
+function date(_this) {
+
+  return (cell, formatterParams, onRendered) => {
+
+    let val = parseInt(cell.getValue())
+
+    if (isNaN(val)) return;
+
+    let str = new Date(val * 1000).toLocaleString(formatterParams?.locale || 'en-GB', formatterParams?.options)
+
+    return str
   }
 
 }


### PR DESCRIPTION
Added a formatter: date to tabulator utils.

formatterParams option are the same as for date type entry in infoj.

And headerFilter: date

```js
{
 "field": "ofsted_date_bigint",
 "title": "Date (Bigint)",
 "headerFilter": "date",
 "formatter": "date",
 "formatterParams": {
  "options": {
   "year": "numeric",
   "month": "numeric",
   "day": "numeric"
  }
 }
}
```