### PR TITLE
Collapse the layer drawer when the layer view becomes disabled.

### DIFF
--- a/lib/ui/layers/view.mjs
+++ b/lib/ui/layers/view.mjs
@@ -115,7 +115,15 @@ export default (layer) => {
   // The layer view drawer should be disabled if layer.tables are not available for the current zoom level.
   layer.mapview.Map.getTargetElement().addEventListener('changeEnd', ()=>{
     if (!layer.tables) return;
-    if (layer.tableCurrent() === null) return layer.view.classList.add('disabled')
-    layer.view.classList.remove('disabled')
+    if (layer.tableCurrent() === null) {
+
+      // Disable layer view out of zoom range
+      layer.view.querySelector('[data-id=layer-drawer]').classList.remove('expanded')
+      layer.view.classList.add('disabled')
+    } else {
+
+      layer.view.classList.remove('disabled')
+    }
+    
   })
 }


### PR DESCRIPTION
The layer view module will check whether a layer is outside it's zoom level range and disable the layer view element.

The layer view drawer should also be collapsed at the same time.