### PR TITLE
Add a question mark icon when tooltip is provided

### DIFF
--- a/lib/ui/locations/infoj.mjs
+++ b/lib/ui/locations/infoj.mjs
@@ -101,16 +101,12 @@ export default (location, infoj) => {
 
     if (entry.title) {
 
-      // if a tooltip is provided, then add a question mark to the title. 
-      let tooltip = '';
-      // This is done so the user is aware that there is a tooltip.
-      if (entry.tooltip) tooltip = mapp.utils.html.node`<div style="height:90%; width:90%;margin-left:1%;" class="mobile-display-none mask-icon question-mark"></div>`
-
       entry.node.append(mapp.utils.html.node`
         <div
           class="label"
           style="${`${entry.css_title || ''}`}"
-          title="${entry.tooltip || null}">${entry.title}${tooltip}`)
+          title="${entry.tooltip || null}">${entry.title}
+          ${entry.tooltip ? mapp.utils.html`<span style="line-height: 1; margin-left: 0.4em;" class="mobile-display-none mask-icon question-mark">${entry.tooltip}`: ''}`)
     }
 
     // Check whether entry has a value

--- a/lib/ui/locations/infoj.mjs
+++ b/lib/ui/locations/infoj.mjs
@@ -101,11 +101,16 @@ export default (location, infoj) => {
 
     if (entry.title) {
 
+      // if a tooltip is provided, then add a question mark to the title. 
+      let tooltip = '';
+      // This is done so the user is aware that there is a tooltip.
+      if (entry.tooltip) tooltip = mapp.utils.html.node`<div style="height:90%; width:90%;margin-left:1%;" class="mobile-display-none mask-icon question-mark"></div>`
+
       entry.node.append(mapp.utils.html.node`
         <div
           class="label"
           style="${`${entry.css_title || ''}`}"
-          title="${entry.tooltip || null}">${entry.title}`)
+          title="${entry.tooltip || null}">${entry.title}${tooltip}`)
     }
 
     // Check whether entry has a value
@@ -119,8 +124,8 @@ export default (location, infoj) => {
 
       // Assign queryparams from layer, and locale.
       entry.queryparams = Object.assign(
-        entry.queryparams || {}, 
-        entry.location.layer.queryparams || {}, 
+        entry.queryparams || {},
+        entry.location.layer.queryparams || {},
         entry.location.layer.mapview.locale.queryparams || {})
 
       // Check whether query returns data.


### PR DESCRIPTION
I am aware that tooltip has been possible within the infoj configuration for a long while. 
However, I noticed that when you provide a tooltip, there is no visual cue for the user to let them know if they hover over a title, they can see additional information. 
This PR simply adds the question mark SVG already defined in the XYZ framework to the end of the title - as a visual cue for the user to hover to see additional information. 
I have also updated the docs to add tooltip. 

https://github.com/GEOLYTIX/xyz/wiki/Workspace-Configuration#tooltip
![image](https://github.com/GEOLYTIX/xyz/assets/56163132/372dd5d5-e8c1-4d01-ac73-4b4214d6fe03)
