### PR TITLE
Field Template Bug

### DIFF
--- a/mod/workspace/templates/mvt.js
+++ b/mod/workspace/templates/mvt.js
@@ -2,7 +2,7 @@ module.exports = _ => {
 
   // Get fields array from query params.
   const fields = _.fields?.split(',')
-    .map(field => _.workspace.templates[field]?.template || field)
+    .map(field => `${_.workspace.templates[field]?.template || field} AS ${field}`)
     .filter(field => !!field)
 
   // Push label (cluster) into fields
@@ -29,7 +29,7 @@ module.exports = _ => {
         ) geom
       FROM ${_.table}
       WHERE
-        ${_.layer.z_field && `${_.layer.z_field} < ${z} AND` ||''}
+        ${_.layer.z_field && `${_.layer.z_field} < ${z} AND` || ''}
         ST_Intersects(
           ST_TileEnvelope(${z},${x},${y}),
           ${_.geom || _.layer.geom}

--- a/mod/workspace/templates/wkt.js
+++ b/mod/workspace/templates/wkt.js
@@ -2,7 +2,7 @@ module.exports = _ => {
 
     // Get fields array from query params.
     const fields = _.fields?.split(',')
-        .map(field => _.workspace.templates[field]?.template || field)
+        .map(field => `${_.workspace.templates[field]?.template || field} AS ${field}`)
         .filter(field => !!field)
 
     // Push label (cluster) into fields


### PR DESCRIPTION
This PR addresses a bug on two layer formats: `mvt` and `wkt`. 
Previously if you provided a `workspace.template` for the thematic field, the `workspace.template` name was not assigned as the field name, meaning the thematic would be drawn as all 0 or null.  

So in the example below, the `mvt` and `wkt` layer formats would return `select case when field > `0 then field*10 else field end` 
which would mean that there was no field for the thematic. 
This PR adds the following code, ensuring the `field` key is used as the field name. 
```
const fields = _.fields?.split(',')
    .map(field => `${_.workspace.templates[field]?.template || field} AS ${field}`)
    .filter(field => !!field)
```
Example: 
``` json 
"templates": { 
"field_template": "case when field > 10 then field*10 else field end"
}
```
``` json 
"themes": {
      "test": {
        "title": "Test",
        "type": "graduated",
        "field": "field_template",
        "cat_arr": [
          {
            "value": 0,
            "label": "Under £75",
            "style": {
              "fillColor": "#edf8fb",
              "fillOpacity": 0.5
            }
          },
        {
            "value": 75,
            "label": "£75 - £150",
            "style": {
              "fillColor": "#edf8fb",
              "fillOpacity": 0.5
            }
          }
       ] 
   } 
}
```

