### PR TITLE
Style labels

### DIFF
--- a/lib/layer/decorate.mjs
+++ b/lib/layer/decorate.mjs
@@ -67,19 +67,26 @@ export default async layer => {
   }, layer.filter);
 
   // Set layer opacity from style.
-  layer.style?.opacity && layer.L.setOpacity(layer.style.opacity);
+  layer.L.setOpacity(layer.style?.opacity || 1);
 
-  // Set the first theme from themes array as layer.style.theme
-  if (layer.style && layer.style.themes) {
+  // Layer style has multiple themes.
+  if (layer.style?.themes) {
 
-    // Assign / keep theme as is if type of object.
-    layer.style.theme = typeof layer.style.theme === 'object' && layer.style.theme
+    // Keep object theme.
+    layer.style.theme = typeof layer.style.theme === 'object' ? layer.style.theme
 
-      // Assign theme from themes if theme is key [string].
-      || typeof layer.style.theme === 'string' && layer.style.themes[layer.style.theme]
+      // Assign theme from key [string], or first theme.
+      : layer.style.themes[layer.style.theme || Object.keys(layer.style.themes)[0]];
+  }
 
-      // Otherwise assign first theme from themes.
-      || layer.style.themes[Object.keys(layer.style.themes)[0]];      
+  // Layer style has multiple themes.
+  if (layer.style?.labels) {
+
+    // Keep object label.
+    layer.style.label = typeof layer.style.label === 'object' ? layer.style.label
+
+      // Assign label from key [string], or first label.
+      : layer.style.labels[layer.style.label || Object.keys(layer.style.labels)[0]];
   }
 
   // Adjust infoj entries for user roles.

--- a/lib/ui/layers/panels/style.mjs
+++ b/lib/ui/layers/panels/style.mjs
@@ -98,13 +98,13 @@ export default layer => {
       }
     }))
   }
-  
-  // Add toggle for label layer.
+
   if (layer.style.label) {
 
-    const labelCheckbox = mapp.ui.elements.chkbox({
+    layer.style.labelCheckbox = mapp.ui.elements.chkbox({
       data_id: 'labelCheckbox',
-      label: layer.style.label.title || mapp.dictionary.layer_style_display_labels,
+      label: layer.style?.labels && mapp.dictionary.layer_style_display_labels
+        || layer.style.label.title || mapp.dictionary.layer_style_display_labels,
       checked: !!layer.style.label.display,
       onchange: (checked) => {
         layer.style.label.display = checked
@@ -112,23 +112,50 @@ export default layer => {
       }
     })
 
-    if (layer.style.label.minZoom || layer.style.label.maxZoom) {
-      layer.mapview.Map.getTargetElement().addEventListener('changeEnd', () => {
-        const z = layer.mapview.Map.getView().getZoom();
+    content.push(layer.style.labelCheckbox)
+  }
 
-        if (z <= layer.style.label.minZoom || z >= layer.style.label.maxZoom) {
-          return labelCheckbox.classList.add('disabled');
-        }
+  // Add label control
+  if (Object.keys(layer.style.labels || 0).length > 1) {
 
-        labelCheckbox.classList.remove('disabled');
-      });
+    content.push(mapp.ui.elements.dropdown({
+      placeholder: layer.style.label.title,
+      entries: Object.keys(layer.style.labels).map(key => ({
+        title: layer.style.labels[key].title || key,
+        option: key
+      })),
+      callback: (e, entry) => {
+
+        const display = layer.style.label.display
+
+        // Set label from dropdown option.
+        layer.style.label = layer.style.labels[entry.option]
+
+        layer.style.label.display = display
+
+        layer.reload()
+      }
+    }))
+  }
+  
+  // Add zoom level check for label display
+  layer.style.label && layer.mapview.Map.getTargetElement().addEventListener('changeEnd', () => {
+    const z = layer.mapview.Map.getView().getZoom();
+
+    if (z <= layer.style.label.minZoom || z >= layer.style.label.maxZoom) {
+      layer.style.labelCheckbox.classList.add('disabled');
+    } else {
+      layer.style.labelCheckbox.classList.remove('disabled');
     }
+  });
 
-    content.push(labelCheckbox)
+  // Add single break between label and theme.
+  if (layer.style.label && layer.style.theme) {
+    content.slice(-1)[0].style.marginBottom = '0.5em'
   }
 
   // Add theme control
-  if (layer.style.themes && Object.keys(layer.style.themes).length > 1) {
+  if (Object.keys(layer.style.themes || 0).length > 1) {
     content.push(mapp.utils.html`
       <div>${mapp.dictionary.layer_style_select_theme}</div>
         ${mapp.ui.elements.dropdown({
@@ -139,7 +166,7 @@ export default layer => {
           })),
           callback: (e, entry) => {
 
-            // Set layer style theme from dropdown option.
+            // Set theme from dropdown option.
             layer.style.theme = layer.style.themes[entry.option]
 
             // Clear the legend container.

--- a/lib/ui/layers/panels/style.mjs
+++ b/lib/ui/layers/panels/style.mjs
@@ -101,6 +101,7 @@ export default layer => {
 
   if (layer.style.label) {
 
+    // Add checkbox to toggle label display.
     layer.style.labelCheckbox = mapp.ui.elements.chkbox({
       data_id: 'labelCheckbox',
       label: layer.style?.labels && mapp.dictionary.layer_style_display_labels
@@ -115,9 +116,9 @@ export default layer => {
     content.push(layer.style.labelCheckbox)
   }
 
-  // Add label control
   if (Object.keys(layer.style.labels || 0).length > 1) {
 
+    // Add dropdown to switch label.
     content.push(mapp.ui.elements.dropdown({
       placeholder: layer.style.label.title,
       entries: Object.keys(layer.style.labels).map(key => ({
@@ -149,7 +150,7 @@ export default layer => {
     }
   });
 
-  // Add single break between label and theme.
+  // Add bottom margin to last element if label and theme are both defined.
   if (layer.style.label && layer.style.theme) {
     content.slice(-1)[0].style.marginBottom = '0.5em'
   }
@@ -183,11 +184,12 @@ export default layer => {
             layer.reload()
           }
         })}`)
-  }
+  } else if (layer.style.theme?.title){
 
-  if (layer.style.theme?.title && !layer.style.themes) {
+    // Add theme title before legend.
     content.push(mapp.utils.html`
       <h3>${layer.style.theme.title}`)
+
   }
 
   function modalButton(){


### PR DESCRIPTION
In a similar fashion to `style.theme{}` and `style.themes{}` do we support now `style.label{}` and `style.labels{}`

A dropdown to change the label will be displayed for `style.labels{}`.

The display status of the label will remain when the label is changed.

A checkbox to toggle the label display will be shown above the dropdown.

The layer decorator will assign the first label from the labels list or the label where the key matches a `style.label` string value.

[Wiki documentation](https://github.com/GEOLYTIX/xyz/wiki/Workspace-Configuration#label-1)

