### PR TITLE
Fix for persistent mvt_clone entry layer.

### DIFF
--- a/lib/ui/layers/panels/style.mjs
+++ b/lib/ui/layers/panels/style.mjs
@@ -116,13 +116,11 @@ export default layer => {
       layer.mapview.Map.getTargetElement().addEventListener('changeEnd', () => {
         const z = layer.mapview.Map.getView().getZoom();
 
-        const chkBox = layer.view.querySelector('[data-id=labelCheckbox]')
-
         if (z <= layer.style.label.minZoom || z >= layer.style.label.maxZoom) {
-          return chkBox.classList.add('disabled');
+          return labelCheckbox.classList.add('disabled');
         }
 
-        chkBox.classList.remove('disabled');
+        labelCheckbox.classList.remove('disabled');
       });
     }
 

--- a/lib/ui/locations/entries/mvt_clone.mjs
+++ b/lib/ui/locations/entries/mvt_clone.mjs
@@ -1,5 +1,9 @@
 export default entry => {
 
+  // The entry has already been processed.
+  // There is an entry.panel to be rendered into the entry.node.
+  if (entry.panel) return entry.panel;
+
   // Assign mapview to entry to provide shortened lookup.
   entry.mapview = entry.location.layer.mapview
 
@@ -29,8 +33,8 @@ export default entry => {
 
   if (entry.style.themes) {
 
-    // Assign the first theme in themes object as theme.
-    entry.style.theme = entry.style.themes[Object.keys(entry.style.themes)[0]]
+    // Assign the first theme from themes if undefined.
+    entry.style.theme ||= entry.style.themes[Object.keys(entry.style.themes)[0]]
   }
 
   // Assign method to show the clone layer.
@@ -63,7 +67,7 @@ export default entry => {
     if (entry.featureLookup === null) {
 
       // Disable the chkbox input.
-      node.querySelector('input').disabled = true
+      entry.panel.querySelector('input').disabled = true
 
       // The entry.view will not be created.
       return;
@@ -71,7 +75,7 @@ export default entry => {
 
     // Create a style panel as entry.view and append to entry.node.
     entry.view = mapp.ui.layers.panels.style(entry)
-    entry.view && entry.node.append(entry.view)
+    entry.view && entry.panel.append(entry.view)
     
     // Add the clone layer to the mapview.Map.
     entry.mapview.Map.addLayer(entry.L)
@@ -113,7 +117,7 @@ export default entry => {
   entry.display && entry.show()
 
   // Create a node consistent of the chkbox and the style drawer.
-  const node = mapp.utils.html.node`<div>${chkbox}`
+  entry.panel = mapp.utils.html.node`<div>${chkbox}`
 
   // Disable chkbox if layer is out of zoom range
   function chkZoom() {
@@ -129,7 +133,7 @@ export default entry => {
     if (entry.Layer.tableCurrent() === null) {
 
       // Disable checkbox.
-      node.querySelector('input').disabled = true
+      entry.panel.querySelector('input').disabled = true
 
       // Hide style drawer if present.
       if (entry.view) entry.view.style.display = 'none'
@@ -141,7 +145,7 @@ export default entry => {
     }
 
     // Enable checkbox.
-    node.querySelector('input').disabled = false
+    entry.panel.querySelector('input').disabled = false
 
     // Display style drawer if present.
     if (entry.view) entry.view.style.display = 'block'
@@ -170,5 +174,5 @@ export default entry => {
   })
 
   // Return the node to the location view.
-  return node
+  return entry.panel
 }

--- a/lib/ui/locations/entries/mvt_clone.mjs
+++ b/lib/ui/locations/entries/mvt_clone.mjs
@@ -45,7 +45,7 @@ export default entry => {
     // The OL clone layer already exists.
     if (entry.L && entry.featureLookup) {
 
-      if (entry.view) entry.view.style.display = 'block'
+      if (entry.style.panel) entry.style.panel.style.display = 'block'
 
       try {
         entry.mapview.Map.addLayer(entry.L)
@@ -69,13 +69,13 @@ export default entry => {
       // Disable the chkbox input.
       entry.panel.querySelector('input').disabled = true
 
-      // The entry.view will not be created.
+      // The entry.style.panel will not be created.
       return;
     }
 
-    // Create a style panel as entry.view and append to entry.node.
-    entry.view = mapp.ui.layers.panels.style(entry)
-    entry.view && entry.panel.append(entry.view)
+    // Create a style panel as entry.style.panel and append to entry.node.
+    entry.style.panel = mapp.ui.layers.panels.style(entry)
+    entry.style.panel && entry.panel.append(entry.style.panel)
     
     // Add the clone layer to the mapview.Map.
     entry.mapview.Map.addLayer(entry.L)
@@ -94,7 +94,7 @@ export default entry => {
     entry.display = false
 
     // Hide the style drawer.
-    if (entry.view) entry.view.style.display = 'none'
+    if (entry.style.panel) entry.style.panel.style.display = 'none'
 
     // Remove the geometry layer from map.
     entry.mapview.Map.removeLayer(entry.L)
@@ -136,7 +136,7 @@ export default entry => {
       entry.panel.querySelector('input').disabled = true
 
       // Hide style drawer if present.
-      if (entry.view) entry.view.style.display = 'none'
+      if (entry.style.panel) entry.style.panel.style.display = 'none'
 
       // Remove clone layer if present in set but should not be displayed.
       !entry.display && entry.mapview.Map.removeLayer(entry.L)
@@ -148,7 +148,7 @@ export default entry => {
     entry.panel.querySelector('input').disabled = false
 
     // Display style drawer if present.
-    if (entry.view) entry.view.style.display = 'block'
+    if (entry.style.panel) entry.style.panel.style.display = 'block'
 
     // Try to add entry.L to mapview.Map
     try {


### PR DESCRIPTION
This PR addresses two issues with the mvt_clone entry.

No entry method should re-process unless necessary.

The node variable to hold the entry panel elements to be return to the entry.node was misleading.

The panel node/elements are now constructed as entry.panel.

If the entry.panel exists it will be returned to the entry.node. Meaning the entry.panel and all associated properties of the entry persist during a location [view] update.