### PR TITLE
Provide format:tiles source and proj param

### DIFF
--- a/lib/layer/format/tiles.mjs
+++ b/lib/layer/format/tiles.mjs
@@ -1,22 +1,15 @@
-const sources = {
-  OSM: layer => new ol.source.OSM({
-    url: decodeURIComponent(layer.URI),
-    opaque: false,
-    transition: 0,
-  }),
-  XYZ: layer => new ol.source.OSM({
-    url: decodeURIComponent(layer.URI),
-    opaque: false,
-    transition: 0,
-  })
-}
-
 export default layer => {
 
   layer.source ??= 'OSM'
 
+  layer.projection ??= 'EPSG:3857'
+
   layer.L = new ol.layer.Tile({
-    source: sources[layer.source](layer),
+    source: new ol.source[layer.source]({
+      projection: layer.projection,
+      url: decodeURIComponent(layer.URI),
+      transition: 0
+    }),
     layer: layer,
     zIndex: layer.style?.zIndex || 0
   })

--- a/lib/layer/format/tiles.mjs
+++ b/lib/layer/format/tiles.mjs
@@ -1,11 +1,22 @@
+const sources = {
+  OSM: layer => new ol.source.OSM({
+    url: decodeURIComponent(layer.URI),
+    opaque: false,
+    transition: 0,
+  }),
+  XYZ: layer => new ol.source.OSM({
+    url: decodeURIComponent(layer.URI),
+    opaque: false,
+    transition: 0,
+  })
+}
+
 export default layer => {
 
+  layer.source ??= 'OSM'
+
   layer.L = new ol.layer.Tile({
-    source: new ol.source.OSM({
-      url: decodeURIComponent(layer.URI),
-      opaque: false,
-      transition: 0,
-    }),
+    source: sources[layer.source](layer),
     layer: layer,
     zIndex: layer.style?.zIndex || 0
   })


### PR DESCRIPTION
This works with:

```js
"autonavi": {
  "format": "tiles",
  "URI": "http://webrd0{1-4}.is.autonavi.com/appmaptile?lang=zh_cn&size=1&scale=1&style=8&x={x}&y={y}&z={z}",
  "source": "XYZ"
},
```

However the tiles are shifted.