### PR TITLE
Merging Templates Array into Template

### DIFF
--- a/mod/workspace/getLayer.js
+++ b/mod/workspace/getLayer.js
@@ -44,12 +44,13 @@ module.exports = async (params) => {
     layer =  merge(await getTemplate(workspace.templates[layer.template || layer.key]), layer)
   }
 
+  // If we have an array of templates in the layer object, merge them into the layer.
   if (Array.isArray(layer.templates)) for (const key of layer.templates){
 
     let template = Object.hasOwn(workspace.templates, key) && await getTemplate(workspace.templates[key])
       
-    // Merge the workspace template into the layer.
-    layer = merge(template, layer)
+    // Merge the layer into the template
+    layer = merge(layer, template)
   }
 
   // Check for layer geom[s].


### PR DESCRIPTION
This PR addresses an issue created from #999 . 
If you have this config 
``` json 
"layer":{
"templates":["template_1", "template_2"] 
}
```
Then in the current set up it will attempt to merge the layer into the array of templates, resulting in ordering changes whereby the merged template, `template_2` would end up at the top of the infoj, when currently it is at the bottom. As such this would be a breaking change. 

To address this, I simply swapped the order of template array merge to `merge(layer,template)` so it functions as it used to. 