### PR TITLE
fixed gazetteer error when datasets layer is missing in mapview 

### DIFF
--- a/lib/utils/gazetteer.mjs
+++ b/lib/utils/gazetteer.mjs
@@ -4,6 +4,11 @@ export function datasets(term, gazetteer) {
 
         let layer = gazetteer.mapview.layers[gazetteer.layer || dataset.layer]
 
+        // Skip if layer defined in datasets is not added to the mapview
+        if (!layer) {
+            return;
+        }
+
         // Abort current dataset query. Onload will not be called.
         dataset.xhr?.abort()
 


### PR DESCRIPTION
Fixed the gazetteer error when a layer defined in datasets caused an error on input if same layer was not added to the mapview.