### PR TITLE
Encode Values returned from DB for filter panel

### DIFF
--- a/api/api.js
+++ b/api/api.js
@@ -115,7 +115,7 @@ module.exports = async (req, res) => {
   Object.entries(req.params)
     .filter(entry => typeof entry[1] === 'string')
     .forEach(entry => {
-      req.params[entry[0]] = decodeURIComponent(entry[1])
+      req.params[entry[0]] = decodeURIComponent(encodeURIComponent(entry[1]))
     })
 
   // Short circuit login view or post request.

--- a/lib/ui/elements/dropdown.mjs
+++ b/lib/ui/elements/dropdown.mjs
@@ -31,7 +31,7 @@ export default (params) => {
 
         // Set btn text to reflect selection or show placeholder.
         btn.querySelector('[data-id=header-span]')
-          .textContent = params.selectedTitles.size && Array.from(params.selectedTitles).map(v => decodeURIComponent(v)).join(', ')
+          .textContent = params.selectedTitles.size && Array.from(params.selectedTitles).map(v => decodeURIComponent(encodeURIComponent(v))).join(', ')
           || params.span || params.placeholder
 
         // Execute callback method and pass array of current selection.

--- a/lib/ui/layers/filters.mjs
+++ b/lib/ui/layers/filters.mjs
@@ -182,10 +182,13 @@ async function filter_in(layer, filter) {
 
   if (filter.dropdown) {
 
+    // Encode values for dropdown.
+    const encoded = filter[filter.type].map(val => encodeURIComponent(val));
+
     return mapp.ui.elements.dropdown({
       multi: true,
       placeholder: 'Select Multiple',
-      entries: filter[filter.type].map(val => ({
+      entries: encoded.map(val => ({
         title: decodeURIComponent(val),
         option: encodeURIComponent(val),
         selected: chkSet.has(val)

--- a/mod/utils/sqlFilter.js
+++ b/mod/utils/sqlFilter.js
@@ -30,11 +30,11 @@ const filterTypes = {
 let SQLparams
 
 function addValues(val, skip) {
-
+console.log('addValues',val);
   SQLparams.push(Array.isArray(val)
-    && val[0].map(v=>decodeURIComponent(v))
+    && val[0].map(v=>decodeURIComponent(encodeURIComponent(v)))
     || skip && val
-    || decodeURIComponent(val))
+    || decodeURIComponent(encodeURIComponent(val)))
 
   return SQLparams.length
 }


### PR DESCRIPTION
This PR addresses an error.
If you use a filter config as shown below, and any of the data returned from the response containing special characters (% etc). The filter fails to create. 
``` json 
{
      "field": "field",
      "title": "Title",
      "inline": true,
      "filter": {
        "type": "in",
        "distinct": true,
        "dropdown": true
      }
    }
```
This PR simply encodes the value responses, and encodes and decodes the values for the dropdown module to remove this error.


Update - also addresses including special characters in the style and filtering there (ie Value % or Value &). 
Also addresses including special characters in the layer.filter. 