### PR TITLE
Provider current filter to distinct values query template

### DIFF
--- a/lib/ui/layers/filters.mjs
+++ b/lib/ui/layers/filters.mjs
@@ -155,6 +155,9 @@ async function filter_in(layer, entry) {
       mapp.utils.paramString({
         template: 'distinct_values',
         dbs: layer.dbs,
+        locale: layer.mapview.locale.key,
+        layer: layer.key,
+        filter: layer.filter && layer.filter.current,
         table: layer.tableCurrent(),
         field: entry.field
       }))

--- a/public/js/queries/distinct_values.js
+++ b/public/js/queries/distinct_values.js
@@ -1,4 +1,5 @@
 module.exports = `
   SELECT distinct(\${field})
   FROM \${table}
+  WHERE true \${filter}
   ORDER BY \${field};`


### PR DESCRIPTION
The distinct values query template should allow for a SQL filter.

In order for the SQL filter to be created in the query module the layer and locale key params must be provided with the query request.

The filter module has been altered to provide the locale, layer, and current filter (json) params.