### PR TITLE
Fix for Legend CSS Bug

### DIFF
--- a/public/css/_mapp.css
+++ b/public/css/_mapp.css
@@ -229,11 +229,11 @@ a > img {
     }
   }
 
-  &.switch {
+  & .switch {
     cursor: pointer;
   }
 
-  &.switch.disabled {
+  & .switch.disabled {
     /* text-decoration: line-through; */
     opacity: 0.5;
   }

--- a/public/css/mapp.css
+++ b/public/css/mapp.css
@@ -205,10 +205,10 @@ a > img {
       justify-content: start;
     }
   }
-  &.switch {
+  & .switch {
     cursor: pointer;
   }
-  &.switch.disabled {
+  & .switch.disabled {
     opacity: 0.5;
   }
 }


### PR DESCRIPTION
## CSS Issue 🐞

Upon hovering over an icon in the legend 🗺️, the cursor did not change to a pointer. Additionally, clicking on the icon did not result in it being greyed out ⛔.**

This is a fix for an incorrect parent selector for a Layer Legend!

```css
& .switch {
    cursor: pointer;
  }

  & .switch.disabled {
    /* text-decoration: line-through; */
    opacity: 0.5;
  }
```

