### PR TITLE
Enable logger for DBS; Retire KEY_LOGFLARE

### DIFF
--- a/mod/utils/logger.js
+++ b/mod/utils/logger.js
@@ -19,7 +19,7 @@ module.exports = (log, key) => {
   if (!logs.has(key)) return;
 
   // Write log to logger if configured.
-  logger && logger(log, key)
+  logger?.(log, key);
 
   console.log(log)
 }

--- a/mod/workspace/assignTemplates.js
+++ b/mod/workspace/assignTemplates.js
@@ -150,7 +150,9 @@ module.exports = async (workspace) => {
       .then((arr) => {
 
         // Log set of template objects from resolved promises.
-        logger(arr, 'templates');
+        logger(arr
+          .filter(o => o.value instanceof Object)
+          .map(o => `${Object.keys(o.value)[0]} - ${o.status}`), 'templates');
 
         let assign = arr
           .filter(o => o.value instanceof Object)


### PR DESCRIPTION
The env `KEY_LOGFLARE` has been retired.

The configuration for the logger module will be done with the env `LOGGER`.

For logging to logflare the apikey and source must be defined in the `LOGGER` env.

```
"LOGGER": "logflare:apikey=***&source=***-***-***-***-***"
```

For logging to a PostgreSQL dbs the corresponding `DBS_*` env must be set.

The account for the dbs connection string must have write permission.

The table schema for logging in PostgreSQL must be like so:

```SQL
CREATE TABLE IF NOT EXISTS table_name
(
   process varchar,
   datetime bigint,
   key varchar,
   log text
);
```

The LOGGER env can be set like so:

```
"DBS_NEON": "postgresql://dbauszus-glx:***@ep-curly-base-242741.eu-central-1.aws.neon.tech/neondb?sslmode=require",
"LOGGER": "postgresql:dbs=NEON&table=schema.table_name"
```
