### PR TITLE
featureSource & getFeatures

### DIFF
--- a/lib/layer/format/mvt.mjs
+++ b/lib/layer/format/mvt.mjs
@@ -12,7 +12,7 @@ export default layer => {
 
   // The snapSource is required for snap interactions on vector tile layer.
   // The featureClasss is detrimental to the render performance.
-  layer.snapSource = new ol.source.VectorTile({
+  layer.featureSource = new ol.source.VectorTile({
     format: new ol.format.MVT({
       featureClass: ol.Feature,
       //idProperty: 'id'
@@ -21,7 +21,7 @@ export default layer => {
     cacheSize: 0,
     tileUrlFunction
   })
-  
+ 
   // Define source for mvt layer.
   const source = new ol.source.VectorTile({
     format: new ol.format.MVT(),

--- a/lib/layer/format/mvt.mjs
+++ b/lib/layer/format/mvt.mjs
@@ -4,8 +4,10 @@ export default layer => {
 
   layer.reload = () => {
 
-    //source.clear()
-    source.refresh()
+    //layer.source.clear()
+    layer.source.refresh()
+    layer.tilesLoaded = []
+    layer.featureSource.refresh()
   }
 
   layer.clones = new Set()
@@ -23,7 +25,7 @@ export default layer => {
   })
  
   // Define source for mvt layer.
-  const source = new ol.source.VectorTile({
+  layer.source = new ol.source.VectorTile({
     format: new ol.format.MVT(),
     transition: 0,
     cacheSize: 0,
@@ -41,7 +43,7 @@ export default layer => {
       layer: layer.key,
       srid: layer.mapview.srid,
       table: tableZ,
-      filter: layer.filter && layer.filter.current
+      filter: layer.filter?.current
     })
 
     return url
@@ -49,7 +51,7 @@ export default layer => {
 
   layer.L = new ol.layer.VectorTile({
     key: layer.key,
-    source: source,
+    source: layer.source,
     renderBuffer: 200,
     //renderMode: 'vector',
     zIndex: layer.style?.zIndex || 1,

--- a/lib/layer/format/vector.mjs
+++ b/lib/layer/format/vector.mjs
@@ -8,6 +8,9 @@ export default layer => {
     console.warn(`Layer: ${layer.key}, does not support cluster.resolution. Please use cluster.distance instead.`)
   }
 
+  // Assign style object if nullish.
+  layer.style ??= {}
+
   layer.srid ??= '4326'
 
   layer.setSource = (features) => {
@@ -21,9 +24,11 @@ export default layer => {
 
     if (!features) return;
   
-    let source = new ol.source.Vector({
+    layer.source = new ol.source.Vector({
       features: mapp.utils.featureFormats[layer.format](layer, [features].flat())
     })
+
+    delete layer.xhr
   
     // Geojson is a cluster layer.
     if (layer.cluster?.distance) {
@@ -31,7 +36,7 @@ export default layer => {
       // Create cluster source.
       layer.cluster.source = new ol.source.Cluster({
         distance: layer.cluster.distance,
-        source
+        source: layer.source
       })
   
       layer.L.setSource(layer.cluster.source)
@@ -39,7 +44,7 @@ export default layer => {
     }
     
     // Set source if not cluster
-    layer.L.setSource(source)
+    layer.L.setSource(layer.source)
   }
   
   layer.reload = ()=>{
@@ -63,7 +68,7 @@ export default layer => {
     // Assign current viewport if not falsy.
     layer.viewport = layer.viewport && layer.mapview.getBounds();
 
-    mapp.utils.xhr(
+    layer.xhr = mapp.utils.xhr(
       `${layer.mapview.host}/api/query?${mapp.utils.paramString({
           template: layer.queryTemplate || layer.format,
           locale: layer.mapview.locale.key,

--- a/lib/mapview/interactions/draw.mjs
+++ b/lib/mapview/interactions/draw.mjs
@@ -150,17 +150,8 @@ export default function(params){
   
   function finish(feature) {
 
-    // Remove snap interaction from mapview.
-    if (mapview.interaction.snap) {
-
-      mapview.Map.removeInteraction(mapview.interaction.snap.interaction)
-
-      // Remove loadend event MVT layer snapSource.
-      if (mapview.interaction.layer.featureSource) {
-        mapview.interaction.layer.featureSource.un('tileloadend', mapview.interaction.snap.tileloadend);
-        mapview.Map.removeLayer(mapview.interaction.snap.vectorTileLayer)
-      }
-    }
+    // Remove snap interaction.
+    mapview.interaction.snap?.remove?.()
 
     // Reset the cursor style.
     mapview.Map.getTargetElement().style.cursor = 'default'

--- a/lib/mapview/interactions/draw.mjs
+++ b/lib/mapview/interactions/draw.mjs
@@ -156,8 +156,8 @@ export default function(params){
       mapview.Map.removeInteraction(mapview.interaction.snap.interaction)
 
       // Remove loadend event MVT layer snapSource.
-      if (mapview.interaction.layer.snapSource) {
-        mapview.interaction.layer.snapSource.un('tileloadend', mapview.interaction.snap.tileloadend);
+      if (mapview.interaction.layer.featureSource) {
+        mapview.interaction.layer.featureSource.un('tileloadend', mapview.interaction.snap.tileloadend);
         mapview.Map.removeLayer(mapview.interaction.snap.vectorTileLayer)
       }
     }

--- a/lib/mapview/interactions/modify.mjs
+++ b/lib/mapview/interactions/modify.mjs
@@ -134,17 +134,8 @@ export default function(params){
   
   function finish(feature) {
 
-    // Remove snap interaction from mapview.
-    if (mapview.interaction.snap) {
-
-      mapview.Map.removeInteraction(mapview.interaction.snap.interaction)
-
-      // Remove loadend event MVT layer snapSource.
-      if (mapview.interaction.layer.featureSource) {
-        mapview.interaction.layer.featureSource.un('tileloadend', mapview.interaction.snap.tileloadend);
-        mapview.Map.removeLayer(mapview.interaction.snap.vectorTileLayer)
-      }
-    }
+    // Remove snap interaction.
+    mapview.interaction.snap?.remove?.()
 
     // Reset the cursor style.
     mapview.Map.getTargetElement().style.cursor = 'default'

--- a/lib/mapview/interactions/modify.mjs
+++ b/lib/mapview/interactions/modify.mjs
@@ -140,8 +140,8 @@ export default function(params){
       mapview.Map.removeInteraction(mapview.interaction.snap.interaction)
 
       // Remove loadend event MVT layer snapSource.
-      if (mapview.interaction.layer.snapSource) {
-        mapview.interaction.layer.snapSource.un('tileloadend', mapview.interaction.snap.tileloadend);
+      if (mapview.interaction.layer.featureSource) {
+        mapview.interaction.layer.featureSource.un('tileloadend', mapview.interaction.snap.tileloadend);
         mapview.Map.removeLayer(mapview.interaction.snap.vectorTileLayer)
       }
     }

--- a/lib/mapview/interactions/snap.mjs
+++ b/lib/mapview/interactions/snap.mjs
@@ -13,21 +13,21 @@ export default function(mapview) {
   }
 
   // Only MVT layer have a snapSource.
-  if (mapview.interaction.layer.snapSource) {
+  if (mapview.interaction.layer.featureSource) {
 
     // Assign loadend event to MVT layer snapSource.
-    mapview.interaction.layer.snapSource.on('tileloadend', mapview.interaction.snap.tileloadend)
+    mapview.interaction.layer.featureSource.on('tileloadend', mapview.interaction.snap.tileloadend)
 
     // An invisible VectorTile layer is required to trigger the loadend event.
     mapview.interaction.snap.vectorTileLayer = new ol.layer.VectorTile({
-      source: mapview.interaction.layer.snapSource,
+      source: mapview.interaction.layer.featureSource,
       opacity: 0
     })
   
     mapview.Map.addLayer(mapview.interaction.snap.vectorTileLayer)
 
     // Refresh the snapSource in order to trigger the loadend event.
-    mapview.interaction.layer.snapSource.refresh()
+    mapview.interaction.layer.featureSource.refresh()
 
   } else {
 

--- a/lib/mapview/interactions/snap.mjs
+++ b/lib/mapview/interactions/snap.mjs
@@ -1,44 +1,62 @@
 export default function(mapview) {
 
+  // The current draw/modify interaction doesn't snap.
   if (!mapview.interaction.snap) return;
 
   // Assign mapview and interaction to be _this.
   mapview.interaction.snap = {
-    source: new ol.source.Vector(),
-    tileloadend: e => {
+    remove: ()=>{
 
-      // Assign features from tile to the snap source.
-      mapview.interaction.snap.source.addFeatures(e.tile.getFeatures())
+      if (mapview.interaction.layer.featureSource) {
+
+        // Detach tile load event,
+        mapview.interaction.layer.featureSource.un('tileloadend', tileloadend)
+
+        // Remove featureSource layer from mapview.Map,
+        mapview.Map.removeLayer(mapview.interaction.snap.vectorTileLayer)
+
+        // And clear featureSource.
+        mapview.interaction.layer.featureSource.clear()
+      }
+
+      mapview.Map.removeInteraction(mapview.interaction.snap.interaction)
     }
+  }
+
+  function tileloadend(e) {
+
+    // Add features from tile to the snap.source.
+    mapview.interaction.snap.source.addFeatures(e.tile.getFeatures())
   }
 
   // Only MVT layer have a snapSource.
   if (mapview.interaction.layer.featureSource) {
 
-    // Assign loadend event to MVT layer snapSource.
-    mapview.interaction.layer.featureSource.on('tileloadend', mapview.interaction.snap.tileloadend)
+    // Create new Vector source for snap features.
+    mapview.interaction.snap.source = new ol.source.Vector()
 
-    // An invisible VectorTile layer is required to trigger the loadend event.
+    // Assign loadend event to MVT layer featureSource.
+    mapview.interaction.layer.featureSource.on('tileloadend', tileloadend)
+
     mapview.interaction.snap.vectorTileLayer = new ol.layer.VectorTile({
       source: mapview.interaction.layer.featureSource,
       opacity: 0
     })
   
+    // Add invisible tile layer for the featureSource to trigger tile loads.
     mapview.Map.addLayer(mapview.interaction.snap.vectorTileLayer)
-
-    // Refresh the snapSource in order to trigger the loadend event.
-    mapview.interaction.layer.featureSource.refresh()
 
   } else {
 
-    // Assign snapSource from the snapLayer's OL source.
+    // Assign vector source as snap source for vector layer.
     mapview.interaction.snap.source = mapview.interaction.layer.L.getSource()
   }
 
-  // Create and assign snap interaction.
+  // Create snap interaction with snap.source.
   mapview.interaction.snap.interaction = new ol.interaction.Snap({
     source: mapview.interaction.snap.source
   })
-
+  
+  // Add snap.interaction to mapview.Map
   mapview.Map.addInteraction(mapview.interaction.snap.interaction)
 }


### PR DESCRIPTION
The mvt layer snapSource has been renamed to featureSource to better represent what it is. It a source which loads features as vector features instead of render features.

Vector layer must have a style object if added through a plugin.

The vector layer source must be accessible from the layer object since the actual source might be an intermediary cluster source.

The vector layer will assign the xhr to the layer object to indicate whether a layer is currently loading data from the [data]source.