### PR TITLE
Placeholders for Text, Textarea and Numeric

### DIFF
--- a/lib/ui/locations/entries/numeric.mjs
+++ b/lib/ui/locations/entries/numeric.mjs
@@ -29,6 +29,7 @@ export default entry => {
       <input
         type="number"
         value="${entry.value || ''}"
+        placeholder="${entry.edit.placeholder || ''}"
         onkeyup=${e => {
 
           // Prevent a float value being sent to an integer field.

--- a/lib/ui/locations/entries/text.mjs
+++ b/lib/ui/locations/entries/text.mjs
@@ -27,6 +27,7 @@ export default entry => {
       <input
         type="text"
         value="${entry.value || ''}"
+        placeholder="${entry.edit.placeholder || ''}"
         onkeyup=${e => {
           entry.newValue = e.target.value
           entry.location.view?.dispatchEvent(

--- a/lib/ui/locations/entries/textarea.mjs
+++ b/lib/ui/locations/entries/textarea.mjs
@@ -16,6 +16,7 @@ export default entry => {
     val = mapp.utils.html`
     <textarea
       style="auto; min-height: 50px;"
+      placeholder="${entry.edit.placeholder || ''}"
       onfocus=${e => {
         e.target.style.height = e.target.scrollHeight + 'px';
       }}


### PR DESCRIPTION
Much like the dropdown that allows for a placeholder, the format text, format textarea and format numeric should all allow for a placeholder on input to be provided