### PR TITLE
Error if incorrect configuration

### DIFF
--- a/lib/layer/format/vector.mjs
+++ b/lib/layer/format/vector.mjs
@@ -10,6 +10,14 @@ export default layer => {
 
   layer.params ??= {}
 
+  // If layer configuration is wrong and contains both cluster.distance and cluster.resolution, error and return
+  if (layer.cluster?.distance && layer.cluster?.resolution) {
+
+    console.error(`Layer: ${layer.key}, cluster.distance and cluster.resolution are mutually exclusive. You cannot use them both on the same layer. Please remove one of them. `)
+
+    return;
+  };
+
   if (layer.cluster?.resolution) {
     layer.format = 'cluster';
     layer.params.viewport = true;
@@ -33,7 +41,7 @@ export default layer => {
     }
 
     if (!features) return;
-  
+
     layer.source = new ol.source.Vector({
       features: mapp.utils.featureFormats[layer.format](layer, [features].flat())
     })
@@ -41,25 +49,25 @@ export default layer => {
     delete layer.xhr
 
     if (layer.fade) mapp.layer.fade(layer)
-  
+
     // Geojson is a cluster layer.
     if (layer.cluster?.distance) {
-  
+
       // Create cluster source.
       layer.cluster.source = new ol.source.Cluster({
         distance: layer.cluster.distance,
         source: layer.source
       })
-  
+
       layer.L.setSource(layer.cluster.source)
       return;
     }
-    
+
     // Set source if not cluster
     layer.L.setSource(layer.source)
   }
 
-  layer.reload = ()=>{
+  layer.reload = () => {
 
     // Do not reload the layer if features have been assigned.
     if (layer.features) return;
@@ -90,21 +98,21 @@ export default layer => {
 
     clearTimeout(layer.timeout)
 
-    layer.timeout = setTimeout(()=>{
+    layer.timeout = setTimeout(() => {
 
       layer.xhr = mapp.utils.xhr(
         `${layer.mapview.host}/api/query?${mapp.utils.paramString({
-            template: layer.params.template || layer.format,
-            locale: layer.mapview.locale.key,
-            layer: layer.key,
-            table,
-            filter: layer.filter?.current,
-            ...layer.params
-          })}`)
-          .then(layer.setSource)
+          template: layer.params.template || layer.format,
+          locale: layer.mapview.locale.key,
+          layer: layer.key,
+          table,
+          filter: layer.filter?.current,
+          ...layer.params
+        })}`)
+        .then(layer.setSource)
 
     }, 100)
-    
+
   }
 
   // Create Openlayer Vector Layer
@@ -173,11 +181,11 @@ export default layer => {
         })
 
       }
-      
+
       // Return length for calculation of max_size.
       return features.length
     })
-  
+
     if (!feature_counts.length) return;
 
     // Calculate max_size for cluster size styling.


### PR DESCRIPTION
This PR console errors and returns if a layer configuration incorrectly specifies within the cluster object `cluster.resolution` and `cluster.object`. 
Presently this will render a layer on a map that is unusable - it cannot be selected, highlighted and no warnings occur. 

Instead of trying to amend the configuration in the Framework, we will just return an error to the configuration developer. 