### PR TITLE
Assign location style to layer type default style.

### DIFF
--- a/lib/ui/locations/entries/mvt_clone.mjs
+++ b/lib/ui/locations/entries/mvt_clone.mjs
@@ -16,7 +16,13 @@ export default entry => {
   }
 
   // The entry must have a style object.
-  entry.style ||= entry.Layer.style
+  entry.style ??= entry.Layer.style
+
+  if (entry.style.default) {
+
+    // Assign the location style to the default style.
+    entry.style.default = Object.assign({}, entry.location?.style || {}, entry.style.default)
+  }
 
   // Create clone VectorTile layer.
   entry.L = new ol.layer.VectorTile({

--- a/lib/ui/locations/entries/mvt_clone.mjs
+++ b/lib/ui/locations/entries/mvt_clone.mjs
@@ -21,7 +21,7 @@ export default entry => {
   if (entry.style.default) {
 
     // Assign the location style to the default style.
-    entry.style.default = Object.assign({}, entry.location?.style || {}, entry.style.default)
+    entry.style.default = {...entry.location?.style, ...entry.style.default}
   }
 
   // Create clone VectorTile layer.

--- a/lib/ui/locations/entries/vector_layer.mjs
+++ b/lib/ui/locations/entries/vector_layer.mjs
@@ -9,6 +9,12 @@ export default entry => {
 
   entry.style ??= {}
 
+  if (entry.style.default) {
+
+    // Assign the location style to the default style.
+    entry.style.default = Object.assign({}, entry.location?.style || {}, entry.style.default)
+  }
+
   // Create checkbox to control geometry display.
   const chkbox = mapp.ui.elements.chkbox({
     label: entry.label || 'MVT Clone',

--- a/lib/ui/locations/entries/vector_layer.mjs
+++ b/lib/ui/locations/entries/vector_layer.mjs
@@ -12,7 +12,7 @@ export default entry => {
   if (entry.style.default) {
 
     // Assign the location style to the default style.
-    entry.style.default = Object.assign({}, entry.location?.style || {}, entry.style.default)
+    entry.style.default = {...entry.location?.style, ...entry.style.default}
   }
 
   // Create checkbox to control geometry display.


### PR DESCRIPTION
Without a default style the location.style will be assigned as default style.

This applies to the `vector_layer` and `mvt_clone` type entries.

The `location.style` is assigned in the listview.mjs `mapview.locations` setter proxy.

Assigning an svg type in the entry default style will allow to create coloured icons from the `layer.style` fill and strokeColor.

```json
"style": {
 "default": {
  "type": "dot"
 }
}
```