### PR TITLE
Set label and hover; then replace children.

### DIFF
--- a/lib/layer/decorate.mjs
+++ b/lib/layer/decorate.mjs
@@ -79,6 +79,16 @@ export default async layer => {
       : layer.style.themes[layer.style.theme || Object.keys(layer.style.themes)[0]];
   }
 
+  if (layer.style?.theme?.setLabel && layer.style?.labels) {
+
+    layer.style.label = layer.style.labels[layer.style.theme.setLabel]
+  }
+
+  if (layer.style?.theme?.setHover && layer.style?.hovers) {
+
+    layer.style.hover = layer.style.hovers[layer.style.theme.setHover]
+  }
+
   if (layer.hover) {
 
     console.warn(`Layer: ${layer.key}, layer.hover{} should be defined within layer.style{}.`)

--- a/lib/ui/layers/legends/categorized.mjs
+++ b/lib/ui/layers/legends/categorized.mjs
@@ -23,8 +23,7 @@ export default (layer) => {
     mapp.utils.html`
       <div
         class="switch-all"
-        style="grid-column: 1/3;"
-      >
+        style="grid-column: 1/3;">
         ${mapp.dictionary.layer_style_switch_caption}
         <button
           class="primary-colour bold"
@@ -34,19 +33,18 @@ export default (layer) => {
             let disabledSwitches = allSwitches.filter((switch_) => switch_.classList.contains('disabled'));
 
             if (disabledSwitches.length == 0 || disabledSwitches.length == allSwitches.length) {
+
               // if all switches are either enabled or disabled, click on all 
               allSwitches.forEach(switch_ => switch_.click());
+
             } else {
+
               // if only some of them are enabled, click only on disabled ones
               disabledSwitches.forEach(switch_ => switch_.click());
             }
 
-          }}
-        >
-          ${mapp.dictionary.layer_style_switch_all}
-        </button>.
-      </div>
-    `
+          }}>${mapp.dictionary.layer_style_switch_all}
+        </button>.`
 
   Object.entries(theme.cat).forEach(cat => {
 
@@ -80,7 +78,9 @@ export default (layer) => {
     let label = mapp.utils.html`
       <div
         class=${`label ${layer.filter && 'switch' ||''} ${
-          layer.filter?.current[theme.field]?.ni?.indexOf(cat[0]) === 0 ? 'disabled' : ''
+
+          // Check whether cat is in current filter.
+          layer.filter?.current[theme.field]?.ni?.indexOf(cat[0]) > 0 ? 'disabled' : ''
         }`}
         style="grid-column: 2;"
         onclick=${e => {

--- a/lib/ui/layers/panels/style.mjs
+++ b/lib/ui/layers/panels/style.mjs
@@ -206,16 +206,19 @@ export default layer => {
             // Set theme from dropdown option.
             layer.style.theme = layer.style.themes[entry.option]
 
-            // Clear the legend container.
-            layer.style.legend.innerHTML = ''
-            
-            // Render legend into drawer.
-            mapp.ui.layers.legends[layer.style.theme.type] && mapp.utils.render(
-              layer.style.legend.parentElement,
-              mapp.ui.layers.legends[layer.style.theme.type](layer))
+            if (layer.style.theme.setLabel && layer.style.labels) {
 
-            // Prepend the theme meta paragraph to the legend if configured.
-            layer.style.theme?.meta && layer.style.legend.parentElement.prepend(mapp.utils.html.node`<p>${layer.style.theme.meta}`)
+              layer.style.label = layer.style.labels[layer.style.theme.setLabel]
+            }
+
+            if (layer.style.theme.setHover && layer.style.hovers) {
+
+              layer.style.hover = layer.style.hovers[layer.style.theme.setHover]
+            }
+
+            // Replace the children of the style panel.
+            layer.view.querySelector('[data-id=style-drawer]')
+              .replaceChildren(...mapp.ui.layers.panels.style(layer).children)
 
             layer.reload()
           }


### PR DESCRIPTION
Introduces setLabel and setHover keys for themes. 

https://github.com/GEOLYTIX/xyz/wiki/Workspace-Configuration#setlabel

https://github.com/GEOLYTIX/xyz/wiki/Workspace-Configuration#sethover

Please note the use of `.replaceChildren`. Instead of fuffing around with modifying elements it is preferred to recreate a panel from the creator method and then replace the children of the existing panel.

Also fixes a bug where the index lookup for categories in the categorical theme legend wasn't correct.