### PR TITLE
Replace version script with javascript version

### DIFF
--- a/lib/mapp.mjs
+++ b/lib/mapp.mjs
@@ -18,7 +18,7 @@ self.mapp = (function (mapp) {
 
   Object.assign(mapp, {
     version: '4.4.0α',
-    hash: '6d0902e65004cba01b03d32debc9bda69b037fd6',
+    hash: 'ca7a67b1159f3940a0ee48922fd3c02c88b355b2',
     language: hooks.current.language || 'en',
   
     dictionaries,

--- a/version.js
+++ b/version.js
@@ -1,0 +1,12 @@
+const fs = require('fs');
+const { execSync } = require('child_process');
+
+const key = "hash:.*";
+const hash = execSync('git rev-parse HEAD').toString().trim();
+
+let data = fs.readFileSync('./lib/mapp.mjs', 'utf-8');
+data = data.replace(new RegExp(key, 'g'), `hash: '${hash}',`);
+
+fs.writeFileSync('./lib/mapp.mjs', data);
+
+execSync('npm run _build');

--- a/version.sh
+++ b/version.sh
@@ -1,5 +1,0 @@
-#!/bin/bash
-key="hash:.*"
-hash=$(git rev-parse HEAD)
-sed -i '' "s/$key/hash: '$hash',/g" ./lib/mapp.mjs
-npm run _build


### PR DESCRIPTION
You can test this by executing `node version.js` in the root of the xyz directory.