### PR TITLE
layer.view() method must return layer

### DIFF
--- a/lib/ui/layers/listview.mjs
+++ b/lib/ui/layers/listview.mjs
@@ -1,5 +1,3 @@
-import view from './view.mjs'
-
 mapp.utils.merge(mapp.dictionaries, {
   en: {
     layer_group_hide_layers: 'Hide all layers in group',
@@ -45,7 +43,7 @@ export default function (params){
     if (layer.hidden) return;
 
     // Create the layer view.
-    view(layer)
+    mapp.ui.layers.view(layer)
 
     if (!layer.group) {
       listview.node.appendChild(layer.view)

--- a/lib/ui/layers/view.mjs
+++ b/lib/ui/layers/view.mjs
@@ -34,7 +34,7 @@ export default (layer) => {
   if (layer.view === null) {
     
     // Do not create a layer view.
-    return;
+     return layer;
   }
 
   layer.view = mapp.utils.html.node`<div class="layer-view">`
@@ -130,4 +130,6 @@ export default (layer) => {
     }
     
   })
+
+  return layer
 }


### PR DESCRIPTION
This will allow to compose the method with other methods before or after in a plugin.

Also the listview must not import the view method but use mapp.ui.layer.view.