### PR TITLE
Lazy load RTL plugin for maplibre

### DIFF
--- a/lib/layer/format/maplibre.mjs
+++ b/lib/layer/format/maplibre.mjs
@@ -34,6 +34,12 @@ async function MaplibreGL() {
 
   await promise
 
+  maplibregl.setRTLTextPlugin(
+    'https://unpkg.com/@mapbox/mapbox-gl-rtl-text@0.2.3/mapbox-gl-rtl-text.min.js',
+    null,
+    true // Lazy load the plugin
+  );
+
   return new maplibregl.Map(...arguments);
 }
 


### PR DESCRIPTION
![image](https://github.com/GEOLYTIX/xyz/assets/22201617/d496e4b0-a984-44e0-90ec-b728f822ee9f)

Solves the issue with RTL label in mapbox vector tile styles.