### PR TITLE
Fix pixelRatio for maplibre canvas

### DIFF
--- a/lib/layer/format/maplibre.mjs
+++ b/lib/layer/format/maplibre.mjs
@@ -47,6 +47,7 @@ export default async layer => {
 
   layer.Map = await MaplibreGL({
     container: layer.container,
+    pixelRatio: 1,
     style: layer.style.URL,
     attributionControl: false,
     boxZoom: false,


### PR DESCRIPTION
By the default the maplibre canvas uses the window.devicePixelRatio. Setting zoom in the browser will affect this value. Zoom to 150% and the devicePixelRatio will be 1.5.

A higher devicePixelRatio can cause the maplibre library to request 2x scaled sprites from the mapbox style api.

e.g. https://api.mapbox.com/styles/v1/dbauszus/cl9795mb900gk14nr88zfoitd/dj4mvp5w7em8guvohio4r8vkg@2x/sprite.png?access_token=token

These sheets are not available.

Forcing the pixelRatio for the maplibre canvas to 1 will not request scaled sprites.
