### PR TITLE
Update queryParams.mjs 

### DIFF
--- a/lib/utils/queryParams.mjs
+++ b/lib/utils/queryParams.mjs
@@ -17,21 +17,19 @@ export default _this => {
 
   _this.queryparams.table &&= table;
 
-  // Assign fieldValues from the location to queryparams.
-  if (Array.isArray(_this.queryparams.fieldValues) && _this.location) {
-    assignFieldValues(_this.queryparams.fieldValues, _this.location.infoj, _this.queryparams);
-  }
+  // Only if a location is provided, can we use the location infoj to assign field values to the queryparams.
+  if (_this.location) {
+    // Assign fieldValues from the location to queryparams.
+    if (Array.isArray(_this.queryparams.fieldValues)) {
+      // Iterate through the fieldValues array.
+      fieldValues.forEach(field => {
+        // Find entry in location infoj matching the field.
+        const entry = infoj.find(entry => entry.field === field);
+        // Assign entry value as field value in queryparams.
+        queryparams[field] = entry.value;
 
-  // Function to assign field values from infoj to queryparams.
-  function assignFieldValues(fieldValues, infoj, queryparams) {
-    // Iterate through the fieldValues array.
-    fieldValues.forEach(field => {
-      // Find entry in location infoj matching the field.
-      const entry = infoj.find(entry => entry.field === field);
-      // Assign entry value as field value in queryparams.
-      queryparams[field] = entry.value;
-
-    });
+      })
+    }
   }
 
   // Get bounds from mapview.

--- a/lib/utils/queryParams.mjs
+++ b/lib/utils/queryParams.mjs
@@ -8,8 +8,9 @@ export default _this => {
 
   // Assign table name from layer, if table is set to true 
   // Table can be set to a string, which is valid
-  if (_this.queryparams.table === true) _this.queryparams.table = _this.location?.layer?.tableCurrent() || _this.layer?.tableCurrent()
-
+  let tableCurrent = _this.location?.layer?.tableCurrent() || _this.layer?.tableCurrent()
+  _this.queryparams.table &&= _this.queryparams.table === true ? tableCurrent : _this.queryparams.table
+ 
   // Assign fieldValues from the location to queryparams.
   if (Array.isArray(_this.queryparams.fieldValues) && _this.location) {
 

--- a/lib/utils/queryParams.mjs
+++ b/lib/utils/queryParams.mjs
@@ -10,10 +10,10 @@ export default _this => {
   _this.queryparams.layer = _this.queryparams.layer || _this.viewport
 
   // Assign table name from layer
-  let tableCurrent = _this.location?.layer?.tableCurrent() || _this.layer?.tableCurrent()
+  const tableCurrent = _this.location?.layer?.tableCurrent() || _this.layer?.tableCurrent()
 
   // If table is set to true, use the current table name from the layer, otherwise use the table name from the queryparams.
-  let table = _this.queryparams.table === true ? tableCurrent : _this.queryparams.table;
+  const table = _this.queryparams.table === true ? tableCurrent : _this.queryparams.table;
 
   _this.queryparams.table &&= table;
 
@@ -27,6 +27,7 @@ export default _this => {
     `EPSG:4326`)
 
   return {
+
     // Spread the queryparams object.
     ..._this.queryparams,
 
@@ -57,6 +58,5 @@ export default _this => {
 
     // The fieldValues array entries should not be part of the url params.
     fieldValues: undefined
-
   }
 }

--- a/lib/utils/queryParams.mjs
+++ b/lib/utils/queryParams.mjs
@@ -17,21 +17,6 @@ export default _this => {
 
   _this.queryparams.table &&= table;
 
-  // Only if a location is provided, can we use the location infoj to assign field values to the queryparams.
-  if (_this.location) {
-    // Assign fieldValues from the location to queryparams.
-    if (Array.isArray(_this.queryparams.fieldValues)) {
-      // Iterate through the fieldValues array.
-      fieldValues.forEach(field => {
-        // Find entry in location infoj matching the field.
-        const entry = infoj.find(entry => entry.field === field);
-        // Assign entry value as field value in queryparams.
-        queryparams[field] = entry.value;
-
-      })
-    }
-  }
-
   // Get bounds from mapview.
   const bounds = _this.viewport && _this.layer.mapview.getBounds();
 

--- a/lib/utils/queryParams.mjs
+++ b/lib/utils/queryParams.mjs
@@ -6,10 +6,13 @@ export default _this => {
   // The layer queryparam must be true to support viewport params.
   _this.queryparams.layer = _this.queryparams.layer || _this.viewport
 
-  // Assign table name from layer, if table is set to true 
-  // Table can be set to a string, which is valid
+  // Assign table name from layer
   let tableCurrent = _this.location?.layer?.tableCurrent() || _this.layer?.tableCurrent()
-  _this.queryparams.table &&= _this.queryparams.table === true ? tableCurrent : _this.queryparams.table
+
+  // If table is set to true, use the current table name from the layer, otherwise use the table name from the queryparams.
+  let table = _this.queryparams.table === true ? tableCurrent : _this.queryparams.table;
+  
+  _this.queryparams.table &&= table;
  
   // Assign fieldValues from the location to queryparams.
   if (Array.isArray(_this.queryparams.fieldValues) && _this.location) {

--- a/lib/utils/queryParams.mjs
+++ b/lib/utils/queryParams.mjs
@@ -1,7 +1,7 @@
 export default _this => {
 
   // Assign empty object if not defined.
-  _this.queryparams = _this.queryparams || {}
+  _this.queryparams ??= {}
 
   // The layer queryparam must be true to support viewport params.
   _this.queryparams.layer = _this.queryparams.layer || _this.viewport
@@ -11,7 +11,7 @@ export default _this => {
 
   // If table is set to true, use the current table name from the layer, otherwise use the table name from the queryparams.
   let table = _this.queryparams.table === true ? tableCurrent : _this.queryparams.table;
-  
+
   _this.queryparams.table &&= table;
  
   // Assign fieldValues from the location to queryparams.

--- a/lib/utils/queryParams.mjs
+++ b/lib/utils/queryParams.mjs
@@ -41,25 +41,6 @@ export default _this => {
     `EPSG:${_this.layer.mapview.srid}`,
     `EPSG:4326`)
 
-
-  // Set the queryparams 
-
-  // If layer is true, the locale and layer params will be taken from the layer object.
-  if (this.queryparams.layer) {
-    locale = this.layer.mapview.locale.key,
-      layer = this.layer.key
-  }
-
-  // If filter is true, the filter param will be taken from the layer object.
-  if (this.queryparams.filter) {
-    filter = this.layer.filter?.current
-  }
-
-  // If id is true, the id param will be taken from the location object.
-  if (this.queryparams.id) {
-    id = this.location?.id
-  }
-
   return {
     // Spread the queryparams object.
     ..._this.queryparams,
@@ -68,16 +49,16 @@ export default _this => {
     template: encodeURIComponent(_this.query),
 
     // Layer filter can only be applied if the layer is provided as reference to a layer object in the layers list.
-    filter: filter,
+    filter: this.queryparams.filter ? this.layer.filter?.current : undefined,
 
     // Locale param is only required for layer lookups.
-    locale: locale,
+    locale: this.queryparams.layer ? this.layer.mapview.locale.key : undefined,
 
     // Layer param is only required for layer lookups.
-    layer: layer,
+    layer: this.queryparams.layer ? this.layer.key : undefined,
 
     // ID will be taken if a location object is provided with the params.
-    id: id,
+    id: this.queryparams.id ? this.location?.id : undefined,
 
     // lat lng must be explicit or the center flag param must be set.
     lat: center && center[1],

--- a/lib/utils/queryParams.mjs
+++ b/lib/utils/queryParams.mjs
@@ -6,8 +6,9 @@ export default _this => {
   // The layer queryparam must be true to support viewport params.
   _this.queryparams.layer = _this.queryparams.layer || _this.viewport
 
-  // Assign table name from layer.
-  _this.queryparams.table &&= _this.location?.layer?.tableCurrent() || _this.layer?.tableCurrent()
+  // Assign table name from layer, if table is set to true 
+  // Table can be set to a string, which is valid
+  if (_this.queryparams.table === true) _this.queryparams.table = _this.location?.layer?.tableCurrent() || _this.layer?.tableCurrent()
 
   // Assign fieldValues from the location to queryparams.
   if (Array.isArray(_this.queryparams.fieldValues) && _this.location) {

--- a/lib/utils/queryParams.mjs
+++ b/lib/utils/queryParams.mjs
@@ -34,16 +34,16 @@ export default _this => {
     template: encodeURIComponent(_this.query),
 
     // Layer filter can only be applied if the layer is provided as reference to a layer object in the layers list.
-    filter: this.queryparams.filter ? this.layer.filter?.current : undefined,
+    filter: _this.queryparams.filter ? _this.layer.filter?.current : undefined,
 
     // Locale param is only required for layer lookups.
-    locale: this.queryparams.layer ? this.layer.mapview.locale.key : undefined,
+    locale: _this.queryparams.layer ? _this.layer.mapview.locale.key : undefined,
 
     // Layer param is only required for layer lookups.
-    layer: this.queryparams.layer ? this.layer.key : undefined,
+    layer: _this.queryparams.layer ? _this.layer.key : undefined,
 
     // ID will be taken if a location object is provided with the params.
-    id: this.queryparams.id ? this.location?.id : undefined,
+    id: _this.queryparams.id ? _this.location?.id : undefined,
 
     // lat lng must be explicit or the center flag param must be set.
     lat: center && center[1],

--- a/lib/utils/queryParams.mjs
+++ b/lib/utils/queryParams.mjs
@@ -42,22 +42,42 @@ export default _this => {
     `EPSG:4326`)
 
 
-  return Object.assign({}, _this.queryparams, {
+  // Set the queryparams 
+
+  // If layer is true, the locale and layer params will be taken from the layer object.
+  if (this.queryparams.layer) {
+    locale = this.layer.mapview.locale.key,
+      layer = this.layer.key
+  }
+
+  // If filter is true, the filter param will be taken from the layer object.
+  if (this.queryparams.filter) {
+    filter = this.layer.filter?.current
+  }
+
+  // If id is true, the id param will be taken from the location object.
+  if (this.queryparams.id) {
+    id = this.location?.id
+  }
+
+  return {
+    // Spread the queryparams object.
+    ..._this.queryparams,
 
     // Queries will fail if the template can not be accessed in workspace.
     template: encodeURIComponent(_this.query),
 
     // Layer filter can only be applied if the layer is provided as reference to a layer object in the layers list.
-    filter: _this.queryparams.filter && _this.layer.filter?.current,
+    filter: filter,
 
     // Locale param is only required for layer lookups.
-    locale: _this.queryparams.layer && _this.layer.mapview.locale.key,
+    locale: locale,
 
     // Layer param is only required for layer lookups.
-    layer: _this.queryparams.layer && _this.layer.key,
+    layer: layer,
 
     // ID will be taken if a location object is provided with the params.
-    id: _this.queryparams?.id && _this.location?.id,
+    id: id,
 
     // lat lng must be explicit or the center flag param must be set.
     lat: center && center[1],
@@ -72,5 +92,5 @@ export default _this => {
     // The fieldValues array entries should not be part of the url params.
     fieldValues: undefined
 
-  })
+  }
 }

--- a/lib/utils/queryParams.mjs
+++ b/lib/utils/queryParams.mjs
@@ -1,7 +1,10 @@
 export default _this => {
 
-  // Assign empty object if not defined.
-  _this.queryparams ??= {}
+  // If queryparams is not an object, return.
+  if (typeof _this.queryparams !== 'object') {
+    console.warn('queryparams must be an object')
+    return;
+  };
 
   // The layer queryparam must be true to support viewport params.
   _this.queryparams.layer = _this.queryparams.layer || _this.viewport
@@ -13,7 +16,7 @@ export default _this => {
   let table = _this.queryparams.table === true ? tableCurrent : _this.queryparams.table;
 
   _this.queryparams.table &&= table;
- 
+
   // Assign fieldValues from the location to queryparams.
   if (Array.isArray(_this.queryparams.fieldValues) && _this.location) {
 
@@ -49,20 +52,20 @@ export default _this => {
     // Locale param is only required for layer lookups.
     locale: _this.queryparams.layer && _this.layer.mapview.locale.key,
 
-    // Locale param is only required for layer lookups.
+    // Layer param is only required for layer lookups.
     layer: _this.queryparams.layer && _this.layer.key,
 
     // ID will be taken if a location object is provided with the params.
     id: _this.queryparams?.id && _this.location?.id,
 
-    // lat lng must be explicit or the the center flag param must be set.
+    // lat lng must be explicit or the center flag param must be set.
     lat: center && center[1],
     lng: center && center[0],
 
-    // z will generated if the z flag is set in the params.
+    // z will be generated if the z flag is set in the params.
     z: _this.queryparams?.z && _this.layer.mapview.Map.getView().getZoom(),
 
-    // Viewport will onlcy be generated if the viewport flag is set on the params.
+    // Viewport will only be generated if the viewport flag is set on the params.
     viewport: bounds && [bounds.west, bounds.south, bounds.east, bounds.north, _this.layer.mapview.srid],
 
     // The fieldValues array entries should not be part of the url params.

--- a/lib/utils/queryParams.mjs
+++ b/lib/utils/queryParams.mjs
@@ -7,7 +7,7 @@ export default _this => {
   _this.queryparams.layer = _this.queryparams.layer || _this.viewport
 
   // Assign table name from layer.
-  _this.queryparams.table &&= _this.location?.layer?.tableCurrent()
+  _this.queryparams.table &&= _this.location?.layer?.tableCurrent() || _this.layer?.tableCurrent()
 
   // Assign fieldValues from the location to queryparams.
   if (Array.isArray(_this.queryparams.fieldValues) && _this.location) {

--- a/lib/utils/queryParams.mjs
+++ b/lib/utils/queryParams.mjs
@@ -19,16 +19,19 @@ export default _this => {
 
   // Assign fieldValues from the location to queryparams.
   if (Array.isArray(_this.queryparams.fieldValues) && _this.location) {
+    assignFieldValues(_this.queryparams.fieldValues, _this.location.infoj, _this.queryparams);
+  }
 
+  // Function to assign field values from infoj to queryparams.
+  function assignFieldValues(fieldValues, infoj, queryparams) {
     // Iterate through the fieldValues array.
-    _this.queryparams.fieldValues.forEach(field => {
-
+    fieldValues.forEach(field => {
       // Find entry in location infoj matching the field.
-      let entry = _this.location.infoj.find(entry => entry.field === field)
-
+      const entry = infoj.find(entry => entry.field === field);
       // Assign entry value as field value in queryparams.
-      _this.queryparams[field] = entry.value
-    })
+      queryparams[field] = entry.value;
+
+    });
   }
 
   // Get bounds from mapview.


### PR DESCRIPTION
This PR is directly related to the fix in this one #960  . However, i omitted the check for if `table: true` is passed from a `layer.dataview`. This PR adds the check for this as well. So now `table:true` is supported whether the dataview comes from an `entry` or a `layer`. 