### PR TITLE
Set source to null on vector reload with features === null

### DIFF
--- a/lib/layer/format/vector.mjs
+++ b/lib/layer/format/vector.mjs
@@ -12,6 +12,13 @@ export default layer => {
 
   layer.setSource = (features) => {
 
+    // The layer datasource is empty.
+    if (features === null) {
+
+      layer.L.setSource(null)
+      return;
+    }
+
     if (!features) return;
   
     let source = new ol.source.Vector({


### PR DESCRIPTION
The vector layer source will remain unchanged if a single feature is deleted. The vector layer reload will return null and the setSource method will return with the single feature remaining in the layer source.