### PR TITLE
Enable maxlength edit config for type text

### DIFF
--- a/lib/ui/locations/entries/text.mjs
+++ b/lib/ui/locations/entries/text.mjs
@@ -13,6 +13,7 @@ export default entry => {
       val = mapp.utils.html`
       <input
         type="text"
+        maxlength=${entry.edit.maxlength}
         value="${entry.value || ''}"
         placeholder="${entry.edit.placeholder || ''}"
         onkeyup=${e => {

--- a/lib/ui/locations/entries/textarea.mjs
+++ b/lib/ui/locations/entries/textarea.mjs
@@ -7,6 +7,7 @@ export default entry => {
     val = mapp.utils.html`
     <textarea
       style="auto; min-height: 50px;"
+      maxlength=${entry.edit.maxlength}
       placeholder="${entry.edit.placeholder || ''}"
       onfocus=${e => {
         e.target.style.height = e.target.scrollHeight + 'px';


### PR DESCRIPTION
https://github.com/GEOLYTIX/xyz/wiki/Workspace-Configuration#text

Setting maxlength in the edit config will set the same attribute on the text input.