### PR TITLE
The distinct values query must not use the current layer filter.

### DIFF
--- a/lib/ui/layers/filters.mjs
+++ b/lib/ui/layers/filters.mjs
@@ -157,7 +157,6 @@ async function filter_in(layer, entry) {
         dbs: layer.dbs,
         locale: layer.mapview.locale.key,
         layer: layer.key,
-        filter: layer.filter && layer.filter.current,
         table: layer.tableCurrent(),
         field: entry.field
       }))


### PR DESCRIPTION
A current IN filter would invalidate the results from the distinct values query making it impossible to alter the filter through the interface.

Role filters will still be applied since they are set in the XYZ Query API.