### PR TITLE
Filter Labelling Bug

### DIFF
--- a/lib/ui/elements/dropdown.mjs
+++ b/lib/ui/elements/dropdown.mjs
@@ -3,15 +3,15 @@ export default (params) => {
   params.selectedTitles = new Set()
   params.selectedOptions = new Set()
 
+  let dropdown_title;
   // Create array of li elements for dropdown.
   const ul = params.entries.map((entry) => {
-
     try {
-      entry.title = decodeURIComponent(entry.title)
+      dropdown_title = decodeURIComponent(entry.filter?.title || entry.title)
     } catch {
       // This prevents falling over on % in title.
     }
-    
+
     // Create li element with click event.
     const li = mapp.utils.html.node`<li onclick=${(e) => {
 
@@ -19,7 +19,7 @@ export default (params) => {
       const btn = e.target.closest('button.dropdown')
 
       // Will collapse the dropdown if current state is 'active'.
-      !params.multi && btn.classList.toggle('active')   
+      !params.multi && btn.classList.toggle('active')
 
       if (params.multi) {
 
@@ -28,10 +28,10 @@ export default (params) => {
 
         // Add or remove title and option value from sets.
         if (e.target.classList.contains('selected')) {
-          params.selectedTitles.add(entry.title)
+          params.selectedTitles.add(dropdown_title)
           params.selectedOptions.add(entry.option)
         } else {
-          params.selectedTitles.delete(entry.title)
+          params.selectedTitles.delete(dropdown_title)
           params.selectedOptions.delete(entry.option)
         }
 
@@ -47,19 +47,19 @@ export default (params) => {
       }
 
       if (!params.keepPlaceholder) {
-        
+
         // Dropdown is not multi
-        btn.querySelector('[data-id=header-span]').textContent = entry.title;
+        btn.querySelector('[data-id=header-span]').textContent = dropdown_title;
       }
 
       params.callback?.(e, entry);
 
-    }}>${entry.title}`
+    }}>${dropdown_title}`
 
     // The entry is already selected during creation of dropdown.
     if (entry.selected) {
       li.classList.add('selected')
-      params.selectedTitles.add(entry.title)
+      params.selectedTitles.add(dropdown_title)
       params.selectedOptions.add(entry.option)
     }
 
@@ -73,39 +73,39 @@ export default (params) => {
       <div class="head"
         onclick=${(e) => {
 
-          const bounds = e.target.getBoundingClientRect()
+      const bounds = e.target.getBoundingClientRect()
 
-          const viewport = document.body.getBoundingClientRect()
+      const viewport = document.body.getBoundingClientRect()
 
-          // Set the maxHeight of the ul based on the difference between the bottom and document.body height.
-          e.target.nextElementSibling.style.maxHeight = `${viewport.height - bounds.bottom}px`
-        
-          e.target.nextElementSibling.style.width = `${e.target.offsetWidth}px`
+      // Set the maxHeight of the ul based on the difference between the bottom and document.body height.
+      e.target.nextElementSibling.style.maxHeight = `${viewport.height - bounds.bottom}px`
 
-          // Collapse dropdown element and short circuit.
-          if (e.target.parentElement.classList.contains('active')) {
-            e.target.parentElement.classList.remove('active');
-            return;
-          }
+      e.target.nextElementSibling.style.width = `${e.target.offsetWidth}px`
 
-          // Collapse any expandxed dropdown elements in document.
-          document.querySelectorAll('button.dropdown')
-            .forEach((el) => el.classList.remove('active'));
-            
-          // Expand this dropdown element.
-          e.target.parentElement.classList.add('active');
+      // Collapse dropdown element and short circuit.
+      if (e.target.parentElement.classList.contains('active')) {
+        e.target.parentElement.classList.remove('active');
+        return;
+      }
 
-        }}>
+      // Collapse any expandxed dropdown elements in document.
+      document.querySelectorAll('button.dropdown')
+        .forEach((el) => el.classList.remove('active'));
+
+      // Expand this dropdown element.
+      e.target.parentElement.classList.add('active');
+
+    }}>
         <span data-id=header-span>${
 
-          // join the selected titles if selectTitles set has a size.
-          params.selectedTitles.size && Array.from(params.selectedTitles).join(', ')
-          
-          // header should be the span value.
-          || params.span
-          
-          // use placeholder.
-          || params.placeholder}</span>
+    // join the selected titles if selectTitles set has a size.
+    params.selectedTitles.size && Array.from(params.selectedTitles).join(', ')
+
+    // header should be the span value.
+    || params.span
+
+    // use placeholder.
+    || params.placeholder}</span>
         <div class="icon"></div>
       </div>
       <ul>${ul}`;


### PR DESCRIPTION
This PR addresses two bugs: 

1. When you provided an infoj entry with a `filter.title` this title was only applied to the filter provided after you have clicked on the dropdown option - not also to the dropdown title   (see screenshot provided).
``` json 
{
      "title": "Hello",
      "field": "field",
      "type": "integer",
      "filter": {
        "title": "TEST ME",
        "type": "integer"
      },
      "inline": true
 }
```
![image](https://github.com/GEOLYTIX/xyz/assets/56163132/822aaac1-b167-4416-a39b-2f17743bdc1b)
![image](https://github.com/GEOLYTIX/xyz/assets/56163132/7185349f-2a6c-4b7d-aeef-c97df8d88ffe)
![image](https://github.com/GEOLYTIX/xyz/assets/56163132/23dfcffb-1aed-44cf-899e-7bbc1bcecd88)


2. The dropdown.mjs module was incorrectly overwriting entry.title, which meant that updating the dropdown value led to the infoj title value also being updated. To correct this a local variable `dropdown_title` has been created, ensuring that the two issues are resolved.