### PR TITLE
Edit Mode with Null Geometry

### DIFF
--- a/lib/ui/locations/entries/geometry.mjs
+++ b/lib/ui/locations/entries/geometry.mjs
@@ -53,7 +53,7 @@ export default entry => {
   const list = []
 
   // Call the draw method 
-  draw(entry);
+  draw(entry, list);
 
   // Push modify button into list.
   if (entry.edit?.geometry) {
@@ -79,7 +79,7 @@ export default entry => {
     else if (entry.draw) {
 
       // Call the draw method 
-      draw(entry);
+      draw(entry, list);
     }
   }
 
@@ -229,7 +229,7 @@ function modify(e, entry) {
 }
 
 // Method for button element to call draw interaction.
-function draw(entry) {
+function draw(entry, list) {
   if (typeof entry.draw === 'object') {
     entry.draw.callback = feature => {
 

--- a/lib/ui/locations/entries/geometry.mjs
+++ b/lib/ui/locations/entries/geometry.mjs
@@ -52,27 +52,8 @@ export default entry => {
   // Push elements for drawing methods into list.
   const list = []
 
-  if (typeof entry.draw === 'object') {
-    entry.draw.callback = feature => {
-
-      if (!feature) return;
-
-      // Remove existing entry geometry layer.
-      entry.location.layer.mapview.Map.removeLayer(entry.L)
-
-      // Assign feature geometry as new value.
-      entry.newValue = feature.geometry
-      entry.location.update()
-    }
-
-    Object.keys(entry.draw).forEach(key => {
-
-      if (mapp.ui.elements.drawing[key]) {
-        list.push(mapp.ui.elements.drawing[key](entry))
-      }
-    })
-
-  }
+  // Call the draw method 
+  draw(entry);
 
   // Push modify button into list.
   if (entry.edit?.geometry) {
@@ -96,29 +77,9 @@ export default entry => {
     }
     // If the entry has no value, but entry.draw is set, then the user can draw a new geometry.
     else if (entry.draw) {
-      // Push elements for drawing methods into list.
-      const list = []
 
-      if (typeof entry.draw === 'object') {
-        entry.draw.callback = feature => {
-
-          if (!feature) return;
-
-          // Remove existing entry geometry layer.
-          entry.location.layer.mapview.Map.removeLayer(entry.L)
-
-          // Assign feature geometry as new value.
-          entry.newValue = feature.geometry
-          entry.location.update()
-        }
-
-        Object.keys(entry.draw).forEach(key => {
-
-          if (mapp.ui.elements.drawing[key]) {
-            list.push(mapp.ui.elements.drawing[key](entry))
-          }
-        })
-      }
+      // Call the draw method 
+      draw(entry);
     }
   }
 
@@ -265,4 +226,29 @@ function modify(e, entry) {
       entry.location.layer.mapview.Map.addLayer(entry.L)
     }
   })
+}
+
+// Method for button element to call draw interaction.
+function draw(entry) {
+  if (typeof entry.draw === 'object') {
+    entry.draw.callback = feature => {
+
+      if (!feature) return;
+
+      // Remove existing entry geometry layer.
+      entry.location.layer.mapview.Map.removeLayer(entry.L)
+
+      // Assign feature geometry as new value.
+      entry.newValue = feature.geometry
+      entry.location.update()
+    }
+
+    Object.keys(entry.draw).forEach(key => {
+
+      if (mapp.ui.elements.drawing[key]) {
+        list.push(mapp.ui.elements.drawing[key](entry))
+      }
+    })
+
+  }
 }

--- a/lib/ui/locations/entries/geometry.mjs
+++ b/lib/ui/locations/entries/geometry.mjs
@@ -130,6 +130,7 @@ export default entry => {
     // Return drawer with list elements to entry node.
     return mapp.ui.elements.drawer({
       data_id: `draw-drawer`,
+      class: `group ${entry.draw?.groupClassList && 'expanded' || ''}`,
       header: mapp.utils.html`
         ${chkbox}
         <div class="mask-icon expander"></div>

--- a/lib/ui/locations/entries/geometry.mjs
+++ b/lib/ui/locations/entries/geometry.mjs
@@ -14,10 +14,10 @@ export default entry => {
 
   // Assign Style if not already assigned.
   entry.Style = entry.Style
-  
+
     // Create OL style object from style object.
     || typeof entry.style === 'object' && mapp.utils
-        .style(Object.assign({}, entry.location?.style || {}, entry.style))
+      .style(Object.assign({}, entry.location?.style || {}, entry.style))
 
     // Assign style from location.
     || entry.location.Style
@@ -32,13 +32,13 @@ export default entry => {
     checked: !!entry.display,
     disabled: !entry.value,
     onchange: (checked) => {
-      
+
       // Show geometry of checked.
       if (checked) {
         entry.show()
 
       } else {
-        
+
         // Remove the geometry layer from map.
         entry.display = false
         entry.L && entry.location.layer.mapview.Map.removeLayer(entry.L)
@@ -51,9 +51,8 @@ export default entry => {
 
   // Push elements for drawing methods into list.
   const list = []
-  
-  if (typeof entry.draw === 'object') {
 
+  if (typeof entry.draw === 'object') {
     entry.draw.callback = feature => {
 
       if (!feature) return;
@@ -67,7 +66,7 @@ export default entry => {
     }
 
     Object.keys(entry.draw).forEach(key => {
-   
+
       if (mapp.ui.elements.drawing[key]) {
         list.push(mapp.ui.elements.drawing[key](entry))
       }
@@ -78,21 +77,51 @@ export default entry => {
   // Push modify button into list.
   if (entry.edit?.geometry) {
 
-    // If label is provided for the Modify Button, use it. Otherwise use default.
-    let modifyBtnLabel = entry.edit?.modifyBtnOnly?.label || 'Modify Geometry';
+    // Only if the entry has a value, should the modify button be shown (as you can't modify a null geometry)
+    if (entry.value) {
+      // If label is provided for the Modify Button, use it. Otherwise use default.
+      let modifyBtnLabel = entry.edit?.modifyBtnOnly?.label || 'Modify Geometry';
 
-    let modifyBtn = mapp.utils.html.node`
+      let modifyBtn = mapp.utils.html.node`
       <button
         class="flat bold wide primary-colour"
-        onclick=${e=>modify(e, entry)}>
+        onclick=${e => modify(e, entry)}>
         ${modifyBtnLabel}`
 
-    if (entry.edit?.modifyBtnOnly) {
-      return modifyBtn
-    }
+      if (entry.edit?.modifyBtnOnly) {
+        return modifyBtn
+      }
 
-    list.push(modifyBtn)
+      list.push(modifyBtn)
+    }
+    // If the entry has no value, but entry.draw is set, then the user can draw a new geometry.
+    else if (entry.draw) {
+      // Push elements for drawing methods into list.
+      const list = []
+
+      if (typeof entry.draw === 'object') {
+        entry.draw.callback = feature => {
+
+          if (!feature) return;
+
+          // Remove existing entry geometry layer.
+          entry.location.layer.mapview.Map.removeLayer(entry.L)
+
+          // Assign feature geometry as new value.
+          entry.newValue = feature.geometry
+          entry.location.update()
+        }
+
+        Object.keys(entry.draw).forEach(key => {
+
+          if (mapp.ui.elements.drawing[key]) {
+            list.push(mapp.ui.elements.drawing[key](entry))
+          }
+        })
+      }
+    }
   }
+
 
   // Push modify button into list.
   entry.value && entry.edit?.delete && list.push(mapp.utils.html`
@@ -100,40 +129,40 @@ export default entry => {
       class="flat wide no-colour"
       onclick=${() => {
 
-        if (entry.display) {
-          remove()
-          return;
+      if (entry.display) {
+        remove()
+        return;
+      }
+
+      entry.show()
+
+      // Allow for geometries to be shown before confirming the deletion.
+      setTimeout(remove, 500)
+
+      function remove() {
+
+        // Return if user does not confirm deletion.
+        if (!confirm('Delete Geometry?')) return;
+
+        // Set newValue to null in order update location field in database.
+        entry.newValue = null
+
+        // Must be removed prior to database update / re-render.
+        if (entry.L) {
+          entry.location.layer.mapview.Map.removeLayer(entry.L)
+          delete entry.L
         }
 
-        entry.show()
+        // Re-renders location view after database update.
+        entry.location.update()
+      }
 
-        // Allow for geometries to be shown before confirming the deletion.
-        setTimeout(remove, 500)
-
-        function remove(){
-
-          // Return if user does not confirm deletion.
-          if (!confirm('Delete Geometry?')) return;
-
-          // Set newValue to null in order update location field in database.
-          entry.newValue = null
-
-          // Must be removed prior to database update / re-render.
-          if (entry.L) {
-            entry.location.layer.mapview.Map.removeLayer(entry.L)
-            delete entry.L
-          }
-          
-          // Re-renders location view after database update.
-          entry.location.update()
-        }
-
-      }}>Delete Geometry`)
+    }}>Delete Geometry`)
 
   const icon = entry.style && mapp.utils.html`
     ${mapp.ui.elements.legendIcon(
-      Object.assign({ width: 24, height: 24 }, entry.style)
-    )}`;
+    Object.assign({ width: 24, height: 24 }, entry.style)
+  )}`;
 
   if (list.length > 0) {
 
@@ -161,9 +190,9 @@ function show() {
 
   const chkbox = this.location
     .view?.querySelector(`[data-id=${this.field}-chkbox] input`)
-  
+
   if (chkbox) chkbox.checked = true
-    
+
   if (this.L) {
 
     // Remove existing layer to prevent assertion error.


### PR DESCRIPTION
This PR fixes a bug whereby if a `location.entry.infoj` geometry type field was present and had edit true, but the field was initially empty, in edit mode the edit button would appear. However, this threw an error as you cannot edit a null geometry. 

Instead what this PR does is check if the entry.value is null and if entry.draw is provided, and if so it will show the user the ability to draw the geometry instead - fixing the issue. 

It also adds the ability for `draw.groupClassList` to be provided, allowing the draw button to be shown iniitally and removing a user click. 

``` json 
{
      "label": "Display Catchment",
      "field": "field_geom",
      "fieldfx": "ST_asGeoJson(field_geom)",
      "type": "geometry",
      "group": "Catchment",
      "display": true,
      "srid": "4326",
      "edit": {
        "geometry": true,
        "modifyBtnOnly": {
          "label": "Edit Catchment"
        }
      },
      "draw": {
        "groupClassList": "expanded",
        "polygon": {
          "label": "Draw Catchment"
        }
      },
      "style": {
        "strokeColor": "#A4036F",
        "strokeWidth": 2,
        "fillOpacity": 0
      }
    }
```