### PR TITLE
Assign point feature default style

### DIFF
--- a/lib/utils/style.mjs
+++ b/lib/utils/style.mjs
@@ -28,7 +28,7 @@ export default (style, feature) => {
         scale *= style.highlightScale || 1
 
         // Create icon url from svgSymbols method if not defined as url or svg source.
-        icon.url = icon.url || icon.svg || mapp.utils.svgSymbols[icon.type](icon, feature)
+        icon.url = icon.url || icon.svg || mapp.utils.svgSymbols[icon.type||'dot'](icon, feature)
 
         if (!icon.url) return;
 


### PR DESCRIPTION
A vector dataset with mixed feature geometries will crash if no default style for point features is provided.

Icon can be set to null to prevent styling of point features.