### PR TITLE
Remove roles.reduce mod

### DIFF
--- a/mod/utils/roles.js
+++ b/mod/utils/roles.js
@@ -1,6 +1,5 @@
 module.exports = {
   check,
-  reduce,
   filter,
   get
 }
@@ -34,34 +33,6 @@ function check(obj, roles) {
   if (somePositiveRole) return obj
   
   return false
-}
-
-async function reduce(obj, roles) {
-
-  if (!roles) return;
-
-  (function objectEval(o, parent, key) {
-
-    if (!check(o, roles)) {
-
-      // if the parent is an array splice the key index.
-      if (parent.length > 0) return parent.splice(parseInt(key), 1)
-
-      // if the parent is an object delete the key from the parent.
-      return delete parent[key]
-    }
-
-    // iterate through the object tree.
-    Object.keys(o).forEach((key) => {
-
-      // Do not remove infoj entries.
-      if (key === 'infoj') return;
-
-      if (o[key] && typeof o[key] === 'object') objectEval(o[key], o, key)
-    });
-
-  })(obj)
-
 }
 
 function filter(obj, roles) {

--- a/mod/workspace/_workspace.js
+++ b/mod/workspace/_workspace.js
@@ -49,8 +49,6 @@ async function getLayer(req, res) {
     return res.status(403).send('Role access denied.')
   }
 
-  await Roles.reduce(layer, roles)
-
   res.json(layer)
 }
 


### PR DESCRIPTION
Roles reduce was initially used to remove entries from the infoj array.

The roles logic has been completely reworked to allow for merging of role objects on individual infoj entries, and layer as a whole.