### PR TITLE
Vector layer

### DIFF
--- a/lib/layer/format/mvt.mjs
+++ b/lib/layer/format/mvt.mjs
@@ -1,6 +1,10 @@
 export default layer => {
 
+  // Assign default SRID if nullish.
   layer.srid ??= '3857'
+
+  // Assign empty style object if nullish.
+  layer.style ??= {}
 
   layer.reload = () => {
 

--- a/lib/layer/format/mvt.mjs
+++ b/lib/layer/format/mvt.mjs
@@ -45,7 +45,7 @@ export default layer => {
       layer: layer.key,
       srid: layer.mapview.srid,
       table: tableZ,
-      filter: layer.filter && layer.filter.current
+      filter: layer.filter?.current
     })
 
     return url

--- a/lib/ui/locations/entries/_entries.mjs
+++ b/lib/ui/locations/entries/_entries.mjs
@@ -30,6 +30,8 @@ import textarea from './textarea.mjs'
 
 import time from './time.mjs'
 
+import vector_layer from './vector_layer.mjs'
+
 export default {
   key,
   boolean,
@@ -50,7 +52,8 @@ export default {
   tab,
   text,
   textarea,
-  time
+  time,
+  vector_layer
 }
 
 function key(entry) {

--- a/lib/ui/locations/entries/vector_layer.mjs
+++ b/lib/ui/locations/entries/vector_layer.mjs
@@ -8,7 +8,7 @@ export default entry => {
     entry.mapview = entry.location.layer.mapview
 
     entry.style ??= {}
-  
+ 
     if (entry.style.themes) {
   
       // Assign the first theme from themes if undefined.

--- a/lib/ui/locations/entries/vector_layer.mjs
+++ b/lib/ui/locations/entries/vector_layer.mjs
@@ -8,12 +8,6 @@ export default entry => {
     entry.mapview = entry.location.layer.mapview
 
     entry.style ??= {}
- 
-    if (entry.style.themes) {
-  
-      // Assign the first theme from themes if undefined.
-      entry.style.theme ||= entry.style.themes[Object.keys(entry.style.themes)[0]]
-    }
   
     // Assign method to show the clone layer.
     entry.show = async () => {
@@ -42,9 +36,7 @@ export default entry => {
       entry.features = await mapp.utils.xhr(`${entry.host || entry.mapview.host}/api/query?${paramString}`)
 
       mapp.layer.formats[entry.format](entry)
-
-      console.log(entry.features)
-  
+ 
       // Create a style panel as entry.style.panel and append to entry.node.
       entry.style.panel = mapp.ui.layers.panels.style(entry)
       entry.style.panel && entry.panel.append(entry.style.panel)
@@ -70,9 +62,7 @@ export default entry => {
       // Remove the geometry layer from map.
       entry.mapview.Map.removeLayer(entry.L)
     }
-  
-    entry.reload = () => entry.L?.changed()
-  
+   
     // Create checkbox to control geometry display.
     const chkbox = mapp.ui.elements.chkbox({
       label: entry.label || 'MVT Clone',

--- a/lib/ui/locations/entries/vector_layer.mjs
+++ b/lib/ui/locations/entries/vector_layer.mjs
@@ -1,0 +1,99 @@
+export default entry => {
+
+    // The entry has already been processed.
+    // There is an entry.panel to be rendered into the entry.node.
+    if (entry.panel) return entry.panel;
+  
+    // Assign mapview to entry to provide shortened lookup.
+    entry.mapview = entry.location.layer.mapview
+
+    entry.style ??= {}
+  
+    if (entry.style.themes) {
+  
+      // Assign the first theme from themes if undefined.
+      entry.style.theme ||= entry.style.themes[Object.keys(entry.style.themes)[0]]
+    }
+  
+    // Assign method to show the clone layer.
+    entry.show = async () => {
+  
+      entry.display = true;
+  
+      // The OL clone layer already exists.
+      if (entry.L) {
+  
+        if (entry.style.panel) entry.style.panel.style.display = 'block'
+  
+        try {
+          entry.mapview.Map.addLayer(entry.L)
+  
+        } catch {
+          // Will catch assertation error when layer is already added.
+        }
+  
+        return;
+      }
+  
+      // Create query paramString from the entry object.
+      const paramString = mapp.utils.paramString(mapp.utils.queryParams(entry))
+  
+      // Query the featureLookup.
+      entry.features = await mapp.utils.xhr(`${entry.host || entry.mapview.host}/api/query?${paramString}`)
+
+      mapp.layer.formats[entry.format](entry)
+
+      console.log(entry.features)
+  
+      // Create a style panel as entry.style.panel and append to entry.node.
+      entry.style.panel = mapp.ui.layers.panels.style(entry)
+      entry.style.panel && entry.panel.append(entry.style.panel)
+      
+      // Add the clone layer to the mapview.Map.
+      entry.mapview.Map.addLayer(entry.L)
+  
+      // Add a location.removeCallback to remove the clone from mapview.Map as well as the mvt layer clones.
+      entry.location.removeCallbacks.push(() => {
+        entry.mapview.Map.removeLayer(entry.L)
+      })
+  
+    };
+  
+    // Assign method to hide the clone layer.
+    entry.hide = async () => {
+  
+      entry.display = false
+  
+      // Hide the style drawer.
+      if (entry.style.panel) entry.style.panel.style.display = 'none'
+  
+      // Remove the geometry layer from map.
+      entry.mapview.Map.removeLayer(entry.L)
+    }
+  
+    entry.reload = () => entry.L?.changed()
+  
+    // Create checkbox to control geometry display.
+    const chkbox = mapp.ui.elements.chkbox({
+      label: entry.label || 'MVT Clone',
+      data_id: `${entry.field}-chkbox`,
+      checked: !!entry.display,
+      onchange: (checked) => checked ? entry.show() : entry.hide()
+    })
+  
+    // Show geometry if entry is set to display.
+    entry.display && entry.show()
+  
+    // Create a node consistent of the chkbox and the style drawer.
+    entry.panel = mapp.utils.html.node`<div>${chkbox}`
+    
+    // Remove zoom level check from mapview changeEnd event.
+    entry.location.removeCallbacks.push(() => {
+  
+      // Remove layer from map when location is removed.
+      entry.mapview.Map.removeLayer(entry.L)
+    })
+  
+    // Return the node to the location view.
+    return entry.panel
+  }

--- a/lib/ui/locations/entries/vector_layer.mjs
+++ b/lib/ui/locations/entries/vector_layer.mjs
@@ -1,89 +1,87 @@
 export default entry => {
 
-    // The entry has already been processed.
-    // There is an entry.panel to be rendered into the entry.node.
-    if (entry.panel) return entry.panel;
-  
-    // Assign mapview to entry to provide shortened lookup.
-    entry.mapview = entry.location.layer.mapview
+  // The entry has already been processed.
+  // There is an entry.panel to be rendered into the entry.node.
+  if (entry.panel) return entry.panel;
 
-    entry.style ??= {}
-  
-    // Assign method to show the clone layer.
-    entry.show = async () => {
-  
-      entry.display = true;
-  
-      // The OL clone layer already exists.
-      if (entry.L) {
-  
-        if (entry.style.panel) entry.style.panel.style.display = 'block'
-  
-        try {
-          entry.mapview.Map.addLayer(entry.L)
-  
-        } catch {
-          // Will catch assertation error when layer is already added.
-        }
-  
-        return;
-      }
-  
-      // Create query paramString from the entry object.
-      const paramString = mapp.utils.paramString(mapp.utils.queryParams(entry))
-  
-      // Query the featureLookup.
-      entry.features = await mapp.utils.xhr(`${entry.host || entry.mapview.host}/api/query?${paramString}`)
+  // Assign mapview to entry to provide shortened lookup.
+  entry.mapview = entry.location.layer.mapview
 
-      mapp.layer.formats[entry.format](entry)
- 
-      // Create a style panel as entry.style.panel and append to entry.node.
-      entry.style.panel = mapp.ui.layers.panels.style(entry)
-      entry.style.panel && entry.panel.append(entry.style.panel)
-      
-      // Add the clone layer to the mapview.Map.
+  entry.style ??= {}
+
+  // Create checkbox to control geometry display.
+  const chkbox = mapp.ui.elements.chkbox({
+    label: entry.label || 'MVT Clone',
+    data_id: `${entry.field}-chkbox`,
+    checked: !!entry.display,
+    onchange: (checked) => checked ? show(entry) : hide(entry)
+  })
+
+  // Show geometry if entry is set to display.
+  entry.display && show(entry)
+
+  // Create a node consistent of the chkbox and the style drawer.
+  entry.panel = mapp.utils.html.node`<div>${chkbox}`
+
+  // Remove zoom level check from mapview changeEnd event.
+  entry.location.removeCallbacks.push(() => {
+
+    // Remove layer from map when location is removed.
+    entry.mapview.Map.removeLayer(entry.L)
+  })
+
+  // Return the node to the location view.
+  return entry.panel
+}
+
+async function show(entry) {
+
+  entry.display = true;
+
+  // The OL clone layer already exists.
+  if (entry.L) {
+
+    if (entry.style.panel) entry.style.panel.style.display = 'block'
+
+    try {
       entry.mapview.Map.addLayer(entry.L)
-  
-      // Add a location.removeCallback to remove the clone from mapview.Map as well as the mvt layer clones.
-      entry.location.removeCallbacks.push(() => {
-        entry.mapview.Map.removeLayer(entry.L)
-      })
-  
-    };
-  
-    // Assign method to hide the clone layer.
-    entry.hide = async () => {
-  
-      entry.display = false
-  
-      // Hide the style drawer.
-      if (entry.style.panel) entry.style.panel.style.display = 'none'
-  
-      // Remove the geometry layer from map.
-      entry.mapview.Map.removeLayer(entry.L)
+
+    } catch {
+      // Will catch assertation error when layer is already added.
     }
-   
-    // Create checkbox to control geometry display.
-    const chkbox = mapp.ui.elements.chkbox({
-      label: entry.label || 'MVT Clone',
-      data_id: `${entry.field}-chkbox`,
-      checked: !!entry.display,
-      onchange: (checked) => checked ? entry.show() : entry.hide()
-    })
-  
-    // Show geometry if entry is set to display.
-    entry.display && entry.show()
-  
-    // Create a node consistent of the chkbox and the style drawer.
-    entry.panel = mapp.utils.html.node`<div>${chkbox}`
-    
-    // Remove zoom level check from mapview changeEnd event.
-    entry.location.removeCallbacks.push(() => {
-  
-      // Remove layer from map when location is removed.
-      entry.mapview.Map.removeLayer(entry.L)
-    })
-  
-    // Return the node to the location view.
-    return entry.panel
+
+    return;
   }
+
+  // Create query paramString from the entry object.
+  const paramString = mapp.utils.paramString(mapp.utils.queryParams(entry))
+
+  // Query the featureLookup.
+  entry.features = await mapp.utils.xhr(`${entry.host || entry.mapview.host}/api/query?${paramString}`)
+
+  mapp.layer.formats[entry.format](entry)
+
+  // Create a style panel as entry.style.panel and append to entry.node.
+  entry.style.panel = mapp.ui.layers.panels.style(entry)
+  entry.style.panel && entry.panel.append(entry.style.panel)
+
+  // Add the clone layer to the mapview.Map.
+  entry.mapview.Map.addLayer(entry.L)
+
+  // Add a location.removeCallback to remove the clone from mapview.Map as well as the mvt layer clones.
+  entry.location.removeCallbacks.push(() => {
+    entry.mapview.Map.removeLayer(entry.L)
+  })
+
+}
+
+function hide(entry) {
+
+  entry.display = false
+
+  // Hide the style drawer.
+  if (entry.style.panel) entry.style.panel.style.display = 'none'
+
+  // Remove the geometry layer from map.
+  entry.mapview.Map.removeLayer(entry.L)
+}

--- a/lib/utils/featureFormats.mjs
+++ b/lib/utils/featureFormats.mjs
@@ -45,7 +45,7 @@ export function wkt(layer, features) {
         const properties = {}
 
         // Assign field key and value to properties object
-        layer.fields.forEach((field, i) => {
+        layer.fields?.forEach((field, i) => {
 
             if (layer.style?.theme?.field_stats?.[field]) {
 


### PR DESCRIPTION
The `type:"vector_layer"` will assign the query response as `features:[]` to the entry object. The entry will passed to the vector layer decorator to create a vector layer associated with the entry.

```json
{
 "label": "Nearest to Catchments",
 "type": "vector_layer",
 "format": "wkt",
 "srid": "4326",
 "display": true,
 "query": "uk_site_catchment",
 "queryparams": {
  "id": true,
  "reduce": true
 }
}
```

Style and themes are possible but will require some test data to work with.