### PR TITLE
Update AWS S3 provider

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,10 +15,9 @@
   },
   "license": "MIT",
   "dependencies": {
-    "@aws-sdk/client-s3": "^3.218.0",
-    "@aws-sdk/cloudfront-signer": "^3.90.0",
-    "@aws-sdk/lib-storage": "^3.223.0",
-    "@aws-sdk/s3-request-presigner": "^3.229.0",
+    "@aws-sdk/cloudfront-signer": "^3.398.0",
+    "@aws-sdk/client-s3": "^3.398.0",
+    "@aws-sdk/s3-request-presigner": "^3.398.0",
     "bcryptjs": "^2.4.3",
     "cloudinary": "^1.37.0",
     "jsonwebtoken": "^9.0.0",


### PR DESCRIPTION
Update S3 and cloudfront dependencies.

```
"@aws-sdk/cloudfront-signer": "^3.398.0",
"@aws-sdk/client-s3": "^3.398.0",
"@aws-sdk/s3-request-presigner": "^3.398.0",
```

Remove `@aws-sdk/lib-storage`.

Remove multi part upload logic.

Get and Put (upload) should be managed by pre signing an URL and then running the fetch(put) or get request from the browser. A process env `AWS_S3_CLIENT` variable must be set with an IAM accessKeyId and secretAccessKey for the resource.

```
"AWS_S3_CLIENT": "accessKeyId=***&secretAccessKey=***",
```

There is a test plugin on the mapp repository to test the S3 provider.
https://github.com/GEOLYTIX/mapp/blob/main/plugins/s3_bucket.js

The plugin must be enabled by providing a region and bucket for the resource.
```
"s3_bucket": {
  "region": "eu-west-2",
  "bucket": "test-bucket-glx"
},
```
The bucket URL must be added to the connect src csp. eg. `test-bucket-glx.s3.eu-west-2.amazonaws.com`