### PR TITLE
Layer show should only be called when not shown.

### DIFF
--- a/lib/location/decorate.mjs
+++ b/lib/location/decorate.mjs
@@ -147,7 +147,5 @@ async function trash() {
       id: this.id
     }))
 
-  this.layer.reload()
-
   this.remove()
 }

--- a/lib/location/decorate.mjs
+++ b/lib/location/decorate.mjs
@@ -31,13 +31,8 @@ function remove() {
   this.layer.mapview.interaction.type !== 'highlight'
     && this.layer.mapview.interactions.highlight()
 
-  if (this.layer.format === 'mvt') {
-
-    this.layer.L.changed()
-  } else {
-
-    this.layer.reload && this.layer.reload()
-  } 
+  // Reload the layer if possible.
+  this.layer.reload && this.layer.reload()
 
   this.removeCallbacks?.forEach(
     fn => typeof fn === 'function' && fn(this))

--- a/lib/ui/elements/drawing.mjs
+++ b/lib/ui/elements/drawing.mjs
@@ -92,7 +92,7 @@ function point(layer) {
       
         btn.classList.add('active')
         
-        layer.show()
+        !layer.display && layer.show()
       
         layer.draw.point.callback = feature => {
       
@@ -140,7 +140,7 @@ function line(layer) {
       
         btn.classList.add('active')
         
-        layer.show()
+        !layer.display && layer.show()
       
         layer.draw.line.callback = feature => {
       
@@ -187,7 +187,7 @@ function polygon(layer) {
       
         btn.classList.add('active')
         
-        layer.show()
+        !layer.display && layer.show()
       
         layer.draw.polygon.callback = feature => {
       
@@ -235,7 +235,7 @@ function rectangle(layer) {
       
         btn.classList.add('active')
         
-        layer.show()
+        !layer.display && layer.show()
       
         layer.draw.rectangle.callback = feature => {
       
@@ -283,7 +283,7 @@ function circle_2pt(layer) {
       
         btn.classList.add('active')
         
-        layer.show()
+        !layer.display && layer.show()
       
         layer.draw.circle_2pt.callback = feature => {
       
@@ -404,7 +404,7 @@ function circle(layer) {
     
       btn.classList.add('active')
       
-      layer.show()
+      !layer.display && layer.show()
     
       layer.draw.circle.callback = feature => {
     


### PR DESCRIPTION
The draw methods called the layer show if layer is already shown causing an unnecessary reload.