### PR TITLE
Fix Source clear bug

### DIFF
--- a/lib/layer/format/mvt.mjs
+++ b/lib/layer/format/mvt.mjs
@@ -40,7 +40,7 @@ export default layer => {
 
     const tableZ = layer.tableCurrent()
 
-    if ((!tableZ || !layer.display) && !layer.clones?.size) return source.clear()
+    if ((!tableZ || !layer.display) && !layer.clones?.size) return layer.source.clear()
 
     const url = `${layer.mapview.host}/api/layer/mvt/${tileCoord[0]}/${tileCoord[1]}/${tileCoord[2]}?` + mapp.utils.paramString({
       locale: layer.mapview.locale.key,


### PR DESCRIPTION
### 🐞 Bug Fix

**Issue:** 
When zooming past the minimum zoom level of an MVT layer, the system attempted to clear the layer's source. However, it was only referencing the source directly rather than accessing it through `layer.source`.

**Solution:** 
Fixed the reference issue by ensuring that we are referencing the source via `layer.source` when attempting to clear it.

---