### PR TITLE
merge infoj entry roles object

### DIFF
--- a/lib/layer/decorate.mjs
+++ b/lib/layer/decorate.mjs
@@ -82,6 +82,24 @@ export default async layer => {
       || layer.style.themes[Object.keys(layer.style.themes)[0]];      
   }
 
+  // Adjust infoj entries for user roles.
+  // Check whether the layer has an infoj array and the user object has a roles array.
+  if (Array.isArray(layer.infoj) && Array.isArray(mapp.user?.roles)) {
+
+    layer.infoj.forEach(entry => {
+
+      // The layer has a roles object and a role key is included in the user roles array.
+      if (entry.roles) {
+
+        // Find the first role key from the entry which is included in the mapp.user.roles
+        const role = Object.keys(entry.roles).find(role => mapp.user.roles.includes(role))
+  
+        // Assign the entry.roles object for the matched user role to the entry object.
+        role && mapp.utils.merge(entry, entry.roles[role])
+      }
+    })
+  }
+
   // Call layer and/or plugin methods.
   Object.keys(layer).forEach((key) => {
 

--- a/mod/utils/roles.js
+++ b/mod/utils/roles.js
@@ -43,6 +43,7 @@ async function reduce(obj, roles) {
   (function objectEval(o, parent, key) {
 
     if (!check(o, roles)) {
+
       // if the parent is an array splice the key index.
       if (parent.length > 0) return parent.splice(parseInt(key), 1)
 
@@ -52,6 +53,10 @@ async function reduce(obj, roles) {
 
     // iterate through the object tree.
     Object.keys(o).forEach((key) => {
+
+      // Do not remove infoj entries.
+      if (key === 'infoj') return;
+
       if (o[key] && typeof o[key] === 'object') objectEval(o[key], o, key)
     });
 


### PR DESCRIPTION
It should be possible to alter an infoj entry based on the user roles.

Adding a roles object to any infoj entry will ensure that this role is returned to the admin console and can be assigned to a user.

Layer will be decorated once. The mapp.user.roles array will be available at this stage.

We can iterate through the role keys in the entry.roles object and merge the object value for the first key which is included in the user.roles array with the entry object.

In this example only the user with the edit_notes role will be able to edit this entry.

```js
{
"title": "note_1",
"field": "note_1",
"type": "textarea",
"roles": {
 "edit_notes": {
  "edit": true
  }
 }
}
```
