### PR TITLE
Added checked for if a feature has no id

### DIFF
--- a/lib/layer/format/geojson.mjs
+++ b/lib/layer/format/geojson.mjs
@@ -93,7 +93,7 @@ export default layer => {
       const features = F.get('features')
 
       // Set cluster feature id for highlight interaction.
-      F.set('id', features[0].get('id'), true)
+      F.set('id', features[0]?.get('id'), true)
 
       if (features.length > 1) {
 
@@ -102,10 +102,10 @@ export default layer => {
 
       } else {
 
-        let fP = features[0].getProperties()
+        let fP = features[0]?.getProperties()
 
         // Set feature properties for for single location cluster.
-        Object.entries(fP.properties || {}).forEach(entry => {
+        Object.entries(fP?.properties || {}).forEach(entry => {
           F.set(entry[0], entry[1], true)
         })
 

--- a/lib/layer/format/wkt.mjs
+++ b/lib/layer/format/wkt.mjs
@@ -87,7 +87,7 @@ export default layer => {
       const features = F.get('features')
 
       // Set cluster feature id for highlight interaction.
-      F.set('id', features[0].get('id'), true)
+      F.set('id', features[0]?.get('id'), true)
 
       if (features.length > 1) {
 
@@ -96,10 +96,10 @@ export default layer => {
 
       } else {
 
-        let fP = features[0].getProperties()
+        let fP = features[0]?.getProperties()
 
         // Set feature properties for for single location cluster.
-        Object.entries(fP.properties || {}).forEach(entry => {
+        Object.entries(fP?.properties || {}).forEach(entry => {
           F.set(entry[0], entry[1], true)
         })
 


### PR DESCRIPTION
If a feature had no id associated with it on a geoJSON and wkt format, the feature load would fail. I have added in checks for that to allow it to load even if no id is present.