### PR TITLE
Use ID if field is undefined in theme.

### DIFF
--- a/lib/layer/themes/distributed.mjs
+++ b/lib/layer/themes/distributed.mjs
@@ -1,31 +1,29 @@
 export default function(theme, feature) {
 
   if (!theme.lookup) {
-
     theme.lookup = {}
     theme.boxes = []
     theme.index = 0
   }
 
+  // Get feature identifier for theme.
+  const ID = feature.properties[theme.field || 'id']
+
   // The feature field property value already has a style assigned.
-  if (theme.lookup[feature.properties[theme.field]]) {
+  if (theme.lookup[ID]) {
 
     // Assign style from lookup object.
-    var catStyle = theme.lookup[feature.properties[theme.field]]
-    mapp.utils.merge(feature.style, catStyle)
+    mapp.utils.merge(feature.style, theme.lookup[ID])
     return;
   }
 
   // Get feature bounding box from geometry extent.
-  let bbox = {
+  const bbox = {
     extent: feature.getGeometry().getExtent()
   }
 
-  // add box to visual check layer.
-  // theme.source.addFeature(new ol.Feature(new ol.geom.Polygon.fromExtent(bbox.extent)))
-
   // Find intersecting bounding boxes with their assigned cat index.
-  let intersects = theme.boxes.filter(b => !(bbox.extent[0] > b.extent[2]
+  const intersects = theme.boxes.filter(b => !(bbox.extent[0] > b.extent[2]
     || bbox.extent[2] < b.extent[0]
     || bbox.extent[1] > b.extent[3]
     || bbox.extent[3] < b.extent[1]))
@@ -34,23 +32,24 @@ export default function(theme, feature) {
   theme.boxes.push(bbox)
 
   // Create a set of cat indices from intersecting bounding boxes.
-  let set = new Set(intersects.map(b => b.themeIdx))
+  const set = new Set(intersects.map(b => b.themeIdx))
 
-  // Increase the cat indix.
+  // Increase the current cat indix.
   theme.index++
 
   // Reset cat index to 0 if the index reaches the length of the cat array.
   if (theme.index === theme.cat_arr.length) theme.index = 0
 
-  // Check whether the set of intersecting bounding boxes has NOT the cat index.
+  // i is the cat index if not in set of intersecting boxes.
   let i = !(set.has(theme.index)) && parseInt(theme.index)
 
-  // Index is not available.
+  // Current index is already in set of intersecting boxes.
   if (i === false) {
 
     // Iterate through the cat array.
     for (let free = 0; free < theme.cat_arr.length; free++) {
 
+      // Find an index which is not in set of intersecting bbox indices.
       if (!set.has(free)) {
 
         // Assign free index and break loop.
@@ -60,22 +59,19 @@ export default function(theme, feature) {
     }
   }
 
-  // No index is available.
+  // Any index is in set of intersecting box indices.
   if (i === false) {
 
-    // Assign cat index.
+    // Just assign the current index. It is not possible to prevent some neighbouring cats.
     i = parseInt(theme.index)
   }
 
   // Assign index to the bounding box which is stored in the array of bounding boxes.
   bbox.themeIdx = i
 
-  // Get the JSON style from cat array via index.
-  var catStyle = theme.cat_arr[i]
-
-  // Assign the JSON style to the lookup object for the feature field property value.
-  theme.lookup[feature.properties[theme.field]] = catStyle
+  // Assign the style to the lookup object for the feature field property value.
+  theme.lookup[ID] = theme.cat_arr[i]
 
   // Merge the cat style with the feature style.
-  mapp.utils.merge(feature.style, catStyle)
+  mapp.utils.merge(feature.style, theme.lookup[ID])
 }

--- a/lib/layer/themes/distributed.mjs
+++ b/lib/layer/themes/distributed.mjs
@@ -7,7 +7,7 @@ export default function(theme, feature) {
   }
 
   // Get feature identifier for theme.
-  const ID = feature.properties[theme.field || 'id']
+  const ID = feature.properties[theme.field || 'id'] || 0
 
   // The feature field property value already has a style assigned.
   if (theme.lookup[ID]) {

--- a/lib/ui/layers/_layers.mjs
+++ b/lib/ui/layers/_layers.mjs
@@ -20,7 +20,6 @@ import reports from './panels/reports.mjs'
 import style from './panels/style.mjs'
 
 // Styles
-
 import categorized from './legends/categorized.mjs'
 
 import distributed from './legends/distributed.mjs'


### PR DESCRIPTION
Use the feature ID from the properties if no distinct field is defined for the distributed theme.