### PR TITLE
assign null value in merge util. fire changeend event on start.

### DIFF
--- a/lib/mapview/_mapview.mjs
+++ b/lib/mapview/_mapview.mjs
@@ -244,7 +244,9 @@ export default (mapview) => {
   })
 
   // changeEnd
-  mapview.Map.getTargetElement().addEventListener('changeEnd', () => {
+  mapview.Map.getTargetElement().addEventListener('changeEnd', changeEnd)
+
+  function changeEnd() {
 
     // Update URL params if enabled on mapview
     if (!mapview.hooks) return;
@@ -261,7 +263,7 @@ export default (mapview) => {
       lng: Math.round((center[0] + Number.EPSILON) * 100000) / 100000,
       z: Math.round((mapview.Map.getView().getZoom() + Number.EPSILON) * 100) / 100
     })
-  })
+  }
 
   // Timer to debounce changeEnd event.
   let changeEndTimer
@@ -274,6 +276,10 @@ export default (mapview) => {
       mapview.Map.getTargetElement().dispatchEvent(new CustomEvent('changeEnd'))
     }, 500)
   })
+
+  changeEndTimer = setTimeout(() => {
+    mapview.Map.getTargetElement().dispatchEvent(new CustomEvent('changeEnd'))
+  }, 500)
 
   return mapview
 }

--- a/lib/utils/merge.mjs
+++ b/lib/utils/merge.mjs
@@ -12,6 +12,11 @@ export default function mergeDeep(target, ...sources) {
     // Iterate over object keys in source.
     for (const key in source) {
 
+      if (source[key] === null) {
+        target[key] = null;
+        continue;
+      }
+
       if (isObject(source[key])) {
 
         // Assign empty object on key.


### PR DESCRIPTION
The merge util incorrectly assigned an empty object instead of null.

The changeEnd event must be fired when the mapview is initialised. Otherwise the event would not be fired with no layer on display. The table check would be omitted in that case.