### PR TITLE
Allow a Query to Set the Edit Options

### DIFF
--- a/lib/ui/locations/entries/text.mjs
+++ b/lib/ui/locations/entries/text.mjs
@@ -29,15 +29,15 @@ function edit(entry) {
       // Create dropdown from options.
       options(entry)
 
-    } 
+    }
     // If options is empty array, we need to query the table to populate it.
     else {
 
-      // Query distinct field values from the layer table.
+      // We can query a particular template or Query distinct field values from the layer table.
       mapp.utils.xhr(
         `${entry.location.layer.mapview.host}/api/query?` +
         mapp.utils.paramString({
-          template: 'distinct_values',
+          template: entry.edit.query || 'distinct_values',
           dbs: entry.location.layer.dbs,
           locale: entry.location.layer.mapview.locale.key,
           layer: entry.location.layer.key,
@@ -49,8 +49,8 @@ function edit(entry) {
           // Return first value from object row as options array.
           entry.edit.options = [response].flat().map(row => {
             return Object.values(row)[0]
-          })//.filter(val => val !== null)
-          
+          })
+
           // Create dropdown from options.
           options(entry)
         })
@@ -81,20 +81,20 @@ function options(entry) {
   const optionEntries = entry.edit.options.map(option => ({
 
     // Assign null if option is null.
-    title: option === null ? null : 
+    title: option === null ? null :
 
       // Assign string as title.
       typeof option === 'string' && option
-      
+
       // Assign first key as title.
       || Object.keys(option)[0],
 
     // Assign null if option is null.
-    option: option === null ? null : 
-    
+    option: option === null ? null :
+
       // Assign string as option.
       typeof option === 'string' && option
-      
+
       // Assign first value as option.
       || Object.values(option)[0]
   }))


### PR DESCRIPTION
This PR is a simple change, in PR #930 we added the ability to use an empty `edit.options` array that would then run the `distinct_values` template on the database. 
This PR simply allows the configuration developer to optionally provide an `entry.edit.query` that will instead be used to populate the `entry.edit.options`. 
This is required as is it possible the options come from a different column / different table entirely, especially if a table is initially empty no options will be provided.