### PR TITLE
changed legend switch all button behaviour

### DIFF
--- a/lib/ui/layers/legends/categorized.mjs
+++ b/lib/ui/layers/legends/categorized.mjs
@@ -30,9 +30,16 @@ export default (layer) => {
           class="primary-colour bold"
           onclick=${e => {
 
-            let switches = e.target.closest('.legend').querySelectorAll('.switch')
+            let allSwitches = [...e.target.closest('.legend').querySelectorAll('.switch')];
+            let disabledSwitches = allSwitches.filter((switch_) => switch_.classList.contains("disabled"));
 
-            switches.forEach(_switch => _switch.click())
+            if (disabledSwitches.length == 0 || disabledSwitches.length == allSwitches.length) {
+              // if all switches are either enabled or disabled, click on all 
+              allSwitches.forEach(switch_ => switch_.click());
+            } else {
+              // if only some of them are enabled, click only on disabled ones
+              disabledSwitches.forEach(switch_ => switch_.click());
+            }
 
           }}
         >


### PR DESCRIPTION
With this change, the "switch all" button in the categorized legend will:
- Enable all items if all are disabled,
- Enable all items if only some items are enabled,
- Disable all items if all are enabled.