### PR TITLE
Distinct True filters on filtered layers

### DIFF
--- a/lib/ui/layers/filters.mjs
+++ b/lib/ui/layers/filters.mjs
@@ -155,25 +155,40 @@ async function filter_in(layer, entry) {
     // Allow layerfilter to be provided to the query.
     if (entry.filter?.layerFilter) { 
 
-      // Turn the filter current from an object of fields and values into a string for SQL.
+      // Create filter string 
       let filter_string = '';
+      let firstRun = true;
+      // Turn the filter current from an object of fields and values into a string for SQL.
+      for (const [key, value] of Object.entries(layer.filter.current)) {   
+        // Get the preposition and values from the filter. 
+          const preposition = Object.entries(value)[0][0];
+          const valuesArr = Object.entries(value)[0][1];
       
-      Object.entries(layer.filter.current).forEach(entry => {
-        console.log(entry);
-        let filter_values = `('` + entry[1].in.join('\', \'') + `')`;
-        let filter_string = `sch_run IN ('Controlled','Free Schools')`
-       filter_string += `${entry[0]} IN ${filter_values}`;
-      })
+          // Add the filter to the filter string, if it's the first run, don't add the AND.
+          filter_string += `${firstRun ? key : ` AND ${key}`} ${preposition} (${valuesArr.map((val)=>`'${val}'`).join(',')})`;
+          firstRun = false;
+      }
+
+      // console log for testing
       console.log(filter_string);
 
+      // build the same query as is created below by passing to distinct_values_filter template.
+      let query  = 
+      `SELECT distinct(${entry.field})
+      FROM ${layer.tableCurrent()}
+      WHERE ${filter_string}
+      ORDER BY ${entry.field}`;
+      console.log(query);
+
+      // Query distinct field values from the layer table, with filter applied.
 response = await mapp.utils.xhr(`${layer.mapview.host}/api/query?` +
  mapp.utils.paramString({
    template: 'distinct_values_filter',
    dbs: layer.dbs,
    table: layer.tableCurrent(),
    field: entry.field,
-   filter: filter_string
- }))
+   filter_string: filter_string
+ })) 
 
     } else {
     // Query distinct field values from the layer table.

--- a/lib/ui/layers/filters.mjs
+++ b/lib/ui/layers/filters.mjs
@@ -148,16 +148,43 @@ async function filter_numeric(layer, entry){
 
 async function filter_in(layer, entry) {
 
+  let response = null; 
+
   if (entry.filter.distinct) {
 
+    // Allow layerfilter to be provided to the query.
+    if (entry.filter?.layerFilter) { 
+
+      // Turn the filter current from an object of fields and values into a string for SQL.
+      let filter_string = '';
+      
+      Object.entries(layer.filter.current).forEach(entry => {
+        console.log(entry);
+        let filter_values = `('` + entry[1].in.join('\', \'') + `')`;
+        let filter_string = `sch_run IN ('Controlled','Free Schools')`
+       filter_string += `${entry[0]} IN ${filter_values}`;
+      })
+      console.log(filter_string);
+
+response = await mapp.utils.xhr(`${layer.mapview.host}/api/query?` +
+ mapp.utils.paramString({
+   template: 'distinct_values_filter',
+   dbs: layer.dbs,
+   table: layer.tableCurrent(),
+   field: entry.field,
+   filter: filter_string
+ }))
+
+    } else {
     // Query distinct field values from the layer table.
-    const response = await mapp.utils.xhr(`${layer.mapview.host}/api/query?` +
+    response = await mapp.utils.xhr(`${layer.mapview.host}/api/query?` +
       mapp.utils.paramString({
         template: 'distinct_values',
         dbs: layer.dbs,
         table: layer.tableCurrent(),
         field: entry.field
       }))
+    };
 
     if (!response) {
       console.warn(`Distinct values query did not return any values for field ${entry.field}`)

--- a/mod/workspace/assignTemplates.js
+++ b/mod/workspace/assignTemplates.js
@@ -24,6 +24,9 @@ module.exports = async (workspace) => {
       distinct_values: {
         template: require('../../public/js/queries/distinct_values'),
       },
+      distinct_values_filter: {
+        template: require('../../public/js/queries/distinct_values_filter'),
+      },
       field_stats: {
         template: require('../../public/js/queries/field_stats'),
       },

--- a/public/js/queries/distinct_values_filter.js
+++ b/public/js/queries/distinct_values_filter.js
@@ -1,0 +1,6 @@
+module.exports = 
+`
+  SELECT distinct(\${field})
+  FROM \${table}
+  WHERE \${filter}
+  ORDER BY \${field};`;

--- a/public/js/queries/distinct_values_filter.js
+++ b/public/js/queries/distinct_values_filter.js
@@ -2,5 +2,5 @@ module.exports =
 `
   SELECT distinct(\${field})
   FROM \${table}
-  WHERE \${filter}
+  WHERE \${filter_string}
   ORDER BY \${field};`;


### PR DESCRIPTION
This PR addresses an issue related to when we use layers that are filtered in the workspace to use filter current. 
If you then apply a distinct true filter on an infoj entry you will see any values from the database table (regardless of if they should have been filtered out or not).  
This PR adds a layerFilter flag to the infoj filter entries configured as so - 
`  "filter": {
                        "type": "in",
                        "distinct": true,
                        "layerFilter": true
                    }`

When layerFilter is provided, the current layer filter will be passed into the SQL query to return distinct values from the database. 

However, I have not yet got this working correctly - so please could i get some help on this one? 