### PR TITLE
prevent prototype polluting assignment in template module.

### DIFF
--- a/mod/templates/_templates.js
+++ b/mod/templates/_templates.js
@@ -97,7 +97,6 @@ module.exports = async (key, language = 'en', params = {}) => {
 
     // Template key / value is a string with a valid get method.
     if (typeof template[key] === 'string'
-      && Object.hasOwn(template, key)
       && Object.hasOwn(getFrom, template[key].split(':')[0])) {
 
       // Assign template key value from method.


### PR DESCRIPTION
A template loaded from a template method maybe of type string or object.

The check for string should come first.

The method should return if the type is not object after the check for the template being a string.

Thereafter the object prototype must be frozen to prevent an object prototype polluting assignment.

The template object keys must be checked whether they should load a nested template.

Replace substitute params if the template key value is type string.
