### PR TITLE
fixed some svg icons not appearing due to invalid css rules

### DIFF
--- a/lib/ui/elements/legendIcon.mjs
+++ b/lib/ui/elements/legendIcon.mjs
@@ -10,7 +10,7 @@ export default (params) => {
       //? `url(${params.icon[0].svg || params.icon[0].url || mapp.utils.svgSymbols[params.icon[0].type](params.icon[0])})`
 
       ? params.icon
-          .map(icon => `url(${icon.svg || icon.url || mapp.utils.svgSymbols[icon.type](icon)})`)
+          .map(icon => `url("${icon.svg || icon.url || mapp.utils.svgSymbols[icon.type](icon)}")`)
           .reverse()
           .join(',')
 

--- a/lib/utils/svgSymbols.mjs
+++ b/lib/utils/svgSymbols.mjs
@@ -212,5 +212,5 @@ export function template(icon) {
   }
 
   // Return encoded string.
-  return `"data:image/svg+xml,${encodeURIComponent(svgString)}"`;
+  return `data:image/svg+xml,${encodeURIComponent(svgString)}`;
 }


### PR DESCRIPTION
Some legend icons were not appearing due to rendering of invalid background-image rules. Wrapping the rule in double quotes fixes this.