### PR TITLE
Ignore negative extent

### DIFF
--- a/lib/mapview/_mapview.mjs
+++ b/lib/mapview/_mapview.mjs
@@ -80,7 +80,7 @@ export default (mapview) => {
     const west = parseFloat(mapview.locale.extent.west || -180);
 
     if ((north - south) >= 0 && (east - west) >= 0) {
-      mapview.extent = ol.proj.transformExtent([north, east, south, west], 'ESPG:4326', `EPSG:${mapview.srid}`);
+      mapview.extent = ol.proj.transformExtent([west, south, east, north], 'ESPG:4326', `EPSG:${mapview.srid}`);
     } else {
       console.warn('Invalid extent. Ensure north >= south and east >= west. Global extent is assumed.');
     }

--- a/lib/mapview/_mapview.mjs
+++ b/lib/mapview/_mapview.mjs
@@ -73,32 +73,25 @@ export default (mapview) => {
   mapview.locale.bounds && console
     .warn('locale.bounds have been renamed to locale.extent')
 
+  console.log(mapview.locale)
+
   if (mapview.locale.extent) {
+    const north = parseFloat(mapview.locale.extent.north || 90);
+    const south = parseFloat(mapview.locale.extent.south || -90);
+    const east = parseFloat(mapview.locale.extent.east || 180);
+    const west = parseFloat(mapview.locale.extent.west || -180);
 
-    if ((parseFloat(mapview.locale.extent.north || 90) - parseFloat(mapview.locale.extent.south || -90)) >= 0
-      && (parseFloat(mapview.locale.extent.east || 180) - parseFloat(mapview.locale.extent.west || -180)) >= 0) {
-
-      // Transform extent from locale.
-      mapview.extent = ol.proj.transformExtent(
-        [
-          parseFloat(mapview.locale.extent.west || -180),
-          parseFloat(mapview.locale.extent.south || -90),
-          parseFloat(mapview.locale.extent.east || 180),
-          parseFloat(mapview.locale.extent.north || 90),
-        ],
-        `EPSG:4326`,
-        `EPSG:${mapview.srid}`)
-
+    if ((north - south) >= 0 && (east - west) >= 0) {
+      mapview.extent = ol.proj.transformExtent([west, south, east, north], 'ESPG:4326', `EPSG:${mapview.srid}`);
     } else {
-
-      console.warn(`Negative extent will be ignored. Global extent is assumed.`)
+      console.warn('Invalid extent. Ensure north >= south and east >= west. Global extent is assumed.');
     }
   }
 
   // Map
   mapview.Map = new ol.Map({
     target: mapview.target,
-    interactions: ol.interaction.defaults.defaults({ 
+    interactions: ol.interaction.defaults.defaults({
       mouseWheelZoom: mapview.scrollWheelZoom && {
         duration: 250, // default
         timeout: 80 // default
@@ -109,7 +102,7 @@ export default (mapview) => {
     }),
     moveTolerance: 5,
     controls: mapview.controls || [], //[new ol.control.Zoom()]
-    view: new ol.View({ 
+    view: new ol.View({
       projection: `EPSG:${mapview.srid}`,
       zoom: initialZoom,
       minZoom: mapview.locale.minZoom,
@@ -126,7 +119,7 @@ export default (mapview) => {
 
     resizeObserverTimeout && clearTimeout(resizeObserverTimeout)
 
-    resizeObserverTimeout = setTimeout(()=>{
+    resizeObserverTimeout = setTimeout(() => {
 
       mapview.Map.getTargetElement().dispatchEvent(new Event('resize'))
 
@@ -140,7 +133,7 @@ export default (mapview) => {
   // WARN!
   mapview.locale.maskBounds && console
     .warn('locale.maskBounds is set as mask:true in locale.extent')
-  
+
   // Extent mask
   if (mapview.locale.extent?.mask) {
 
@@ -172,7 +165,7 @@ export default (mapview) => {
         .Polygon([world, extent])
         .transform(`EPSG:4326`, `EPSG:${mapview.srid}`)
     })
-  
+
     // Add masklayer with the maskFeature
     // and infinite zIndex to mapview.Map
     mapview.Map.addLayer(new ol.layer.Vector({
@@ -276,13 +269,13 @@ export default (mapview) => {
   let changeEndTimer
 
   // moveend to call changeEnd event.
-  mapview.Map.on('moveend', ()=>{
+  mapview.Map.on('moveend', () => {
     clearTimeout(changeEndTimer)
 
-    changeEndTimer = setTimeout(()=>{
+    changeEndTimer = setTimeout(() => {
       mapview.Map.getTargetElement().dispatchEvent(new CustomEvent('changeEnd'))
     }, 500)
   })
-  
+
   return mapview
 }

--- a/lib/mapview/_mapview.mjs
+++ b/lib/mapview/_mapview.mjs
@@ -73,16 +73,27 @@ export default (mapview) => {
   mapview.locale.bounds && console
     .warn('locale.bounds have been renamed to locale.extent')
 
-  // Get the mapview extent from the locale.
-  const extent = mapview.locale.extent && ol.proj.transformExtent(
-    [
-      parseFloat(mapview.locale.extent.west || -180),
-      parseFloat(mapview.locale.extent.south || -90),
-      parseFloat(mapview.locale.extent.east || 180),
-      parseFloat(mapview.locale.extent.north || 90),
-    ],
-    `EPSG:4326`,
-    `EPSG:${mapview.srid}`)
+  if (mapview.locale.extent) {
+
+    if ((parseFloat(mapview.locale.extent.north || 90) - parseFloat(mapview.locale.extent.south || -90)) >= 0
+      && (parseFloat(mapview.locale.extent.east || 180) - parseFloat(mapview.locale.extent.west || -180)) >= 0) {
+
+      // Transform extent from locale.
+      mapview.extent = ol.proj.transformExtent(
+        [
+          parseFloat(mapview.locale.extent.west || -180),
+          parseFloat(mapview.locale.extent.south || -90),
+          parseFloat(mapview.locale.extent.east || 180),
+          parseFloat(mapview.locale.extent.north || 90),
+        ],
+        `EPSG:4326`,
+        `EPSG:${mapview.srid}`)
+
+    } else {
+
+      console.warn(`Negative extent will be ignored. Global extent is assumed.`)
+    }
+  }
 
   // Map
   mapview.Map = new ol.Map({
@@ -104,7 +115,7 @@ export default (mapview) => {
       minZoom: mapview.locale.minZoom,
       maxZoom: mapview.locale.maxZoom,
       center: initialCenter,
-      extent: extent
+      extent: mapview.extent
     })
   })
 

--- a/lib/mapview/_mapview.mjs
+++ b/lib/mapview/_mapview.mjs
@@ -73,8 +73,6 @@ export default (mapview) => {
   mapview.locale.bounds && console
     .warn('locale.bounds have been renamed to locale.extent')
 
-  console.log(mapview.locale)
-
   if (mapview.locale.extent) {
     const north = parseFloat(mapview.locale.extent.north || 90);
     const south = parseFloat(mapview.locale.extent.south || -90);
@@ -82,7 +80,7 @@ export default (mapview) => {
     const west = parseFloat(mapview.locale.extent.west || -180);
 
     if ((north - south) >= 0 && (east - west) >= 0) {
-      mapview.extent = ol.proj.transformExtent([west, south, east, north], 'ESPG:4326', `EPSG:${mapview.srid}`);
+      mapview.extent = ol.proj.transformExtent([north, east, south, west], 'ESPG:4326', `EPSG:${mapview.srid}`);
     } else {
       console.warn('Invalid extent. Ensure north >= south and east >= west. Global extent is assumed.');
     }

--- a/lib/mapview/_mapview.mjs
+++ b/lib/mapview/_mapview.mjs
@@ -80,7 +80,7 @@ export default (mapview) => {
     const west = parseFloat(mapview.locale.extent.west || -180);
 
     if ((north - south) >= 0 && (east - west) >= 0) {
-      mapview.extent = ol.proj.transformExtent([west, south, east, north], 'ESPG:4326', `EPSG:${mapview.srid}`);
+      mapview.extent = ol.proj.transformExtent([west, south, east, north], 'EPSG:4326', `EPSG:${mapview.srid}`);
     } else {
       console.warn('Invalid extent. Ensure north >= south and east >= west. Global extent is assumed.');
     }


### PR DESCRIPTION
A check will be run to ensure that extent space is not negative.

The `locale.extent` config will be ignored otherwise.