### PR TITLE
Merge dataset object into gazetteer defaults

### DIFF
--- a/lib/utils/gazetteer.mjs
+++ b/lib/utils/gazetteer.mjs
@@ -7,11 +7,22 @@ export function datasets(term, gazetteer) {
     }
 
     // Search additional datasets.
-    gazetteer.datasets?.forEach(search)
+    gazetteer.datasets?.forEach(dataset => search({
+        layer: gazetteer.layer,
+        table: gazetteer.table,
+        query: gazetteer.query,
+        qterm: gazetteer.qterm,
+        label: gazetteer.label,
+        title: gazetteer.title,
+        limit: gazetteer.limit,
+        leading_wildcard: gazetteer.leading_wildcard,
+        callback: gazetteer.callback,
+        maxZoom: gazetteer.maxZoom,
+        ...dataset}))
 
     function search(dataset) {
 
-        let layer = gazetteer.mapview.layers[gazetteer.layer || dataset.layer]
+        const layer = gazetteer.mapview.layers[dataset.layer]
 
         // Skip if layer defined in datasets is not added to the mapview
         if (!layer) {
@@ -21,7 +32,7 @@ export function datasets(term, gazetteer) {
         }
 
         // Skip if layer table is not defined and no table is defined in dataset or gazetteer.
-        if (!layer.table && !dataset.table && !gazetteer.table) {
+        if (!layer.table && !dataset.table) {
 
             console.warn('No table definition for gazetteer search.')
             return;
@@ -32,18 +43,19 @@ export function datasets(term, gazetteer) {
 
         dataset.xhr = new XMLHttpRequest()
 
-        dataset.xhr.open('GET', gazetteer.mapview.host + '/api/query/gaz_query?' +
+        dataset.xhr.open('GET', gazetteer.mapview.host + '/api/query?' +
             mapp.utils.paramString({
-                label: dataset.qterm,
+                template: dataset.query || 'gaz_query',
+                label: dataset.label || dataset.qterm,
                 qterm: dataset.qterm,
                 qID: layer.qID,
                 locale: gazetteer.mapview.locale.key,
                 layer: layer.key,
                 filter: layer.filter?.current,
-                table: dataset.table || gazetteer.table || layer.table,
+                table: dataset.table || layer.table,
                 wildcard: '*',
                 term: `${dataset.leading_wildcard ? '*' : ''}${term}*`,
-                limit: dataset.limit || gazetteer.limit || 10
+                limit: dataset.limit || 10
             }))
 
         dataset.xhr.setRequestHeader('Content-Type', 'application/json')
@@ -71,12 +83,12 @@ export function datasets(term, gazetteer) {
                     <li
                         onclick=${e => {
 
-                            if (gazetteer.callback) return gazetteer.callback(row, gazetteer);
+                            if (dataset.callback) return dataset.callback(row, dataset);
 
                             mapp.location.get({
                                 layer,
                                 id: row.id
-                            }).then(loc => loc && loc.flyTo(gazetteer.maxZoom || dataset.maxZoom))
+                            }).then(loc => loc && loc.flyTo(dataset.maxZoom))
 
                         }}>
                         <span class="label">${dataset.title || layer.name}</span>

--- a/lib/utils/gazetteer.mjs
+++ b/lib/utils/gazetteer.mjs
@@ -88,7 +88,7 @@ export function datasets(term, gazetteer) {
                             mapp.location.get({
                                 layer,
                                 id: row.id
-                            }).then(loc => loc && loc.flyTo(dataset.maxZoom))
+                            }).then(loc => loc?.flyTo?.(dataset.maxZoom))
 
                         }}>
                         <span class="label">${dataset.title || layer.name}</span>


### PR DESCRIPTION
The dataset object should be spread into an object with the gazetteer defaults possible accessed within the search method.

The dataset object received as argument by the search method will be passed to a callback.

The layer should be defined as a const.

It should be possible to define a custom `query` template.

The label param wasn't provided for the default gaz_query.