### PR TITLE
Create a default locale with empty layers array.

### DIFF
--- a/api/api.js
+++ b/api/api.js
@@ -97,7 +97,6 @@ module.exports = async (req, res) => {
 
       // Slice square brackets of string and split on comma.
       req.params[key] = req.params[key].slice(1, -1).split(',')
-      return;
     }
   })
 

--- a/api/api.js
+++ b/api/api.js
@@ -62,14 +62,42 @@ module.exports = async (req, res) => {
 
   Object.keys(req.params).forEach(key => {
 
-    // Make null string params null.
+    // Set null from string.
     if (req.params[key]?.toLowerCase() === 'null') {
       req.params[key] = null
+      return;
+    }
+
+    // Set boolean false from string.
+    if (req.params[key]?.toLowerCase() === 'false') {
+      req.params[key] = false
+      return;
+    }
+
+    // Set boolean true from string.
+    if (req.params[key]?.toLowerCase() === 'true') {
+      req.params[key] = true
+      return;
     }
 
     // Delete param keys with undefined values.
     if (req.params[key] === undefined) {
       delete req.params[key]
+      return;
+    }
+    
+    // Delete param keys with empty string value.
+    if (req.params[key] === '') {
+      delete req.params[key]
+      return;
+    }
+
+    // Check whether param begins and ends with square braces.
+    if (req.params[key].match(/^[\[].*[\]]$/)) {
+
+      // Slice square brackets of string and split on comma.
+      req.params[key] = req.params[key].slice(1, -1).split(',')
+      return;
     }
   })
 
@@ -78,20 +106,6 @@ module.exports = async (req, res) => {
 
     return res.status(403).send('URL parameter key validation failed.')
   }
-
-  // Check for array URL parameter
-  Object.keys(req.params).forEach(key => {
-    
-    // Return if parameter isn't braced square.
-    if(!req.params[key]?.match(/^[\[].*[\]]$/)) return;
-
-    // Return if key param is not a string.
-    if(typeof req.params[key] !== 'string') return;
-
-    // Slice square brackets of string and split on comma.
-    req.params[key] = req.params[key].slice(1, -1).split(',')
-
-  })
 
   // Language param will default to english [en] is not explicitly set.
   req.params.language = req.params.language || 'en'

--- a/api/api.js
+++ b/api/api.js
@@ -93,7 +93,7 @@ module.exports = async (req, res) => {
     }
 
     // Check whether param begins and ends with square braces.
-    if (req.params[key].match(/^[\[].*[\]]$/)) {
+    if (req.params[key].match(/^\[.*\]$/)) {
 
       // Slice square brackets of string and split on comma.
       req.params[key] = req.params[key].slice(1, -1).split(',')

--- a/mod/workspace/_workspace.js
+++ b/mod/workspace/_workspace.js
@@ -56,8 +56,6 @@ async function getLayer(req, res) {
 
 function getLocales(req, res) {
 
-  if (!req.params.workspace.locales) return res.send({})
-
   const roles = req.params.user?.roles || []
 
   const locales = Object.values(req.params.workspace.locales)
@@ -72,11 +70,11 @@ function getLocales(req, res) {
 
 function getLocale(req, res) {
 
-  if (!Object.hasOwn(req.params.workspace.locales, req.params.locale)) {
+  if (req.params.locale && !Object.hasOwn(req.params.workspace.locales, req.params.locale)) {
     return res.status(400).send(`Unable to validate locale param.`)
   }
 
-  const locale = clone(req.params.workspace.locales[req.params.locale])
+  const locale = clone(req.params.workspace.locales?.[req.params.locale] || req.params.workspace.locale || {})
 
   const roles = req.params.user?.roles || []
 
@@ -84,7 +82,8 @@ function getLocale(req, res) {
     return res.status(403).send('Role access denied.')
   }
 
-  locale.layers = Object.entries(locale.layers)
+  // Check layer access.
+  locale.layers = locale.layers && Object.entries(locale.layers)
     .filter(layer => !!Roles.check(layer[1], roles))
     .map(layer => layer[0])
 

--- a/mod/workspace/assignDefaults.js
+++ b/mod/workspace/assignDefaults.js
@@ -4,6 +4,14 @@ const merge = require('../utils/merge')
 
 module.exports = async workspace => {
 
+  workspace.locale ??= {
+    layers: {}
+  }
+
+  workspace.locales ??= {
+    locale: workspace.locale
+  }
+
   // Loop through locale keys in workspace.
   Object.keys(workspace.locales).forEach(locale_key => {
 
@@ -17,7 +25,7 @@ module.exports = async workspace => {
       merge(locale, workspace.locale)
     }
 
-    // A template exists for the workspace key.
+    // A template exists for the locale key.
     if (Object.hasOwn(workspace.templates, locale_key) && typeof workspace.templates[locale_key] === 'object') {
 
       // Merge the workspace template into workspace.

--- a/mod/workspace/cache.js
+++ b/mod/workspace/cache.js
@@ -15,8 +15,6 @@ const getFrom = {
 
 const assignTemplates = require('./assignTemplates')
 
-const defaults = require('./defaults')
-
 const assignDefaults = require('./assignDefaults')
 
 let workspace = null
@@ -57,33 +55,19 @@ async function cache() {
   // Return error if source failed.
   if (workspace instanceof Error) return workspace
 
-  // Assign default locale as locales if missing.
-  workspace.locales = workspace.locales || { zero: defaults.locale }
-
   await assignTemplates(workspace)
 
   await assignDefaults(workspace)
 
-  Object.values(workspace.locales).forEach(locale => {
+  if (workspace.plugins) {
 
-    // The workspace has an array of plugins to be used for all locales.
-    if (Array.isArray(workspace.plugins)) {
-
-      // Are locale plugins defined.
-      locale.plugins = Array.isArray(locale.plugins)
-
-        // Concat the workspace plugins with locale plugins
-        ? locale.plugins.concat(workspace.plugins)
-
-        // Assign workspace plugins as locale plugins.
-        : workspace.plugins
-    }
-
-  })
+    console.warn(`Defult plugins should be defined in the default workspace.locale{}`)
+  }
 
   // Substitute all SRC_* variables in locales.
   workspace.locales = JSON.parse(
     JSON.stringify(workspace.locales).replace(/\$\{(.*?)\}/g,
       matched => process.env[`SRC_${matched.replace(/\$|\{|\}/g, '')}`] || matched)
   )
+
 }

--- a/mod/workspace/defaults.js
+++ b/mod/workspace/defaults.js
@@ -1,19 +1,4 @@
 module.exports = defaults = {
-  locale: {
-    key: 'zero',
-    name: 'zero',
-    layers: {
-      OSM: {
-        key: 'OSM',
-        display: true,
-        format: 'tiles',
-        URI: 'https://{a-c}.tile.openstreetmap.org/{z}/{x}/{y}.png',
-        style: {
-          hidden: true
-        }
-      }
-    },
-  },
   layers: {
     geojson: {
       srid: '4326',

--- a/public/views/_default.js
+++ b/public/views/_default.js
@@ -328,9 +328,18 @@ window.onload = async () => {
   });
 
   // Load JSON layers from Workspace API.
-  const layers = await mapp.utils.promiseAll(locale.layers.map(
+  const layers = locale.layers.length ? await mapp.utils.promiseAll(locale.layers.map(
     layer => mapp.utils.xhr(`${host}/api/workspace/layer?`
       + `locale=${locale.key}&layer=${layer}`)))
+    : [{
+      key: 'OSM',
+      display: true,
+      format: 'tiles',
+      URI: 'https://{a-c}.tile.openstreetmap.org/{z}/{x}/{y}.png',
+      style: {
+        hidden: true
+      }
+    }]
 
   // Add layers to mapview.
   await mapview.addLayer(layers);
@@ -401,12 +410,6 @@ window.onload = async () => {
         title="${mapp.user && mapp.dictionary.toolbar_logout || mapp.dictionary.toolbar_login}"
         href="${(mapp.user && '?logout=true') || '?login=true'}">
         <div class="${`mask-icon ${(mapp.user && 'logout') || 'lock-open'}`}">`);
-
-  // btnColumn.appendChild(mapp.utils.html.node`
-  //   <a
-  //     title="GEOLYTIX MAPP"
-  //     href="https://geolytix.com">
-  //     <div class="bg-icon mapp">`);
 
   // Append spacer for tableview
   btnColumn.appendChild(mapp.utils.html.node`


### PR DESCRIPTION
XYZ should not use a default locale with the OSM layer if no locale or locales array are configured in the workspace.

The default locale should be a locale with an empty layers array. The _default view can load an OSM tile layer if the layers array is empty.

The api module should turn `"null"` string params to `null`, `"true"` string params to `true`, and `"false"` string params to `false`.

The api module turns array strings into array params. This should happen in the same iteration with all the other req.params methods.

`workspace.plugins[]` will warn. The correct way to assign default plugins is by defining a default locale with plugins.

`workspace.locales` is optional. The `workspace.locale` will be assigned as `locale` in the workspace locales object.