### PR TITLE
Allow for cluster layer to fade between change:resolution event and render.

### DIFF
--- a/lib/layer/format/cluster.mjs
+++ b/lib/layer/format/cluster.mjs
@@ -1,3 +1,5 @@
+import { ListBucketAnalyticsConfigurationsCommand } from "@aws-sdk/client-s3"
+
 export default layer => {
 
   layer.highlight = true
@@ -16,7 +18,9 @@ export default layer => {
   // If legacy cluster properties are set, provide warning to update. 
   if (layer.cluster_label || layer.cluster_kmeans || layer.cluster_dbscan || layer.cluster_resolution || layer.cluster_hexgrid) {
     console.warn(`Layer ${layer.key} is using legacy cluster properties. Please update to use cluster:{} config object.`)
-  }  
+  }
+
+  let timeout
 
   function loader () {
 
@@ -85,6 +89,34 @@ export default layer => {
         useSpatialIndex: false,
         features: features,
       }))
+
+      // Initiate fadein after source with features is set.
+      if (layer.cluster.fade) {
+
+        // Will also clear fadeout sequence if still in process.
+        clearTimeout(timeout)
+ 
+        function fadeIn() {
+
+          clearTimeout(timeout)
+
+          // Get current opacity.
+          let o = layer.L.getOpacity()
+
+          // End fadein process when opacity equals or exceeds 1.
+          if (o >= 1) return;
+
+          // Increase opacity by 20%.
+          layer.L.setOpacity(o+0.2)
+
+          // Continue fadein process after timeout delay.
+          timeout = setTimeout(fadeIn, layer.cluster.fade)
+        }
+    
+        // Begin fadein.
+        timeout = setTimeout(fadeIn, layer.cluster.fade)
+      }
+
     }
 
     layer.xhr.send()
@@ -97,15 +129,34 @@ export default layer => {
     style: mapp.layer.Style(layer)
   })
 
-  if (layer.debug) {
+  if (layer.cluster.fade) {
 
-    layer.L.on('prerender',()=>{
-      console.log(`${layer.key} - prerender ${layer.renderCount++}`)
-    })
-  
-    layer.L.on('postrender',()=>{
-      console.log(`${layer.key} - postrender ${layer.renderCount++}`)
-    })
+    // Set fade to 50ms delay.
+    layer.cluster.fade = parseInt(layer.cluster.fade) || 50
+
+    layer.mapview.Map.getView().on('change:resolution', () => {
+
+      // Initiate fadeout after zoom change event.
+      timeout = setTimeout(fadeOut, layer.cluster.fade)
+    });
+  }
+
+  function fadeOut() {
+
+    // Clear current fade process.
+    clearTimeout(timeout)
+
+    // Get current opacity.
+    let o = layer.L.getOpacity()
+
+    // Layer has an opacity of 0 or below. Ends fade sequence.
+    if (o <= 0) return;
+
+    // Opacity will be reduced by 20% on every fade delay step.
+    layer.L.setOpacity(o - 0.2)
+
+    // Continue fade sequence after timeout delay.
+    timeout = setTimeout(fadeOut, layer.cluster.fade)
   }
 
   layer.mapview.Map.getTargetElement().addEventListener('changeEnd', loader)


### PR DESCRIPTION
Setting the `layer.cluster.fade` flag will fadeout the layer by 20% with a 50ms interval.

Once data is loaded and features are assigned to the layer source the layer opacity is faded in by 20% with a 50ms interval.

The interval length can be controlled by setting the ms as the `layer.cluster.fade` value.