### PR TITLE
get and merge templates in a for of loop

### DIFF
--- a/mod/workspace/getLayer.js
+++ b/mod/workspace/getLayer.js
@@ -44,14 +44,12 @@ module.exports = async (params) => {
     layer =  merge(await getTemplate(workspace.templates[layer.template || layer.key]), layer)
   }
 
-  if (Array.isArray(layer.templates)) {
+  if (Array.isArray(layer.templates)) for (const key of layer.templates){
 
-    // Merge templates from templates array into layer.
-    layer.templates.forEach(async template => {
+    let template = Object.hasOwn(workspace.templates, key) && await getTemplate(workspace.templates[key])
       
-      // Merge the workspace template into the layer.
-      layer = merge(await getTemplate(workspace.templates[template]), layer)
-    })
+    // Merge the workspace template into the layer.
+    layer = merge(template, layer)
   }
 
   // Check for layer geom[s].


### PR DESCRIPTION
The async getTemplate and subsequent merge must happen in a for...of loop in the getLayer method. Otherwise the merge would happen after the layer is already returned from method.