### PR TITLE
DBS initialisation and timeouts

### DIFF
--- a/mod/location/delete.js
+++ b/mod/location/delete.js
@@ -1,4 +1,4 @@
-const dbs = require('../utils/dbs')()
+const dbs = require('../utils/dbs')
 
 const workspaceCache = require('../workspace/cache')
 

--- a/mod/location/get.js
+++ b/mod/location/get.js
@@ -1,4 +1,4 @@
-const dbs = require('../utils/dbs')()
+const dbs = require('../utils/dbs')
 
 const sqlFilter = require('../utils/sqlFilter')
 

--- a/mod/location/new.js
+++ b/mod/location/new.js
@@ -1,4 +1,4 @@
-const dbs = require('../utils/dbs')()
+const dbs = require('../utils/dbs')
 
 const workspaceCache = require('../workspace/cache')
 

--- a/mod/location/update.js
+++ b/mod/location/update.js
@@ -1,4 +1,4 @@
-const dbs = require('../utils/dbs')()
+const dbs = require('../utils/dbs')
 
 const workspaceCache = require('../workspace/cache')
 

--- a/mod/query.js
+++ b/mod/query.js
@@ -1,4 +1,4 @@
-const dbs_connections = require('./utils/dbs')()
+const dbs_connections = require('./utils/dbs')
 
 const sqlFilter = require('./utils/sqlFilter')
 

--- a/mod/user/acl.js
+++ b/mod/user/acl.js
@@ -1,11 +1,11 @@
 const { Pool } = require('pg');
 
+const connection = process.env.PRIVATE && process.env.PRIVATE.split('|')
+|| process.env.PUBLIC && process.env.PUBLIC.split('|')
+
 let pool = null
 
 module.exports = () => {
-
-  const connection = process.env.PRIVATE && process.env.PRIVATE.split('|')
-    || process.env.PUBLIC && process.env.PUBLIC.split('|')
 
   if(!connection || !connection[1]) return
 

--- a/mod/user/acl.js
+++ b/mod/user/acl.js
@@ -1,8 +1,11 @@
 const { Pool } = require('pg');
 
+let pool = null
+
 module.exports = () => {
 
-  const connection = process.env.PRIVATE && process.env.PRIVATE.split('|') || process.env.PUBLIC && process.env.PUBLIC.split('|')
+  const connection = process.env.PRIVATE && process.env.PRIVATE.split('|')
+    || process.env.PUBLIC && process.env.PUBLIC.split('|')
 
   if(!connection || !connection[1]) return
 
@@ -11,9 +14,8 @@ module.exports = () => {
   const acl_schema = connection[1].split('.')[0] === acl_table ? 'public' : connection[1].split('.')[0]
 
   // Create PostgreSQL connection pool for ACL table.
-  const pool = new Pool({
-    connectionString: connection[0],
-    statement_timeout: 1000
+  pool ??= new Pool({
+    connectionString: connection[0]
   })
 
   // Method to query ACL. arr must be empty array by default.
@@ -21,14 +23,17 @@ module.exports = () => {
 
     try {
 
-      const { rows } = await pool.query(q.replace(/acl_table/g, acl_table).replace(/acl_schema/g, acl_schema), arr)
+      const client = await pool.connect()
+
+      const { rows } = await client.query(q.replace(/acl_table/g, acl_table).replace(/acl_schema/g, acl_schema), arr)
+
+      client.release()
+      
       return rows
     
     } catch (err) {
       console.error(err)
       return err
     }
-
   }
-
 }

--- a/mod/utils/dbs.js
+++ b/mod/utils/dbs.js
@@ -13,10 +13,10 @@ Object.keys(process.env)
 
     const pool = new Pool({
       connectionString: process.env[key],
-      options: `-c statement_timeout=${parseInt(process.env.STATEMENT_TIMEOUT)||10000}`
+      options: `-c statement_timeout=${parseInt(process.env.STATEMENT_TIMEOUT) || 10000}`
     });
 
-    dbs[key.split('_')[1]] = async (q, arr, timeout) => {
+    dbs[key.split('_')[1]] = async (query, variables, timeout) => {
 
       try {
 
@@ -24,8 +24,9 @@ Object.keys(process.env)
 
         timeout && await client.query(`SET statement_timeout = ${parseInt(timeout)}`)
 
-        const { rows } = await client.query(q, arr)
+        const { rows } = await client.query(query, variables)
 
+        // Reset the statement timeout to value from process.env or default 10000 (10 seconds).
         timeout && await client.query(`SET statement_timeout = ${parseInt(process.env.STATEMENT_TIMEOUT) || 10000}`)
 
         client.release()
@@ -34,7 +35,7 @@ Object.keys(process.env)
 
       } catch (err) {
 
-        logger({ err, q, arr })
+        logger({ err, query, variables })
         return err;
       }
     }

--- a/mod/utils/dbs.js
+++ b/mod/utils/dbs.js
@@ -13,7 +13,6 @@ Object.keys(process.env)
 
     const pool = new Pool({
       connectionString: process.env[key],
-      options: `-c statement_timeout=${parseInt(process.env.STATEMENT_TIMEOUT) || 10000}`
     });
 
     dbs[key.split('_')[1]] = async (query, variables, timeout) => {
@@ -22,12 +21,11 @@ Object.keys(process.env)
 
         const client = await pool.connect()
 
-        timeout && await client.query(`SET statement_timeout = ${parseInt(timeout)}`)
+        if (timeout || process.env.STATEMENT_TIMEOUT) {
+          await client.query(`SET statement_timeout = ${parseInt(timeout) || parseInt(process.env.STATEMENT_TIMEOUT)}`)
+        }
 
         const { rows } = await client.query(query, variables)
-
-        // Reset the statement timeout to value from process.env or default 10000 (10 seconds).
-        timeout && await client.query(`SET statement_timeout = ${parseInt(process.env.STATEMENT_TIMEOUT) || 10000}`)
 
         client.release()
 


### PR DESCRIPTION
The dbs object shouldn't be created on each require but only once when the process initiates with only the dbs object exported from the module.

The dbs should only be required without executing the exported method.

The statement_timeout does nothing on the pool. Setting the statement_timeout environment variable will set the statement prior to the query.

The statement_timeout doesn't have to be reset since the client is released after the query.

Only one pool should be created for the acl connection and stored outside the closure which returns the async query. The method should release the client after each query.