### PR TITLE
Remove duplication of create button when entry geometry is null

### DIFF
--- a/lib/ui/locations/entries/geometry.mjs
+++ b/lib/ui/locations/entries/geometry.mjs
@@ -75,12 +75,7 @@ export default entry => {
 
       list.push(modifyBtn)
     }
-    // If the entry has no value, but entry.draw is set, then the user can draw a new geometry.
-    else if (entry.draw) {
-
-      // Call the draw method 
-      draw(entry, list);
-    }
+    
   }
 
 


### PR DESCRIPTION
This PR removes a bug introduced. If the location has no `entry.value` and the location is in edit mode, the draw button will appear instead of modify - as fixed in this PR. https://github.com/GEOLYTIX/xyz/pull/942

However, accidentally we were calling the draw method twice for this, once outside the `if(entry.edit?.geometry)` and once within it - using an else when the value was null. This has the unintended side effect of generating the draw button twice when edit mode is toggled on a location with a geometry type of null value. 

This PR simply removes the `else` so that only one button is generated. 