### PR TITLE
Distinct Edit Options from the DB

### DIFF
--- a/lib/ui/locations/entries/text.mjs
+++ b/lib/ui/locations/entries/text.mjs
@@ -1,61 +1,112 @@
 export default entry => {
-
-  // val maybe the input element with the entry.value.
   let val = entry.value;
 
+  // Check if the entry is editable.
   if (entry.edit) {
-
+    // If the entry has options, create a dropdown element; otherwise, create an input element.
     if (entry.edit.options) {
-
-      val = options(entry)
+      val = createDropdown(entry);
     } else {
-
-      val = mapp.utils.html`
-      <input
-        type="text"
-        maxlength=${entry.edit.maxlength}
-        value="${entry.value || ''}"
-        placeholder="${entry.edit.placeholder || ''}"
-        onkeyup=${e => {
-          entry.newValue = e.target.value
-          entry.location.view?.dispatchEvent(
-            new CustomEvent('valChange', {
-              detail: entry
-            })
-          )
-        }}>`
+      val = createInputElement(entry);
     }
   }
 
+  // Return an HTML element representing the entry.
   return mapp.utils.html.node`
     <div
       class="val"
-      style="${`${entry.css_val || ''}`}">
+      style="${entry.css_val || ''}">
       ${entry.prefix}${val}${entry.suffix}`
-
 }
 
-function options(entry){
+// Function to create an input element based on the provided entry.
+function createInputElement(entry) {
+  return mapp.utils.html`
+    <input
+      type="text"
+      maxlength=${entry.edit.maxlength}
+      value="${entry.value || ''}"
+      placeholder="${entry.edit.placeholder || ''}"
+      onkeyup=${e => {
+        // Update the newValue property in the entry and dispatch a 'valChange' event.
+        entry.newValue = e.target.value
+        entry.location.view?.dispatchEvent(
+          new CustomEvent('valChange', {
+            detail: entry
+          })
+        )
+      }}>
+  `;
+}
 
-  const chk = entry.edit.options.find(
-    option => typeof option === 'object' && Object.values(option)[0] === entry.value || option === entry.value
-  ) || entry.value
+// Function to create a dropdown element based on the provided entry.
+function createDropdown(entry) {
+  let chk;
+  const distinct = entry.edit.options.distinct;
 
-  entry.value = chk 
-    && typeof chk === 'object' 
-    && Object.keys(chk)[0] || chk || entry.value || '';
+  if (distinct) {
+    // Make an XHR request to fetch distinct values for the field.
+    mapp.utils.xhr(`${entry.location.layer.mapview.host}/api/query?` +
+      mapp.utils.paramString({
+        template: 'distinct_values',
+        dbs: entry.location.layer.dbs,
+        locale: entry.location.layer.mapview.locale.key,
+        layer: entry.location.layer.key,
+        table: entry.location.layer.tableCurrent(),
+        field: entry.field
+      })).then(response => {
+        if (!response) {
+          console.warn(`Distinct values query did not return any values for field ${entry.field}`);
+          return;
+        }
 
-  const entries = entry.edit.options.map(option => ({
-    title: typeof option === 'string' && option || Object.keys(option)[0],
-    option: typeof option === 'string' && option || Object.values(option)[0]
-  }))
+        // Process the response and update the entry's options and value.
+        entry.edit.options = [response].flat()
+          .map(record => record[entry.field])
+          .filter(val => val !== null);
 
-  const dropdown = mapp.ui.elements.dropdown({
+        chk = findMatchingOption(entry);
+
+        entry.value = chk && typeof chk === 'object' && Object.keys(chk)[0] || chk || entry.value || '';
+
+        const entries = entry.edit.options.map(option => ({
+          title: typeof option === 'string' && option || Object.keys(option)[0],
+          option: typeof option === 'string' && option || Object.values(option)[0]
+        }));
+
+        // Create the dropdown element with the updated options.
+        return createDropdownElement(entry, entries);
+      });
+  } else {
+    chk = findMatchingOption(entry);
+    entry.value = chk && typeof chk === 'object' && Object.keys(chk)[0] || chk || entry.value || '';
+
+    const entries = entry.edit.options.map(option => ({
+      title: typeof option === 'string' && option || Object.keys(option)[0],
+      option: typeof option === 'string' && option || Object.values(option)[0]
+    }));
+
+    // Create the dropdown element.
+    return createDropdownElement(entry, entries);
+  }
+}
+
+// Function to find a matching option in the entry's options.
+function findMatchingOption(entry) {
+  return entry.edit.options.find(option =>
+    typeof option === 'object' && Object.values(option)[0] === entry.value || option === entry.value
+  ) || entry.value;
+}
+
+// Function to create the actual dropdown element.
+function createDropdownElement(entry, entries) {
+  return mapp.ui.elements.dropdown({
     placeholder: entry.edit.placeholder,
     span: entry.value,
     entries: entries,
     callback: (e, _entry) => {
-      entry.newValue = _entry.option
+      // Update the newValue property in the entry and dispatch a 'valChange' event.
+      entry.newValue = _entry.option;
       entry.location.view?.dispatchEvent(
         new CustomEvent('valChange', {
           detail: entry,
@@ -63,6 +114,4 @@ function options(entry){
       );
     },
   });
-
-  return dropdown
 }


### PR DESCRIPTION
It should be possible to get the distinct values from the db for editable options in a dropdown for the user. 
This is required to prevent the config needing to be manually updated each time a new option is provided in the db, and is also important for consistency - as currently the filter allows this. 

This PR is a draft as i'm having some issues - the logic is set up and i've created functions in text.mjs for the various steps. 
However, in my current code: 
1. using toggleLocationViewEdits you have to click it twice for the dropdown containing the distinct values to be rendered for display.
2. using toggleLocationViewEdits when you press save and the value is stored back to the db, the edit mode button is set to inactive, but the dropdowns remain instead of swapping back to non-editable entries. 