### PR TITLE
Merge locale.layer

### DIFF
--- a/lib/mapview/addLayer.mjs
+++ b/lib/mapview/addLayer.mjs
@@ -7,11 +7,13 @@ export default async function (layers) {
 
   if (!Array.isArray(layers)) return;
 
+  console.log(this.locale)
+
   const layersSet = this.hooks && new Set(mapp.hooks.current.layers);
 
-  for (let _layer of layers) {
+  for (const _layer of layers) {
 
-    let layer = mapp.utils.clone(_layer);
+    const layer = mapp.utils.merge({}, this.locale.layer || {}, _layer)
 
     layer.mapview = this;
 

--- a/lib/mapview/addLayer.mjs
+++ b/lib/mapview/addLayer.mjs
@@ -7,8 +7,6 @@ export default async function (layers) {
 
   if (!Array.isArray(layers)) return;
 
-  console.log(this.locale)
-
   const layersSet = this.hooks && new Set(mapp.hooks.current.layers);
 
   for (const _layer of layers) {


### PR DESCRIPTION
The `locale.layer{}` will be used as a master template for all layers in the locale.

The `mapview.addLayer()` will merge the layer JSON onto the `locale.layer{}` into a new object.

It should not be necessary to clone the layer object but this needs some in depth testing.

```json
      "layer": {
        "filter": {
          "current": {
            "country_code": {
              "match": "GBR"
            }
          }
        },
        "draw": {
          "defaults": {
            "country_code": "GBR"
          }
        }
      },
```

https://github.com/GEOLYTIX/xyz/wiki/Workspace-Configuration#layer-1

