### PR TITLE
Check whether entries are editable for toggle condition

### DIFF
--- a/lib/ui/locations/view.mjs
+++ b/lib/ui/locations/view.mjs
@@ -71,7 +71,7 @@ export default location => {
       }}>`)
 
   // Edit icon.
-  if (location.layer?.toggleLocationViewEdits) {
+  if (location.layer?.toggleLocationViewEdits && location.infoj.some(entry => typeof entry.edit !== 'undefined')) {
 
     // Remove edit from infoj entries
     function removeEdits(){


### PR DESCRIPTION
The toggle location view edits button should only be added to the location view header if there are editable entries.

Edit roles maybe assigned by roles when the layer is decorated. In that case the toggle button might be shown but no entry is actually editable.