### PR TITLE
Vector Cluster Changes

### DIFF
--- a/lib/layer/format/_format.mjs
+++ b/lib/layer/format/_format.mjs
@@ -15,5 +15,6 @@ export default {
   mvt,
   cluster: vector,
   geojson: vector,
-  wkt: vector
+  wkt: vector,
+  vector
 }

--- a/lib/layer/format/vector.mjs
+++ b/lib/layer/format/vector.mjs
@@ -190,6 +190,17 @@ function clusterConfig(layer) {
   // If cluster.resolution is used, the layer srid must be set to 3857.
   if (layer.cluster.resolution) {
 
+    // Check if resolution is numeric.
+    if (typeof layer.cluster.resolution === 'number') {
+      // Assign resolution as float.
+      layer.params.resolution = parseFloat(layer.cluster.resolution);
+    } 
+    // Otherwise, warn and return.
+    else {
+      console.warn(`Layer: ${layer.key}, cluster.resolution must be a number.`)
+      return;
+    }
+
     // Check if srid is set to 4326, not allowed for cluster layer
     if (layer.srid === '4326') {
       console.warn(`Layer: ${layer.key}, srid 4326 is not allowed for cluster.resolution layers.`)
@@ -202,9 +213,6 @@ function clusterConfig(layer) {
 
     // Format is cluster if resolution is set.
     layer.format = 'cluster';
-
-    // Assign resolution as float.
-    layer.params.resolution = parseFloat(layer.cluster.resolution);
 
     // Assign default template.
     layer.params.template ??= layer.cluster.hexgrid ? 'cluster_hex' : 'cluster';

--- a/lib/layer/format/vector.mjs
+++ b/lib/layer/format/vector.mjs
@@ -1,27 +1,45 @@
 export default layer => {
 
   if (!layer.srid) {
-    console.warn(`No SRID provided for ${layer.key}`)
+    console.warn(`Layer: ${layer.key},No SRID provided`)
   }
 
   if (layer.properties) {
     console.warn(`Layer: ${layer.key},layer.properties{} are no longer required for wkt & geojson datasets.`)
   }
 
+  // Set default layer params if nullish.
   layer.params ??= {}
 
-  // If layer configuration is wrong and contains both cluster.distance and cluster.resolution, error and return
-  if (layer.cluster?.distance && layer.cluster?.resolution) {
+  // Checks on layer.cluster
+  if (layer.cluster) {
+    // Check if both cluster.distance and cluster.resolution are set.
+    if (layer.cluster?.distance && layer.cluster?.resolution) {
 
-    console.error(`Layer: ${layer.key}, cluster.distance and cluster.resolution are mutually exclusive. You cannot use them both on the same layer. Please remove one of them. `)
+      console.warn(`Layer: ${layer.key}, cluster.distance and cluster.resolution are mutually exclusive. You cannot use them both on the same layer. Please remove one of them. `)
 
-    return;
-  };
+      return;
+    };
 
-  // Check if neither cluster.distance and cluster.resolution are set.
-  if (!layer.cluster?.distance && !layer.cluster?.resolution) {
-    console.error(`Layer: ${layer.key}, cluster.distance or cluster.resolution must be set.`)
-    return;
+    // Check if neither cluster.distance and cluster.resolution are set.
+    if (!layer.cluster?.distance && !layer.cluster?.resolution) {
+      console.warn(`Layer: ${layer.key}, cluster.distance or cluster.resolution must be set.`)
+      return;
+    };
+
+    // If cluster.resolution is used, the layer srid must be set to 3857.
+    if (layer.cluster?.resolution) {
+      // Check if srid provided for cluster layer.
+      if (!layer.srid) {
+        console.warn(`Layer: ${layer.key}, srid must be set for cluster.resolution layers, defaulting to 3857.`)
+      };
+
+      // Check if srid is set to 4326, not allowed for cluster layer
+      if (layer.srid === '4326') {
+        console.warn(`Layer: ${layer.key}, srid 4326 is not allowed for cluster.resolution layers.`)
+        return;
+      };
+    }
   };
 
   // If resolution is provided, and its numeric
@@ -31,15 +49,16 @@ export default layer => {
     // Format is cluster if resolution is set.
     layer.format = 'cluster';
     // Assign resolution to params.
-    layer.params.resolution ??= layer.cluster.resolution;
+    layer.params.resolution = layer.cluster.resolution;
     // layer.params.template.cluster_hex can also be passed
     layer.params.template ??= 'cluster';
   }
 
   // Assign style object if nullish.
-  layer.style ??= {}
+  layer.style ??= {};
 
-  layer.srid ??= '4326'
+  // Assign srid if nullish (cluster.resolution requires srid to be set to 3857, otherwise default to 4326)
+  layer.srid ??= layer.cluster.resolution? '3857': '4326';
 
   layer.setSource = (features) => {
 

--- a/lib/layer/format/vector.mjs
+++ b/lib/layer/format/vector.mjs
@@ -18,21 +18,22 @@ export default layer => {
     return;
   };
 
-  // If the layer is cluster format and the resolution is not defined and/or the resolution is not numeric, set a default value of 0.2
-  if (layer.format === 'cluster' && (!layer.cluster.resolution || typeof layer.cluster.resolution !== 'number')) {
-
-    layer.cluster.resolution = 0.2;
-
-    // Warn that the layer.cluster.resolution is not defined.
-    console.warn(`Layer: ${layer.key}, layer.cluster.resolution is not defined and/or is not numeric. A default value of 0.2 has been set, but please explicitly set this.`)
+  // Check if neither cluster.distance and cluster.resolution are set.
+  if (!layer.cluster?.distance && !layer.cluster?.resolution) {
+    console.error(`Layer: ${layer.key}, cluster.distance or cluster.resolution must be set.`)
+    return;
   };
 
-  if (layer.cluster?.resolution) {
-    layer.format = 'cluster';
+  // If resolution is provided, and its numeric
+  if (layer.cluster?.resolution && typeof (layer.cluster.resolution === 'number')) {
     layer.params.viewport = true;
     layer.params.z = true;
-    layer.params.resolution = layer.cluster.resolution;
-    layer.params.template = layer.cluster.hexgrid ? 'cluster_hex' : 'cluster';
+    // Format is cluster if resolution is set.
+    layer.format = 'cluster';
+    // Assign resolution to params.
+    layer.params.resolution ??= layer.cluster.resolution;
+    // layer.params.template.cluster_hex can also be passed
+    layer.params.template ??= 'cluster';
   }
 
   // Assign style object if nullish.

--- a/lib/layer/format/vector.mjs
+++ b/lib/layer/format/vector.mjs
@@ -135,6 +135,7 @@ export default layer => {
           locale: layer.mapview.locale.key,
           layer: layer.key,
           table,
+          srid: layer.srid,
           filter: layer.filter?.current,
           ...layer.params
         })}`)

--- a/lib/layer/format/vector.mjs
+++ b/lib/layer/format/vector.mjs
@@ -18,6 +18,15 @@ export default layer => {
     return;
   };
 
+  // If the layer is cluster format and the resolution is not defined and/or the resolution is not numeric, set a default value of 0.2
+  if (layer.format === 'cluster' && (!layer.cluster.resolution || typeof layer.cluster.resolution !== 'number')) {
+
+    layer.cluster.resolution = 0.2;
+
+    // Warn that the layer.cluster.resolution is not defined.
+    console.warn(`Layer: ${layer.key}, layer.cluster.resolution is not defined and/or is not numeric. A default value of 0.2 has been set, but please explicitly set this.`)
+  };
+
   if (layer.cluster?.resolution) {
     layer.format = 'cluster';
     layer.params.viewport = true;

--- a/lib/layer/format/vector.mjs
+++ b/lib/layer/format/vector.mjs
@@ -1,64 +1,19 @@
 export default layer => {
 
-  if (!layer.srid) {
-    console.warn(`Layer: ${layer.key},No SRID provided`)
-  }
+  // 3857 is assumed to be the default SRID for all vector format layer.
+  layer.srid ??= '3857'
 
   if (layer.properties) {
-    console.warn(`Layer: ${layer.key},layer.properties{} are no longer required for wkt & geojson datasets.`)
+    console.warn(`Layer: ${layer.key}, layer.properties{} are no longer required for wkt & geojson datasets.`)
   }
 
   // Set default layer params if nullish.
   layer.params ??= {}
 
-  // Checks on layer.cluster
-  if (layer.cluster) {
-    // Check if both cluster.distance and cluster.resolution are set.
-    if (layer.cluster?.distance && layer.cluster?.resolution) {
-
-      console.warn(`Layer: ${layer.key}, cluster.distance and cluster.resolution are mutually exclusive. You cannot use them both on the same layer. Please remove one of them. `)
-
-      return;
-    };
-
-    // Check if neither cluster.distance and cluster.resolution are set.
-    if (!layer.cluster?.distance && !layer.cluster?.resolution) {
-      console.warn(`Layer: ${layer.key}, cluster.distance or cluster.resolution must be set.`)
-      return;
-    };
-
-    // If cluster.resolution is used, the layer srid must be set to 3857.
-    if (layer.cluster?.resolution) {
-      // Check if srid provided for cluster layer.
-      if (!layer.srid) {
-        console.warn(`Layer: ${layer.key}, srid must be set for cluster.resolution layers, defaulting to 3857.`)
-      };
-
-      // Check if srid is set to 4326, not allowed for cluster layer
-      if (layer.srid === '4326') {
-        console.warn(`Layer: ${layer.key}, srid 4326 is not allowed for cluster.resolution layers.`)
-        return;
-      };
-    }
-  };
-
-  // If resolution is provided, and its numeric
-  if (layer.cluster?.resolution && typeof (layer.cluster.resolution === 'number')) {
-    layer.params.viewport = true;
-    layer.params.z = true;
-    // Format is cluster if resolution is set.
-    layer.format = 'cluster';
-    // Assign resolution to params.
-    layer.params.resolution = layer.cluster.resolution;
-    // layer.params.template.cluster_hex can also be passed
-    layer.params.template ??= 'cluster';
-  }
+  clusterConfig(layer)
 
   // Assign style object if nullish.
   layer.style ??= {};
-
-  // Assign srid if nullish (cluster.resolution requires srid to be set to 3857, otherwise default to 4326)
-  layer.srid ??= layer.cluster.resolution? '3857': '4326';
 
   layer.setSource = (features) => {
 
@@ -174,18 +129,10 @@ export default layer => {
   }
 
   // Change method for the cluster feature properties and layer stats.
-  layer.L.on('change', e => {
-
-    // Do not process cluster for non cluster layers.
-    if (!layer.cluster) return;
+  layer.cluster?.distance && layer.L.on('change', e => {
 
     // To prevent layer.L.change() from crashing if called before data is loaded.
     if (!layer.cluster.source) return;
-
-    // The OL cluster must not be processed with a resolution.
-    if (layer.cluster.resolution) return;
-
-    if (!layer.cluster?.distance) return;
 
     delete layer.max_size;
 
@@ -221,5 +168,45 @@ export default layer => {
     // Calculate max_size for cluster size styling.
     layer.max_size = Math.max(...feature_counts)
   })
+}
 
+function clusterConfig(layer) {
+
+  // The clusterConfig can not work without the layer having a cluster config object.
+  if (typeof layer.cluster !== 'object') return;
+
+  // Check if both cluster.distance and cluster.resolution are set.
+  if (layer.cluster.distance && layer.cluster.resolution) {
+    console.warn(`Layer: ${layer.key}, cluster.distance and cluster.resolution are mutually exclusive. You cannot use them both on the same layer. Please remove one of them. `)
+    return;
+  };
+
+  // Check if neither cluster.distance and cluster.resolution are set.
+  if (!layer.cluster.distance && !layer.cluster.resolution) {
+    console.warn(`Layer: ${layer.key}, cluster.distance or cluster.resolution must be set.`)
+    return;
+  };
+
+  // If cluster.resolution is used, the layer srid must be set to 3857.
+  if (layer.cluster.resolution) {
+
+    // Check if srid is set to 4326, not allowed for cluster layer
+    if (layer.srid === '4326') {
+      console.warn(`Layer: ${layer.key}, srid 4326 is not allowed for cluster.resolution layers.`)
+      return;
+    };
+
+    // Provide default params for resolution cluster.
+    layer.params.viewport = true;
+    layer.params.z = true;
+
+    // Format is cluster if resolution is set.
+    layer.format = 'cluster';
+
+    // Assign resolution as float.
+    layer.params.resolution = parseFloat(layer.cluster.resolution);
+
+    // Assign default template.
+    layer.params.template ??= layer.cluster.hexgrid ? 'cluster_hex' : 'cluster';
+  }
 }

--- a/lib/mapp.mjs
+++ b/lib/mapp.mjs
@@ -18,7 +18,7 @@ self.mapp = (function (mapp) {
 
   Object.assign(mapp, {
     version: '4.7.2',
-    hash: 'f836737e4c92e114f788dc6461ffcd5ecddba295',
+    hash: '4026463d6e57c02f0da8ad676d81f59e47baacc8',
     language: hooks.current.language || 'en',
   
     dictionaries,


### PR DESCRIPTION
Fixes #978 

If a layer is format cluster, and has no resolution or resolution is not number, it currently fails. 
This PR addresses the issue, checking for this and setting a default value and a console warning if so. 