### PR TITLE
Set point style zindex to infinity for highlight feature

### DIFF
--- a/lib/layer/Style.mjs
+++ b/lib/layer/Style.mjs
@@ -89,6 +89,9 @@ export default layer => feature => {
 
     if (feature.geometryType === 'Point') {
 
+      // Highlighted point features should be drawn on top.
+      feature.style.zIndex = Infinity
+
       if (layer.style.highlight.icon) {
 
         feature.style.icon = Array.isArray(layer.style.highlight.icon)

--- a/lib/utils/style.mjs
+++ b/lib/utils/style.mjs
@@ -39,7 +39,8 @@ export default (style, feature) => {
             crossOrigin: 'anonymous',
             scale: scale,
             anchor: icon.anchor || [0.5, 0.5],
-          })
+          }),
+          zIndex: style.zIndex
         }))
       })
 
@@ -79,7 +80,7 @@ export default (style, feature) => {
       })
 
       // Push OL text Style into Styles array.
-      Styles.push(new ol.style.Style({ text }))
+      Styles.push(new ol.style.Style({ text, zIndex: style.zIndex }))
     }
 
   })


### PR DESCRIPTION
A highlighted feature should always be rendered on top [`zIndex: Infinity`].