### PR TITLE
Enable dataview entry with data from querycheck on update.

### DIFF
--- a/lib/ui/locations/entries/dataview.mjs
+++ b/lib/ui/locations/entries/dataview.mjs
@@ -9,6 +9,9 @@ export default entry => {
     // This is to prevent the query running over and over again getting the same result.
     delete entry.display
     entry.disabled = true
+  } else {
+
+    delete entry.disabled
   }
 
   // Dataview methods require the layer and host to be defined on the entry.


### PR DESCRIPTION
This is to fix an issue where a dataview would be disabled without data and stay disabled during the update event even if data is returned from the query in the queryCheck.