### PR TITLE
geometry entry draw & edit/modify

### DIFF
--- a/lib/mapview/geoJSON.mjs
+++ b/lib/mapview/geoJSON.mjs
@@ -22,24 +22,6 @@ export default function (params){
 
   if (!feature) return;
 
-  if (feature.getGeometry().getType() !== 'Point') {
-
-    const styles = [params.Style].flat().map(style => style.getStroke())
-
-    // All other geometry types must have a Stroke style.
-    if (!styles.some(style => !!style)) {
-
-      params.Style = new ol.style.Style({
-        stroke: new ol.style.Stroke({
-          color: '#3399CC'
-        })
-      })
-
-      console.warn('Missing Stroke style for geojson vector geometry')
-    }
-
-  }
-  
   const layerVector = new ol.layer.Vector({
     source: new ol.source.Vector({
       features: [feature]

--- a/lib/ui/locations/entries/geometry.mjs
+++ b/lib/ui/locations/entries/geometry.mjs
@@ -99,16 +99,7 @@ export default entry => {
 
         entry.value = null
 
-        await postUpdate(entry)
-
-        // Must be removed prior to database update / re-render.
-        if (entry.L) {
-          entry.location.layer.mapview.Map.removeLayer(entry.L)
-          delete entry.L
-        }
-
-        // Render the geometry entry.
-        mapp.utils.render(entry.node, mapp.ui.locations.entries.geometry(entry))
+        postUpdate(entry)
       }
 
     }}>Delete Geometry`)
@@ -195,7 +186,7 @@ function modify(e, entry) {
     layer: entry.location.layer,
     snap: entry.edit.snap,
     srid: entry.srid || entry.location.layer.srid,
-    callback: async feature => {
+    callback: feature => {
 
       // Reset interaction and button
       btn.classList.remove('active')
@@ -213,9 +204,7 @@ function modify(e, entry) {
         // Assign feature geometry as new value.
         entry.value = feature.geometry
 
-        await postUpdate(entry)
-
-        mapp.utils.render(entry.node, mapp.ui.locations.entries.geometry(entry))
+        postUpdate(entry)
 
         return;
       }
@@ -241,25 +230,14 @@ function draw(entry, list) {
   // Short circuit without an entry.draw config.
   if (!entry.draw) return;
 
-  entry.draw.callback = async feature => {
+  entry.draw.callback = feature => {
 
     if (!feature) return;
-
-    if (entry.L) {
-
-      // Remove existing entry geometry layer.
-      entry.location.layer.mapview.Map.removeLayer(entry.L)
-
-      delete entry.L
-    }
 
     // Assign feature geometry as new value.
     entry.value = feature.geometry
 
-    await postUpdate(entry)
-
-    // Render geometry entry with updated entry.value
-    mapp.utils.render(entry.node, mapp.ui.locations.entries.geometry(entry))
+    postUpdate(entry)
   }
 
   Object.keys(entry.draw).forEach(key => {
@@ -272,6 +250,14 @@ function draw(entry, list) {
 }
 
 async function postUpdate(entry) {
+
+  if (entry.L) {
+
+    // Remove existing entry geometry layer.
+    entry.location.layer.mapview.Map.removeLayer(entry.L)
+
+    delete entry.L
+  }
 
   entry.location.view?.classList.add('disabled')
 
@@ -288,6 +274,15 @@ async function postUpdate(entry) {
       }),
     body: JSON.stringify({ [entry.field]: entry.value }),
   })
+
+  if (entry.location.layer.geom === entry.field) {
+
+    // Reload the layer if the layers geom field has been updated.
+    entry.location.layer.reload()
+  }
+
+  // Render geometry entry with updated entry.value
+  mapp.utils.render(entry.node, mapp.ui.locations.entries.geometry(entry))
 
   entry.location.view?.classList.remove('disabled')
 

--- a/lib/ui/locations/entries/geometry.mjs
+++ b/lib/ui/locations/entries/geometry.mjs
@@ -97,25 +97,9 @@ export default entry => {
         // Return if user does not confirm deletion.
         if (!confirm('Delete Geometry?')) return;
 
-        delete entry.value
+        entry.value = null
 
-        entry.location.view?.classList.add('disabled')
-
-        // Update the geometry field value.
-        await mapp.utils.xhr({
-          method: 'POST',
-          url:
-            `${entry.location.layer.mapview.host}/api/location/update?` +
-            mapp.utils.paramString({
-              locale: entry.location.layer.mapview.locale.key,
-              layer: entry.location.layer.key,
-              table: entry.location.table,
-              id: entry.location.id,
-            }),
-          body: JSON.stringify({ [entry.field]: null }),
-        })
-
-        entry.location.view?.classList.remove('disabled')
+        await postUpdate(entry)
 
         // Must be removed prior to database update / re-render.
         if (entry.L) {
@@ -229,23 +213,7 @@ function modify(e, entry) {
         // Assign feature geometry as new value.
         entry.value = feature.geometry
 
-        entry.location.view?.classList.add('disabled')
-
-        // Update the geometry field value.
-        await mapp.utils.xhr({
-          method: 'POST',
-          url:
-            `${entry.location.layer.mapview.host}/api/location/update?` +
-            mapp.utils.paramString({
-              locale: entry.location.layer.mapview.locale.key,
-              layer: entry.location.layer.key,
-              table: entry.location.table,
-              id: entry.location.id,
-            }),
-          body: JSON.stringify({ [entry.field]: entry.value }),
-        })
-
-        entry.location.view?.classList.remove('disabled')
+        await postUpdate(entry)
 
         mapp.utils.render(entry.node, mapp.ui.locations.entries.geometry(entry))
 
@@ -288,23 +256,7 @@ function draw(entry, list) {
     // Assign feature geometry as new value.
     entry.value = feature.geometry
 
-    entry.location.view?.classList.add('disabled')
-
-    // Update the geometry field value.
-    await mapp.utils.xhr({
-      method: 'POST',
-      url:
-        `${entry.location.layer.mapview.host}/api/location/update?` +
-        mapp.utils.paramString({
-          locale: entry.location.layer.mapview.locale.key,
-          layer: entry.location.layer.key,
-          table: entry.location.table,
-          id: entry.location.id,
-        }),
-      body: JSON.stringify({ [entry.field]: entry.value }),
-    })
-
-    entry.location.view?.classList.remove('disabled')
+    await postUpdate(entry)
 
     // Render geometry entry with updated entry.value
     mapp.utils.render(entry.node, mapp.ui.locations.entries.geometry(entry))
@@ -316,5 +268,27 @@ function draw(entry, list) {
       list.push(mapp.ui.elements.drawing[key](entry))
     }
   })
+
+}
+
+async function postUpdate(entry) {
+
+  entry.location.view?.classList.add('disabled')
+
+  // Update the geometry field value.
+  await mapp.utils.xhr({
+    method: 'POST',
+    url:
+      `${entry.location.layer.mapview.host}/api/location/update?` +
+      mapp.utils.paramString({
+        locale: entry.location.layer.mapview.locale.key,
+        layer: entry.location.layer.key,
+        table: entry.location.table,
+        id: entry.location.id,
+      }),
+    body: JSON.stringify({ [entry.field]: entry.value }),
+  })
+
+  entry.location.view?.classList.remove('disabled')
 
 }

--- a/lib/ui/locations/entries/geometry.mjs
+++ b/lib/ui/locations/entries/geometry.mjs
@@ -12,15 +12,11 @@ export default entry => {
   // Assigning the mapview to the entry makes the entry behave like a layer object for draw and modify interactions.
   entry.mapview = entry.location.layer.mapview
 
-  // Assign Style if not already assigned.
-  entry.Style = entry.Style
+  // Assign entry.style to location.style
+  entry.style = Object.assign({}, entry.location?.style || {}, entry.style)
 
-    // Create OL style object from style object.
-    || typeof entry.style === 'object' && mapp.utils
-      .style(Object.assign({}, entry.location?.style || {}, entry.style))
-
-    // Assign style from location.
-    || entry.location.Style
+  // Create ol style from entry.style if not yet defined.
+  entry.Style ??= mapp.utils.style(entry.style)
 
   // Assign method to show geometry in mapview.
   entry.show = show
@@ -125,7 +121,7 @@ export default entry => {
     // Return drawer with list elements to entry node.
     return mapp.ui.elements.drawer({
       data_id: `draw-drawer`,
-      class: `group ${entry.draw?.groupClassList && 'expanded' || ''}`,
+      class: entry.draw?.classList,
       header: mapp.utils.html`
         ${chkbox}
         <div class="mask-icon expander"></div>

--- a/lib/ui/locations/entries/geometry.mjs
+++ b/lib/ui/locations/entries/geometry.mjs
@@ -52,10 +52,11 @@ export default entry => {
   draw(entry, list);
 
   // Push modify button into list.
-  if (entry.edit?.geometry) {
+  if (entry.edit) {
 
     // Only if the entry has a value, should the modify button be shown (as you can't modify a null geometry)
     if (entry.value) {
+
       // If label is provided for the Modify Button, use it. Otherwise use default.
       let modifyBtnLabel = entry.edit?.modifyBtnOnly?.label || 'Modify Geometry';
 
@@ -209,8 +210,10 @@ function modify(e, entry) {
       if (feature) {
 
         // Assign feature geometry as new value.
-        entry.newValue = feature.geometry
-        entry.location.update()
+        entry.value = feature.geometry
+
+        mapp.utils.render(entry.node, mapp.ui.locations.entries.geometry(entry))
+
         return;
       }
 
@@ -222,7 +225,9 @@ function modify(e, entry) {
 
 // Method for button element to call draw interaction.
 function draw(entry, list) {
+
   if (typeof entry.draw === 'object') {
+
     entry.draw.callback = feature => {
 
       if (!feature) return;

--- a/lib/ui/locations/entries/geometry.mjs
+++ b/lib/ui/locations/entries/geometry.mjs
@@ -92,13 +92,30 @@ export default entry => {
       // Allow for geometries to be shown before confirming the deletion.
       setTimeout(remove, 500)
 
-      function remove() {
+      async function remove() {
 
         // Return if user does not confirm deletion.
         if (!confirm('Delete Geometry?')) return;
 
-        // Set newValue to null in order update location field in database.
-        entry.newValue = null
+        delete entry.value
+
+        entry.location.view?.classList.add('disabled')
+
+        // Update the geometry field value.
+        await mapp.utils.xhr({
+          method: 'POST',
+          url:
+            `${entry.location.layer.mapview.host}/api/location/update?` +
+            mapp.utils.paramString({
+              locale: entry.location.layer.mapview.locale.key,
+              layer: entry.location.layer.key,
+              table: entry.location.table,
+              id: entry.location.id,
+            }),
+          body: JSON.stringify({ [entry.field]: null }),
+        })
+
+        entry.location.view?.classList.remove('disabled')
 
         // Must be removed prior to database update / re-render.
         if (entry.L) {
@@ -106,8 +123,8 @@ export default entry => {
           delete entry.L
         }
 
-        // Re-renders location view after database update.
-        entry.location.update()
+        // Render the geometry entry.
+        mapp.utils.render(entry.node, mapp.ui.locations.entries.geometry(entry))
       }
 
     }}>Delete Geometry`)
@@ -194,7 +211,7 @@ function modify(e, entry) {
     layer: entry.location.layer,
     snap: entry.edit.snap,
     srid: entry.srid || entry.location.layer.srid,
-    callback: feature => {
+    callback: async feature => {
 
       // Reset interaction and button
       btn.classList.remove('active')
@@ -212,6 +229,24 @@ function modify(e, entry) {
         // Assign feature geometry as new value.
         entry.value = feature.geometry
 
+        entry.location.view?.classList.add('disabled')
+
+        // Update the geometry field value.
+        await mapp.utils.xhr({
+          method: 'POST',
+          url:
+            `${entry.location.layer.mapview.host}/api/location/update?` +
+            mapp.utils.paramString({
+              locale: entry.location.layer.mapview.locale.key,
+              layer: entry.location.layer.key,
+              table: entry.location.table,
+              id: entry.location.id,
+            }),
+          body: JSON.stringify({ [entry.field]: entry.value }),
+        })
+
+        entry.location.view?.classList.remove('disabled')
+
         mapp.utils.render(entry.node, mapp.ui.locations.entries.geometry(entry))
 
         return;
@@ -226,26 +261,60 @@ function modify(e, entry) {
 // Method for button element to call draw interaction.
 function draw(entry, list) {
 
-  if (typeof entry.draw === 'object') {
+  // Drawing is only available within an edit context.
+  if (entry.edit?.draw) {
 
-    entry.draw.callback = feature => {
+    entry.draw = entry.edit.draw
+  }
 
-      if (!feature) return;
+  // Editing with drawing is toggled off.
+  if (entry._edit?.draw) delete entry.draw
+
+  // Short circuit without an entry.draw config.
+  if (!entry.draw) return;
+
+  entry.draw.callback = async feature => {
+
+    if (!feature) return;
+
+    if (entry.L) {
 
       // Remove existing entry geometry layer.
       entry.location.layer.mapview.Map.removeLayer(entry.L)
 
-      // Assign feature geometry as new value.
-      entry.newValue = feature.geometry
-      entry.location.update()
+      delete entry.L
     }
 
-    Object.keys(entry.draw).forEach(key => {
+    // Assign feature geometry as new value.
+    entry.value = feature.geometry
 
-      if (mapp.ui.elements.drawing[key]) {
-        list.push(mapp.ui.elements.drawing[key](entry))
-      }
+    entry.location.view?.classList.add('disabled')
+
+    // Update the geometry field value.
+    await mapp.utils.xhr({
+      method: 'POST',
+      url:
+        `${entry.location.layer.mapview.host}/api/location/update?` +
+        mapp.utils.paramString({
+          locale: entry.location.layer.mapview.locale.key,
+          layer: entry.location.layer.key,
+          table: entry.location.table,
+          id: entry.location.id,
+        }),
+      body: JSON.stringify({ [entry.field]: entry.value }),
     })
 
+    entry.location.view?.classList.remove('disabled')
+
+    // Render geometry entry with updated entry.value
+    mapp.utils.render(entry.node, mapp.ui.locations.entries.geometry(entry))
   }
+
+  Object.keys(entry.draw).forEach(key => {
+
+    if (mapp.ui.elements.drawing[key]) {
+      list.push(mapp.ui.elements.drawing[key](entry))
+    }
+  })
+
 }

--- a/lib/ui/locations/entries/geometry.mjs
+++ b/lib/ui/locations/entries/geometry.mjs
@@ -13,7 +13,7 @@ export default entry => {
   entry.mapview = entry.location.layer.mapview
 
   // Assign entry.style to location.style
-  entry.style = Object.assign({}, entry.location?.style || {}, entry.style)
+  entry.style = {...entry.location?.style, ...entry.style}
 
   // Create ol style from entry.style if not yet defined.
   entry.Style ??= mapp.utils.style(entry.style)

--- a/lib/utils/style.mjs
+++ b/lib/utils/style.mjs
@@ -12,7 +12,7 @@ export default (style, feature) => {
   style.forEach(style => {
 
     // Only process icon for features if they are point geometries.
-    if (style.icon && (!feature || feature?.geometryType === 'Point')) {
+    if (style.icon) {
 
       // icon styles must always be processed as an array.
       style.icon = Array.isArray(style.icon) ? style.icon : [style.icon]
@@ -44,7 +44,9 @@ export default (style, feature) => {
         }))
       })
 
-    } else {
+    } 
+    
+    if (style.fillColor || style.strokeColor) {
 
       // Create OL fill.
       let fill = style.fillColor && new ol.style.Fill({


### PR DESCRIPTION
The mapview geojson method must not apply a default stroke if non is defined. It is valid to draw an area with a fill only.

The style method should create combined styles for icon, stroke and fill. It is valid to have a geojson layer with mixed geometries.

The drawer element for drawing elements is not a location-view group class element. This should not be displayed as grid by default. The classList (eg. "expanded") can be defined as classList in the draw config. This should not take the listview group classlist.

The modify callback will assign a value and render the geometry type entry element into it's node instead of setting a newValue and calling the update method. This will ensure that editing remains toggled on without affecting other edits in progress.

```js
      // The callback returns a feature as geojson.
      if (feature) {

        // Assign feature geometry as new value.
        entry.value = feature.geometry

        mapp.utils.render(entry.node, mapp.ui.locations.entries.geometry(entry))

        return;
      }
```

Editing must be possible with `edit:true`. The type:geometry does not have to specified within the edit object. This is implied by the entry type.

Drawing can now be toggled with editing if defined in the edit config.

```js
{
    "type": "geometry",
    "display": true,
    "field": "draw",
    "fieldfx": "ST_asGeoJSON(draw)",
    "edit": {
        "delete": true,
        "draw": {
            "classList": "expanded",
            "point": {
                "label": "Add Point"
            },
            "line": {
                "label": "Add Line Yeah"
            },
            "polygon": {
                "label": "Add Polygon Now"
            },
            "rectangle": {
                "label": "Add Rectangle Here"
            },
            "circle_2pt": {
                "label": "Add Circle 2pt Go"
            },
            "circle": {
                "label": "Add Circle On Me"
            }
        }
    },
    "style": {
        "strokeColor": "#090",
        "strokeWidth": 2,
        "fillColor": "#ff69b4",
        "fillOpacity": 0.8,
        "icon": {
            "type": "dot",
            "fillColor": "#090"
        }
    }
}
```
