### PR TITLE
Sanitise remote_address

### DIFF
--- a/mod/templates/mails.js
+++ b/mod/templates/mails.js
@@ -4,42 +4,42 @@ module.exports = {
       subject: `Please verify your password reset for \${host}`,
       text: `A new password has been set for this account.
       Please verify that you are the account holder: \${link}
-      The reset occured from this remote address \${address}
+      The reset occured from this remote address \${remote_address}
       This wasn't you? Please let your manager know.`
     },
     fr: {
     	subject: `Vérifiez votre mot de passe réinitialisé sur \${host}.`,
     	text: `Le nouveau mot de passe a été défini pour ce compte.
     	Vérifiez que vous disposez des droits d'accès du compte \${link}
-    	La réinitialisation a été exécutée par \${address}
+    	La réinitialisation a été exécutée par \${remote_address}
     	Vous ne l’avez pas demandé? Veuillez informer votre directeur.`
     },
     pl: {
       subject: `Zweryfikuj nowe hasło \${host}.`,
       text: `Dla tego konta ustawiono nowe hasło.
       Potwierdź swoje prawa dostępu do \${link}
-      Proces zmiany hasła rozpoczęto z tego adresu \${address}
+      Proces zmiany hasła rozpoczęto z tego adresu \${remote_address}
       To nie Ty? Zgłoś to osobie odpowiedzialnej.`
     },
     ja: {
     	subject: `リセットするパスワードを検証してください \${host}`,
     	text: `このアカウントに新規パスワードが設定されました.
       アカウントホールダーであることを検証してください \${link}
-      このリモートアドレスによりリセットがされました \${address}
+      このリモートアドレスによりリセットがされました \${remote_address}
       あなたではなかった場合、マネージャーに連絡をして下さい`
     },
     ko: {
       subject: `비밀번호 재설정을 확인해주십시오. \${host}`,
       text: `이 계정의 새로운 비밀번호가 설정되었습니다.
       계정 소유자임을 확인해주십시오. \${link}
-      기기의 고유주소로부터 재설정이 되었습니다. \${address}
+      기기의 고유주소로부터 재설정이 되었습니다. \${remote_address}
       본인이 아니면 담당매니저에게 알려주십시오.`
     },
     zh: {
       subject: `请验证您的密码重置 \${host}`,
       text: `为此帐户设置了新密码
       请确认您是帐户持有人 \${link}
-      账户重置发生于远程地址 \${address}
+      账户重置发生于远程地址 \${remote_address}
       如果这不是您本人的操作，请告知您的相关负责人`
     }
   },

--- a/mod/user/login.js
+++ b/mod/user/login.js
@@ -84,6 +84,8 @@ async function view(req, res, message) {
 
 async function post(req, res) {
 
+  const remote_address = /^[A-Za-z0-9.,_-\s]*$/.test(req.headers['x-forwarded-for']) ? req.headers['x-forwarded-for'] : 'unknown';
+
   if(!req.body.email) return new Error(await templates('missing_email', req.params.language))
   
   if(!req.body.password) return new Error(await templates('missing_password', req.params.language))
@@ -97,7 +99,7 @@ async function post(req, res) {
   // Update access_log and return user record matched by email.
   var rows = await acl(`
     UPDATE acl_schema.acl_table
-    SET access_log = array_append(access_log, '${date.toISOString().replace(/\..*/,'')}@${req.headers['x-forwarded-for'] || 'localhost'}')
+    SET access_log = array_append(access_log, '${date.toISOString().replace(/\..*/,'')}@${remote_address}')
     WHERE lower(email) = lower($1)
     RETURNING email, roles, language, blocked, approved, approved_by, verified, admin, password;`,
     [req.body.email])
@@ -153,7 +155,7 @@ async function post(req, res) {
     var mail_template = await templates('failed_login', user.language, {
       host: host,
       protocol: protocol,
-      remote_address: `${req.headers['x-forwarded-for'] || 'localhost'}`
+      remote_address
     })
   
     await mailer(Object.assign(mail_template, {
@@ -224,7 +226,7 @@ async function post(req, res) {
       failed_attempts: parseInt(process.env.FAILED_ATTEMPTS) || 3,
       protocol: protocol,
       verificationtoken: verificationtoken,
-      remote_address: `${req.headers['x-forwarded-for'] || 'localhost'}`
+      remote_address
     })
   
     await mailer(Object.assign(mail_template, {
@@ -237,7 +239,7 @@ async function post(req, res) {
   // Login has failed but account is not locked (yet).
   var mail_template = await templates('login_incorrect', user.language, {
     host: host,
-    remote_address: `${req.headers['x-forwarded-for'] || 'localhost'}`
+    remote_address
   })
 
   await mailer(Object.assign(mail_template, {

--- a/mod/user/login.js
+++ b/mod/user/login.js
@@ -84,7 +84,9 @@ async function view(req, res, message) {
 
 async function post(req, res) {
 
-  const remote_address = /^[A-Za-z0-9.,_-\s]*$/.test(req.headers['x-forwarded-for']) ? req.headers['x-forwarded-for'] : 'unknown';
+  const remote_address = req.headers['x-forwarded-for']
+    && /^[A-Za-z0-9.,_-\s]*$/.test(req.headers['x-forwarded-for']) ? req.headers['x-forwarded-for'] : 'invalid'
+    || 'unknown';
 
   if(!req.body.email) return new Error(await templates('missing_email', req.params.language))
   

--- a/mod/user/register.js
+++ b/mod/user/register.js
@@ -34,7 +34,9 @@ async function view(req, res) {
 
 async function post(req, res) {
 
-  const remote_address = /^[A-Za-z0-9.,_-\s]*$/.test(req.headers['x-forwarded-for']) ? req.headers['x-forwarded-for'] : 'unknown';
+  const remote_address = req.headers['x-forwarded-for']
+    && /^[A-Za-z0-9.,_-\s]*$/.test(req.headers['x-forwarded-for']) ? req.headers['x-forwarded-for'] : 'invalid'
+    || 'unknown';
 
   if (!req.body.email) return res.status(400).send('No email provided')
 

--- a/mod/user/register.js
+++ b/mod/user/register.js
@@ -34,6 +34,8 @@ async function view(req, res) {
 
 async function post(req, res) {
 
+  const remote_address = /^[A-Za-z0-9.,_-\s]*$/.test(req.headers['x-forwarded-for']) ? req.headers['x-forwarded-for'] : 'unknown';
+
   if (!req.body.email) return res.status(400).send('No email provided')
 
   // Test email address
@@ -106,7 +108,7 @@ async function post(req, res) {
       UPDATE acl_schema.acl_table SET
         password_reset = '${password}',
         verificationtoken = '${verificationtoken}',
-        access_log = array_append(access_log, '${date}@${req.headers['x-forwarded-for'] || 'localhost'}')
+        access_log = array_append(access_log, '${date}@${remote_address}')
       WHERE lower(email) = lower($1);`,
       [req.body.email])
 
@@ -116,7 +118,7 @@ async function post(req, res) {
     var mail_template = await templates('verify_password_reset', user.language, {
       host: host,
       link: `${protocol}${host}/api/user/verify/${verificationtoken}`,
-      address: req.headers['x-forwarded-for'] || 'localhost',
+      remote_address
     })
     
     await mailer(Object.assign(mail_template, {
@@ -149,7 +151,7 @@ async function post(req, res) {
   var mail_template = await templates('verify_account', req.body.language, {
     host: host,
     link: `${protocol}${host}/api/user/verify/${verificationtoken}`,
-    remote_address: req.headers['x-forwarded-for'] || 'localhost',
+    remote_address
   })
 
   await mailer(Object.assign(mail_template, {

--- a/tests/mod/user/remote_address.js
+++ b/tests/mod/user/remote_address.js
@@ -1,0 +1,7 @@
+function extractRemoteAddress(req) {
+    return /^[A-Za-z0-9.,_-\s]*$/.test(req.headers['x-forwarded-for']) 
+      ? req.headers['x-forwarded-for'] 
+      : 'unknown';
+  }
+  
+  module.exports = extractRemoteAddress;

--- a/tests/mod/user/remote_address.js
+++ b/tests/mod/user/remote_address.js
@@ -1,3 +1,6 @@
+//This function is to replicate the remote address regex expression on line 87 of mod/user/login.js 
+// & line 37 of mod/user/register.js
+
 function extractRemoteAddress(req) {
     return /^[A-Za-z0-9.,_-\s]*$/.test(req.headers['x-forwarded-for']) 
       ? req.headers['x-forwarded-for'] 

--- a/tests/mod/user/remote_address.js
+++ b/tests/mod/user/remote_address.js
@@ -2,9 +2,9 @@
 // & line 37 of mod/user/register.js
 
 function extractRemoteAddress(req) {
-    return /^[A-Za-z0-9.,_-\s]*$/.test(req.headers['x-forwarded-for']) 
-      ? req.headers['x-forwarded-for'] 
-      : 'unknown';
+    return req.headers['x-forwarded-for']
+    && /^[A-Za-z0-9.,_-\s]*$/.test(req.headers['x-forwarded-for']) ? req.headers['x-forwarded-for'] : 'invalid'
+    || 'unknown';
   }
   
   module.exports = extractRemoteAddress;

--- a/tests/mod/user/remote_address.test.js
+++ b/tests/mod/user/remote_address.test.js
@@ -1,0 +1,38 @@
+const extractRemoteAddress = require('./remote_address');
+
+describe('extractRemoteAddress', () => {
+  
+  it('should return the x-forwarded-for header if it is valid', () => {
+    const mockReq = {
+      headers: {
+        'x-forwarded-for': '192.168.0.1, 172.16.0.1'
+      }
+    };
+
+    const result = extractRemoteAddress(mockReq);
+
+    expect(result).toEqual('192.168.0.1, 172.16.0.1');
+  });
+
+  it('should return "unknown" if the x-forwarded-for header is invalid', () => {
+    const mockReq = {
+      headers: {
+        'x-forwarded-for': 'invalid#header'
+      }
+    };
+
+    const result = extractRemoteAddress(mockReq);
+
+    expect(result).toEqual('unknown');
+  });
+
+  it('should return "unknown" if the x-forwarded-for header is not present', () => {
+    const mockReq = {
+      headers: {}
+    };
+
+    const result = extractRemoteAddress(mockReq);
+
+    expect(result).toEqual('unknown');
+  });
+});

--- a/tests/mod/user/remote_address.test.js
+++ b/tests/mod/user/remote_address.test.js
@@ -14,7 +14,7 @@ describe('extractRemoteAddress', () => {
     expect(result).toEqual('192.168.0.1, 172.16.0.1');
   });
 
-  it('should return "unknown" if the x-forwarded-for header is invalid', () => {
+  it('should return "invalid" if the x-forwarded-for header is invalid', () => {
     const mockReq = {
       headers: {
         'x-forwarded-for': 'invalid#header'
@@ -23,16 +23,16 @@ describe('extractRemoteAddress', () => {
 
     const result = extractRemoteAddress(mockReq);
 
-    expect(result).toEqual('unknown');
+    expect(result).toEqual('invalid');
   });
 
-  it('should return "unknown" if the x-forwarded-for header is not present', () => {
+  it('should return "invalid" if the x-forwarded-for header is not present', () => {
     const mockReq = {
       headers: {}
     };
 
     const result = extractRemoteAddress(mockReq);
 
-    expect(result).toEqual('unknown');
+    expect(result).toEqual('invalid');
   });
 });


### PR DESCRIPTION
I order to prevent a database query being built from uncontrolled user input it is necessary to sanitise the remote_address from x-forwarded-for header.

The x-forwarded-for header can be spoofed. Prior to storing the value in the ACL a test against whitelisted characters must be made.