### PR TITLE
Zoom Toggle Fix

### DIFF
--- a/lib/ui/layers/view.mjs
+++ b/lib/ui/layers/view.mjs
@@ -117,6 +117,7 @@ export default (layer) => {
   
   // Add an event listener to the magnifying glass icon to show the zoom level button when clicked
   zoomButton.addEventListener('click', () => {
+
     // Zoom to the extent of the layer if table provided. 
     if (layer.tableCurrent() !== null) {
       layer.zoomToExtent();
@@ -142,6 +143,8 @@ export default (layer) => {
 
     if (layer.tableCurrent() === null) {
 
+      // The layer should be set to display false, as it is not available at the current zoom level.
+      layer.display = false;
       // Collapse drawer and disable layer.view.
       layer.view.querySelector('[data-id=layer-drawer]').classList.remove('expanded')
 


### PR DESCRIPTION
Steps to reproduce the bug prior to this PR: 

1. Click zoom to button on a zoom restricted layer
2. Click zoom to button again (zooms you out and turns layer 'off')
3. Zoom in using box zoom
4. Layer appears but toggle isn't orange

This was due to missing setting the layer to display false when the zoom to button was pressed twice