### PR TITLE
Allow for empty roles update

### DIFF
--- a/mod/user/update.js
+++ b/mod/user/update.js
@@ -10,7 +10,7 @@ module.exports = async (req, res) => {
   const email = req.params.email.replace(/\s+/g, '')
 
   if (req.params.field === 'roles') {
-    req.params.value = req.params.value.split(',')
+    req.params.value = req.params.value?.split(',') || []
   }
 
   // Get user to update from ACL.

--- a/public/views/_user.html
+++ b/public/views/_user.html
@@ -425,6 +425,11 @@
     };
 
     function rolesEdited(e) {
+
+      if (JSON.stringify(e._cell.value) === JSON.stringify(e._cell.oldValue)) return;
+
+      //if (e._cell.value.every((val, i) => val === e._cell.oldValue[i])) return;
+
       xhrPromise(`${document.head.dataset.dir}/api/user/update?email=${e._cell.row.data.email}&field=roles&value=${e._cell.value}`)
     }
   }

--- a/public/views/_user.html
+++ b/public/views/_user.html
@@ -428,8 +428,6 @@
 
       if (JSON.stringify(e._cell.value) === JSON.stringify(e._cell.oldValue)) return;
 
-      //if (e._cell.value.every((val, i) => val === e._cell.oldValue[i])) return;
-
       xhrPromise(`${document.head.dataset.dir}/api/user/update?email=${e._cell.row.data.email}&field=roles&value=${e._cell.value}`)
     }
   }


### PR DESCRIPTION
It must be possible to set the roles value to an empty array (remove all roles).

The cellEdited method rolesEdit in the user admin view should check whether the value has changed before sending an update request.