### PR TITLE
Fix hover/hovers and label/labels bug

### DIFF
--- a/lib/layer/decorate.mjs
+++ b/lib/layer/decorate.mjs
@@ -14,6 +14,7 @@ export default async layer => {
     zoomToExtent,
   });
 
+  // Warn if outdated layer.edit configuration is used.
   if (layer.edit) {
     console.warn(`Layer: ${layer.key}, please update edit:{} to use draw:{} as layer.edit has been superseeded with layer.draw to be in line with the OL drawing interaction.`)
     layer.draw = Object.assign(layer.draw || {}, layer.edit)
@@ -22,6 +23,7 @@ export default async layer => {
   // Layer must have an empty draw config to allow for role based assignment of drawing methods.
   layer.draw ??= {}
 
+  // Warn if outdated layer.draw.delete configuration is used.
   if (layer.draw?.delete) {
     console.warn(`Layer: ${layer.key}, please move draw.delete to use layer.deleteLocation:true.`)
   }
@@ -29,8 +31,10 @@ export default async layer => {
   // Callback which creates and stores a location from a feature returned by the drawing interaction.
   layer.draw.callback = async (feature, params) => {
 
+    // If the feature is null, return.
     if (!feature) return;
 
+    // Get the current table and set new to true.
     const location = {
       layer,
       table: layer.tableCurrent(),
@@ -56,8 +60,6 @@ export default async layer => {
         layer.draw?.defaults || {}))
     })
 
-    //layer.reload()
-
     // Get the newly created location.
     mapp.location.get(location)
   }
@@ -70,6 +72,20 @@ export default async layer => {
   // Set layer opacity from style.
   layer.L.setOpacity(layer.style?.opacity || 1);
 
+  // Layer style has multiple hovers and a single hover (incorrect configuration)
+  if (layer.style?.hovers && layer.style?.hover) {
+
+    console.warn(`Layer: ${layer.key}, cannot use both layer.style.hover and layer.style.hovers. Layer.style.hover has been deleted.`)
+    delete layer.style.hover;
+  }
+
+  // Layer style has multiple labels and a single label (incorrect configuration)
+  if (layer.style?.labels && layer.style?.label) {
+
+    console.warn(`Layer: ${layer.key}, cannot use both layer.style.label and layer.style.labels. Layer.style.label has been deleted.`)
+    delete layer.style.label;
+  }
+
   // Layer style has multiple themes.
   if (layer.style?.themes) {
 
@@ -80,16 +96,15 @@ export default async layer => {
       : layer.style.themes[layer.style.theme || Object.keys(layer.style.themes)[0]];
   }
 
+  // If setLabel is included and labels object exists.
   if (layer.style?.theme?.setLabel && layer.style?.labels) {
 
+    // Swap the label based on the setLabel key.
     layer.style.label = layer.style.labels[layer.style.theme.setLabel]
   }
 
-  if (layer.style?.theme?.setHover && layer.style?.hovers) {
-
-    layer.style.hover = layer.style.hovers[layer.style.theme.setHover]
-  }
-
+    // Warn if outdated layer.hover configuration is used.
+  // Set layer.style.hover and remove layer.hover.
   if (layer.hover) {
 
     console.warn(`Layer: ${layer.key}, layer.hover{} should be defined within layer.style{}.`)
@@ -97,7 +112,15 @@ export default async layer => {
     delete layer.hover;
   }
 
-  // Layer style has multiple themes.
+  // If setHover is included and hovers object exists.
+  if (layer.style?.theme?.setHover && layer.style?.hovers) {
+
+    // Swap the hover based on the setHover key.
+    layer.style.hover = layer.style.hovers[layer.style.theme.setHover]
+  }
+
+
+  // Layer style has multiple hovers
   if (layer.style?.hovers) {
 
     // Keep object hover.
@@ -113,7 +136,7 @@ export default async layer => {
     layer.style.hover.method ??= mapp.layer.featureHover;
   }
 
-  // Layer style has multiple themes.
+  // Layer style has multiple labels.
   if (layer.style?.labels) {
 
     // Keep object label.
@@ -131,7 +154,7 @@ export default async layer => {
 
       // Check if the role is an object and not null
       if (layer.roles[role] !== null && typeof layer.roles[role] === 'object') {
-        
+
         // Extract the role name from negated roles (e.g., "!role" becomes "role")
         const negatedRole = role.match(/(?<=^!)(.*)/g)?.[0];
 
@@ -191,13 +214,12 @@ export default async layer => {
 }
 
 function show() {
-  /**
-   * Reveals the layer
-   */
 
+  // Show the layer
   this.display = true;
 
-  try { // Add layer to map
+  try {
+    // Add layer to map
     this.mapview.Map.addLayer(this.L);
   } catch {
     // Will catch assertation error when layer is already added.
@@ -217,10 +239,8 @@ function show() {
 }
 
 function hide() {
-  /**
-   * Hides the layer
-   */
 
+  // Hide the layer.
   this.display = false;
 
   // Remove OL layer from mapview.
@@ -237,9 +257,8 @@ function hide() {
 }
 
 function tableCurrent() {
-  /**
-   * Returns the current table
-   */
+
+  // Return the current table if it exists.
 
   // A layer must have either a table or tables configuration.
   if (!this.tables) return this.table;
@@ -269,9 +288,8 @@ function tableCurrent() {
 }
 
 function tableMax() {
-  /**
-   * Returns the max table
-   */
+
+  // Returns the max table
 
   // A layer must have either a table or tables configuration.
   if (!this.tables) return this.table;
@@ -281,9 +299,8 @@ function tableMax() {
 }
 
 function tableMin() {
-  /**
-   * Returns the min table
-   */
+
+  // Returns the min table.
 
   // A layer must have either a table or tables configuration.
   if (!this.tables) return this.table;
@@ -293,9 +310,8 @@ function tableMin() {
 }
 
 async function zoomToExtent(params) {
-  /**
-   * Zooms to a specific extent
-   */
+
+  // Zooms to a specific extent
 
   // XMLHttpRequest to layer extent endpoint
   let response = await mapp.utils.xhr(`${this.mapview.host}/api/query/layer_extent?` +


### PR DESCRIPTION
Fixes #979 . 

If both `hover` and `hovers` are provided, a console warning is provided and `hover` is removed.
If both `label` and `labels` are provided, a console warning is provided and `label` is removed.