### PR TITLE
Flag for suffix_date for cloudinary image upload

### DIFF
--- a/lib/ui/locations/entries/cloudinary.mjs
+++ b/lib/ui/locations/entries/cloudinary.mjs
@@ -124,13 +124,15 @@ function imageLoad(e, entry){
 
         const dataURL = canvas.toDataURL('image/jpeg', 0.5)
 
+        const public_id = `${entry.file.name.replace(/^.*\//, '').replace(/\.([\w-]{3})/, '')}${entry.suffix_date ? `@${Date.now()}`:''}`
+
         const response = await mapp.utils.xhr({
             method: 'POST',
             requestHeader: {
                 'Content-Type': 'application/octet-stream'
             },
             url: `${entry.location.layer.mapview.host}/api/provider/cloudinary?${mapp.utils.paramString({
-                public_id: entry.file.name.replace(/^.*\//, '').replace(/\.([\w-]{3})/, ''),
+                public_id,
                 resource_type: 'image',
                 folder: entry.cloudinary_folder
             })}`,

--- a/lib/ui/locations/entries/cloudinary.mjs
+++ b/lib/ui/locations/entries/cloudinary.mjs
@@ -124,7 +124,7 @@ function imageLoad(e, entry){
 
         const dataURL = canvas.toDataURL('image/jpeg', 0.5)
 
-        const public_id = `${entry.file.name.replace(/^.*\//, '').replace(/\.([\w-]{3})/, '')}${entry.suffix_date ? `@${Date.now()}`:''}`
+        const public_id = entry.file.name.replace(/^.*\//, '').replace(/\.([\w-]{3})/, '') + entry.suffix_date ? `@${Date.now()}` : '';
 
         const response = await mapp.utils.xhr({
             method: 'POST',


### PR DESCRIPTION
Setting the `suffix_date` flag in a cloudinary `type:images` entry will add `@date` to the image name.

```
                    {
                        "title": "Pictures",
                        "skipFalsyValue": true,
                        "field": "images",
                        "type": "images",
                        "cloudinary_folder": "test",
                        "suffix_date": true,
                        "edit": true
                    },
```

This is to prevent images with the same name overwriting existing images.

![image](https://github.com/GEOLYTIX/xyz/assets/22201617/8200723c-0be6-4581-a8d6-2aee6ede694b)
