### PR TITLE
Dynamically adjust the position tabulator dropdown elements. Tabulator 5.5.2

### DIFF
--- a/lib/ui/elements/dropdown.mjs
+++ b/lib/ui/elements/dropdown.mjs
@@ -73,6 +73,13 @@ export default (params) => {
       <div class="head"
         onclick=${(e) => {
 
+          const bounds = e.target.getBoundingClientRect()
+
+          const viewport = document.body.getBoundingClientRect()
+
+          // Set the maxHeight of the ul based on the difference between the bottom and document.body height.
+          e.target.nextElementSibling.style.maxHeight = `${viewport.height - bounds.bottom}px`
+        
           e.target.nextElementSibling.style.width = `${e.target.offsetWidth}px`
 
           // Collapse dropdown element and short circuit.

--- a/lib/ui/utils/Tabulator.mjs
+++ b/lib/ui/utils/Tabulator.mjs
@@ -28,26 +28,6 @@ export default async function() {
       return
     }
 
-    // // Append the tabulator css to the document head.
-    // document.getElementsByTagName('HEAD')[0].append(mapp.utils.html.node`
-    // <link rel="stylesheet" href="https://unpkg.com/tabulator-tables@5.4.3/dist/css/tabulator.min.css"/>`);
-
-    // // Import Chart and plugins.
-    // Promise
-    //   .all([
-    //     import('https://cdn.skypack.dev/pin/tabulator-tables@v5.4.3-Vy9m0B6vzJzRwJ1amSyz/mode=imports,min/optimized/tabulator-tables.js')
-    //   ])
-    //   .then(imports => {
-  
-    //     Tabulator = imports[0].TabulatorFull
-
-    //     resolve()
-    //   })
-    //   .catch(error => {
-    //     console.error(error.message)
-    //     alert('Failed to load Tabulator library. Please reload the browser.')
-    //   })
-
     // Append the tabulator css to the document head.
     document.getElementsByTagName('HEAD')[0].append(mapp.utils.html.node`
     <link rel="stylesheet" href="https://unpkg.com/tabulator-tables@5.5.2/dist/css/tabulator.min.css"/>`);

--- a/lib/ui/utils/Tabulator.mjs
+++ b/lib/ui/utils/Tabulator.mjs
@@ -28,14 +28,34 @@ export default async function() {
       return
     }
 
+    // // Append the tabulator css to the document head.
+    // document.getElementsByTagName('HEAD')[0].append(mapp.utils.html.node`
+    // <link rel="stylesheet" href="https://unpkg.com/tabulator-tables@5.4.3/dist/css/tabulator.min.css"/>`);
+
+    // // Import Chart and plugins.
+    // Promise
+    //   .all([
+    //     import('https://cdn.skypack.dev/pin/tabulator-tables@v5.4.3-Vy9m0B6vzJzRwJ1amSyz/mode=imports,min/optimized/tabulator-tables.js')
+    //   ])
+    //   .then(imports => {
+  
+    //     Tabulator = imports[0].TabulatorFull
+
+    //     resolve()
+    //   })
+    //   .catch(error => {
+    //     console.error(error.message)
+    //     alert('Failed to load Tabulator library. Please reload the browser.')
+    //   })
+
     // Append the tabulator css to the document head.
     document.getElementsByTagName('HEAD')[0].append(mapp.utils.html.node`
-    <link rel="stylesheet" href="https://unpkg.com/tabulator-tables@5.4.3/dist/css/tabulator.min.css"/>`);
+    <link rel="stylesheet" href="https://unpkg.com/tabulator-tables@5.5.2/dist/css/tabulator.min.css"/>`);
 
     // Import Chart and plugins.
     Promise
       .all([
-        import('https://cdn.skypack.dev/pin/tabulator-tables@v5.4.3-Vy9m0B6vzJzRwJ1amSyz/mode=imports,min/optimized/tabulator-tables.js')
+        import('https://unpkg.com/tabulator-tables@5.5.2/dist/js/tabulator_esm.min.js')
       ])
       .then(imports => {
   
@@ -46,7 +66,7 @@ export default async function() {
       .catch(error => {
         console.error(error.message)
         alert('Failed to load Tabulator library. Please reload the browser.')
-      })
+      })      
   
   })
 
@@ -57,6 +77,34 @@ export default async function() {
 
   // Await for the Tabulator table instance to be built in Promise
   await new Promise(resolve => T.on('tableBuilt', resolve))
+
+  // Find ul_parents that are positioned fixed in table header.
+  let ul_parents = T.element.querySelectorAll('.ul-parent')
+
+  // Adjust fixed dropdowns on scroll.
+  ul_parents.length && T.on("scrollHorizontal", left => {
+
+    // Get the table element bounds.
+    const table_bounds = T.element.getBoundingClientRect()
+
+    for (const ul_parent of ul_parents) {
+
+      // Get the ul_parent bounds.
+      let header_bounds = ul_parent.getBoundingClientRect()
+
+      // Get ul element itself
+      const ul = ul_parent.querySelector('ul')
+
+      // The ul may not exist if populated from a query.
+      if (ul) {
+
+        // Set fixed element to be the difference of the parent and table bounds on scroll.
+        ul.style.left = `${header_bounds.left - table_bounds.left}px`
+      }
+
+    }
+
+  });
 
   // Return built Tabulator instance.
   return T

--- a/lib/ui/utils/tabulatorUtils.mjs
+++ b/lib/ui/utils/tabulatorUtils.mjs
@@ -249,10 +249,10 @@ function set(_this) {
 
     const field = cell.getColumn().getField()
 
-    if (headerFilterParams.distinct) {
+    // Create dropdown for render.
+    let dropdown = mapp.utils.html.node`<div class="ul-parent">`
 
-      // Create dropdown for render.
-      let dropdown = mapp.utils.html.node`<div>`
+    if (headerFilterParams.distinct) {
 
       // Query distinct field values.
       mapp.utils.xhr(`${_this.layer.mapview.host}/api/query?` +
@@ -279,7 +279,7 @@ function set(_this) {
       return dropdown
     }
 
-    let dropdown = mapp.ui.elements.dropdown({
+    mapp.utils.render(dropdown, mapp.ui.elements.dropdown({
       multi: true,
       placeholder: headerFilterParams.placeholder || 'Set filter',
       entries: headerFilterParams.options.map(option => ({
@@ -288,7 +288,7 @@ function set(_this) {
         //selected: chkSet.has(val)
       })),
       callback 
-    })
+    }))
 
     return dropdown
 

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "eslint-plugin-promise": "^6.1.1",
     "express": "^4.17.1",
     "jest": "^29.5.0",
-    "sass": "^1.58.0",
+    "sass": "^1.66.1",
     "uhtml": "^3.1.0"
   }
 }

--- a/public/views/_default.html
+++ b/public/views/_default.html
@@ -23,8 +23,8 @@
     <script src='https://unpkg.com/maplibre-gl@2.4.0/dist/maplibre-gl.js'></script> -->
 
   <!-- Tabulator will not be imported from skypack if loaded here.-->
-  <!-- <link rel="stylesheet" href="https://unpkg.com/tabulator-tables@5.4.4/dist/css/tabulator.min.css" />
-  <script type="text/javascript" src="https://unpkg.com/tabulator-tables@5.4.4/dist/js/tabulator.min.js"></script>  -->
+  <!-- <link rel="stylesheet" href="https://unpkg.com/tabulator-tables/dist/css/tabulator.min.css" />
+  <script type="text/javascript" src="https://unpkg.com/tabulator-tables/dist/js/tabulator.min.js"></script>  -->
 
   <!-- ChartJS will not be imported from skypack if loaded here
     <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>-->


### PR DESCRIPTION
UL dropdown elements must be positioned fixed in order to be visible outside of their element.

The Tabulator container maybe scroll-able. The fixed elements must be re-positioned in the horizontal scroll event of the Tabulator table element.

The maxHeight should be adjusted in the click event on the dropdown header.

**Tabulator has been bumped to 5.5.2 and is imported as ESM from unpkg instead of skypack.**
