### PR TITLE
Locations/entries/date - now takes user local time;

### DIFF
--- a/lib/ui/locations/entries/date.mjs
+++ b/lib/ui/locations/entries/date.mjs
@@ -1,47 +1,40 @@
 export default entry => {
 
-  let val;
+  const dateString = new Date(entry.newValue || entry.value * 1000)
+    .toLocaleDateString(entry.locale, entry.options); // day only as configured in workspace
 
-  let d = new Date(entry.value * 1000)
-  .toLocaleDateString(entry.locale, entry.options); // day only as configured in workspace
-
-  let t = new Date(entry.value * 1000)
-  .toLocaleTimeString([], {hour: '2-digit', minute:'2-digit'}); // time only as 00:00
+  const timeString = new Date(entry.newValue || entry.value * 1000)
+    .toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' }); // time only as 00:00
 
   if (entry.edit) {
 
-    // these formats are only needed to pass values formatted for the input element
+    // formatted value for input element.
     const formats = {
-      datetime: `${new Date(entry.value * 1000).toLocaleDateString("fr-CA")}T${t}`, // YYYY-MM-DDT00:00
-      date: `${new Date(entry.value * 1000).toLocaleDateString("fr-CA")}` // YYYY-MM-DD
+      datetime: `${new Date(entry.newValue || entry.value * 1000).toLocaleDateString("fr-CA")}T${timeString}`, // YYYY-MM-DDT00:00
+      date: `${new Date(entry.newValue || entry.value * 1000).toLocaleDateString("fr-CA")}` // YYYY-MM-DD
     }
 
-    val = mapp.utils.html.node`
+    // return date/time input
+    return mapp.utils.html.node`
       <input
         type=${entry.type === 'datetime' ? 'datetime-local' : 'date'}
         value="${formats[entry.type]}"
         onchange=${e => {
 
-          // this gets user timezone
-          //let timezone = Intl.DateTimeFormat().resolvedOptions().timeZone;
+        entry.newValue = new Date(e.target.value).getTime() / 1000;
 
-          let unix = new Date(e.target.value).getTime() / 1000;
+        entry.location.view?.dispatchEvent(
+          new CustomEvent('valChange', {
+            detail: entry
+          }))
+      }}>`;
 
-          entry.newValue = unix;
-
-          entry.location.view?.dispatchEvent(
-            new CustomEvent('valChange', {
-              detail: entry
-            })
-          )
-
-        }}>`;
-        
-  } 
-  else {
-
-    val = entry.value && entry.type === 'datetime' ? `${d} ${t}` : `${d}`;
   }
+
+  // Assign val for non-editable entry.
+  const val = entry.value
+    && (entry.type === 'datetime' ? `${dateString} ${timeString}` : dateString)
+    || 'null'
 
   const node = mapp.utils.html.node`
     <div

--- a/lib/ui/locations/entries/date.mjs
+++ b/lib/ui/locations/entries/date.mjs
@@ -1,18 +1,33 @@
 export default entry => {
 
-  let val
+  let val;
+
+  let d = new Date(entry.value * 1000)
+  .toLocaleDateString(entry.locale, entry.options); // day only as configured in workspace
+
+  let t = new Date(entry.value * 1000)
+  .toLocaleTimeString([], {hour: '2-digit', minute:'2-digit'}); // time only as 00:00
 
   if (entry.edit) {
 
+    // these formats are only needed to pass values formatted for the input element
+    const formats = {
+      datetime: `${new Date(entry.value * 1000).toLocaleDateString("fr-CA")}T${t}`, // YYYY-MM-DDT00:00
+      date: `${new Date(entry.value * 1000).toLocaleDateString("fr-CA")}` // YYYY-MM-DD
+    }
+
     val = mapp.utils.html.node`
       <input
-        type=${entry.type === 'datetime' && 'datetime-local' || 'date'}
-        value=${entry.value &&
-          (entry.type === 'datetime' && new Date(entry.value * 1000).toISOString().split('Z')[0]
-            || new Date(entry.value * 1000).toISOString().split('T')[0])}
+        type=${entry.type === 'datetime' ? 'datetime-local' : 'date'}
+        value="${formats[entry.type]}"
         onchange=${e => {
 
-          entry.newValue = new Date(e.target.value).getTime() / 1000
+          // this gets user timezone
+          //let timezone = Intl.DateTimeFormat().resolvedOptions().timeZone;
+
+          let unix = new Date(e.target.value).getTime() / 1000;
+
+          entry.newValue = unix;
 
           entry.location.view?.dispatchEvent(
             new CustomEvent('valChange', {
@@ -22,9 +37,10 @@ export default entry => {
 
         }}>`;
         
-  } else {
+  } 
+  else {
 
-    val = entry.value && new Date(entry.value * 1000).toLocaleString(entry.locale, entry.options)
+    val = entry.value && entry.type === 'datetime' ? `${d} ${t}` : `${d}`;
   }
 
   const node = mapp.utils.html.node`


### PR DESCRIPTION
Resolved problem of displayed value, unix epochs and formatting for the input of type date.

Works well for me - I see my local time and the unix epoch saved in the db is correct.
Let me know if it works for you as you are both in different timezones.