### PR TITLE
Assign layer, locale queryparams to layer dataview

### DIFF
--- a/lib/ui/Dataview.mjs
+++ b/lib/ui/Dataview.mjs
@@ -1,6 +1,8 @@
 export default async (_this) => {
+
   // The dataview target is defined as string.
   if (typeof _this.target === 'string') {
+
     // assign target element by ID.
     _this.target = document.getElementById(_this.target);
   }
@@ -12,8 +14,15 @@ export default async (_this) => {
     return;
   }
 
+  // Assign queryparams from layer, locale.
+  _this.queryparams = Object.assign(
+    _this.queryparams || {},
+    _this.layer?.queryparams || {},
+    _this.layer?.mapview.locale.queryparams || {})
+
   // Update method for _this.
   _this.update = async () => {
+
     // Dataviews must not update without a query.
     if (!_this.query) return;
 


### PR DESCRIPTION
The layer and locale queryparams should be assigned in the `lib.ui.Dataview()` method. This will ensure that layer dataviews have the queryparams assigned.