### PR TITLE
Remove style highlight default

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-**v4.5.0**
+**v4.6.0**
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 ![example workflow](https://github.com/GEOLYTIX/xyz/actions/workflows/unit_tests.yml/badge.svg)

--- a/lib/layer/Style.mjs
+++ b/lib/layer/Style.mjs
@@ -23,7 +23,7 @@ export default layer => feature => {
   }
 
   // Assign default style as feature.style.
-  feature.style =  Object.assign({}, mapp.utils.clone(layer.style.default), layer.style.theme?.style)
+  feature.style =  {...mapp.utils.clone(layer.style.default), ...layer.style.theme?.style}
 
   // The featureLookup is an array of features
   if (layer.featureLookup) {

--- a/lib/layer/Style.mjs
+++ b/lib/layer/Style.mjs
@@ -85,7 +85,7 @@ export default layer => feature => {
   const featureID = feature.get('id') || feature.getId()
 
   // Check whether highlight style should be applied.
-  if (layer.highlight && layer.highlight === featureID){
+  if (layer.style.highlight && layer.highlight && layer.highlight === featureID){
 
     if (feature.geometryType === 'Point') {
 

--- a/lib/mapp.mjs
+++ b/lib/mapp.mjs
@@ -17,8 +17,8 @@ self.mapp = (function (mapp) {
   hooks.parse();
 
   Object.assign(mapp, {
-    version: '4.5.0',
-    hash: 'b5f53d30530543c1f520e00b34296658189fd6e7',
+    version: '4.6.0',
+    hash: '5ff50af69ddc6d0aec4987b3f928a2caa56f4288',
     language: hooks.current.language || 'en',
   
     dictionaries,

--- a/lib/mapview/interactions/highlight.mjs
+++ b/lib/mapview/interactions/highlight.mjs
@@ -201,6 +201,7 @@ export default function (params) {
 
     // Style the feature itself if possible.
     if (mapview.interaction.current.layer.format !== 'mvt'
+      && mapview.interaction.current.layer.style.highlight
       && typeof mapview.interaction.current.F.setStyle === 'function') {
 
       feature.F.set('highlight', true)

--- a/lib/mapview/interactions/highlight.mjs
+++ b/lib/mapview/interactions/highlight.mjs
@@ -5,7 +5,7 @@ export default function (params) {
   // Finish the current interaction.
   mapview.interaction?.finish()
 
-  mapview.interaction = Object.assign({
+  mapview.interaction = {
 
     mapview: this,
 
@@ -35,9 +35,10 @@ export default function (params) {
     layerFilter: L => Object.values(this.layers)
 
       // layer L matching the feature layer L must have a qID defined
-      .some(layer => layer.qID && layer.L === L)
+      .some(layer => layer.qID && layer.L === L),
 
-  }, params)
+    ...params
+  }
 
   // Set mapview.interaction to be the current mapview mapview.interaction.
   mapview.interaction = mapview.interaction

--- a/mod/workspace/defaults.js
+++ b/mod/workspace/defaults.js
@@ -9,8 +9,7 @@ module.exports = defaults = {
           icon: {
             type: 'dot'
           }
-        },
-        highlight: {}
+        }
       },
       filter: {},
     },
@@ -23,8 +22,7 @@ module.exports = defaults = {
           icon: {
             type: 'dot'
           }
-        },
-        highlight: {}
+        }
       },
       filter: {},
     },
@@ -37,8 +35,7 @@ module.exports = defaults = {
           icon: {
             type: 'dot'
           }
-        },
-        highlight: {}
+        }
       },
       filter: {},
     },
@@ -50,8 +47,7 @@ module.exports = defaults = {
         },
         cluster: {
           clusterScale: 2
-        },
-        highlight: {}
+        }
       },
       filter: {},
     },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "xyz",
-  "version": "v4.5.0",
+  "version": "v4.6.0",
   "repository": {
     "type": "git",
     "url": "https://github.com/geolytix/xyz"


### PR DESCRIPTION
The empty style.highlight has been removed from the defaults.

The `layer.Style()` method and the mapview `highlight` interaction will no longer call for a re-style of the layer if there is nothing to restyle.