### PR TITLE
Fix for interaction finish

### DIFF
--- a/lib/mapview/interactions/draw.mjs
+++ b/lib/mapview/interactions/draw.mjs
@@ -6,10 +6,7 @@ export default function(params){
   mapview.interaction?.finish()
 
   // Assign params onto the defaults as mapview.interaction.
-  mapview.interaction = Object.assign({
-
-    // Interactions are bound to the mapview as this.
-    mapview: this,
+  mapview.interaction = {
 
     type: 'draw',
 
@@ -77,12 +74,12 @@ export default function(params){
         }),
         geometry: mapp.utils.verticeGeoms
       })
-    ]
-  }, params)
-
-  // Set mapview.interaction to be the current mapview interaction.
-  mapview.interaction = mapview.interaction  
-  
+    ],
+    
+    // Spread params argument.
+    ...params
+  }
+ 
   // Change cursor style over mapview element.
   mapview.Map.getTargetElement().style.cursor = 'crosshair'
 
@@ -165,14 +162,6 @@ export default function(params){
       }
     }
 
-    // Execute callback if defined as function.
-    if (typeof mapview.interaction.callback === 'function') {
-
-      // Must be run delayed to prevent a callback
-      const callback = mapview.interaction.callback
-      setTimeout(()=>callback(feature), 400)
-    }
-
     // Reset the cursor style.
     mapview.Map.getTargetElement().style.cursor = 'default'
     
@@ -184,6 +173,8 @@ export default function(params){
   
     // Remove draw Layer from mapview.Map.
     mapview.Map.removeLayer(mapview.interaction.Layer)
+
+    mapview.interaction.callback?.(feature)
 
     delete mapview.interaction
   }

--- a/lib/mapview/interactions/highlight.mjs
+++ b/lib/mapview/interactions/highlight.mjs
@@ -7,8 +7,6 @@ export default function (params) {
 
   mapview.interaction = {
 
-    mapview: this,
-
     type: 'highlight',
 
     finish,
@@ -37,6 +35,7 @@ export default function (params) {
       // layer L matching the feature layer L must have a qID defined
       .some(layer => layer.qID && layer.L === L),
 
+    // Spread params argument.
     ...params
   }
 
@@ -352,7 +351,7 @@ export default function (params) {
       }
 
       mapp.location.nnearest({
-        mapview: mapview.interaction.mapview,
+        mapview,
         layer: feature.layer,
         table: feature.layer.table || feature.layer.tableCurrent(),
         feature: feature.F
@@ -384,13 +383,7 @@ export default function (params) {
     mapview.Map.getTargetElement().removeEventListener('touchstart', touchStart)
     mapview.Map.getTargetElement().removeEventListener('mouseup', mouseUp)
 
-    // Execute callback if defined as function.
-    if (mapview.interaction.callback instanceof Function) {
-
-      // Must be run delayed to prevent a callback loop.
-      const callback = mapview.interaction.callback
-      setTimeout(callback, 400)
-    }
+    mapview.interaction.callback?.()
 
     delete mapview.interaction
   }

--- a/lib/mapview/interactions/modify.mjs
+++ b/lib/mapview/interactions/modify.mjs
@@ -3,11 +3,9 @@ export default function(params){
   const mapview = this
   
   // Finish the current interaction.
-  this.interaction?.finish()
+  mapview.interaction?.finish()
 
-  mapview.interaction = Object.assign({
-
-    mapview: this,
+  mapview.interaction = {
 
     type: 'modify',
 
@@ -85,9 +83,11 @@ export default function(params){
             }}>${mapp.dictionary.delete_vertex}`
         })
       }
-    }
-
-  }, params)
+    },
+    
+    // Spread params argument.
+    ...params
+  }
 
   // Set mapview.interaction to be the current mapview interaction.
   mapview.interaction = mapview.interaction
@@ -149,14 +149,6 @@ export default function(params){
       }
     }
 
-    // Execute callback if defined as function.
-    if (typeof mapview.interaction.callback === 'function') {
-
-      // Must be run delayed to prevent a callback
-      const callback = mapview.interaction.callback
-      setTimeout(()=>callback(feature), 400)
-    }
-
     // Reset the cursor style.
     mapview.Map.getTargetElement().style.cursor = 'default'
   
@@ -171,6 +163,8 @@ export default function(params){
   
     // Remove draw Layer from mapview.Map.
     mapview.Map.removeLayer(mapview.interaction.Layer)
+
+    mapview.interaction.callback?.(feature)
 
     delete mapview.interaction
   }

--- a/lib/mapview/interactions/zoom.mjs
+++ b/lib/mapview/interactions/zoom.mjs
@@ -2,6 +2,7 @@ export default function(params){
 
   const mapview = this
 
+  // Finish the current interaction.
   mapview.interaction?.finish()
 
   mapview.interaction = {
@@ -10,10 +11,11 @@ export default function(params){
 
     Layer: new ol.layer.Vector({
       source: new ol.source.Vector()
-    })
-  }
+    }),
 
-  mapview.interaction.callback = params.callback
+     // Spread params argument.
+    ...params
+  }
 
   mapview.interaction.Layer.getSource().clear()
 
@@ -47,14 +49,6 @@ export default function(params){
 
   function finish() {
 
-    // Execute callback if defined as function.
-    if (typeof mapview.interaction.callback === 'function') {
-
-      // Must be run delayed to prevent a callback
-      const callback = mapview.interaction.callback
-      setTimeout(()=>callback(), 400)
-    }
-
     mapview.Map.getTargetElement().style.cursor = 'auto';
 
     mapview.Map.removeInteraction(mapview.interaction.interaction)
@@ -62,6 +56,8 @@ export default function(params){
     mapview.Map.removeLayer(mapview.interaction.Layer)
 
     mapview.interaction.Layer.getSource().clear()
+
+    mapview.interaction.callback?.()
 
     delete mapview.interaction
   }

--- a/lib/ui/elements/drawing.mjs
+++ b/lib/ui/elements/drawing.mjs
@@ -72,41 +72,48 @@ function point(layer) {
     layer,
     type: 'Point',
   }, typeof layer.draw.point === 'object' && layer.draw.point || {})
-  
-    // If a label is provided, use it, otherwise use the default
-    let label = layer.draw.point?.label || mapp.dictionary.draw_point
+
+  // If a label is provided, use it, otherwise use the default
+  let label = layer.draw.point?.label || mapp.dictionary.draw_point
 
   // Create the button
   layer.draw.point.btn = mapp.utils.html.node`
     <button
       class="flat wide bold primary-colour"
-      onclick=${e=>{
+      onclick=${e => {
 
-        const btn = e.target
+      const btn = e.target
+
+      if (btn.classList.contains('active')) {
+
+        // Cancel draw interaction.
+        btn.classList.remove('active')
+        layer.mapview.interactions.highlight()
+        return;
+      }
+
+      btn.classList.add('active')
+
+      !layer.display && layer.show()
+
+      layer.draw.point.callback = feature => {
+
+        layer.draw.callback(feature, layer.draw.point)
 
         if (btn.classList.contains('active')) {
+
           btn.classList.remove('active')
-          layer.mapview.interactions.highlight()
-          return;
+
+          // Set highlight interaction if no other interaction is current after 400ms.
+          setTimeout(() => {
+            !layer.mapview.interaction && layer.mapview.interactions.highlight()
+          }, 400)
         }
-      
-        btn.classList.add('active')
-        
-        !layer.display && layer.show()
-      
-        layer.draw.point.callback = feature => {
-      
-          layer.draw.callback(feature, layer.draw.point)
-      
-          if (btn.classList.contains('active')) {
-            btn.classList.remove('active')
-            layer.mapview.interactions.highlight()
-          }
-        }
-      
-        layer.mapview.interactions.draw(layer.draw.point)
-        
-      }}>
+      }
+
+      layer.mapview.interactions.draw(layer.draw.point)
+
+    }}>
       ${label}`
 
   return layer.draw.point.btn
@@ -118,43 +125,50 @@ function line(layer) {
   layer.draw.line = Object.assign({
     layer,
     type: 'LineString',
-  }, typeof layer.draw.line === 'object' && layer.draw.line || {})  
-  
-      // If a label is provided, use it, otherwise use the default
-      let label = layer.draw.line?.label || mapp.dictionary.draw_line
+  }, typeof layer.draw.line === 'object' && layer.draw.line || {})
 
-      
+  // If a label is provided, use it, otherwise use the default
+  let label = layer.draw.line?.label || mapp.dictionary.draw_line
+
+
   // Create the button
   layer.draw.line.btn = mapp.utils.html.node`
     <button
       class="flat wide bold primary-colour"
-      onclick=${e=>{
+      onclick=${e => {
 
-        const btn = e.target
+      const btn = e.target
+
+      if (btn.classList.contains('active')) {
+
+        // Cancel draw interaction.
+        btn.classList.remove('active')
+        layer.mapview.interactions.highlight()
+        return;
+      }
+
+      btn.classList.add('active')
+
+      !layer.display && layer.show()
+
+      layer.draw.line.callback = feature => {
+
+        layer.draw.callback(feature, layer.draw.polygon)
 
         if (btn.classList.contains('active')) {
+
           btn.classList.remove('active')
-          layer.mapview.interactions.highlight()
-          return;
+
+          // Set highlight interaction if no other interaction is current after 400ms.
+          setTimeout(() => {
+            !layer.mapview.interaction && layer.mapview.interactions.highlight()
+          }, 400)
         }
-      
-        btn.classList.add('active')
-        
-        !layer.display && layer.show()
-      
-        layer.draw.line.callback = feature => {
-      
-          layer.draw.callback(feature, layer.draw.polygon)
-      
-          if (btn.classList.contains('active')) {
-            btn.classList.remove('active')
-            layer.mapview.interactions.highlight()
-          }
-        }
-      
-        layer.mapview.interactions.draw(layer.draw.line)
-        
-      }}>
+      }
+
+      layer.mapview.interactions.draw(layer.draw.line)
+
+    }}>
       ${label}`
 
   return layer.draw.line.btn
@@ -167,7 +181,7 @@ function polygon(layer) {
     layer,
     type: 'Polygon',
   }, typeof layer.draw.polygon === 'object' && layer.draw.polygon || {})
- 
+
   // If a label is provided, use it, otherwise use the default
   let label = layer.draw.polygon?.label || mapp.dictionary.draw_polygon
 
@@ -175,33 +189,40 @@ function polygon(layer) {
   layer.draw.polygon.btn = mapp.utils.html.node`
     <button
       class="flat wide bold primary-colour"
-      onclick=${e=>{
+      onclick=${e => {
 
-        const btn = e.target
+      const btn = e.target
+
+      if (btn.classList.contains('active')) {
+
+        // Cancel draw interaction.
+        btn.classList.remove('active')
+        layer.mapview.interactions.highlight()
+        return;
+      }
+
+      btn.classList.add('active')
+
+      !layer.display && layer.show()
+
+      layer.draw.polygon.callback = feature => {
+
+        layer.draw.callback(feature, layer.draw.polygon)
 
         if (btn.classList.contains('active')) {
+
           btn.classList.remove('active')
-          layer.mapview.interactions.highlight()
-          return;
+
+          // Set highlight interaction if no other interaction is current after 400ms.
+          setTimeout(() => {
+            !layer.mapview.interaction && layer.mapview.interactions.highlight()
+          }, 400)
         }
-      
-        btn.classList.add('active')
-        
-        !layer.display && layer.show()
-      
-        layer.draw.polygon.callback = feature => {
-      
-          layer.draw.callback(feature, layer.draw.polygon)
-      
-          if (btn.classList.contains('active')) {
-            btn.classList.remove('active')
-            layer.mapview.interactions.highlight()
-          }
-        }
-      
-        layer.mapview.interactions.draw(layer.draw.polygon)
-        
-      }}>
+      }
+
+      layer.mapview.interactions.draw(layer.draw.polygon)
+
+    }}>
       ${label}`
 
   return layer.draw.polygon.btn
@@ -218,41 +239,48 @@ function rectangle(layer) {
 
   // If a label is provided, use it, otherwise use the default
   let label = layer.draw.rectangle?.label || mapp.dictionary.draw_rectangle
-  
+
   // Create the button
   layer.draw.rectangle.btn = mapp.utils.html.node`
     <button
       class="flat wide bold primary-colour"
-      onclick=${e=>{
+      onclick=${e => {
 
-        const btn = e.target
+      const btn = e.target
+
+      if (btn.classList.contains('active')) {
+
+        // Cancel draw interaction.
+        btn.classList.remove('active')
+        layer.mapview.interactions.highlight()
+        return;
+      }
+
+      btn.classList.add('active')
+
+      !layer.display && layer.show()
+
+      layer.draw.rectangle.callback = feature => {
+
+        layer.draw.callback(feature, layer.draw.rectangle)
 
         if (btn.classList.contains('active')) {
+
           btn.classList.remove('active')
-          layer.mapview.interactions.highlight()
-          return;
+
+          // Set highlight interaction if no other interaction is current after 400ms.
+          setTimeout(() => {
+            !layer.mapview.interaction && layer.mapview.interactions.highlight()
+          }, 400)
         }
-      
-        btn.classList.add('active')
-        
-        !layer.display && layer.show()
-      
-        layer.draw.rectangle.callback = feature => {
-      
-          layer.draw.callback(feature, layer.draw.rectangle)
-      
-          if (btn.classList.contains('active')) {
-            btn.classList.remove('active')
-            layer.mapview.interactions.highlight()
-          }
-        }
-      
-        layer.mapview.interactions.draw(layer.draw.rectangle)
-        
-      }}>
+      }
+
+      layer.mapview.interactions.draw(layer.draw.rectangle)
+
+    }}>
       ${label}`
 
-   return layer.draw.rectangle.btn
+  return layer.draw.rectangle.btn
 }
 
 function circle_2pt(layer) {
@@ -271,36 +299,43 @@ function circle_2pt(layer) {
   layer.draw.circle_2pt.btn = mapp.utils.html.node`
     <button
       class="flat wide bold primary-colour"
-      onclick=${e=>{
+      onclick=${e => {
 
-        const btn = e.target
+      const btn = e.target
+
+      if (btn.classList.contains('active')) {
+
+        // Cancel draw interaction.
+        btn.classList.remove('active')
+        layer.mapview.interactions.highlight()
+        return;
+      }
+
+      btn.classList.add('active')
+
+      !layer.display && layer.show()
+
+      layer.draw.circle_2pt.callback = feature => {
+
+        layer.draw.callback(feature, layer.draw.circle_2pt)
 
         if (btn.classList.contains('active')) {
+
           btn.classList.remove('active')
-          layer.mapview.interactions.highlight()
-          return;
+
+          // Set highlight interaction if no other interaction is current after 400ms.
+          setTimeout(() => {
+            !layer.mapview.interaction && layer.mapview.interactions.highlight()
+          }, 400)
         }
-      
-        btn.classList.add('active')
-        
-        !layer.display && layer.show()
-      
-        layer.draw.circle_2pt.callback = feature => {
-      
-          layer.draw.callback(feature, layer.draw.circle_2pt)
-      
-          if (btn.classList.contains('active')) {
-            btn.classList.remove('active')
-            layer.mapview.interactions.highlight()
-          }
-        }
-      
-        layer.mapview.interactions.draw(layer.draw.circle_2pt)
-        
-      }}>
+      }
+
+      layer.mapview.interactions.draw(layer.draw.circle_2pt)
+
+    }}>
       ${label}`
 
-  return layer.draw.circle_2pt.btn      
+  return layer.draw.circle_2pt.btn
 }
 
 function circle(layer) {
@@ -333,9 +368,9 @@ function circle(layer) {
       return polygonCircular.transform('EPSG:4326', 'EPSG:3857')
     }
   }, typeof layer.draw.circle === 'object' && layer.draw.circle || {})
-  
-      // if label is provided, use it, otherwise use the default
-      let label= layer.draw.circle?.label || mapp.dictionary.draw_circle;
+
+  // if label is provided, use it, otherwise use the default
+  let label = layer.draw.circle?.label || mapp.dictionary.draw_circle;
 
   // Create the button
   const unitsDropDown = mapp.utils.html.node`
@@ -343,33 +378,33 @@ function circle(layer) {
       <div style="grid-column: 1;">Units</div>
       <div style="grid-column: 2;">
         ${mapp.ui.elements.dropdown({
-          placeholder: layer.draw.circle.units,
-          entries: [
-            {
-              title: 'Meter',
-              option: 'meter',
-            },
-            {
-              title: 'KM',
-              option: 'km',
-            },
-            {
-              title: 'Miles',
-              option: 'miles',
-            },
-            {
-              title: 'Meter²',
-              option: 'meter2',
-            },
-            {
-              title: 'KM²',
-              option: 'km2',
-            },
-          ],
-          callback: (e, entry) => {
-            layer.draw.circle.units = entry.option;
-          }
-        })}`
+    placeholder: layer.draw.circle.units,
+    entries: [
+      {
+        title: 'Meter',
+        option: 'meter',
+      },
+      {
+        title: 'KM',
+        option: 'km',
+      },
+      {
+        title: 'Miles',
+        option: 'miles',
+      },
+      {
+        title: 'Meter²',
+        option: 'meter2',
+      },
+      {
+        title: 'KM²',
+        option: 'km2',
+      },
+    ],
+    callback: (e, entry) => {
+      layer.draw.circle.units = entry.option;
+    }
+  })}`
 
   const rangeSlider = mapp.ui.elements.slider({
     label: 'Radius',
@@ -389,11 +424,13 @@ function circle(layer) {
   layer.draw.circle.btn = mapp.utils.html.node`
   <button
     class="flat wide bold primary-colour"
-    onclick=${e=>{
+    onclick=${e => {
 
       const btn = e.target
 
       if (btn.classList.contains('active')) {
+
+        // Cancel draw interaction.
         btn.classList.remove('active')
         layer.mapview.interactions.highlight()
         return;
@@ -401,34 +438,38 @@ function circle(layer) {
 
       // Expand the config drawer.
       btn.previousElementSibling.classList.add('expanded')
-    
+
       btn.classList.add('active')
-      
+
       !layer.display && layer.show()
-    
+
       layer.draw.circle.callback = feature => {
-    
+
         layer.draw.callback(feature, layer.draw.circle)
-    
+
         if (btn.classList.contains('active')) {
           btn.classList.remove('active')
-          layer.mapview.interactions.highlight()
+
+          // Set highlight interaction if no other interaction is current after 400ms.
+          setTimeout(() => {
+            !layer.mapview.interaction && layer.mapview.interactions.highlight()
+          }, 400)
         }
       }
-    
+
       layer.mapview.interactions.draw(layer.draw.circle)
-      
+
     }}>
     ${label}`
 
   // Return the config element in a drawer with the interaction toggle button as sibling.
   return mapp.utils.html.node`<div>
     ${mapp.ui.elements.drawer({
-      header: mapp.utils.html`
+    header: mapp.utils.html`
         <h3>${mapp.dictionary.circle_config}</h3>
         <div class="mask-icon expander"></div>`,
-      content: layer.draw.circle.panel
-    })}
+    content: layer.draw.circle.panel
+  })}
     ${layer.draw.circle.btn}`
 }
 
@@ -437,48 +478,48 @@ function locator(layer) {
   layer.draw.locator = Object.assign({
     layer,
     type: 'Point',
-  }, typeof layer.draw.locator === 'object' && layer.draw.locator || {})  
-  
+  }, typeof layer.draw.locator === 'object' && layer.draw.locator || {})
+
   layer.draw.locator.btn = mapp.utils.html.node`
     <button
       class="flat wide bold primary-colour"  
-      onclick=${e=>{
+      onclick=${e => {
 
-        mapp.utils.getCurrentPosition(async (pos) => {
+      mapp.utils.getCurrentPosition(async (pos) => {
 
-          const location = {
-            layer: layer,
-            new: true
-          }
+        const location = {
+          layer: layer,
+          new: true
+        }
 
-          const coords = ol.proj.transform(
-            [parseFloat(pos.coords.longitude), parseFloat(pos.coords.latitude)],
-            'EPSG:4326', `EPSG:${layer.srid}`)
- 
-          location.id = await mapp.utils.xhr({
-            method: 'POST',
-            url: `${location.layer.mapview.host}/api/location/new?` +
-              mapp.utils.paramString({
-                locale: location.layer.mapview.locale.key,
-                layer: location.layer.key,
-                table: location.layer.tableCurrent()
-              }),
-            body: JSON.stringify({
-              [location.layer.geom]: {
-                type: 'Point',
-                coordinates: coords
-              }
-            })
+        const coords = ol.proj.transform(
+          [parseFloat(pos.coords.longitude), parseFloat(pos.coords.latitude)],
+          'EPSG:4326', `EPSG:${layer.srid}`)
+
+        location.id = await mapp.utils.xhr({
+          method: 'POST',
+          url: `${location.layer.mapview.host}/api/location/new?` +
+            mapp.utils.paramString({
+              locale: location.layer.mapview.locale.key,
+              layer: location.layer.key,
+              table: location.layer.tableCurrent()
+            }),
+          body: JSON.stringify({
+            [location.layer.geom]: {
+              type: 'Point',
+              coordinates: coords
+            }
           })
-        
-          location.layer.reload()
-                                  
-          mapp.location.get(location)
         })
-        
-        
-      }}>
+
+        location.layer.reload()
+
+        mapp.location.get(location)
+      })
+
+
+    }}>
       ${mapp.dictionary.draw_position}`
 
-  return layer.draw.locator.btn      
+  return layer.draw.locator.btn
 }

--- a/lib/ui/locations/entries/geometry.mjs
+++ b/lib/ui/locations/entries/geometry.mjs
@@ -191,9 +191,9 @@ function modify(e, entry) {
   // Check whether to cancel interaction.
   if (btn.classList.contains('active')) {
 
-    // Finish current interaction.
-    // The callback will begin the highlight interaction.
-    entry.mapview.interaction.finish()
+    // Cancel modify interaction.
+    btn.classList.remove('active')
+    entry.mapview.interactions.highlight()
     return;
   }
 
@@ -216,7 +216,11 @@ function modify(e, entry) {
 
       // Reset interaction and button
       btn.classList.remove('active')
-      entry.mapview.interactions.highlight()
+
+      // Set highlight interaction if no other interaction is current after 400ms.
+      setTimeout(() => {
+        !entry.mapview.interaction && entry.mapview.interactions.highlight()
+      }, 400)
 
       // The callback returns a feature as geojson.
       if (feature) {

--- a/public/views/_default.js
+++ b/public/views/_default.js
@@ -276,7 +276,10 @@ window.onload = async () => {
 
         // If active cancel zoom and enable highlight interaction.
         if (e.target.classList.contains('active')) {
-          return mapview.interactions.highlight()
+          
+          e.target.classList.remove('active')
+          mapview.interactions.highlight()
+          return;
         }
 
         // Add active class
@@ -288,7 +291,6 @@ window.onload = async () => {
           // The interaction callback is executed on cancel or finish.
           callback: () => {
             e.target.classList.remove('active');
-            mapview.interactions.highlight();
           },
         })
 


### PR DESCRIPTION
The highlight interaction should not be activated in a callback as this will cause a callback hell.

The cancellation of an interaction should create a timeout to activate highlight interaction after 400ms if no other action is active.

This will allow to switch from one interaction to another without an intermediary highlight interaction.