### PR TITLE
Fix toggling edit mode with no changes

### DIFF
--- a/lib/ui/locations/view.mjs
+++ b/lib/ui/locations/view.mjs
@@ -95,6 +95,7 @@ export default location => {
     // New locations should be editable.
     !location.new && location.removeEdits()
 
+    // Create edit toggle button.
     location.editToggle = mapp.utils.html.node`
       <button
         title = "Enable edits"
@@ -107,17 +108,26 @@ export default location => {
           // Remove on class from button.
           e.target.classList.remove('on')
 
+          // If there are unsaved edits.
           if (location.infoj.some(entry => typeof entry.newValue !== 'undefined')) {
 
+            // Ask user whether to save edits.
             if (confirm(`Save your changes to this location?`)) {
 
+              // Save edits.
               await location.update()
 
+            // If user does not want to save edits.
             } else {
 
               // Remove edits from infoj entries.
               location.removeEdits()
             }
+          } 
+          // If there's nothing to save.
+          else {
+            // Just remove edits from infoj entries.
+            location.removeEdits()
           }
 
         } else {


### PR DESCRIPTION
This PR addresses an issue that came about as a result of #1000 . 
The issue was that when you toggle the edit mode button but there is no changes, edit mode is not removed. 