### PR TITLE
provide a custom valchange method on entry

### DIFF
--- a/lib/ui/locations/view.mjs
+++ b/lib/ui/locations/view.mjs
@@ -190,6 +190,12 @@ export default location => {
   // Add listener for custom valChange event.
   location.view.addEventListener('valChange', e => {
 
+    if (e.detail.valChangeMethod instanceof Function) {
+
+      e.detail.valChangeMethod(e.detail)
+      return;
+    }
+
     // entry object is provided as event detail.
     if (e.detail.value != e.detail.newValue) {
 


### PR DESCRIPTION
The custom valchange method allows to shortcircuit the valchange event method of the location.view node.

This will allow for plugins to run an immediate update query or other methods on valchange, for example in a dropdown.