### PR TITLE
added icon-done.svg needed for building css

### DIFF
--- a/public/icons/icon-done.svg
+++ b/public/icons/icon-done.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" height="24" viewBox="0 -960 960 960" width="24"><path d="M382-240 154-468l57-57 171 171 367-367 57 57-424 424Z"/></svg>


### PR DESCRIPTION
icon-done.svg is needed for building the css through the esbuild command