### PR TITLE
Ensure that the modify callback enables the highlight interaction.

### DIFF
--- a/lib/ui/locations/entries/geometry.mjs
+++ b/lib/ui/locations/entries/geometry.mjs
@@ -192,7 +192,6 @@ function modify(e, entry) {
   if (btn.classList.contains('active')) {
 
     // Cancel modify interaction.
-    btn.classList.remove('active')
     entry.mapview.interactions.highlight()
     return;
   }
@@ -216,6 +215,8 @@ function modify(e, entry) {
 
       // Reset interaction and button
       btn.classList.remove('active')
+
+      delete entry.mapview.interaction
 
       // Set highlight interaction if no other interaction is current after 400ms.
       setTimeout(() => {


### PR DESCRIPTION
The interaction callback must delete the interaction before a timeout to check whether no other interaction is current and then enabling the highlight interaction.