### PR TITLE
added optional target container html element as second param for data…

### DIFF
--- a/lib/ui/Dataview.mjs
+++ b/lib/ui/Dataview.mjs
@@ -1,10 +1,15 @@
-export default async (_this) => {
+export default async (_this, targetContainer) => {
+
+  // if a target container is passed, use that to query
+  const queryDocument = targetContainer || document;
 
   // The dataview target is defined as string.
   if (typeof _this.target === 'string') {
-
+    
     // assign target element by ID.
-    _this.target = document.getElementById(_this.target);
+    // must be querySelector
+    _this.target = queryDocument.querySelector(`#${_this.target}`);
+
   }
 
   // Dataviews must be rendered into a target element.

--- a/lib/ui/Dataview.mjs
+++ b/lib/ui/Dataview.mjs
@@ -1,14 +1,15 @@
-export default async (_this, targetContainer) => {
+export default async (_this, targetElement) => {
 
-  // if a target container is passed, use that to query
-  const queryDocument = targetContainer || document;
+  if (targetElement) {
 
-  // The dataview target is defined as string.
-  if (typeof _this.target === 'string') {
-    
+    // if a target element is passed, use that
+    _this.target = targetElement;
+
+  } else if (typeof _this.target === 'string') {
+
+    // The dataview target is defined as string.
     // assign target element by ID.
-    // must be querySelector
-    _this.target = queryDocument.querySelector(`#${_this.target}`);
+    _this.target = document.getElementById(_this.target);
 
   }
 


### PR DESCRIPTION
Dataview was unable to access elements within shadow DOMs of web components and could not draw certain charts and tables because of this. With this, an optional targetContainer second parameter can be passed into the dataview call so the target element can be found.