### PR TITLE
Edit Distinct Options

### DIFF
--- a/lib/ui/locations/entries/text.mjs
+++ b/lib/ui/locations/entries/text.mjs
@@ -1,48 +1,66 @@
 export default entry => {
-
   // val maybe the input element with the entry.value.
   let val = entry.value;
 
   if (entry.edit) {
 
     if (entry.edit.options) {
+      
+      // If distinct get the values from the field on the table.
+      if (entry.edit.distinct) {
 
-      val = options(entry)
+        // Create empty container to be populated by the API call
+        const containerEl = mapp.utils.html.node`<div class="val-container">Loading...</div>`;
+        
+        // start async API call to load options
+        handleDistinctOptions(entry, containerEl);
+
+        val = containerEl;
+
+      } else {
+
+        val = options(entry);
+      }
+
     } else {
 
       val = mapp.utils.html`
-      <input
-        type="text"
-        maxlength=${entry.edit.maxlength}
-        value="${entry.value || ''}"
-        placeholder="${entry.edit.placeholder || ''}"
-        onkeyup=${e => {
-          entry.newValue = e.target.value
-          entry.location.view?.dispatchEvent(
-            new CustomEvent('valChange', {
-              detail: entry
-            })
-          )
-        }}>`
+        <input
+          type="text"
+          maxlength=${entry.edit.maxlength}
+          value="${entry.value || ''}"
+          placeholder="${entry.edit.placeholder || ''}"
+          onkeyup=${e => {
+            entry.newValue = e.target.value
+            entry.location.view?.dispatchEvent(
+              new CustomEvent('valChange', {
+                detail: entry
+              })
+            )
+          }}
+        >
+      `
     }
   }
 
   return mapp.utils.html.node`
     <div
       class="val"
-      style="${`${entry.css_val || ''}`}">
-      ${entry.prefix}${val}${entry.suffix}`
-
+      style="${`${entry.css_val || ''}`}"
+    >
+      ${entry.prefix}${val}${entry.suffix}
+    </div>  
+  `
 }
 
-function options(entry){
+function options(entry) {
 
   const chk = entry.edit.options.find(
     option => typeof option === 'object' && Object.values(option)[0] === entry.value || option === entry.value
   ) || entry.value
 
-  entry.value = chk 
-    && typeof chk === 'object' 
+  entry.value = chk
+    && typeof chk === 'object'
     && Object.keys(chk)[0] || chk || entry.value || '';
 
   const entries = entry.edit.options.map(option => ({
@@ -65,4 +83,39 @@ function options(entry){
   });
 
   return dropdown
+}
+
+async function handleDistinctOptions(entry, containerEl) {
+
+  // Query distinct field values from the layer table.
+  const response = await mapp.utils.xhr(`${entry.location.layer.mapview.host}/api/query?` +
+    mapp.utils.paramString({
+      template: 'distinct_values',
+      dbs: entry.location.layer.dbs,
+      locale: entry.location.layer.mapview.locale.key,
+      layer: entry.location.layer.key,
+      filter: entry.location.layer.filter?.current,
+      table: entry.location.layer.tableCurrent(),
+      field: entry.field
+    })
+  )
+  
+  if (!response) {
+    console.warn(`Distinct values query did not return any values for field ${entry.field}`)
+    return;
+  }
+
+  entry.edit.options = [response]
+    // Flatten response in array to account for the response being a single record and not an array.
+    .flat()
+
+    // Map the entry field from response records.
+    .map(record => record[entry.field])
+
+    // Filter out null values.
+    .filter(val => val !== null)
+
+  const contentsEl = options(entry);
+
+  containerEl.replaceChildren(contentsEl);
 }


### PR DESCRIPTION
It should be possible to get the distinct values from the db for editable options in a dropdown for the user.
This is required to prevent the config needing to be manually updated each time a new option is provided in the db, and is also important for consistency - as currently the filter allows this.
Providing the code sample below will run the `distinct_values` query on the db and populate the options dropdown when loaded. Prior to loading a Loading... message will appear to the user. 
```
"edit": { 
"distinct":true, 
"options":[]
}
```