### PR TITLE
Dataview Update

### DIFF
--- a/lib/ui/locations/view.mjs
+++ b/lib/ui/locations/view.mjs
@@ -233,7 +233,6 @@ export default location => {
 
     // Refresh dataviews
     if (location.layer?.dataviews) {
-      console.log(location.layer.dataviews);
       Object.values(location.layer.dataviews).forEach(dv => {
         if (dv.display === true) {
           dv.update();

--- a/lib/ui/locations/view.mjs
+++ b/lib/ui/locations/view.mjs
@@ -67,13 +67,13 @@ export default location => {
         }}>`)
 
   // Edits must be toggled.
-  if (location.layer?.toggleLocationViewEdits 
-    
+  if (location.layer?.toggleLocationViewEdits
+
     // Check whether there is anything to edit in the first place.
     && location.infoj.some(entry => typeof entry.edit !== 'undefined')) {
 
     // Remove edit from infoj entries
-    location.removeEdits = ()=>{
+    location.removeEdits = () => {
 
       // Iterate through the location.infoj entries.
       location.infoj
@@ -230,10 +230,15 @@ export default location => {
       // Remove edits from infoj entries.
       location.removeEdits()
     }
-    
+
     // Refresh dataviews
     if (location.layer?.dataviews) {
-      Object.values(location.layer.dataviews).forEach(dv => dv.update());
+      console.log(location.layer.dataviews);
+      Object.values(location.layer.dataviews).forEach(dv => {
+        if (dv.display === true) {
+          dv.update();
+        }
+      });
     }
 
     // Enables the location view node and child elements.


### PR DESCRIPTION
This PR addresses an issue whereby if a layer has `dataviews` but they are all unchecked, ie not turn on. The `dv.update()` fails with update is not a function. 
This PR simply checks and updates only dataviews that are display true - ie turned on. 