### PR TITLE
added visibility setting for layers instead of adding and removing la…

### DIFF
--- a/lib/layer/decorate.mjs
+++ b/lib/layer/decorate.mjs
@@ -225,7 +225,8 @@ function show() {
     // Add layer to map
     this.mapview.Map.addLayer(this.L);
   } catch {
-    // Will catch assertation error when layer is already added.
+    // If layer is already added, set its visibility to true
+    this.L.setVisible(true);
   }
 
   // Reload layer data if available.
@@ -247,7 +248,7 @@ function hide() {
   this.display = false;
 
   // Remove OL layer from mapview.
-  this.mapview.Map.removeLayer(this.L);
+  this.L.setVisible(false);
 
   // Remove layer attribution from mapview attribution.
   this.mapview.attribution?.check();


### PR DESCRIPTION
Toggling layers on and off used to change layer order and cause scenarios where labels would end up under the base map. With this, layers will retain their order as their visibility is set to true/false rather than getting removed/re-added to the map layers array.