### PR TITLE
Long click hover popup

### DIFF
--- a/lib/mapview/_mapview.mjs
+++ b/lib/mapview/_mapview.mjs
@@ -12,6 +12,8 @@ import locate from './locate.mjs'
 
 import popup from './popup.mjs'
 
+import allFeatures from './allFeatures.mjs'
+
 import _highlight from './interactions/highlight.mjs'
 
 import _draw from './interactions/draw.mjs'
@@ -39,6 +41,7 @@ export default (mapview) => {
       length: (geometry) => ol.sphere.getLength(geometry),
     },
     popup,
+    allFeatures,
     layers: {},
     locations: {},
     interactions: {

--- a/lib/mapview/allFeatures.mjs
+++ b/lib/mapview/allFeatures.mjs
@@ -1,0 +1,42 @@
+export default function (e, mapview) {
+
+    // Remove popup from mapview.
+    mapview.popup(null)
+
+    const features = [];
+
+    // Find locations at pixel.
+    mapview.Map.forEachFeatureAtPixel(e.pixel,
+        (F, L) => {
+
+            const feature = {
+                F, L,
+                layer: mapview.layers[L.get('key')],
+                id: F.get('id') || F.getId()
+            }
+
+            features.push(feature)
+        },
+        {
+            layerFilter: mapview.interaction.layerFilter,
+            hitTolerance: mapview.interaction.hitTolerance,
+        })
+
+    // No features at pixel.
+    if (!features.length) return;
+
+    const content = mapp.utils.html.node`
+      <div style="max-width: 66vw; max-height: 300px; overflow-x: hidden;">
+        <ul>
+        ${features.map(feature => mapp.utils.html.node`
+          <li onclick=${e => {
+            mapview.interaction.getFeature(feature)
+            mapview.popup(null)
+        }}
+        }}>${feature.L.get('key')} [${feature.id}]`)}`;
+
+    mapview.popup({
+        content,
+        autoPan: true,
+    });
+}

--- a/lib/mapview/interactions/highlight.mjs
+++ b/lib/mapview/interactions/highlight.mjs
@@ -193,8 +193,9 @@ export default function(params){
     // Change cursor if the highlight is selectable.
     if (mapview.interaction.current.layer.infoj) mapview.Map.getTargetElement().style.cursor = 'pointer'
 
-    // Execute any hover method assigned to the current feature layer.
-    typeof mapview.interaction.current.layer.hover?.show === 'function' && mapview.interaction.current.layer.hover.show(feature.F)
+    // Execute hover method assigned to the current feature layer.
+    // Only if no popup is present.
+    !mapview.popup() && typeof mapview.interaction.current.layer.hover?.show === 'function' && mapview.interaction.current.layer.hover.show(feature.F)
 
     // Style the feature itself if possible.
     if (mapview.interaction.current.layer.format !== 'mvt'
@@ -262,19 +263,26 @@ export default function(params){
     // Remove popup from mapview.
     mapview.popup(null)
 
-    const locations = [];
+    //const locations = [];
+
+    const features = [];
 
     // Find locations at pixel.
     mapview.Map.forEachFeatureAtPixel(e.pixel,
       (F, L) => {
 
-        const properties = F.getProperties()
+        // const properties = F.getProperties()
 
-        // Do not include cluster features.
-        if (properties.count) return;
+        // console.log(properties)
+
+        console.log(L.get('key'))
+
+        console.log(F.get('id') || F.getId())
 
         // Push location key into locations array.
-        locations.push(`${L.get('key') || ol.util.getUid(L)}!${F.get('id') || F.getId() || ol.util.getUid(F)}`)
+        //locations.push(`${L.get('key')}!${F.get('id') || F.getId() || ol.util.getUid(F)}`)
+
+        features.push({F,L})
       },
       {
         layerFilter: mapview.interaction.layerFilter,
@@ -282,21 +290,23 @@ export default function(params){
       })
 
     // No features at pixel.
-    if (!locations.length) return;
+    if (!features.length) return;
 
     const content = mapp.utils.html.node`
       <div style="max-width: 66vw; max-height: 300px; overflow-x: hidden;">
         <ul>
-        ${locations.map(key => mapp.utils.html.node`
+        ${features.map(FL => mapp.utils.html.node`
           <li onclick=${e => {           
-            mapp.location.get({
-              layer: mapview.layers[key.split('!')[0]],
-              id: key.split('!')[1]
-            })
+            // mapp.location.get({
+            //   layer: mapview.layers[key.split('!')[0]],
+            //   id: key.split('!')[1]
+            // })
+
+            getFeature(FL.F)
 
             mapview.popup(null)
           }}
-        }}>${key.split('!')[0]} [${key.split('!')[1]}]`)}`;      
+        }}>${FL.L.get('key')} []`)}`;      
 
     mapview.popup({
       content,

--- a/lib/mapview/interactions/highlight.mjs
+++ b/lib/mapview/interactions/highlight.mjs
@@ -27,7 +27,7 @@ export default function(params){
 
     locations: new Set(),
 
-    longClickMethod: selectAll,
+    longClickMethod: mapview.allFeatures,
 
     longClickMS: 500,
 
@@ -224,7 +224,7 @@ export default function(params){
 
     if (mapview.interaction.longClick && typeof mapview.interaction.longClickMethod === 'function') {
 
-      mapview.interaction.longClickMethod(e)
+      mapview.interaction.longClickMethod(e, mapview)
       return;
     }
 
@@ -256,62 +256,6 @@ export default function(params){
     if (typeof mapview.interaction.noLocationClick === 'function') {
       mapview.interaction.noLocationClick(e)
     }
-  }
-
-  function selectAll(e) {
-
-    // Remove popup from mapview.
-    mapview.popup(null)
-
-    //const locations = [];
-
-    const features = [];
-
-    // Find locations at pixel.
-    mapview.Map.forEachFeatureAtPixel(e.pixel,
-      (F, L) => {
-
-        // const properties = F.getProperties()
-
-        // console.log(properties)
-
-        console.log(L.get('key'))
-
-        console.log(F.get('id') || F.getId())
-
-        // Push location key into locations array.
-        //locations.push(`${L.get('key')}!${F.get('id') || F.getId() || ol.util.getUid(F)}`)
-
-        features.push({F,L})
-      },
-      {
-        layerFilter: mapview.interaction.layerFilter,
-        hitTolerance: mapview.interaction.hitTolerance,
-      })
-
-    // No features at pixel.
-    if (!features.length) return;
-
-    const content = mapp.utils.html.node`
-      <div style="max-width: 66vw; max-height: 300px; overflow-x: hidden;">
-        <ul>
-        ${features.map(FL => mapp.utils.html.node`
-          <li onclick=${e => {           
-            // mapp.location.get({
-            //   layer: mapview.layers[key.split('!')[0]],
-            //   id: key.split('!')[1]
-            // })
-
-            getFeature(FL.F)
-
-            mapview.popup(null)
-          }}
-        }}>${FL.L.get('key')} []`)}`;      
-
-    mapview.popup({
-      content,
-      autoPan: true,
-    });
   }
 
   function clear() {
@@ -406,7 +350,7 @@ export default function(params){
     mapp.location.get({
       layer: feature.layer,
       table: feature.layer.table || feature.layer.tableCurrent(),
-      id: feature.layer.highlight
+      id: feature.id
     })
   }
 

--- a/lib/mapview/interactions/highlight.mjs
+++ b/lib/mapview/interactions/highlight.mjs
@@ -197,8 +197,7 @@ export default function(params){
     if (mapview.interaction.current.layer.infoj) mapview.Map.getTargetElement().style.cursor = 'pointer'
 
     // Execute hover method assigned to the current feature layer.
-    // Only if no popup is present.
-    !mapview.popup() && typeof mapview.interaction.current.layer.hover?.show === 'function' && mapview.interaction.current.layer.hover.show(feature.F)
+    typeof mapview.interaction.current.layer.hover?.show === 'function' && mapview.interaction.current.layer.hover.show(feature.F)
 
     // Style the feature itself if possible.
     if (mapview.interaction.current.layer.format !== 'mvt'

--- a/lib/mapview/interactions/highlight.mjs
+++ b/lib/mapview/interactions/highlight.mjs
@@ -91,6 +91,9 @@ export default function(params){
 
   function pointerMove(e) {
 
+    // A popup is open.
+    if (mapview.popup()) return;
+
     // Clear longClick timeout.
     clearTimeout(mapview.interaction.longClickTimeout)
 
@@ -215,6 +218,14 @@ export default function(params){
 
   // Select the current highlighted feature.
   function click(e) {
+
+    // A popup is open.
+    if (mapview.popup()) {
+
+      // Close the popup.
+      mapview.popup(null)
+      return;
+    }
 
     // Reset cursor.
     mapview.Map.getTargetElement().style.cursor = 'auto'

--- a/lib/mapview/interactions/highlight.mjs
+++ b/lib/mapview/interactions/highlight.mjs
@@ -1,9 +1,9 @@
-export default function(params){
+export default function (params) {
 
   const mapview = this;
 
   // Finish the current interaction.
-  mapview.interaction?.finish()  
+  mapview.interaction?.finish()
 
   mapview.interaction = Object.assign({
 
@@ -59,7 +59,7 @@ export default function(params){
     e.preventDefault()
   }
 
-  function mouseDown(){
+  function mouseDown() {
 
     // Short circuit the mouseDown event method if the longClickMethod is falsy.
     if (!mapview.interaction.longClickMethod) return;
@@ -78,12 +78,12 @@ export default function(params){
         mapview.interaction.longClick = true
         mapview.Map.getTargetElement().style.cursor = 'wait'
       },
-      
+
       // 1000ms default timeout for longclick.
       mapview.interaction.longClickMS)
   }
 
-  function mouseUp(){
+  function mouseUp() {
     mapview.Map.getTargetElement().style.cursor = 'auto'
   }
 
@@ -218,14 +218,6 @@ export default function(params){
   // Select the current highlighted feature.
   function click(e) {
 
-    // A popup is open.
-    if (mapview.popup()) {
-
-      // Close the popup.
-      mapview.popup(null)
-      return;
-    }
-
     // Reset cursor.
     mapview.Map.getTargetElement().style.cursor = 'auto'
 
@@ -235,6 +227,14 @@ export default function(params){
     if (mapview.interaction.longClick && typeof mapview.interaction.longClickMethod === 'function') {
 
       mapview.interaction.longClickMethod(e, mapview)
+      return;
+    }
+
+    // A popup is open.
+    if (mapview.popup()) {
+
+      // Close the popup.
+      mapview.popup(null)
       return;
     }
 
@@ -252,7 +252,7 @@ export default function(params){
       pointerMove(e)
       return
     }
-    
+
     // Remove any existing popup. e.g. Cluster select dialogue.
     mapview.popup(null)
 
@@ -320,7 +320,8 @@ export default function(params){
           return {
             id: F.id,
             label: F.properties[feature.layer.cluster?.label]
-          }})
+          }
+        })
 
         // Create list to get cluster features
         const list = mapp.utils.html.node`
@@ -329,13 +330,13 @@ export default function(params){
           ${featuresList.map(li => mapp.utils.html.node`
             <li
               onclick=${e => {
-                mapview.popup(null)
-                mapp.location.get({
-                  layer: feature.layer,
-                  table: feature.layer.table || feature.layer.tableCurrent(),
-                  id: li.id
-                })
-              }}>${li.label || li.id}`)}`;
+            mapview.popup(null)
+            mapp.location.get({
+              layer: feature.layer,
+              table: feature.layer.table || feature.layer.tableCurrent(),
+              id: li.id
+            })
+          }}>${li.label || li.id}`)}`;
 
         // Create popup to select cluster features.
         mapview.popup({

--- a/lib/mapview/popup.mjs
+++ b/lib/mapview/popup.mjs
@@ -2,7 +2,16 @@ const popup = {}
 
 export default function(params) {
 
+  if (typeof params === 'undefined') {
+
+    // Return true if a popup is present on mapview.
+    return popup.node?.parentNode ? true : false;
+  }
+
   const mapview = this;
+
+  // Remove a current tooltip.
+  mapview.infotip(null)
 
   // Remove infotip node element
   popup.node?.remove()

--- a/lib/mapview/popup.mjs
+++ b/lib/mapview/popup.mjs
@@ -4,8 +4,8 @@ export default function(params) {
 
   if (typeof params === 'undefined') {
 
-    // Return true if a popup is present on mapview.
-    return popup.node?.parentNode ? true : false;
+    // Returns undefined / falsy if popup.node has been removed.
+    return popup.node?.parentNode;
   }
 
   const mapview = this;


### PR DESCRIPTION
The longClickMethod assigned to the highlight interaction has been moved to the mapview.

`mapview.allFeatures()` receives the event and mapview as arguments. The event pixel is used to lookup all features and provide a popup to get the feature.

It is possible to override the method with a plugin, thus allowing to alter the popup style if desired.

The `mapview.popup()` method will return true without an argument to indicate that a popup is present in the mapview.

The highlight interaction (`pointermove()`) will break if a popup is present in the mapview.

The highlight interaction (`click()`) will close the popup if present in the mapview.