### PR TITLE
no_result configuration for gazetteer.

### DIFF
--- a/lib/utils/gazetteer.mjs
+++ b/lib/utils/gazetteer.mjs
@@ -15,6 +15,7 @@ export function datasets(term, gazetteer) {
         label: gazetteer.label,
         title: gazetteer.title,
         limit: gazetteer.limit,
+        no_result: gazetteer.no_result,
         leading_wildcard: gazetteer.leading_wildcard,
         callback: gazetteer.callback,
         maxZoom: gazetteer.maxZoom,

--- a/lib/utils/gazetteer.mjs
+++ b/lib/utils/gazetteer.mjs
@@ -69,10 +69,11 @@ export function datasets(term, gazetteer) {
             
             // No results
             if (!e.target.response) {
+                if (dataset.no_result === null) return;
                 gazetteer.list.append(mapp.utils.html.node`
                     <li>
                         <span class="label">${dataset.title || layer.name}</span>
-                        <span>${mapp.dictionary.no_results}</span>`)
+                        <span>${dataset.no_result || mapp.dictionary.no_results}</span>`)
                 return;
             }
 


### PR DESCRIPTION
Setting `no_result` in the gazetteer config will display the value as no result message instead of the default from the dictionary.

Setting `no_result` as null will display no message.