### PR TITLE
classList option for layer, layer-group, style, filter, and draw panels

### DIFF
--- a/lib/ui/layers/listview.mjs
+++ b/lib/ui/layers/listview.mjs
@@ -95,7 +95,7 @@ export default function (params){
 
     group.drawer = mapp.ui.elements.drawer({
       data_id: `layer-drawer`,
-      class: 'layer-group',
+      class: `layer-group ${layer.groupClassList || ''}`,
       header: mapp.utils.html`
         <h2>${layer.group}</h2>
         ${hideLayers}

--- a/lib/ui/layers/panels/draw.mjs
+++ b/lib/ui/layers/panels/draw.mjs
@@ -42,7 +42,7 @@ export default layer => {
 
   const panel = mapp.ui.elements.drawer({
     data_id: `draw-drawer`,
-    class: 'raised',
+    class: `raised ${layer.draw.classList || ''}`,
     header: mapp.utils.html`
       <h3>${mapp.dictionary.layer_add_new_location}</h3>
       <div class="mask-icon expander"></div>`,

--- a/lib/ui/layers/panels/filter.mjs
+++ b/lib/ui/layers/panels/filter.mjs
@@ -136,7 +136,7 @@ export default layer => {
 
   layer.filter.view = mapp.ui.elements.drawer({
     data_id: `filter-drawer`,
-    class: 'raised',
+    class: `raised ${layer.filter.classList || ''}`,
     header: mapp.utils.html`
       <h3>${mapp.dictionary.layer_filter_header}</h3>
       <div class="mask-icon expander"></div>`,

--- a/lib/ui/layers/panels/style.mjs
+++ b/lib/ui/layers/panels/style.mjs
@@ -196,7 +196,7 @@ export default layer => {
 
   layer.style.drawer = mapp.ui.elements.drawer({
     data_id: `style-drawer`,
-    class: 'raised',
+    class: `raised ${layer.style.classList || ''}`,
     header: mapp.utils.html`
       <h3>${mapp.dictionary.layer_style_header}</h3>
       <div class="mask-icon expander"></div>`,

--- a/lib/ui/layers/view.mjs
+++ b/lib/ui/layers/view.mjs
@@ -98,7 +98,7 @@ export default (layer) => {
     // Create layer drawer node.
     layer.drawer = mapp.ui.elements.drawer({
       data_id: `layer-drawer`,
-      class: `layer-view raised ${content.length ? '' : 'empty'}`,
+      class: `layer-view raised ${layer.classList || ''} ${content.length? '' : 'empty'}`,
       header: header,
       content: content
     })

--- a/lib/ui/locations/infoj.mjs
+++ b/lib/ui/locations/infoj.mjs
@@ -89,7 +89,7 @@ export default (location, infoj) => {
         if (entry.expanded) {
           console.warn('entry.expanded is deprecated. Use entry.groupClassList: "expanded" instead.')
           // Add to the string as this can have other classes.
-          entry.groupClassList+= 'expanded'
+          entry.groupClassList += ' expanded'
         }
 
         groups[entry.group] = entry.listview.appendChild(

--- a/lib/ui/locations/infoj.mjs
+++ b/lib/ui/locations/infoj.mjs
@@ -84,9 +84,16 @@ export default (location, infoj) => {
       // Create new group
       if (!groups[entry.group]) {
 
+        // If entry.expanded, then console warn to change this 
+        // As the configuration has changed
+        if (entry.expanded) {
+          console.warn('entry.expanded is deprecated. Use entry.groupClassList: "expanded" instead.')
+          entry.groupClassList = 'expanded'
+        }
+        
         groups[entry.group] = entry.listview.appendChild(
           mapp.ui.elements.drawer({
-            class: `group ${entry.expanded && 'expanded' || ''}`,
+            class: `group ${entry.groupClassList && 'expanded' || ''}`,
             header: mapp.utils.html`
               <h3>${entry.group}</h3>
               <div class="mask-icon expander"></div>`,

--- a/lib/ui/locations/infoj.mjs
+++ b/lib/ui/locations/infoj.mjs
@@ -88,9 +88,10 @@ export default (location, infoj) => {
         // As the configuration has changed
         if (entry.expanded) {
           console.warn('entry.expanded is deprecated. Use entry.groupClassList: "expanded" instead.')
-          entry.groupClassList = 'expanded'
+          // Add to the string as this can have other classes.
+          entry.groupClassList+= 'expanded'
         }
-        
+
         groups[entry.group] = entry.listview.appendChild(
           mapp.ui.elements.drawer({
             class: `group ${entry.groupClassList && 'expanded' || ''}`,


### PR DESCRIPTION
Adding `classList: "expanded"` to the layer config will add this classList to the layer view drawer.

Adding `groupClassList: "expanded"` to the layer config will add this classList to the layer group drawer.

Adding `classList: "expanded"` to either the style, filter, or draw config block will add this classList to the corresponding panel drawer.