### PR TITLE
make cluster label for wkt optional

### DIFF
--- a/lib/layer/format/wkt.mjs
+++ b/lib/layer/format/wkt.mjs
@@ -56,11 +56,11 @@ export default layer => {
           })
 
           // Geojson is a cluster layer.
-          if (layer.cluster) {
+          if (layer.cluster?.distance > 1) {
 
             // Create cluster source.
             layer.cluster.source = new ol.source.Cluster({
-              distance: layer.cluster.distance || 50,
+              distance: layer.cluster.distance,
               source
             })
 
@@ -86,7 +86,9 @@ export default layer => {
 
     delete layer.max_size;
 
-    const feature_counts = layer.cluster.source.getFeatures().map(F => {
+    if (layer.cluster?.distance === 1) return;
+
+    const feature_counts = layer.cluster.source?.getFeatures().map(F => {
 
       const features = F.get('features')
 

--- a/mod/layer/wkt.js
+++ b/mod/layer/wkt.js
@@ -40,7 +40,7 @@ module.exports = async (req, res) => {
     SELECT
       ${layer.qID || null},
       ST_AsText(${geom})
-      ${fields.length && `, ${fields.join(', ')}` || ''}
+      ${fields && `, ${fields.join(', ')}` || ''}
 
     FROM ${req.params.table || layer.table}
     WHERE ${geom} IS NOT NULL ${filter};`


### PR DESCRIPTION
The WKT cluster should not require a label. The ID will be used instead.