### PR TITLE
Roles Check

### DIFF
--- a/lib/layer/decorate.mjs
+++ b/lib/layer/decorate.mjs
@@ -1,8 +1,8 @@
 export default async layer => {
-  
+
   // Decorate layer format methods.
   await mapp.layer.formats[layer.format](layer);
-  
+
   Object.assign(layer, {
     show,
     showCallbacks: [],
@@ -24,17 +24,17 @@ export default async layer => {
     if (layer.draw?.delete) {
       console.warn(`Layer: ${layer.key}, please move draw.delete to use layer.deleteLocation:true.`)
     }
-    
+
     // Callback which creates and stores a location from a feature returned by the drawing interaction.
     layer.draw.callback = async (feature, params) => {
- 
+
       if (!feature) return;
-    
+
       const location = {
         layer,
         new: true
       }
-    
+
       // Store location in database.
       // The id must be returned from a serial ID field.
       location.id = await mapp.utils.xhr({
@@ -49,13 +49,13 @@ export default async layer => {
           [layer.geom]: feature.geometry
         },
 
-        // Assign default properties.
-        params?.defaults || {},
-        layer.draw?.defaults || {}))
+          // Assign default properties.
+          params?.defaults || {},
+          layer.draw?.defaults || {}))
       })
-    
+
       layer.reload()
-    
+
       // Get the newly created location.
       mapp.location.get(location)
     }
@@ -97,7 +97,7 @@ export default async layer => {
   }
 
   if (layer.style?.hover) {
-    
+
     // Assign default featureHover method if non is provided.
     layer.style.hover.method ??= mapp.layer.featureHover;
   }
@@ -112,44 +112,59 @@ export default async layer => {
       : layer.style.labels[layer.style.label || Object.keys(layer.style.labels)[0]];
   }
 
-  // Ammend layer json with user role config.
+  // Check if the mapp.user.roles array exists and is an array
   if (Array.isArray(mapp.user?.roles)) {
 
-    // Iterate through the layer.roles object.
-    Object.keys(layer.roles || {}).forEach(role => {
+    // Iterate through each role in the layer.roles object
+    for (const role in layer.roles || {}) {
 
-      // Check whether the role value is an object and not null
-      if (layer.roles[role] !== null && typeof layer.roles[role] === 'object'
+      // Check if the role is an object and not null
+      if (layer.roles[role] !== null && typeof layer.roles[role] === 'object') {
+        
+        // Extract the role name from negated roles (e.g., "!role" becomes "role")
+        const roleName = role.match(/(?<=^!)(.*)/g)?.[0];
 
-        // Check whether role is included or a negated role is not included in user.roles
-        && mapp.user.roles.includes(role) || !mapp.user.roles.includes(role.match(/(?<=^!)(.*)/g)?.[0])) {
+        // Check if the role is included in mapp.user.roles
+        if (mapp.user.roles.includes(role)) {
+          // Log the merge operation
+          console.log('Merging', layer.roles[role], 'into', layer);
 
-        // Merge the role object with the layer.
-        mapp.utils.merge(layer, layer.roles[role])
+          // Merge the role object with the layer
+          mapp.utils.merge(layer, layer.roles[role]);
+        }
+        // Check if the negated role is not included in mapp.user.roles
+        else if (roleName && !mapp.user.roles.includes(roleName)) {
+          // Log the merge operation
+          console.log('Merging', layer.roles[role], 'into', layer);
+
+          // Merge the role object with the layer.
+          mapp.utils.merge(layer, layer.roles[role]);
+        }
       }
-    })
+    }
 
     // Adjust infoj entries for user roles.
     layer.infoj?.filter(entry => typeof entry.roles === 'object').forEach(entry => {
+      for (const role in entry.roles) {
 
-      Object.keys(entry.roles).forEach(role => {
+        // Check if the role is an object
+        if (typeof entry.roles[role] === 'object') {
+          // Extract the role name from negated roles (e.g., "!admin" becomes "admin")
+          const roleName = role.match(/(?<=^!)(.*)/g)?.[0];
 
-        // Check whether the role value is an object
-        if (typeof entry.roles[role] === 'object'
-
-          // Check whether role is included
-          && mapp.user.roles.includes(role)
-          
-          // or whether a negated role is not included in user.roles
-          || role.match(/(?<=^!)(.*)/g)?.[0] && !mapp.user.roles.includes(role.match(/(?<=^!)(.*)/g)?.[0])) {
-
-            // Merge the role object with the entry.
-            mapp.utils.merge(entry, entry.roles[role])
-
+          // Check if the role is included in 'mapp.user.roles'
+          if (mapp.user.roles.includes(role)) {
+            // Merge the role object with the entry
+            mapp.utils.merge(entry, entry.roles[role]);
+          }
+          // Check if the negated role is not included in 'mapp.user.roles'
+          else if (roleName && !mapp.user.roles.includes(roleName)) {
+            // Merge the role object with the entry
+            mapp.utils.merge(entry, entry.roles[role]);
+          }
         }
-      })
-
-    })
+      }
+    });
   }
 
   // Call layer and/or plugin methods.
@@ -232,7 +247,7 @@ function tableCurrent() {
   // Get first zoom level key from array.
   const minZoomKey = parseInt(zoomKeys[0]);
   const maxZoomKey = parseInt(zoomKeys[zoomKeys.length - 1]);
-     
+
   // Get the table for the current zoom level.
   table = this.tables[zoom];
 
@@ -273,9 +288,9 @@ async function zoomToExtent(params) {
   /**
    * Zooms to a specific extent
    */
-  
+
   // XMLHttpRequest to layer extent endpoint
-  let response = await mapp.utils.xhr(`${this.mapview.host}/api/query/layer_extent?`+
+  let response = await mapp.utils.xhr(`${this.mapview.host}/api/query/layer_extent?` +
     mapp.utils.paramString({ // build query string for the url
       dbs: this.dbs,
       locale: this.mapview.locale.key,

--- a/lib/layer/decorate.mjs
+++ b/lib/layer/decorate.mjs
@@ -122,20 +122,17 @@ export default async layer => {
       if (layer.roles[role] !== null && typeof layer.roles[role] === 'object') {
         
         // Extract the role name from negated roles (e.g., "!role" becomes "role")
-        const roleName = role.match(/(?<=^!)(.*)/g)?.[0];
+        const negatedRole = role.match(/(?<=^!)(.*)/g)?.[0];
 
         // Check if the role is included in mapp.user.roles
         if (mapp.user.roles.includes(role)) {
-          // Log the merge operation
-          console.log('Merging', layer.roles[role], 'into', layer);
 
           // Merge the role object with the layer
           mapp.utils.merge(layer, layer.roles[role]);
         }
+
         // Check if the negated role is not included in mapp.user.roles
-        else if (roleName && !mapp.user.roles.includes(roleName)) {
-          // Log the merge operation
-          console.log('Merging', layer.roles[role], 'into', layer);
+        else if (negatedRole && !mapp.user.roles.includes(negatedRole)) {
 
           // Merge the role object with the layer.
           mapp.utils.merge(layer, layer.roles[role]);


### PR DESCRIPTION
I noticed that with the previous logic around layer.roles merging, if the user has a single role found in the roles object, then the method loops through all roles in the layer.roles object and merges everything. 
This is incorrect, it should only merge the relevant roles object. 
I have refactored the roles to hopefully make it a little more readable, and this should fix the described issue. 

Please note, i've left the console logs in for testing - but we need to remember to remove as a final commit when we are happy!