### PR TITLE
Allow for an infotip render method

### DIFF
--- a/lib/layer/featureHover.mjs
+++ b/lib/layer/featureHover.mjs
@@ -3,12 +3,12 @@ export default function (feature, layer) {
   // The hover method must only execute if the display flag is set.
   if (!layer.style.hover.display) return;
 
-  if (!layer.mapview.interaction.current) return;
+  // Store current highlight (feature) key.
+  const featureKey = layer.mapview.interaction?.current?.key?.toString()
 
-  // Store current highlight key.
-  let key = layer.mapview.interaction.current.key.toString()
+  if (!featureKey) return;
 
-  let paramString = mapp.utils.paramString({
+  const paramString = mapp.utils.paramString({
     dbs: layer.dbs,
     locale: layer.mapview.locale.key,
     layer: layer.key,
@@ -29,20 +29,23 @@ export default function (feature, layer) {
   mapp.utils.xhr(`${layer.mapview.host}/api/query?${paramString}`)
     .then(response => {
 
-      // Check whether highlight feature is still current.
-      if (layer.mapview.interaction?.current?.key !== key) return;
-
-      // Check whether cursor has position (in map).
-      if (!layer.mapview.position) return;
-
       // Check whether there is a response to display.
       if (!response) return;
 
+      if (typeof layer.style.hover.render === 'function') {
+
+        const content = layer.style.hover.render(response)
+        layer.mapview.infotip(content)
+        return;
+      }
+
       // Check whether the response label field has a value.
-      if (response.label == '') return;
+      if (response.label == '') return;      
+
+      // Check whether highlight feature is still current.
+      if (layer.mapview.interaction?.current?.key !== featureKey) return;
 
       // Display the response label as infotip.
       layer.mapview.infotip(response.label)
     })
-
 }

--- a/lib/mapview/infotip.mjs
+++ b/lib/mapview/infotip.mjs
@@ -7,20 +7,42 @@ export default function(content) {
   // Remove infotip node element
   infotip.node?.remove()
 
+  // The mapview must have a position to place the infotip.
+  if (!mapview.position) return;
+
   // Remove infotip positioning event from mapview Map.
   mapview.Map.un('pointermove', position)
 
   // Just clears the infotip.
   if (!content) return;
 
-  // Creates the infotip node.
-  infotip.node = mapp.utils.html.node`<div class="infotip box-shadow">`
+  if (content instanceof HTMLElement) {
 
-  // Assigns the infotip content.
-  infotip.node.innerHTML = content
+    infotip.node = content
+
+  // Content type object but not HTMLElement cannot be rendered.
+  } else if (typeof content === 'object') {
+
+    console.log(content)
+    return;
+
+  } else {
+
+    // Check for braces in content string.
+    if (/[()]/.test(content)) {
+
+      console.warn(`Potential XSS detected in infotip content ${content}`)
+    }
+
+    // Creates the infotip node.
+    infotip.node = mapp.utils.html.node`<div class="infotip box-shadow">`
+
+    // Assigns the infotip content.
+    infotip.node.innerHTML = content
+  }
 
   // Appends the infotip to the mapview.Map.
-  mapview.Map.getTargetElement().appendChild(infotip.node)
+  mapview.Map.getTargetElement().append(infotip.node)
 
   // Assign infotip positioning event to mapview.Map.
   mapview.Map.on('pointermove', position)
@@ -37,5 +59,4 @@ export default function(content) {
     infotip.node.style.left = mapview.pointerLocation.x - infotip.node.offsetWidth / 2 + 'px'
     infotip.node.style.top = mapview.pointerLocation.y - infotip.node.offsetHeight - 15 + 'px'
   }
-
 }


### PR DESCRIPTION
The featureHover callback will check for a render method to render the response as html.

The infotip method allow content as HTMLElement.

The infotip method will not process content objects but will log this content to the console.

The infotip method will warn if string content passed to the innerHTML contains braces.