### PR TITLE
WKT doesn't support resolution, so warn if config is wrong

### DIFF
--- a/lib/layer/format/wkt.mjs
+++ b/lib/layer/format/wkt.mjs
@@ -6,6 +6,10 @@ export default layer => {
 
   layer.reload = loader;
   
+  if (layer.cluster.resolution){
+    console.warn(`Layer ${layer.key} is format:wkt and does not support cluster.resolution. Please use cluster.distance instead.`)
+  };
+  
   function loader () {
 
     // Get unique, not empty, fields array for request.


### PR DESCRIPTION
Simple PR this one. 
Noticed that a lot of WKT layers have been converted from old cluster format, but resolution has been left in. 
Resolution is not supported by WKT - so this PR just adds a console warning to tell people to use distance instead 