### PR TITLE
sqlfilter / json url parameter encoding

### DIFF
--- a/api/api.js
+++ b/api/api.js
@@ -111,13 +111,6 @@ module.exports = async (req, res) => {
 
   req.params.template = req.params._template || req.params.template
 
-  // Decode string params.
-  Object.entries(req.params)
-    .filter(entry => typeof entry[1] === 'string')
-    .forEach(entry => {
-      req.params[entry[0]] = decodeURIComponent(entry[1])
-    })
-
   // Short circuit login view or post request.
   if (req.params.login || req.body && req.body.login) return login(req, res)
 

--- a/lib/ui/elements/dropdown.mjs
+++ b/lib/ui/elements/dropdown.mjs
@@ -31,7 +31,7 @@ export default (params) => {
 
         // Set btn text to reflect selection or show placeholder.
         btn.querySelector('[data-id=header-span]')
-          .textContent = params.selectedTitles.size && Array.from(params.selectedTitles).map(v => decodeURIComponent(v)).join(', ')
+          .textContent = params.selectedTitles.size && Array.from(params.selectedTitles).map(v => v).join(', ')
           || params.span || params.placeholder
 
         // Execute callback method and pass array of current selection.

--- a/lib/ui/layers/filters.mjs
+++ b/lib/ui/layers/filters.mjs
@@ -13,16 +13,12 @@ export default {
 
 let timeout;
 
-function applyFilter(layer, zoom) {
-  clearTimeout(timeout);
+function applyFilter(layer) {
 
-  // enable zoomToExtent button.
-  let btn = layer.view.querySelector('[data-id=zoomToExtent]')
-  if (btn) btn.disabled = false;
+  clearTimeout(timeout);
 
   // Debounce layer reload by 500
   timeout = setTimeout(() => {
-    timeout = null;
     layer.reload();
     layer.mapview.Map.getTargetElement().dispatchEvent(new Event('changeEnd'))
   }, 500);
@@ -192,11 +188,20 @@ async function filter_in(layer, filter) {
       })),
       callback: async (e, options) => {
 
-        Object.assign(layer.filter.current, {
-          [filter.field]:{
-            [filter.type]: options
-          }
-        })
+        if (!options.length) {
+
+          // Remove empty array filter.
+          delete layer.filter.current[filter.field]
+        } else {
+
+          // Set filter values array from options.
+          Object.assign(layer.filter.current, {
+            [filter.field]:{
+              [filter.type]: options
+            }
+          })
+        }
+
         layer.reload()
         layer.mapview.Map.getTargetElement().dispatchEvent(new Event('changeEnd'))
       }

--- a/lib/ui/layers/filters.mjs
+++ b/lib/ui/layers/filters.mjs
@@ -186,8 +186,8 @@ async function filter_in(layer, filter) {
       multi: true,
       placeholder: 'Select Multiple',
       entries: filter[filter.type].map(val => ({
-        title: decodeURIComponent(val),
-        option: encodeURIComponent(val),
+        title: val,
+        option: val,
         selected: chkSet.has(val)
       })),
       callback: async (e, options) => {
@@ -204,8 +204,8 @@ async function filter_in(layer, filter) {
   }
 
   return filter[filter.type].map(val => mapp.ui.elements.chkbox({
-    val: encodeURIComponent(val),
-    label: decodeURIComponent(val),
+    val: val,
+    label: val,
     checked: chkSet.has(val),
     onchange: (checked, val) => {
   

--- a/lib/ui/utils/tabulatorUtils.mjs
+++ b/lib/ui/utils/tabulatorUtils.mjs
@@ -62,7 +62,7 @@ function like(_this) {
 
           // Set filter
           _this.layer.filter.current[field] = {
-            [headerFilterParams.type || 'like']: encodeURIComponent(e.target.value)
+            [headerFilterParams.type || 'like']: e.target.value
           }
 
         } else { 

--- a/lib/utils/paramString.mjs
+++ b/lib/utils/paramString.mjs
@@ -1,6 +1,10 @@
 // Create param string for XHR request.
 export default params => Object.entries(params)
+
+  // Value should be 0 or truthy
   .filter(entry => entry[1] === 0 || !!entry[1])
+
+  // Value must not be empty functional brackets.
   .filter(entry => entry[1] !== '{}')
 
   // Filter out zero length array and objects with empty object values.
@@ -10,16 +14,10 @@ export default params => Object.entries(params)
 
   .map(entry => {
 
-    // if (Array.isArray(entry[1])) {
-
-    //   return entry[1].map(val => `${entry[0]}=${val}`).join('&')
-    // }
-
     // Stringify non array objects.
     if (typeof entry[1] === 'object' && !Array.isArray(entry[1])) {
 
-      entry[1] = JSON.stringify(entry[1])
-
+      return `${entry[0]}=${encodeURIComponent(JSON.stringify(entry[1]))}`
     }
 
     return encodeURI(`${entry[0]}=${entry[1]}`)

--- a/mod/utils/sqlFilter.js
+++ b/mod/utils/sqlFilter.js
@@ -21,7 +21,7 @@ const filterTypes = {
     `(${val
       .split(',')
       .filter((val) => val.length > 0)
-      .map((val) => `"${col}" ILIKE \$${addValues(`${val}%`, true)}`)
+      .map((val) => `"${col}" ILIKE \$${addValues(`${val}%`)}`)
       .join(' OR ')})`,
 
   match: (col, val) => `"${col}"::text ILIKE \$${addValues(val)}`
@@ -29,12 +29,9 @@ const filterTypes = {
 
 let SQLparams
 
-function addValues(val, skip) {
+function addValues(val) {
 
-  SQLparams.push(Array.isArray(val)
-    && val[0].map(v=>decodeURIComponent(v))
-    || skip && val
-    || decodeURIComponent(val))
+  SQLparams.push(val)
 
   return SQLparams.length
 }


### PR DESCRIPTION
JSON does not want to be encoded as stringified URI. A JSON value may contain an ampersand (&) character. The JSON value should be stringified and URLComponent encoded.

The api module script should not be required to decode URI parameter. This should happen by default.

Hence the parameter value is already assumed to be encoded by the time the value is added to [filter] SQLParams array. The skip option for the wildcard is therefore unnecessary.