### PR TITLE
Layer should be merged into workspace values

### DIFF
--- a/mod/workspace/getLayer.js
+++ b/mod/workspace/getLayer.js
@@ -33,21 +33,24 @@ module.exports = async (params) => {
     return new Error('Unable to validate layer param.')
   }
 
-  const layer = locale.layers[params.layer]
+  let layer = locale.layers[params.layer]
 
   // Assign key value as key on layer object.
   layer.key ??= params.layer
 
   if (Object.hasOwn(workspace.templates, layer.template || layer.key)) {
-
-    merge(layer, await getTemplate(workspace.templates[layer.template || layer.key]))
+    // Merge the workspace template into the layer.
+    layer = 
+    merge(await getTemplate(workspace.templates[layer.template || layer.key]),layer)
   }
 
   if (Array.isArray(layer.templates)) {
 
     // Merge templates from templates array into layer.
     layer.templates.forEach(async template => {
-      merge(layer, await getTemplate(workspace.templates[template]))
+      // Merge the workspace template into the layer.
+      layer =
+      merge(await getTemplate(workspace.templates[template]),layer)
     })
   }
 

--- a/mod/workspace/getLayer.js
+++ b/mod/workspace/getLayer.js
@@ -39,18 +39,18 @@ module.exports = async (params) => {
   layer.key ??= params.layer
 
   if (Object.hasOwn(workspace.templates, layer.template || layer.key)) {
+
     // Merge the workspace template into the layer.
-    layer = 
-    merge(await getTemplate(workspace.templates[layer.template || layer.key]),layer)
+    layer =  merge(await getTemplate(workspace.templates[layer.template || layer.key]), layer)
   }
 
   if (Array.isArray(layer.templates)) {
 
     // Merge templates from templates array into layer.
     layer.templates.forEach(async template => {
+      
       // Merge the workspace template into the layer.
-      layer =
-      merge(await getTemplate(workspace.templates[template]),layer)
+      layer = merge(await getTemplate(workspace.templates[template]), layer)
     })
   }
 

--- a/mod/workspace/getLocale.js
+++ b/mod/workspace/getLocale.js
@@ -14,7 +14,7 @@ module.exports = async (params) => {
     return new Error('Unable to validate locale param.')
   }
 
-  const locale = workspace.locales[params.locale]
+  let locale = workspace.locales[params.locale]
 
   const roles = params.user?.roles || []
 
@@ -26,7 +26,7 @@ module.exports = async (params) => {
   if (Object.hasOwn(workspace.templates, params.locale)) {
 
     // Merge the workspace template into workspace.
-    merge(locale, await getTemplate(workspace.templates[params.locale]))
+    locale = merge(await getTemplate(workspace.templates[params.locale]), locale)
   }
 
   return locale

--- a/mod/workspace/getTemplate.js
+++ b/mod/workspace/getTemplate.js
@@ -55,7 +55,7 @@ module.exports = async (template) => {
   if (typeof response === 'object') {
 
     // Get template from src.
-    merge(template, response)
+    template = merge(response, template)
 
   } else if (typeof response === 'string') {
 


### PR DESCRIPTION
This PR simply reverses the merging order of the getLayer.js, 
The object (e.g layer) should be merged into the template not the other way around. 
This is so we can overwrite values defined in a layer template via the workspace
``` json
"template": {
"name": "NEW NAME"
}
```
This would overwrite the `name` value defined on the `template`, allowing for flexibility from within teh workspace. 