### PR TITLE
Multiple execution of infoj process from updateCallbacks array

### DIFF
--- a/lib/ui/locations/view.mjs
+++ b/lib/ui/locations/view.mjs
@@ -76,31 +76,25 @@ export default location => {
     // Remove edit from infoj entries
     function removeEdits(){
 
-      location.infoj.forEach(entry => {
+      // Iterate through the location.infoj entries.
+      location.infoj
 
-        // Remove newValue
-        delete entry.newValue
+        // Filter entries which have an edit key.
+        .filter(entry => typeof entry.edit !== 'undefined')
+        .forEach(entry => {
 
-        if (!entry.edit) return;
-  
-        entry._edit = entry.edit
-        delete entry.edit
-      })
+          // Remove newValue
+          // Unsaved edits will be lost.
+          delete entry.newValue
+
+          // Change edit key to _edit
+          entry._edit = entry.edit
+          delete entry.edit
+        })
     }
 
     // New locations should be editable.
     !location.new && removeEdits()
-
-    // After location update...
-    location.updateCallbacks.push(()=>{
-
-      // Remove on class from toggle.
-      editToggle.classList.remove('on')
-      removeEdits()
-      infoj.remove()
-      infoj = mapp.ui.locations.infoj(location)
-      location.view.appendChild(infoj)
-    })
 
     const editToggle = mapp.utils.html.node`
       <button
@@ -114,7 +108,7 @@ export default location => {
             // Remove on class from button.
             e.target.classList.remove('on')
 
-            // Remove edits from infoj.
+            // Remove edits from infoj entries.
             removeEdits()
 
           } else {
@@ -133,14 +127,25 @@ export default location => {
 
           }
 
-          infoj.remove()
+          // Remove location.viewEntries
+          location.viewEntries.remove()
         
-          infoj = mapp.ui.locations.infoj(location)
-      
-          location.view.appendChild(infoj)
+          // Recreate location.viewEntries
+          location.viewEntries = location.view.appendChild(mapp.ui.locations.infoj(location))
+          
         }}>`
 
     header.push(editToggle)
+
+    // After location update...
+    location.updateCallbacks.push(() => {
+
+      // Remove on class from toggle.
+      editToggle.classList.remove('on')
+
+      // Remove edits from infoj entries.
+      removeEdits()
+    })
   }
 
   // Update icon.
@@ -181,9 +186,7 @@ export default location => {
     header: header
   })
 
-  let infoj = location.view.appendChild(mapp.ui.locations.infoj(location))
-
-  //location.view.dispatchEvent(new CustomEvent('appendInfoj'))
+  location.viewEntries = location.view.appendChild(mapp.ui.locations.infoj(location))
 
   location.view.querySelector('.header').style.borderBottom = `3px solid ${location.record.colour}`
 
@@ -219,14 +222,16 @@ export default location => {
 
   location.view.addEventListener('updateInfo', ()=>{
 
-    infoj.remove()
+    // Remove location.viewEntries.
+    location.viewEntries.remove()
 
+    // Hides the upload icon.
     location.view.querySelector('.cloud-upload').style.display = 'none'
 
+    // Enables the location view node and child elements.
     location.view.classList.remove('disabled')
 
-    infoj = mapp.ui.locations.infoj(location)
-
-    location.view.appendChild(infoj)
+    // Recreate location.viewEntries.
+    location.viewEntries = location.view.appendChild(mapp.ui.locations.infoj(location))
   })
 }


### PR DESCRIPTION
The infoj variable defined locally with let in the location view method has been renamed to location.viewEntries to better reflect the nature of the variable.

We prefer variables to be assigned to an object rather than being declared in the closure of a function.

Locations where the layer is flagged to toggle edits assigned an updateCallback method which would recreate the location.viewEntries. This caused the location.viewEntries to be created twice in quick succession. Once from the location.update method which calls the `updateInfo` event, and once from the callback method assigned to remove edits when toggled.