### PR TITLE
Add cloudfront logger; signedURL short circuit; Await templates before merge.

### DIFF
--- a/mod/provider/cloudfront.js
+++ b/mod/provider/cloudfront.js
@@ -11,6 +11,8 @@ const { join } = require('path')
 
 const { getSignedUrl } = require('@aws-sdk/cloudfront-signer');
 
+const logger = require('../utils/logger')
+
 module.exports = async ref => {
 
   try {
@@ -28,15 +30,18 @@ module.exports = async ref => {
       privateKey: String(readFileSync(join(__dirname, `../../${process.env.KEY_CLOUDFRONT}.pem`)))
     });
 
-    const response = await fetch(signedURL, {
-      agent: process.env.CUSTOM_AGENT && httpsAgent
-    })
-
+    // Return signedURL only from request.
     if (ref.params?.signedURL) {
 
       return signedURL;
     }
-  
+
+    const response = await fetch(signedURL, {
+      agent: process.env.CUSTOM_AGENT && httpsAgent
+    })
+
+    logger(`${response.status} - ${url}`,'cloudfront')
+
     if (response.status >= 300) return new Error(`${response.status} ${ref}`)
 
     if (url.match(/\.json$/i)) return await response.json()

--- a/mod/templates/_templates.js
+++ b/mod/templates/_templates.js
@@ -4,8 +4,6 @@ const mail_templates = require('./mails')
 
 const msg_templates = require('./msgs')
 
-const merge = require('../utils/merge')
-
 const cloudfront = require('../provider/cloudfront')
 
 const file = require('../provider/file')
@@ -46,11 +44,14 @@ module.exports = async (key, language = 'en', params = {}) => {
   // Prevent prototype polluting assignment.
   if (/__proto__/.test(key)) return;
 
-  const templates = merge({},
-    view_templates,
-    mail_templates,
-    msg_templates,
-    await custom_templates)
+  const _templates = await custom_templates;
+
+  const templates = {
+    ...view_templates,
+    ...mail_templates,
+    ...msg_templates,
+    ..._templates
+  }
 
   if (!Object.hasOwn(templates, key)) {
 

--- a/mod/templates/_templates.js
+++ b/mod/templates/_templates.js
@@ -4,6 +4,8 @@ const mail_templates = require('./mails')
 
 const msg_templates = require('./msgs')
 
+const merge = require('../utils/merge')
+
 const cloudfront = require('../provider/cloudfront')
 
 const file = require('../provider/file')
@@ -46,13 +48,12 @@ module.exports = async (key, language = 'en', params = {}) => {
 
   const _templates = await custom_templates;
 
-  const templates = {
-    ...view_templates,
-    ...mail_templates,
-    ...msg_templates,
-    ..._templates
-  }
-
+  const templates = merge({},
+    view_templates,
+    mail_templates,
+    msg_templates,
+    _templates)
+    
   if (!Object.hasOwn(templates, key)) {
 
     console.warn(`Template key ${key} not found in templates`)


### PR DESCRIPTION
I added the `cloudfront` logger key which logs the response status and url for the cloudfront request.

The signedURL for cloudfront must be returned before the the actual signed URL request.

The custom_templates are awaited before being merged.