### PR TITLE
Update to default gazetteer query

### DIFF
--- a/lib/ui/Gazetteer.mjs
+++ b/lib/ui/Gazetteer.mjs
@@ -47,18 +47,22 @@ export default gazetteer => {
       return;
     }
 
-    if (Array.isArray(gazetteer.datasets)) {
+    // An external gazetteer provider is requested
+    if (gazetteer.provider) {
 
-      mapp.utils.gazetteer.datasets(e.target.value, gazetteer)
+      // Check whether the gazetteer provider is available.
+      if (!Object.hasOwn(mapp.utils.gazetteer, gazetteer.provider)) {
+
+        console.warn('Requested gazetteer service not available');
+      } else {
+
+        // Query the external gazetteer provider
+        mapp.utils.gazetteer[gazetteer.provider](e.target.value, gazetteer)
+      }
     }
 
-    // Validate whether gazetteer service is available.
-    if (!Object.hasOwn(mapp.utils.gazetteer, gazetteer.provider)) {
-
-      return console.warn('Requested gazetteer service not available');
-    }
-
-    mapp.utils.gazetteer[gazetteer.provider](e.target.value, gazetteer)
+    // Request datasets gazetteer
+    mapp.utils.gazetteer.datasets(e.target.value, gazetteer)
   }
   
 }

--- a/lib/utils/gazetteer.mjs
+++ b/lib/utils/gazetteer.mjs
@@ -1,7 +1,12 @@
 export function datasets(term, gazetteer) {
 
-    search(gazetteer)
+    if (!gazetteer.provider) {
 
+        // The default gazetteer config is for a dataset search.
+        search(gazetteer)
+    }
+
+    // Search additional datasets.
     gazetteer.datasets?.forEach(search)
 
     function search(dataset) {

--- a/lib/utils/gazetteer.mjs
+++ b/lib/utils/gazetteer.mjs
@@ -3,7 +3,7 @@ export function datasets(term, gazetteer) {
     if (!gazetteer.provider) {
 
         // The default gazetteer config is for a dataset search.
-        search(gazetteer)
+        gazetteer.qterm && search(gazetteer)
     }
 
     // Search additional datasets.

--- a/lib/utils/gazetteer.mjs
+++ b/lib/utils/gazetteer.mjs
@@ -1,11 +1,17 @@
 export function datasets(term, gazetteer) {
 
-    gazetteer.datasets.forEach(dataset => {
+    search(gazetteer)
+
+    gazetteer.datasets?.forEach(search)
+
+    function search(dataset) {
 
         let layer = gazetteer.mapview.layers[gazetteer.layer || dataset.layer]
 
         // Skip if layer defined in datasets is not added to the mapview
         if (!layer) {
+
+            console.warn('No layer definition for gazetteer search.')
             return;
         }
 
@@ -69,8 +75,7 @@ export function datasets(term, gazetteer) {
 
         dataset.xhr.send()
 
-    })
-
+    }
 }
 
 export function getLocation(location, gazetteer) {
@@ -118,5 +123,4 @@ export function getLocation(location, gazetteer) {
     gazetteer.mapview.locations[location.hook] = location
 
     location.flyTo(gazetteer.maxZoom)
-
 }

--- a/lib/utils/gazetteer.mjs
+++ b/lib/utils/gazetteer.mjs
@@ -20,6 +20,13 @@ export function datasets(term, gazetteer) {
             return;
         }
 
+        // Skip if layer table is not defined and no table is defined in dataset or gazetteer.
+        if (!layer.table && !dataset.table && !gazetteer.table) {
+
+            console.warn('No table definition for gazetteer search.')
+            return;
+        };
+        
         // Abort current dataset query. Onload will not be called.
         dataset.xhr?.abort()
 


### PR DESCRIPTION
It must be possible to query a dataset without specifying the datasets array in the gazetteer config. The datasets array is strictly for additional queries.

At it's most basic the gazetteer configuration will look as follows:

The `layer` will define the table to be queried and from where to select a found location.

The `qterm` defines the field which will be queried.

```json
"gazetteer": {
  "layer": "retailpoints",
  "qterm": "store_name"
}
```

Any current layer filter as well as role restrictions will apply to the query.

Additional configuration keys are:

* `table` - Use this table instead of the layer table in the query.
* `placeholder` - Set the gazetteer input placeholder. Can not be used in datasets[].
* `label` - The field which will be returned in the results. By default this is the `qterm`, however it is possible to query one field but display a different field as label in the gazetteer results.
* `title` - The title is shown next to the records in the gazetteer results. Will default to `layer.name`, or `provider`.
* `leading_wildcard` - Whether the search term should be prefixed with a wildcard.
* `limit` - Limits the maximum number of results per search/dataset. Defaults to 10.

## datasets[]
Additional queries are made for each dataset defined in the datasets array. A `placeholder` or `provider` can not be defined in a dataset. The `layer` and `limit` parameter will be taken from the gazetteer configuration if not implicit in the dataset configuration.

```json
"gazetteer": {
  "layer": "retailpoints",
  "qterm": "store_name",
  "leading_wildcard": true,
  "limit": 5,
  "datasets": [{
    "title": "Postcode"
    "qterm": "postcode"
  }]
}
```

![image](https://github.com/GEOLYTIX/xyz/assets/22201617/8905ae59-c690-47b0-8b87-edb99aa9c2c7)

## provider
An external gazetteer can be queried if a `provider` is defined in the gazetteer configuration. A layer must **NOT** be defined together with a provider.