### PR TITLE
Check whether a query entry should be skipped

### DIFF
--- a/lib/ui/locations/infoj.mjs
+++ b/lib/ui/locations/infoj.mjs
@@ -55,24 +55,13 @@ export default (location, infoj) => {
         .some(val => new Set(entry.location?.layer?.infoj_skip).has(val))) continue;
     }
 
-    // Skip entry.
+    // Skip entry, no matter what.
     if (entry.skipEntry) continue;
 
-    // Skip entries which are falsy if flagged.
-    if (entry.skipFalsyValue
-      && !entry.value
-      && !entry.edit) continue;
+    // Skip entry depending on flag and value.
+    if (skipEntry(entry)) continue;
 
-    // Skip entries which are undefined if flagged.
-    if (entry.skipUndefinedValue
-      && typeof entry.value === 'undefined'
-      && !entry.edit) continue;
-
-    // Skip entries which are null if flagged.
-    if (entry.skipNullValue
-      && entry.value === null
-      && !entry.edit) continue;
-
+    // Assign a default nullValue
     if (entry.nullValue
       && entry.value === null
       && !entry.defaults
@@ -148,6 +137,14 @@ export default (location, infoj) => {
             // Assign query response as entry value.
             entry.value = response;
 
+            // Check whether entry should be skipped.
+            if (skipEntry(entry)) {
+
+              // Remove the entry.node from location view.
+              entry.node.remove();
+              return;
+            }
+
             // Create element to be appended into empty entry.node
             const el = mapp.ui.locations.entries[entry.type]?.(entry)
 
@@ -169,4 +166,23 @@ export default (location, infoj) => {
   }
 
   return listview
+}
+
+function skipEntry(entry) {
+
+  // Skip entries which are falsy if flagged.
+  if (entry.skipFalsyValue
+    && !entry.value
+    && !entry.edit) return true;
+
+  // Skip entries which are undefined if flagged.
+  if (entry.skipUndefinedValue
+    && typeof entry.value === 'undefined'
+    && !entry.edit) return true;
+
+  // Skip entries which are null if flagged.
+  if (entry.skipNullValue
+    && entry.value === null
+    && !entry.edit) return true;
+
 }


### PR DESCRIPTION
The skip flags which check whether an entry should be skipped according to the entry.value have been moved into a method to be called after a query response has been assigned as entry.value.