### PR TITLE
Assign layer as request param for queries

### DIFF
--- a/mod/workspace/templates/cluster.js
+++ b/mod/workspace/templates/cluster.js
@@ -1,9 +1,7 @@
 module.exports = _ => {
 
-    const layer = _.workspace.locales[_.locale].layers[_.layer]
-
-    _.qID ??= layer.qID || null
-    _.geom ??= layer.geom
+    _.qID ??= _.layer.qID || null
+    _.geom ??= _.layer.geom
 
     // Get fields array from query params.
     const fields = _.fields?.split(',')

--- a/mod/workspace/templates/cluster_hex.js
+++ b/mod/workspace/templates/cluster_hex.js
@@ -1,9 +1,7 @@
 module.exports = _ => {
 
-    const layer = _.workspace.locales[_.locale].layers[_.layer]
-
-    _.qID ??= layer.qID || null
-    _.geom ??= layer.geom
+    _.qID ??= _.layer.qID || null
+    _.geom ??= _.layer.geom
 
     // Get fields array from query params.
     const fields = _.fields?.split(',')

--- a/mod/workspace/templates/get_last_location.js
+++ b/mod/workspace/templates/get_last_location.js
@@ -1,16 +1,14 @@
 module.exports = _ => {
 
-  const layer = _.workspace.locales[_.locale].layers[_.layer]
+  const table = _.layer.table || Object.values(_.layer.tables).find(tab => !!tab);
 
-  const table = layer.table || Object.values(layer.tables).find(tab => !!tab);
-
-  const geom = layer.geom || Object.values(layer.geoms).find(tab => !!tab);
+  const geom = _.layer.geom || Object.values(_.layer.geoms).find(tab => !!tab);
 
   return `
           SELECT
-          ${layer.qID} as id
+          ${_.layer.qID} as id
           FROM ${table}
-          WHERE ${geom} IS NOT NULL AND ${layer.qID} IS NOT NULL
-          ORDER BY ${layer.qID} DESC
+          WHERE ${geom} IS NOT NULL AND ${_.layer.qID} IS NOT NULL
+          ORDER BY ${_.layer.qID} DESC
           LIMIT 1`
 }

--- a/mod/workspace/templates/mvt_cache.js
+++ b/mod/workspace/templates/mvt_cache.js
@@ -1,25 +1,23 @@
 module.exports = _ => {
 
-  const layer = _.workspace.locales[_.locale].layers[_.layer]
-
-  if (!layer.mvt_cache) return;
+  if (!_.layer.mvt_cache) return;
   
   return `
     
-    DROP table if exists ${layer.mvt_cache};
+    DROP table if exists ${_.layer.mvt_cache};
 
-    Create UNLOGGED table ${layer.mvt_cache}
+    Create UNLOGGED table ${_.layer.mvt_cache}
     (
       z integer not null,
       x integer not null,
       y integer not null,
       mvt bytea,
       tile geometry(Polygon, ${layer.srid}),
-      constraint ${layer.mvt_cache.replace(/\./, '_')}_z_x_y_pk
+      constraint ${_.layer.mvt_cache.replace(/\./, '_')}_z_x_y_pk
         primary key (z, x, y)
     );
 
-    Create index IF NOT EXISTS ${layer.mvt_cache.replace(/\./, '_')}_tile on ${layer.mvt_cache} (tile);
+    Create index IF NOT EXISTS ${_.layer.mvt_cache.replace(/\./, '_')}_tile on ${_.layer.mvt_cache} (tile);
 
-    SELECT '${layer.mvt_cache} cache OK' as msg;`
+    SELECT '${_.layer.mvt_cache} cache OK' as msg;`
 }

--- a/mod/workspace/templates/wkt.js
+++ b/mod/workspace/templates/wkt.js
@@ -1,7 +1,5 @@
 module.exports = _ => {
 
-    const layer = _.workspace.locales[_.locale].layers[_.layer]
-
     // Get fields array from query params.
     const fields = _.fields?.split(',')
         .map(field => _.workspace.templates[field]?.template || field)
@@ -10,12 +8,12 @@ module.exports = _ => {
     // Push label (cluster) into fields
     _.label && fields.push(_.workspace.templates[_.label]?.template || _.label)
 
-    const where = _.viewport || `AND ${_.geom || layer.geom} IS NOT NULL`
+    const where = _.viewport || `AND ${_.geom || _.layer.geom} IS NOT NULL`
 
     return `
         SELECT
         \${qID} AS id,
-        ST_AsText(${_.geom || layer.geom}) AS geometry
+        ST_AsText(${_.geom || _.layer.geom}) AS geometry
         ${fields && `, ${fields.join(', ')}` || ''}
         FROM \${table}
         WHERE TRUE ${where} \${filter};`


### PR DESCRIPTION
Queries which have the layer param need to access the layer object which may be constructed from templates. The query module gets the layer from the getLayer mod. The layer object will replace the req.params.layer string and be accessible in query methods.

**A query may access templates as referenced by fields. The templates must be available as string and not be loaded from a src.**