### PR TITLE
Allow multiple fields returned from a query

### DIFF
--- a/lib/ui/locations/infoj.mjs
+++ b/lib/ui/locations/infoj.mjs
@@ -8,6 +8,9 @@ export default (location, infoj) => {
   // Create object to hold view groups.
   const groups = {}
 
+  // Create a set to store queries that have been run.
+  const querySet = new Set();
+
   // Iterate through info fields and add to info table.
   for (const entry of infoj || location.infoj) {
     // The location view entries should not be processed if the view is disabled.
@@ -16,6 +19,7 @@ export default (location, infoj) => {
     // Location view elements will appended to the entry.listview element.
     entry.listview = listview
 
+    console.log(entry);
     // The default entry type is text.
     entry.type = entry.type || 'text'
 
@@ -108,6 +112,8 @@ export default (location, infoj) => {
           ${entry.tooltip ? mapp.utils.html`<span style="line-height: 1; margin-left: 0.4em;" class="mobile-display-none mask-icon question-mark">${entry.tooltip}` : ''}`)
     }
 
+    console.log(entry.value);
+
     // Check whether entry has a value
     if (entry.value === null || typeof entry.value === 'undefined') {
 
@@ -128,12 +134,21 @@ export default (location, infoj) => {
         // Stringify paramString from object.
         const paramString = mapp.utils.paramString(mapp.utils.queryParams(entry))
 
+        // Check if that query has already been run.
+        if (querySet.has(paramString)) {
+          console.log('query already run', paramString, 'skipping')
+          continue;
+        }
+        // Add the query to the querySet so that it is not run again.
+        querySet.add(paramString);
+
+        console.log('query added to Set', paramString)
         // Run the entry query.
         mapp.utils
           .xhr(`${entry.host || entry.location.layer.mapview.host}/api/query?${paramString}`)
           .then(response => {
 
-            // The query may return a column and field value, to allow us to update multiple fields with one query..
+            // The query may return a column and field value, to allow us to update multiple fields with one query.
             if (entry.field) {
               // Check if response is not null.
               if (response) {

--- a/lib/ui/locations/infoj.mjs
+++ b/lib/ui/locations/infoj.mjs
@@ -8,6 +8,9 @@ export default (location, infoj) => {
   // Create object to hold view groups.
   const groups = {}
 
+  // Create a set to hold queries that have been run.
+  const queriesRan = new Set();
+
   // Iterate through info fields and add to info table.
   for (const entry of infoj || location.infoj) {
     // The location view entries should not be processed if the view is disabled.
@@ -116,7 +119,9 @@ export default (location, infoj) => {
     }
 
     if (entry.query) {
-
+      console.log(queriesRan);
+      // Check if entry.query exists in queriesRan Set.
+      if (queriesRan.has(entry.query)) continue;
       // Assign queryparams from layer, and locale.
       entry.queryparams = Object.assign(
         entry.queryparams || {},
@@ -134,25 +139,32 @@ export default (location, infoj) => {
           .xhr(`${entry.host || entry.location.layer.mapview.host}/api/query?${paramString}`)
           .then(response => {
 
-            // The query may return a column and field value, to allow us to update multiple fields with one query.
-            // Check if response is not null.
-            if (response) {
-              // Iterate through response object.
-              response instanceof Object && Object.entries(response).forEach(keyVal => {
+            // The query may return a column and field value, to allow us to update multiple fields with one query..
+            if (entry.field) {
+              // Check if response is not null.
+              if (response) {
+                // Iterate through response object.
+                response instanceof Object && Object.entries(response).forEach(keyVal => {
 
-                // Find keyEntry associated with the column returned from the query.
-                const keyEntry = entry.location.infoj.find(entry => entry.field === keyVal[0])
+                  // Find keyEntry associated with the column returned from the query.
+                  const keyEntry = entry.location.infoj.find(entry => entry.field === keyVal[0])
 
-                // If keyEntry is not found, then skip.
-                if (!keyEntry) return;
+                  // If keyEntry is not found, then skip.
+                  if (!keyEntry) return;
 
-                // Assign key value.
-                keyEntry.value = keyVal[1]
-              })
+                  // Assign key value.
+                  keyEntry.value = keyVal[1]
+
+                  // Add to set queries that have been run.
+                  queriesRan.add(entry.query);
+
+                })
+              }
             } else {
               // Assign query response as entry value.
               entry.value = response;
             }
+
             // Check whether entry should be skipped.
             if (skipEntry(entry)) {
 

--- a/lib/ui/locations/infoj.mjs
+++ b/lib/ui/locations/infoj.mjs
@@ -10,7 +10,6 @@ export default (location, infoj) => {
 
   // Iterate through info fields and add to info table.
   for (const entry of infoj || location.infoj) {
-
     // The location view entries should not be processed if the view is disabled.
     if (location.view && location.view.classList.contains('disabled')) break;
 
@@ -106,7 +105,7 @@ export default (location, infoj) => {
           class="label"
           style="${`${entry.css_title || ''}`}"
           title="${entry.tooltip || null}">${entry.title}
-          ${entry.tooltip ? mapp.utils.html`<span style="line-height: 1; margin-left: 0.4em;" class="mobile-display-none mask-icon question-mark">${entry.tooltip}`: ''}`)
+          ${entry.tooltip ? mapp.utils.html`<span style="line-height: 1; margin-left: 0.4em;" class="mobile-display-none mask-icon question-mark">${entry.tooltip}` : ''}`)
     }
 
     // Check whether entry has a value
@@ -125,7 +124,7 @@ export default (location, infoj) => {
         entry.location.layer.mapview.locale.queryparams || {})
 
       // Check whether query returns data.
-      if (entry.queryCheck || entry.run === true) {
+      if (entry.queryCheck || entry.run === true || entry.field) {
 
         // Stringify paramString from object.
         const paramString = mapp.utils.paramString(mapp.utils.queryParams(entry))
@@ -135,9 +134,25 @@ export default (location, infoj) => {
           .xhr(`${entry.host || entry.location.layer.mapview.host}/api/query?${paramString}`)
           .then(response => {
 
-            // Assign query response as entry value.
-            entry.value = response;
+            // The query may return a column and field value, to allow us to update multiple fields with one query.
+            // Check if response is not null.
+            if (response) {
+              // Iterate through response object.
+              response instanceof Object && Object.entries(response).forEach(keyVal => {
 
+                // Find keyEntry associated with the column returned from the query.
+                const keyEntry = entry.location.infoj.find(entry => entry.field === keyVal[0])
+
+                // If keyEntry is not found, then skip.
+                if (!keyEntry) return;
+
+                // Assign key value.
+                keyEntry.value = keyVal[1]
+              })
+            } else {
+              // Assign query response as entry value.
+              entry.value = response;
+            }
             // Check whether entry should be skipped.
             if (skipEntry(entry)) {
 

--- a/lib/ui/locations/infoj.mjs
+++ b/lib/ui/locations/infoj.mjs
@@ -142,7 +142,6 @@ export default (location, infoj) => {
         // Add the query to the querySet so that it is not run again.
         querySet.add(paramString);
 
-        console.log('query added to Set', paramString)
         // Run the entry query.
         mapp.utils
           .xhr(`${entry.host || entry.location.layer.mapview.host}/api/query?${paramString}`)

--- a/lib/ui/locations/infoj.mjs
+++ b/lib/ui/locations/infoj.mjs
@@ -8,9 +8,6 @@ export default (location, infoj) => {
   // Create object to hold view groups.
   const groups = {}
 
-  // Create a set to hold queries that have been run.
-  const queriesRan = new Set();
-
   // Iterate through info fields and add to info table.
   for (const entry of infoj || location.infoj) {
     // The location view entries should not be processed if the view is disabled.
@@ -119,9 +116,6 @@ export default (location, infoj) => {
     }
 
     if (entry.query) {
-      console.log(queriesRan);
-      // Check if entry.query exists in queriesRan Set.
-      if (queriesRan.has(entry.query)) continue;
       // Assign queryparams from layer, and locale.
       entry.queryparams = Object.assign(
         entry.queryparams || {},
@@ -154,9 +148,6 @@ export default (location, infoj) => {
 
                   // Assign key value.
                   keyEntry.value = keyVal[1]
-
-                  // Add to set queries that have been run.
-                  queriesRan.add(entry.query);
 
                 })
               }


### PR DESCRIPTION
This PR adds the ability for a query used in the `infoj` to return multiple columns, and those columns to be assigned to `infoj` `entry` values. This also allows queries that return `{"column": value}` to be correct assigned, as currently the response object is assigned as the `entry` value.

This is advantageous as it removes the need for multiple calls to the database, and tidies up the infoj as instead of loads of `fieldfx` you can just assign `query` and `field`. 

I've added a `queriesRan` Set to the file to check if a query has already been ran - but not working just yet.