### PR TITLE
Bump Maplibre skypack import to v3.3.1

### DIFF
--- a/lib/layer/format/maplibre.mjs
+++ b/lib/layer/format/maplibre.mjs
@@ -17,10 +17,10 @@ async function MaplibreGL() {
 
     Promise
       .all([
-        import('https://cdn.skypack.dev/pin/maplibre-gl@v2.4.0-H4IHKk1NcQVlmkNN8f4I/mode=imports,min/optimized/maplibre-gl.js'),
+        import('https://cdn.skypack.dev/pin/maplibre-gl@v3.3.1-tpQnCWSKVKnsrj9mKNGz/mode=imports,min/optimized/maplibre-gl.js')
       ])
       .then(imports => {
-  
+ 
         maplibregl = imports[0]
 
         resolve()


### PR DESCRIPTION
This is another intermediary bump while we wait for the library conversion to ESM modules.

https://github.com/maplibre/maplibre-gl-js/issues/1595