### PR TITLE
Do not merge HTMLElement

### DIFF
--- a/lib/utils/merge.mjs
+++ b/lib/utils/merge.mjs
@@ -32,5 +32,13 @@ export default function mergeDeep(target, ...sources) {
 }
 
 function isObject(item) {
-  return (item && typeof item === 'object' && !Array.isArray(item));
+
+  if (item instanceof HTMLElement) {
+    console.warn(item)
+    return false;
+  }
+
+  if (Array.isArray(item)) return false;
+
+  if (typeof item === 'object') return true;
 }


### PR DESCRIPTION
The deepmerge method must check for items which are instanceof HTMLElement.

Technically objects, these cannot be merged as it will cause the stack to max out and crash the party.

I'll add warning with the element and return false indicating that this is not an object from the object check method.