### PR TITLE
Ensure tables response is always a string

### DIFF
--- a/lib/location/get.mjs
+++ b/lib/location/get.mjs
@@ -27,10 +27,10 @@ export default async function (location, list = location.layer.mapview.locations
     return;
   }
 
+
   // Get dbs table from layer.
-  location.table = location.table
-    || location.layer.table
-    || Object.values(location.layer.tables).find(table => !!table)
+  location.table ??= location.layer.table ||
+    Object.values(location.layer.tables).find(table => typeof table === 'string')
 
   // Get data from location api.
   const response = await mapp.utils.xhr(
@@ -74,10 +74,10 @@ export default async function (location, list = location.layer.mapview.locations
   location.layer.mapview.interaction?.locations?.delete(location.hook)
 
   // A location must have a record from a listview.
-  location.record 
+  location.record
 
     // Hooks must be enabled on the mapview.
-    && location.layer.mapview.hooks 
+    && location.layer.mapview.hooks
 
     // Push location hook to URL params.
     && mapp.hooks.push('locations', location.hook)


### PR DESCRIPTION
In the `location.get` get, it is currently getting the first table in the `tables` object that is not null. However, null is converted to an empty object in XYZ, so presently this returns an error. 
This PR simply adds a check to ensure that the response has to be a string, ensuring objects and null are omitted. 

Example here 
``` 

// example 
const layer2 = {
    "tables": {
    "10": {},
    "11": "schema.table"
  }
}

//  CURRENT METHOD
const layer2table = layer2.table || Object.values(layer2.tables).find(table => !!table)
console.log(layer2table);

// PR CHANGE
const layer2tableNEW = layer2.table ??= 
    Object.values(layer2.tables).find(table => typeof table === 'string')

console.log(layer2tableNEW);
```