### PR TITLE
Do not delete interaction when finishing

### DIFF
--- a/lib/mapview/interactions/draw.mjs
+++ b/lib/mapview/interactions/draw.mjs
@@ -175,7 +175,5 @@ export default function(params){
     mapview.Map.removeLayer(mapview.interaction.Layer)
 
     mapview.interaction.callback?.(feature)
-
-    delete mapview.interaction
   }
 }

--- a/lib/mapview/interactions/highlight.mjs
+++ b/lib/mapview/interactions/highlight.mjs
@@ -39,9 +39,6 @@ export default function (params) {
     ...params
   }
 
-  // Set mapview.interaction to be the current mapview mapview.interaction.
-  mapview.interaction = mapview.interaction
-
   // pointerMove will highlight features.
   mapview.Map.on('pointermove', pointerMove)
 
@@ -68,7 +65,7 @@ export default function (params) {
     delete mapview.interaction.longClick
 
     // Clear longClick timeout.
-    clearTimeout(mapview.interaction.longClickTimeout)
+    mapview.interaction.longClickTimeout && clearTimeout(mapview.interaction.longClickTimeout)
 
     // Set longClick timeout.
     mapview.interaction.longClickTimeout = setTimeout(
@@ -95,7 +92,7 @@ export default function (params) {
     if (mapview.popup()) return;
 
     // Clear longClick timeout.
-    clearTimeout(mapview.interaction.longClickTimeout)
+    mapview.interaction.longClickTimeout && clearTimeout(mapview.interaction.longClickTimeout)
 
     // Method should short circuit if still processing.
     if (shortCircuit) return;
@@ -227,7 +224,7 @@ export default function (params) {
     mapview.Map.getTargetElement().style.cursor = 'auto'
 
     // Clear longClick timeout.
-    clearTimeout(mapview.interaction.longClickTimeout)
+    mapview.interaction.longClickTimeout && clearTimeout(mapview.interaction.longClickTimeout)
 
     if (mapview.interaction.longClick && typeof mapview.interaction.longClickMethod === 'function') {
 
@@ -390,7 +387,5 @@ export default function (params) {
     mapview.Map.getTargetElement().removeEventListener('mouseup', mouseUp)
 
     mapview.interaction.callback?.()
-
-    delete mapview.interaction
   }
 }

--- a/lib/mapview/interactions/modify.mjs
+++ b/lib/mapview/interactions/modify.mjs
@@ -89,9 +89,6 @@ export default function(params){
     ...params
   }
 
-  // Set mapview.interaction to be the current mapview interaction.
-  mapview.interaction = mapview.interaction
-
   mapview.Map.getTargetElement().style.cursor = 'crosshair'
 
   mapview.interaction.source.addFeature(mapview.interaction.Feature)
@@ -165,7 +162,5 @@ export default function(params){
     mapview.Map.removeLayer(mapview.interaction.Layer)
 
     mapview.interaction.callback?.(feature)
-
-    delete mapview.interaction
   }
 }

--- a/lib/mapview/interactions/zoom.mjs
+++ b/lib/mapview/interactions/zoom.mjs
@@ -58,7 +58,5 @@ export default function(params){
     mapview.interaction.Layer.getSource().clear()
 
     mapview.interaction.callback?.()
-
-    delete mapview.interaction
   }
 }


### PR DESCRIPTION
The `mapview.interaction` is assigned after the current interaction is finished, `mapview.interaction?.finish()`

The finish method can call a callback prior to deleting the current interaction.

If the callback method were to enable the highlight interaction this would cause an issue.

The highlight interaction would be enabled and immediately deleted once the callback execution finished and the event loop jumps back into the finish method, deleting now the current highlight interaction and not itself.

The interaction must not be deleted. This is legacy logic from a time where we (object) assigned the interaction and it's parameter argument on initialisation. The interaction is now set with the params argument spread in.