### PR TITLE
Ensure table is defined when table=true passed

### DIFF
--- a/lib/utils/queryParams.mjs
+++ b/lib/utils/queryParams.mjs
@@ -1,5 +1,5 @@
 export default _this => {
- 
+
   // Assign empty object if not defined.
   _this.queryparams = _this.queryparams || {}
 
@@ -7,9 +7,7 @@ export default _this => {
   _this.queryparams.layer = _this.queryparams.layer || _this.viewport
 
   // Assign table name from layer.
-  if (_this.queryparams.table === true) {
-    _this.queryparams.table = _this.layer?.tableCurrent()
-  }
+  _this.queryparams.table &&= _this.location?.layer?.tableCurrent()
 
   // Assign fieldValues from the location to queryparams.
   if (Array.isArray(_this.queryparams.fieldValues) && _this.location) {


### PR DESCRIPTION
If you pass `queryparams: {"table": true}` to an `entry`, there is a bug where is it currently defined as `undefined`. 

This PR addresses that issue by ensuring it correctly calls `_this.location?.layer?.tableCurrent()` 