### PR TITLE
Console Warning Update

### DIFF
--- a/lib/layer/decorate.mjs
+++ b/lib/layer/decorate.mjs
@@ -15,14 +15,14 @@ export default async layer => {
   });
 
   if (layer.edit) {
-    console.warn(`Layer: ${layer.key} please update edit:{} to use draw:{} as layer.edit has been superseeded with layer.draw to be in line with the OL drawing interaction.`)
+    console.warn(`Layer: ${layer.key}, please update edit:{} to use draw:{} as layer.edit has been superseeded with layer.draw to be in line with the OL drawing interaction.`)
     layer.draw = Object.assign(layer.draw || {}, layer.edit)
   }
 
   if (layer.draw) {
 
     if (layer.draw?.delete) {
-      console.warn(`Layer: ${layer.key} please move draw.delete to use layer.deleteLocation:true.`)
+      console.warn(`Layer: ${layer.key}, please move draw.delete to use layer.deleteLocation:true.`)
     }
     
     // Callback which creates and stores a location from a feature returned by the drawing interaction.
@@ -81,7 +81,7 @@ export default async layer => {
 
   if (layer.hover) {
 
-    console.warn(`layer.hover{} should be defined within layer.style{}.`)
+    console.warn(`Layer: ${layer.key}, layer.hover{} should be defined within layer.style{}.`)
     layer.style.hover = layer.hover;
     delete layer.hover;
   }

--- a/lib/layer/format/cluster.mjs
+++ b/lib/layer/format/cluster.mjs
@@ -15,7 +15,7 @@ export default layer => {
 
   // If legacy cluster properties are set, provide warning to update. 
   if (layer.cluster_label || layer.cluster_kmeans || layer.cluster_dbscan || layer.cluster_resolution || layer.cluster_hexgrid) {
-    console.warn(`Layer ${layer.key} is using legacy cluster properties. Please update to use cluster:{} config object.`)
+    console.warn(`Layer: ${layer.key}, is using legacy cluster properties. Please update to use cluster:{} config object.`)
   }
 
   let timeout

--- a/lib/layer/format/vector.mjs
+++ b/lib/layer/format/vector.mjs
@@ -1,11 +1,11 @@
 export default layer => {
 
   if (layer.properties) {
-    console.warn(`layer.properties{} are no longer required for wkt & geojson datasets.`)
+    console.warn(`Layer: ${layer.key},layer.properties{} are no longer required for wkt & geojson datasets.`)
   }
 
   if (layer?.cluster?.resolution){
-    console.warn(`Layer ${layer.key} does not support cluster.resolution. Please use cluster.distance instead.`)
+    console.warn(`Layer: ${layer.key}, does not support cluster.resolution. Please use cluster.distance instead.`)
   }
 
   layer.srid ??= '4326'

--- a/lib/mapview/addLayer.mjs
+++ b/lib/mapview/addLayer.mjs
@@ -23,7 +23,7 @@ export default async function (layers) {
 
     // Check the layer format.
     if (!mapp.layer.formats[layer.format]) {
-      console.warn(`${layer.key} layer format is unknown or undefined. This is likely due to an incorrect file path.`)
+      console.warn(`Layer: ${layer.key}, format is unknown or undefined. This is likely due to an incorrect file path.`)
       continue;
     }
 

--- a/mod/workspace/assignDefaults.js
+++ b/mod/workspace/assignDefaults.js
@@ -65,7 +65,7 @@ module.exports = async workspace => {
       // Check for layer geom[s].
       if ((layer.table || layer.tables) && (!layer.geom && !layer.geoms)) {
 
-        console.warn(`Layer ${layer?.name || layer.key} has a table or tables defined, but no geom or geoms.`)
+        console.warn(`Layer: ${layer.key},has a table or tables defined, but no geom or geoms.`)
       }
 
       // Assign layer key as name with no existing name on layer object.

--- a/mod/workspace/cache.js
+++ b/mod/workspace/cache.js
@@ -61,7 +61,7 @@ async function cache() {
 
   if (workspace.plugins) {
 
-    console.warn(`Defult plugins should be defined in the default workspace.locale{}`)
+    console.warn(`Default plugins should be defined in the default workspace.locale{}`)
   }
 
   // Substitute all SRC_* variables in locales.


### PR DESCRIPTION
This PR is simply amending the console warnings - 
all layer based console warnings now begin with `Layer: ${layer.key}, ` for consistency. 
Addressed a spelling mistake in another console warning