### PR TITLE
Infoj Skip Update

### DIFF
--- a/lib/ui/locations/infoj.mjs
+++ b/lib/ui/locations/infoj.mjs
@@ -47,10 +47,17 @@ export default (location, infoj) => {
         && mapp.utils.merge(entry, fieldEntry.merge)
     }
 
-    // Skip entries from infoj_skip array;
-    if (new Set(entry.location?.layer?.infoj_skip).has(entry.key || entry.field || entry.query || entry.type || entry.group)) {
-      continue;
-    }
+  // Skip entries from infoj_skip array;
+  if (
+    entry.location?.layer?.infoj_skip &&
+    (entry.location.layer.infoj_skip.includes(entry.key) ||
+      entry.location.layer.infoj_skip.includes(entry.field) ||
+      entry.location.layer.infoj_skip.includes(entry.query) ||
+      entry.location.layer.infoj_skip.includes(entry.type) ||
+      entry.location.layer.infoj_skip.includes(entry.group))
+  ) {
+    continue;
+  }
 
     // Skip entry.
     if (entry.skipEntry) continue;


### PR DESCRIPTION
It was noticed that the infoj_skip method wasn't working correctly when you tried to use group in the current codebase. 
To fix this, the code has been amended to check if each property exists n the infoj_skip array, rather than using OR operator.