### PR TITLE
Set path as / if not defined in DIR env

### DIFF
--- a/api/api.js
+++ b/api/api.js
@@ -119,7 +119,7 @@ module.exports = async (req, res) => {
     res.setHeader('Set-Cookie', `${process.env.TITLE}=null;HttpOnly;Max-Age=0;Path=${process.env.DIR || '/'}`)
 
     // Remove logout parameter.
-    res.setHeader('location', `${process.env.DIR}`)
+    res.setHeader('location', `${process.env.DIR || '/'}`)
 
     return res.status(302).send()
   }


### PR DESCRIPTION
The logout api redirect the location to the path defined as DIR environment variable.

This fails if undefined.

In that case the location should be redirected to '/'