### PR TITLE
added refreshing of dataviews when a location is edited

### DIFF
--- a/lib/ui/locations/view.mjs
+++ b/lib/ui/locations/view.mjs
@@ -145,6 +145,9 @@ export default location => {
 
       // Remove edits from infoj entries.
       removeEdits()
+
+      // Refresh dataviews
+      Object.values(location.layer.dataviews).forEach(dv => dv.update());
     })
   }
 


### PR DESCRIPTION
With this PR, dataviews no longer need to be manually refreshed after a location is edited.