### PR TITLE
Cancel drawing interaction with escape key.

### DIFF
--- a/lib/mapview/interactions/draw.mjs
+++ b/lib/mapview/interactions/draw.mjs
@@ -38,7 +38,8 @@ export default function(params){
 
         const moveEvent = new ol.MapBrowserEvent('pointermove', mapview.Map, e.originalEvent)
         mapview.interaction.interaction.handleEvent(moveEvent)
-        mapview.interaction.interaction.handleEvent(moveEvent)
+
+        mapview.interaction.conditions?.forEach(fn => typeof fn === 'function' && fn(e))
         return false;
       }
 
@@ -88,6 +89,13 @@ export default function(params){
   
   // Add mapview.interaction.Layer to mapview.
   mapview.Map.addLayer(mapview.interaction.Layer)
+
+  document.addEventListener('keyup', escape)
+
+  function escape(e){
+
+    e.key === 'Escape' && mapview.interaction.finish()
+  }
   
   // Create OL draw interaction.
   mapview.interaction.interaction = new ol.interaction.Draw(mapview.interaction)
@@ -149,6 +157,8 @@ export default function(params){
   }
   
   function finish(feature) {
+
+    document.removeEventListener('keyup', escape)
 
     // Remove snap interaction.
     mapview.interaction.snap?.remove?.()


### PR DESCRIPTION
The `Esc/Escape` key will cancel the drawing interaction.

Right click to remove the last vertex will executed conditions [array] methods. This allows to undo the last section from routes in the measure_distance plugin.