### PR TITLE
Drawing elements must enable highlight interaction callback

### DIFF
--- a/lib/ui/elements/drawing.mjs
+++ b/lib/ui/elements/drawing.mjs
@@ -100,15 +100,15 @@ function point(layer) {
 
         layer.draw.callback(feature, layer.draw.point)
 
-        if (btn.classList.contains('active')) {
+        btn.classList.remove('active')
 
-          btn.classList.remove('active')
+        delete layer.mapview.interaction
 
-          // Set highlight interaction if no other interaction is current after 400ms.
-          setTimeout(() => {
-            !layer.mapview.interaction && layer.mapview.interactions.highlight()
-          }, 400)
-        }
+        // Set highlight interaction if no other interaction is current after 400ms.
+        setTimeout(() => {
+          !layer.mapview.interaction && layer.mapview.interactions.highlight()
+        }, 400)
+
       }
 
       layer.mapview.interactions.draw(layer.draw.point)
@@ -155,15 +155,15 @@ function line(layer) {
 
         layer.draw.callback(feature, layer.draw.polygon)
 
-        if (btn.classList.contains('active')) {
+        btn.classList.remove('active')
 
-          btn.classList.remove('active')
+        delete layer.mapview.interaction
 
-          // Set highlight interaction if no other interaction is current after 400ms.
-          setTimeout(() => {
-            !layer.mapview.interaction && layer.mapview.interactions.highlight()
-          }, 400)
-        }
+        // Set highlight interaction if no other interaction is current after 400ms.
+        setTimeout(() => {
+          !layer.mapview.interaction && layer.mapview.interactions.highlight()
+        }, 400)
+
       }
 
       layer.mapview.interactions.draw(layer.draw.line)
@@ -209,15 +209,15 @@ function polygon(layer) {
 
         layer.draw.callback(feature, layer.draw.polygon)
 
-        if (btn.classList.contains('active')) {
+        btn.classList.remove('active')
 
-          btn.classList.remove('active')
+        delete layer.mapview.interaction
 
-          // Set highlight interaction if no other interaction is current after 400ms.
-          setTimeout(() => {
-            !layer.mapview.interaction && layer.mapview.interactions.highlight()
-          }, 400)
-        }
+        // Set highlight interaction if no other interaction is current after 400ms.
+        setTimeout(() => {
+          !layer.mapview.interaction && layer.mapview.interactions.highlight()
+        }, 400)
+
       }
 
       layer.mapview.interactions.draw(layer.draw.polygon)
@@ -264,15 +264,15 @@ function rectangle(layer) {
 
         layer.draw.callback(feature, layer.draw.rectangle)
 
-        if (btn.classList.contains('active')) {
+        btn.classList.remove('active')
 
-          btn.classList.remove('active')
+        delete layer.mapview.interaction
 
-          // Set highlight interaction if no other interaction is current after 400ms.
-          setTimeout(() => {
-            !layer.mapview.interaction && layer.mapview.interactions.highlight()
-          }, 400)
-        }
+        // Set highlight interaction if no other interaction is current after 400ms.
+        setTimeout(() => {
+          !layer.mapview.interaction && layer.mapview.interactions.highlight()
+        }, 400)
+
       }
 
       layer.mapview.interactions.draw(layer.draw.rectangle)
@@ -319,15 +319,15 @@ function circle_2pt(layer) {
 
         layer.draw.callback(feature, layer.draw.circle_2pt)
 
-        if (btn.classList.contains('active')) {
+        btn.classList.remove('active')
 
-          btn.classList.remove('active')
+        delete layer.mapview.interaction
 
-          // Set highlight interaction if no other interaction is current after 400ms.
-          setTimeout(() => {
-            !layer.mapview.interaction && layer.mapview.interactions.highlight()
-          }, 400)
-        }
+        // Set highlight interaction if no other interaction is current after 400ms.
+        setTimeout(() => {
+          !layer.mapview.interaction && layer.mapview.interactions.highlight()
+        }, 400)
+
       }
 
       layer.mapview.interactions.draw(layer.draw.circle_2pt)
@@ -447,14 +447,15 @@ function circle(layer) {
 
         layer.draw.callback(feature, layer.draw.circle)
 
-        if (btn.classList.contains('active')) {
-          btn.classList.remove('active')
+        btn.classList.remove('active')
 
-          // Set highlight interaction if no other interaction is current after 400ms.
-          setTimeout(() => {
-            !layer.mapview.interaction && layer.mapview.interactions.highlight()
-          }, 400)
-        }
+        delete layer.mapview.interaction
+
+        // Set highlight interaction if no other interaction is current after 400ms.
+        setTimeout(() => {
+          !layer.mapview.interaction && layer.mapview.interactions.highlight()
+        }, 400)
+
       }
 
       layer.mapview.interactions.draw(layer.draw.circle)


### PR DESCRIPTION
It is not required to check whether the btn contains the active class. This can always be removed since the callback indicates that the interaction is finished. Likewise the interaction must be removed from the mapview. Otherwise the highlight interaction will not be activated in the timeout.