### PR TITLE
disable mongodb require in cache module

### DIFF
--- a/mod/workspace/cache.js
+++ b/mod/workspace/cache.js
@@ -2,7 +2,7 @@ const file = require('../provider/file')
 
 const cloudfront = require('../provider/cloudfront')
 
-const mongodb = require('../provider/mongodb')
+//const mongodb = require('../provider/mongodb')
 
 const http = require('./httpsAgent')
 
@@ -10,7 +10,7 @@ const getFrom = {
   'https': ref => http(ref),
   'file': ref => file(ref.split(/:(.*)/s)[1]),
   'cloudfront': ref => cloudfront(ref.split(/:(.*)/s)[1]),
-  'mongodb': ref => mongodb(JSON.parse(ref.split(/:(.*)/s)[1]))
+  //'mongodb': ref => mongodb(JSON.parse(ref.split(/:(.*)/s)[1]))
 }
 
 const assignTemplates = require('./assignTemplates')


### PR DESCRIPTION
The mongodb, as well as cloudfront porvider should be dynamically loaded when required.