### PR TITLE
Cache OL Styles object

### DIFF
--- a/lib/layer/Style.mjs
+++ b/lib/layer/Style.mjs
@@ -10,6 +10,10 @@ export default layer => {
 
   return function Style(feature) {
 
+    // Check for and return existing Styles object.
+    const Styles = feature.get('Styles')
+    if (Styles) return Styles
+
     feature.properties = feature.getProperties()
 
     // Geojson features have a properties property

--- a/lib/mapview/interactions/highlight.mjs
+++ b/lib/mapview/interactions/highlight.mjs
@@ -201,12 +201,15 @@ export default function (params) {
     typeof mapview.interaction.current.layer.style?.hover?.method === 'function'
       && mapview.interaction.current.layer.style.hover.method(feature.F, mapview.interaction.current.layer)
 
+    // Unset cached OL Styles object.
+    feature.F.set('Styles', null, true)
+
     // Style the feature itself if possible.
     if (mapview.interaction.current.layer.format !== 'mvt'
       && mapview.interaction.current.layer.style.highlight
       && typeof mapview.interaction.current.F.setStyle === 'function') {
 
-      feature.F.set('highlight', true)
+      feature.F.set('highlight', true, true)
       mapview.interaction.current.F.setStyle()
 
     } else if (mapview.interaction.current.layer.style.highlight) {
@@ -285,11 +288,14 @@ export default function (params) {
     // Delete the highlight id from current layer.
     delete mapview.interaction.current.layer.highlight
 
+    // Unset cached style to allow for highlight style.
+    mapview.interaction.current.F.set('Styles', null, true)
+
     // Style the feature itself if possible.
     if (mapview.interaction.current.layer.format !== 'mvt'
       && typeof mapview.interaction.current.F.setStyle === 'function') {
 
-      mapview.interaction.current.F.set('highlight', false)
+      mapview.interaction.current.F.set('highlight', false, true)
       mapview.interaction.current.F.setStyle()
 
     } else if (mapview.interaction.current.layer.style.highlight) {

--- a/lib/utils/style.mjs
+++ b/lib/utils/style.mjs
@@ -84,6 +84,9 @@ export default (style, feature) => {
     }
 
   })
+
+  // Set Styles object to cache style.
+  feature?.set('Styles', Styles, true)
   
   return Styles
 }


### PR DESCRIPTION
Generated OL styles can be set on a feature.

The highlight method must unset the style to allow for a highlight style to be applied.