### PR TITLE
Remove cloudinary sdk

### DIFF
--- a/lib/ui/locations/entries/documents.mjs
+++ b/lib/ui/locations/entries/documents.mjs
@@ -52,6 +52,12 @@ export default entry => {
         })}`,
         body: readerOnload.target.result
       })
+
+      if (!response) {
+
+        console.warn('Cloudinary document upload failed without response from XYZ host.')
+        return;
+      }
       
       const secure_url = response.secure_url;
       const public_id = response.public_id.replace(/.*\//, '').replace(/\.([\w-]{3})/, '');
@@ -96,11 +102,16 @@ export default entry => {
 
 		const doc = e.target;
 
-    mapp.utils.xhr(`${entry.location.layer.mapview.host}/api/provider/cloudinary?${mapp.utils.paramString({
+    const response = mapp.utils.xhr(`${entry.location.layer.mapview.host}/api/provider/cloudinary?${mapp.utils.paramString({
       destroy: true,
       public_id: doc.dataset.name,
       folder: entry.cloudinary_folder
     })}`)
+
+    if (!response) {
+      console.warn('Cloudinary destroy failed without response from XYZ host.')
+      return;
+    }
 
     await mapp.utils.xhr(`${entry.location.layer.mapview.host}/api/query?` +
       mapp.utils.paramString({

--- a/lib/ui/locations/entries/documents.mjs
+++ b/lib/ui/locations/entries/documents.mjs
@@ -109,7 +109,7 @@ export default entry => {
     })}`)
 
     if (!response) {
-      console.warn('Cloudinary destroy failed without response from XYZ host.')
+      console.warn('Cloudinary document destroy failed without response from XYZ host.')
       return;
     }
 

--- a/lib/ui/locations/entries/images.mjs
+++ b/lib/ui/locations/entries/images.mjs
@@ -81,6 +81,12 @@ export default entry => {
           body: mapp.utils.dataURLtoBlob(dataURL)
         })
 
+        if (!response) {
+
+          console.warn('Cloudinary image upload failed without response from XYZ host.')
+          return;
+        }
+
         await mapp.utils.xhr(`${entry.location.layer.mapview.host}/api/query?` +
           mapp.utils.paramString({
             template: 'set_field_array',
@@ -124,11 +130,16 @@ export default entry => {
 
     const img = e.target;
 
-    mapp.utils.xhr(`${entry.location.layer.mapview.host}/api/provider/cloudinary?${mapp.utils.paramString({
+    const response = mapp.utils.xhr(`${entry.location.layer.mapview.host}/api/provider/cloudinary?${mapp.utils.paramString({
       destroy: true,
       public_id: img.dataset.name,
       folder: entry.cloudinary_folder
     })}`)
+
+    if (!response) {
+      console.warn('Cloudinary destroy failed without response from XYZ host.')
+      return;
+    }
 
     await mapp.utils.xhr(`${entry.location.layer.mapview.host}/api/query?` +
       mapp.utils.paramString({
@@ -141,8 +152,8 @@ export default entry => {
         action: 'remove',
         field: entry.field,
         value: img.dataset.src
-      }))      
-
+      }))
+      
     img.parentNode.remove()
   }
 }

--- a/lib/ui/locations/entries/images.mjs
+++ b/lib/ui/locations/entries/images.mjs
@@ -9,151 +9,153 @@ export default entry => {
             class="mask-icon trash no"
             data-name=${image.replace(/.*\//, '').replace(/\.([\w-]{3})/, '')}
             data-src=${image}
-            onclick=${e => removeDocument(e)}>`
+            onclick=${e => removeDocument(e, entry)}>`
           }`)
 
-  const upLoadBtn = mapp.utils.html.node`
+  entry.upLoadBtn = mapp.utils.html.node`
     <div class="mask-icon add-photo pos-center">
       <input
         type="file"
         accept="image/*;capture=camera"
-        onchange=${upload}>`
+        onchange=${e=>upload(e, entry)}>`
 
-  entry.edit && images.push(upLoadBtn)
+  entry.edit && images.push(entry.upLoadBtn)
 
   if (!images.length) return;
 
-  const images_grid = mapp.utils.html.node`
+  entry.images_grid = mapp.utils.html.node`
     <div
       class="images-grid">${images}`
 
-  return images_grid;
+  return entry.images_grid; 
 
-  async function upload(e) {
-
-    entry.location.view?.classList.add('disabled')
-
-    const reader = new FileReader()
-      
-    const file = e.target.files[0]
   
-    if (!file) return;
+}
 
-    reader.onload = readerOnload => {
+async function upload(e, entry) {
 
-      const img = new Image()
+  entry.location.view?.classList.add('disabled')
+
+  const reader = new FileReader()
+    
+  const file = e.target.files[0]
+
+  if (!file) return;
+
+  reader.onload = readerOnload => {
+
+    const img = new Image()
+    
+    img.onload = async () => {
       
-      img.onload = async () => {
-        
-        let
-          canvas = mapp.utils.html.node`<canvas>`,
-          max_size = 1024,
-          width = img.width,
-          height = img.height
+      let
+        canvas = mapp.utils.html.node`<canvas>`,
+        max_size = 1024,
+        width = img.width,
+        height = img.height
 
-        // resize
-        if (width > height && width > max_size) {
-          height *= max_size / width
-          width = max_size
+      // resize
+      if (width > height && width > max_size) {
+        height *= max_size / width
+        width = max_size
 
-        } else if (height > max_size) {
-          width *= max_size / height
-          height = max_size
-        }
-
-        canvas.width = width
-        canvas.height = height
-
-        canvas.getContext('2d').drawImage(img, 0, 0, width, height)
-
-        const dataURL = canvas.toDataURL('image/jpeg', 0.5)
-
-        const response = await mapp.utils.xhr({
-          method: 'POST',
-          requestHeader: {
-            'Content-Type': 'application/octet-stream'
-          },
-          url: `${entry.location.layer.mapview.host}/api/provider/cloudinary?${mapp.utils.paramString({
-            public_id: file.name.replace(/.*\//, '').replace(/\.([\w-]{3})/, ''),
-            resource_type: 'image',
-            folder: entry.cloudinary_folder
-          })}`,
-          body: mapp.utils.dataURLtoBlob(dataURL)
-        })
-
-        if (!response) {
-
-          console.warn('Cloudinary image upload failed without response from XYZ host.')
-          return;
-        }
-
-        await mapp.utils.xhr(`${entry.location.layer.mapview.host}/api/query?` +
-          mapp.utils.paramString({
-            template: 'set_field_array',
-            locale: entry.location.layer.mapview.locale.key,
-            layer: entry.location.layer.key,
-            table: entry.location.table,
-            qID: entry.location.layer.qID,
-            id: entry.location.id,
-            action: 'append',
-            field: entry.field,
-            value:  response.secure_url,
-          }))
-
-        const newImg = mapp.utils.html.node`
-          <div>
-            <img
-              src=${response.secure_url}
-              onclick=${mapp.ui.utils.imagePreview}>
-              <button
-                class="mask-icon trash no"
-                data-name=${response.public_id}
-                data-src=${response.secure_url}
-                onclick=${e => removeDocument(e)}>`
-  
-        images_grid.insertBefore(newImg, upLoadBtn)
-
-        entry.location.view?.classList.remove('disabled')
+      } else if (height > max_size) {
+        width *= max_size / height
+        height = max_size
       }
 
-      img.src = readerOnload.target.result
+      canvas.width = width
+      canvas.height = height
+
+      canvas.getContext('2d').drawImage(img, 0, 0, width, height)
+
+      const dataURL = canvas.toDataURL('image/jpeg', 0.5)
+
+      const response = await mapp.utils.xhr({
+        method: 'POST',
+        requestHeader: {
+          'Content-Type': 'application/octet-stream'
+        },
+        url: `${entry.location.layer.mapview.host}/api/provider/cloudinary?${mapp.utils.paramString({
+          public_id: file.name.replace(/.*\//, '').replace(/\.([\w-]{3})/, ''),
+          resource_type: 'image',
+          folder: entry.cloudinary_folder
+        })}`,
+        body: mapp.utils.dataURLtoBlob(dataURL)
+      })
+
+      if (!response) {
+
+        console.warn('Cloudinary image upload failed without response from XYZ host.')
+        return;
+      }
+
+      await mapp.utils.xhr(`${entry.location.layer.mapview.host}/api/query?` +
+        mapp.utils.paramString({
+          template: 'set_field_array',
+          locale: entry.location.layer.mapview.locale.key,
+          layer: entry.location.layer.key,
+          table: entry.location.table,
+          qID: entry.location.layer.qID,
+          id: entry.location.id,
+          action: 'append',
+          field: entry.field,
+          value:  response.secure_url,
+        }))
+
+      const newImg = mapp.utils.html.node`
+        <div>
+          <img
+            src=${response.secure_url}
+            onclick=${mapp.ui.utils.imagePreview}>
+            <button
+              class="mask-icon trash no"
+              data-name=${response.public_id}
+              data-src=${response.secure_url}
+              onclick=${e => removeDocument(e, entry)}>`
+
+      entry.images_grid.insertBefore(newImg, entry.upLoadBtn)
+
+      entry.location.view?.classList.remove('disabled')
     }
 
-    reader.readAsDataURL(file)
-
-    e.target.value = ''
+    img.src = readerOnload.target.result
   }
 
-  async function removeDocument(e) {
+  reader.readAsDataURL(file)
 
-    if (!confirm('Remove image?')) return;
+  e.target.value = ''
+}
 
-    const img = e.target;
+async function removeDocument(e, entry) {
 
-    const response = mapp.utils.xhr(`${entry.location.layer.mapview.host}/api/provider/cloudinary?${mapp.utils.paramString({
-      destroy: true,
-      public_id: img.dataset.name,
-      folder: entry.cloudinary_folder
-    })}`)
+  if (!confirm('Remove image?')) return;
 
-    if (!response) {
-      console.warn('Cloudinary destroy failed without response from XYZ host.')
-      return;
-    }
+  const img = e.target;
 
-    await mapp.utils.xhr(`${entry.location.layer.mapview.host}/api/query?` +
-      mapp.utils.paramString({
-        template: 'set_field_array',
-        locale: entry.location.layer.mapview.locale.key,
-        layer: entry.location.layer.key,
-        table: entry.location.table,
-        qID: entry.location.layer.qID,
-        id: entry.location.id,
-        action: 'remove',
-        field: entry.field,
-        value: img.dataset.src
-      }))
-      
-    img.parentNode.remove()
+  const response = mapp.utils.xhr(`${entry.location.layer.mapview.host}/api/provider/cloudinary?${mapp.utils.paramString({
+    destroy: true,
+    public_id: img.dataset.name,
+    folder: entry.cloudinary_folder
+  })}`)
+
+  if (!response) {
+    console.warn('Cloudinary destroy failed without response from XYZ host.')
+    return;
   }
+
+  await mapp.utils.xhr(`${entry.location.layer.mapview.host}/api/query?` +
+    mapp.utils.paramString({
+      template: 'set_field_array',
+      locale: entry.location.layer.mapview.locale.key,
+      layer: entry.location.layer.key,
+      table: entry.location.table,
+      qID: entry.location.layer.qID,
+      id: entry.location.id,
+      action: 'remove',
+      field: entry.field,
+      value: img.dataset.src
+    }))
+    
+  img.parentNode.remove()
 }

--- a/lib/ui/locations/entries/images.mjs
+++ b/lib/ui/locations/entries/images.mjs
@@ -140,7 +140,7 @@ async function removeDocument(e, entry) {
   })}`)
 
   if (!response) {
-    console.warn('Cloudinary destroy failed without response from XYZ host.')
+    console.warn('Cloudinary image destroy failed without response from XYZ host.')
     return;
   }
 

--- a/mod/provider/cloudinary.js
+++ b/mod/provider/cloudinary.js
@@ -12,29 +12,11 @@ module.exports = async req => {
     return
   }
 
+  // Destroy cloudinary resource.
+  if (req.params.destroy) return await destroy(req)
+
   // The timestamp is required for the signature which is valid for 1hr.
   const timestamp = Date.now()
-
-  if (req.params.destroy) {
-
-    const toSign = `public_id=${req.params.public_id}&timestamp=${timestamp}${cloudinary[2]}`
-
-    const signature = createHash('sha256').update(toSign).digest('hex')
-  
-    const data = new FormData();
-  
-    data.append('public_id', req.params.public_id)
-    data.append('api_key', cloudinary[1])
-    data.append('timestamp', timestamp)
-    data.append('signature', signature);
-
-    const response = await fetch(`https://api.cloudinary.com/v1_1/${cloudinary[3]}/image/destroy`, {
-      method: "post",
-      body: data,
-    });
-
-    return await response.json()
-  }
 
   const toSign = `folder=${req.params.folder}&public_id=${req.params.public_id}&timestamp=${timestamp}${cloudinary[2]}`
 
@@ -55,6 +37,30 @@ module.exports = async req => {
   data.append('file', file);
 
   const response = await fetch(`https://api.cloudinary.com/v1_1/${cloudinary[3]}/upload`, {
+    method: "post",
+    body: data,
+  });
+
+  return await response.json()
+}
+
+async function destroy(req) {
+
+  // The timestamp is required for the signature which is valid for 1hr.
+  const timestamp = Date.now()
+
+  const toSign = `public_id=${req.params.public_id}&timestamp=${timestamp}${cloudinary[2]}`
+
+  const signature = createHash('sha256').update(toSign).digest('hex')
+
+  const data = new FormData();
+
+  data.append('public_id', req.params.public_id)
+  data.append('api_key', cloudinary[1])
+  data.append('timestamp', timestamp)
+  data.append('signature', signature);
+
+  const response = await fetch(`https://api.cloudinary.com/v1_1/${cloudinary[3]}/image/destroy`, {
     method: "post",
     body: data,
   });

--- a/mod/provider/cloudinary.js
+++ b/mod/provider/cloudinary.js
@@ -3,7 +3,7 @@ const { createHash } = require('crypto');
 // 1: api_key
 // 2: api_secret
 // 3: cloud_name
-const cloudinary = process.env.CLOUDINARY_URL?.replaceAll("://", " ").replaceAll(":", " ").replaceAll("@", " ").split(" ")
+const cloudinary = process.env.CLOUDINARY_URL?.replaceAll('://', ' ').replaceAll(':', ' ').replaceAll('@', ' ').split(' ')
 
 module.exports = async req => {
 
@@ -37,7 +37,7 @@ module.exports = async req => {
   data.append('file', file);
 
   const response = await fetch(`https://api.cloudinary.com/v1_1/${cloudinary[3]}/upload`, {
-    method: "post",
+    method: 'post',
     body: data,
   });
 
@@ -61,7 +61,7 @@ async function destroy(req) {
   data.append('signature', signature);
 
   const response = await fetch(`https://api.cloudinary.com/v1_1/${cloudinary[3]}/image/destroy`, {
-    method: "post",
+    method: 'post',
     body: data,
   });
 

--- a/mod/provider/cloudinary.js
+++ b/mod/provider/cloudinary.js
@@ -1,32 +1,65 @@
-const cloudinary_v2 = require('cloudinary').v2
+const { createHash } = require('crypto');
+
+// 1: api_key
+// 2: api_secret
+// 3: cloud_name
+const cloudinary = process.env.CLOUDINARY_URL?.replaceAll("://", " ").replaceAll(":", " ").replaceAll("@", " ").split(" ")
 
 module.exports = async req => {
 
-  req.body = req.body && await bodyData(req) || null
-
-  req.params.folder = req.params.folder || process.env.CLOUDINARY.split(' ')[3]
-
-  if (!process.env.CLOUDINARY_URL) {
-
-    cloudinary_v2.config({
-      api_key: process.env.CLOUDINARY.split(' ')[0],
-      api_secret: process.env.CLOUDINARY.split(' ')[1],
-      cloud_name: process.env.CLOUDINARY.split(' ')[2],
-    })
-
+  if (!cloudinary) {
+    console.warn(`process.env.CLOUDINARY_URL not set`)
+    return
   }
 
-  if (req.params.destroy) return await cloudinary_v2.uploader.destroy(`${req.params.folder}/${req.params.public_id}`)
+  // The timestamp is required for the signature which is valid for 1hr.
+  const timestamp = Date.now()
 
-  const ressource = req.params.resource_type === 'raw' && req.body.toString() || `data:image/jpeg;base64,${req.body.toString('base64')}`
+  if (req.params.destroy) {
 
-  return await cloudinary_v2.uploader.upload(ressource,
-    {
-      resource_type: req.params.resource_type,
-      public_id: `${req.params.folder}/${req.params.public_id}`, //${Date.now()}`,
-      overwrite: true
-    })
+    const toSign = `public_id=${req.params.public_id}&timestamp=${timestamp}${cloudinary[2]}`
 
+    const signature = createHash('sha256').update(toSign).digest('hex')
+  
+    const data = new FormData();
+  
+    data.append('public_id', req.params.public_id)
+    data.append('api_key', cloudinary[1])
+    data.append('timestamp', timestamp)
+    data.append('signature', signature);
+
+    const response = await fetch(`https://api.cloudinary.com/v1_1/${cloudinary[3]}/image/destroy`, {
+      method: "post",
+      body: data,
+    });
+
+    return await response.json()
+  }
+
+  const toSign = `folder=${req.params.folder}&public_id=${req.params.public_id}&timestamp=${timestamp}${cloudinary[2]}`
+
+  const signature = createHash('sha256').update(toSign).digest('hex')
+
+  const data = new FormData();
+
+  data.append('public_id', req.params.public_id)
+  data.append('folder', req.params.folder)
+  data.append('api_key', cloudinary[1])
+  data.append('timestamp', timestamp)
+  data.append('signature', signature);
+
+  req.body = req.body && await bodyData(req) || null
+
+  const file = req.params.resource_type === 'raw' ? req.body.toString() : `data:image/jpeg;base64,${req.body.toString('base64')}`
+
+  data.append('file', file);
+
+  const response = await fetch(`https://api.cloudinary.com/v1_1/${cloudinary[3]}/upload`, {
+    method: "post",
+    body: data,
+  });
+
+  return await response.json()
 }
 
 function bodyData(req) {

--- a/mod/provider/cloudinary.js
+++ b/mod/provider/cloudinary.js
@@ -3,37 +3,24 @@ const { createHash } = require('crypto');
 // 1: api_key
 // 2: api_secret
 // 3: cloud_name
-const cloudinary = process.env.CLOUDINARY_URL?.replaceAll('://', ' ').replaceAll(':', ' ').replaceAll('@', ' ').split(' ')
+const cloudinary = process.env.CLOUDINARY_URL?.replaceAll('://', ' ').replaceAll(':', ' ').replaceAll('@', ' ').split(' ');
 
 module.exports = async req => {
 
   if (!cloudinary) {
-    console.warn(`process.env.CLOUDINARY_URL not set`)
-    return
+    console.warn(`process.env.CLOUDINARY_URL not set`);
+    return;
   }
 
   // Destroy cloudinary resource.
-  if (req.params.destroy) return await destroy(req)
+  if (req.params.destroy) return await destroy(req);
 
-  // The timestamp is required for the signature which is valid for 1hr.
-  const timestamp = Date.now()
+  const data = generateData(req, 'upload');
 
-  const toSign = `folder=${req.params.folder}&public_id=${req.params.public_id}&timestamp=${timestamp}${cloudinary[2]}`
+  req.body = req.body && await bodyData(req) || null;
 
-  const signature = createHash('sha256').update(toSign).digest('hex')
-
-  const data = new FormData();
-
-  data.append('public_id', req.params.public_id)
-  data.append('folder', req.params.folder)
-  data.append('api_key', cloudinary[1])
-  data.append('timestamp', timestamp)
-  data.append('signature', signature);
-
-  req.body = req.body && await bodyData(req) || null
-
-  const file = req.params.resource_type === 'raw' ? req.body.toString() : `data:image/jpeg;base64,${req.body.toString('base64')}`
-
+  // Convert body to appropriate format
+  const file = req.params.resource_type === 'raw' ? req.body.toString() : `data:image/jpeg;base64,${req.body.toString('base64')}`;
   data.append('file', file);
 
   const response = await fetch(`https://api.cloudinary.com/v1_1/${cloudinary[3]}/upload`, {
@@ -41,44 +28,53 @@ module.exports = async req => {
     body: data,
   });
 
-  return await response.json()
+  return await response.json();
 }
 
 async function destroy(req) {
-
-  // The timestamp is required for the signature which is valid for 1hr.
-  const timestamp = Date.now()
-
-  const toSign = `public_id=${req.params.public_id}&timestamp=${timestamp}${cloudinary[2]}`
-
-  const signature = createHash('sha256').update(toSign).digest('hex')
-
-  const data = new FormData();
-
-  data.append('public_id', req.params.public_id)
-  data.append('api_key', cloudinary[1])
-  data.append('timestamp', timestamp)
-  data.append('signature', signature);
-
+  const data = generateData(req, 'destroy');
   const response = await fetch(`https://api.cloudinary.com/v1_1/${cloudinary[3]}/image/destroy`, {
     method: 'post',
     body: data,
   });
 
-  return await response.json()
+  return await response.json();
+}
+
+function generateData(req, action) {
+  // The timestamp is required for the signature which is valid for 1hr.
+  const timestamp = Date.now();
+  let toSign = '';
+
+  // Define signature string based on the action (upload/destroy)
+  if (action === 'upload') {
+    toSign = `folder=${req.params.folder}&public_id=${req.params.public_id}&timestamp=${timestamp}${cloudinary[2]}`;
+  } else if (action === 'destroy') {
+    toSign = `public_id=${req.params.public_id}&timestamp=${timestamp}${cloudinary[2]}`;
+  }
+
+  const signature = createHash('sha256').update(toSign).digest('hex');
+  const data = new FormData();
+
+  data.append('public_id', req.params.public_id);
+  data.append('api_key', cloudinary[1]);
+  data.append('timestamp', timestamp);
+  data.append('signature', signature);
+
+  // Append folder for upload action
+  if (action === 'upload') {
+    data.append('folder', req.params.folder);
+  }
+
+  return data;
 }
 
 function bodyData(req) {
-
   return new Promise((resolve, reject) => {
+    const chunks = [];
 
-    const chunks = []
-
-    req.on('data', chunk => chunks.push(chunk))
-
-    req.on('end', () => resolve(Buffer.concat(chunks)))
-
-    req.on('error', error => reject(error))
-
-  })
+    req.on('data', chunk => chunks.push(chunk));
+    req.on('end', () => resolve(Buffer.concat(chunks)));
+    req.on('error', error => reject(error));
+  });
 }

--- a/package.json
+++ b/package.json
@@ -20,7 +20,6 @@
     "@aws-sdk/lib-storage": "^3.223.0",
     "@aws-sdk/s3-request-presigner": "^3.229.0",
     "bcryptjs": "^2.4.3",
-    "cloudinary": "^1.37.0",
     "jsonwebtoken": "^9.0.0",
     "nanoid": "^3.2.0",
     "nodemailer": "^6.6.0",


### PR DESCRIPTION
`process.env.CLOUDINARY` has now been removed.

`process.env.CLOUDINARY_URL` as copied from the cloudinary dashboard works the same. The api_secret, api_key, and cloud_name will be split from the env string.

The cloudinary sdk has been removed from the package dependencies.

Cloudinary image & document upload work well with the cloudinary api. The requests are signed with `crypto` (builtin node module).

```js
    const toSign = `public_id=${req.params.public_id}&timestamp=${timestamp}${cloudinary[2]}`

    const signature = createHash('sha256').update(toSign).digest('hex')
```