### PR TITLE
querycheck & queryparams

### DIFF
--- a/lib/ui/locations/entries/dataview.mjs
+++ b/lib/ui/locations/entries/dataview.mjs
@@ -1,5 +1,16 @@
 export default entry => {
 
+  // The entry value may have been assigned if the query was already run in the infoj method.
+  entry.data ??= entry.value
+
+  if (entry.data === null) {
+
+    // The entry must be disabled if the query has run and the data is null.
+    // This is to prevent the query running over and over again getting the same result.
+    delete entry.display
+    entry.disabled = true
+  }
+
   // Dataview methods require the layer and host to be defined on the entry.
   entry.layer = entry.location.layer
   entry.host = entry.host || entry.location.layer.mapview.host

--- a/lib/ui/locations/entries/json.mjs
+++ b/lib/ui/locations/entries/json.mjs
@@ -1,16 +1,5 @@
 export default entry => {
 
-  if (entry.query) {
-
-    mapp.utils.xhr(`${entry.location.layer.mapview.host}/api/query/${entry.query}`)
-      .then(response => {
-        mapp.utils.render(
-          entry.node.querySelector('.val'),
-          mapp.utils.html`<pre><code>${JSON.stringify(response[entry.params.field], null, 2)}`)
-      })
-
-  }
-
   let val = mapp.utils.html`
     <pre><code>${JSON.stringify(entry.value, null, 2)}`
 

--- a/lib/ui/locations/entries/text.mjs
+++ b/lib/ui/locations/entries/text.mjs
@@ -1,20 +1,7 @@
 export default entry => {
 
-  let node, val = entry.value;
-
-  if (entry.query) {
-
-    const params = mapp.utils.queryParams(entry)
-
-    const paramString = mapp.utils.paramString(params)
-
-    mapp.utils
-      .xhr(`${entry.host || entry.location.layer.mapview.host}/api/query?${paramString}`)
-      .then(response => {
-        node.innerHTML = response === null ? '' : Object.values(response)[0]
-      })
-
-  }
+  // val maybe the input element with the entry.value.
+  let val = entry.value;
 
   if (entry.edit) {
 
@@ -39,13 +26,12 @@ export default entry => {
     }
   }
 
-  node = mapp.utils.html.node`
+  return mapp.utils.html.node`
     <div
       class="val"
       style="${`${entry.css_val || ''}`}">
       ${entry.prefix}${val}${entry.suffix}`
 
-  return node
 }
 
 function options(entry){

--- a/lib/ui/locations/entries/textarea.mjs
+++ b/lib/ui/locations/entries/textarea.mjs
@@ -1,14 +1,5 @@
 export default entry => {
 
-  if (entry.query) {
-
-    mapp.utils.xhr(`${entry.location.layer.mapview.host}/api/query/${entry.query}`)
-      .then(response => {
-        entry.node.querySelector('.val').innerHTML = response[entry.params.field]
-      })
-
-  }
-
   let val = entry.type !== 'html' ? entry.value : ''
 
   if (entry.edit) {

--- a/lib/ui/locations/infoj.mjs
+++ b/lib/ui/locations/infoj.mjs
@@ -126,36 +126,37 @@ export default (location, infoj) => {
       entry.value = entry.default || entry.value
     }
 
-    // Check whether query returns data.
-    if (entry.queryCheck) {
+    if (entry.query) {
 
-      // Stringify paramString from object.
-      const paramString = mapp.utils.paramString(mapp.utils.queryParams(entry))
+      // Assign queryparams from layer, and locale.
+      entry.queryparams = Object.assign(
+        entry.queryparams || {}, 
+        entry.location.layer.queryparams || {}, 
+        entry.location.layer.mapview.locale.queryparams || {})
 
-      // Run the entry query.
-      mapp.utils
-        .xhr(`${entry.host || entry.location.layer.mapview.host}/api/query?${paramString}`)
-        .then(response => {
+      // Check whether query returns data.
+      if (entry.queryCheck || entry.run === true) {
 
-          if (response === null) {
+        // Stringify paramString from object.
+        const paramString = mapp.utils.paramString(mapp.utils.queryParams(entry))
 
-            // Entries without response in the queryCheck should not be displayed and disabled.
-            delete entry.display
-            entry.disabled = true
-          } else {
+        // Run the entry query.
+        mapp.utils
+          .xhr(`${entry.host || entry.location.layer.mapview.host}/api/query?${paramString}`)
+          .then(response => {
 
-            // Assign response to entry data.
-            // Prevents dataviews to query again the same data.
-            entry.data = response;
-          };
+            // Assign query response as entry value.
+            entry.val = response;
 
-          // Create element to be appended into empty entry.node
-          const el = mapp.ui.locations.entries[entry.type]?.(entry)
+            // Create element to be appended into empty entry.node
+            const el = mapp.ui.locations.entries[entry.type]?.(entry)
 
-          el && entry.node.append(el)
-        })
+            el && entry.node.append(el)
+          })
 
-      continue;
+        continue;
+      }
+
     }
 
     // Create element to be appended into empty entry.node

--- a/lib/ui/locations/infoj.mjs
+++ b/lib/ui/locations/infoj.mjs
@@ -146,7 +146,7 @@ export default (location, infoj) => {
           .then(response => {
 
             // Assign query response as entry value.
-            entry.val = response;
+            entry.value = response;
 
             // Create element to be appended into empty entry.node
             const el = mapp.ui.locations.entries[entry.type]?.(entry)


### PR DESCRIPTION
The infoj process will assign queryparams from the layer, and locale, making the assign_queryparams plugin redundant.

With either the querycheck or run flag set in an entry with a query the query will be executed from the infoj method. The entry method will be called after the query response has been assigned as entry.value.

The dataview entry method will assign entry.value as entry.data and will perform checks whether the entry.value is null.

The query will no longer be called from the `json`, `text`, and `textarea` type methods but only from the infoj method.