### PR TITLE
CSS Changes

### DIFF
--- a/public/css/ui.css
+++ b/public/css/ui.css
@@ -1068,11 +1068,11 @@ label.checkbox {
       padding: 5px;
     }
     & > li:hover {
-      background-color: var(--color-light);
+      background-color: var(--color-mid);
       cursor: pointer;
     }
     & > li.selected {
-      background-color: var(--color-light-secondary);
+      background-color: var(--color-mid);
     }
     & .label {
       padding: 0 6px;


### PR DESCRIPTION
This PR addresses:  
1. The dropdown styling so the user can see which values they are hovering over and are selected. 
Before and after pictures attached, you cannot see the hover on the before. 

Before 
![image](https://github.com/GEOLYTIX/xyz/assets/56163132/4b7a003f-7d9f-43f5-aeba-43b139d0b13c)

After
![image](https://github.com/GEOLYTIX/xyz/assets/56163132/aff406b8-a61e-4f0e-8650-cbceb484f604)
