### PR TITLE
csvDownload params; toLocaleString

### DIFF
--- a/lib/ui/elements/toolbar_el.mjs
+++ b/lib/ui/elements/toolbar_el.mjs
@@ -52,18 +52,7 @@ function download_csv(dataview) {
         // download_csv is an object with 
         if (dataview.toolbar.download_csv instanceof Object) {
 
-          // Parse data from download_csv.fields
-          const data = dataview.data.map(record => {
-
-            // Check whether string values should be escaped.
-            return dataview.toolbar.download_csv.fields.map(field => (record[field.field] && field.string) ?
-              `"${record[field.field].replace(`"`, `\\"`)}"` : record[field.field])
-          })
-
-          // Unshift the header row with either the title or field names.
-          data.unshift(dataview.toolbar.download_csv.fields.map(field => field.title || field.field))
-
-          mapp.utils.csvDownload(data, dataview.toolbar.download_csv)
+          mapp.utils.csvDownload(dataview.data, dataview.toolbar.download_csv)
           return;
         }
         

--- a/lib/ui/utils/tabulatorUtils.mjs
+++ b/lib/ui/utils/tabulatorUtils.mjs
@@ -6,7 +6,7 @@ export default {
     date: dateFilter
   },
   formatter: {
-    toLocalString,
+    toLocaleString,
     date
   },
   select,
@@ -37,8 +37,7 @@ function columns(_this) {
     }
 
     // Check for custom formatter in the ui utils.
-    if (typeof col.formatter === 'string'
-      && mapp.ui.utils.tabulator.formatter[col.formatter]) {
+    if (Object.hasOwn(mapp.ui.utils.tabulator.formatter, col.formatter)) {
 
       // Assign custom formatter from ui utils.
       col.formatter =
@@ -397,7 +396,7 @@ function select(_this, params = {}) {
   }
 }
 
-function toLocalString(_this) {
+function toLocaleString(_this) {
 
   return (cell, formatterParams, onRendered) => {
 
@@ -405,7 +404,7 @@ function toLocalString(_this) {
 
     if (isNaN(val)) return;
 
-    return val.toLocaleString(formatterParams?.locale || 'en-GB', formatterParams?.options)
+    return val.toLocaleString(formatterParams?.locale || navigator.language, formatterParams?.options)
   }
 }
 
@@ -417,7 +416,7 @@ function date(_this) {
 
     if (isNaN(val)) return;
 
-    let str = new Date(val * 1000).toLocaleString(formatterParams?.locale || 'en-GB', formatterParams?.options)
+    let str = new Date(val * 1000).toLocaleString(formatterParams?.locale || navigator.language, formatterParams?.options)
 
     return str
   }

--- a/lib/utils/csvDownload.mjs
+++ b/lib/utils/csvDownload.mjs
@@ -10,36 +10,11 @@ export default function csvDownload(data, params = {}) {
 
   const rows = data.map(record => {
 
-    if (Array.isArray(params.fields)) {
-
-      let row = params.fields.map(field => {
-
-        if (!field.field) return;
-
-        // Escape quotes in string value.
-        if (typeof record[field.field] === 'string' && field.string) {
-
-          return `"${record[field.field].replace(`"`, `\\"`)}"`
-        }
-
-        // Format number toLocaleString
-        if (field.formatter === 'toLocaleString') {
-
-          let val = parseFloat(record[field.field])
-
-          if (isNaN(val)) return;
-      
-          return `"${val.toLocaleString(field.locale || navigator.language, field.options)}"`
-        }
-
-        return record[field.field]
-
-      })
-
-      return row.join(params.separator)
-    }
-
-    return Object.values(record).join(params.separator)
+    let row = Array.isArray(params.fields)
+     ? fieldsFunction(record, params.fields)
+     : Object.values(record)
+     
+    return row.join(params.separator)
   })
 
   // Set default type for the blob.
@@ -66,4 +41,31 @@ export default function csvDownload(data, params = {}) {
   document.body.append(link)
   link.click()
   link.remove()
+}
+
+function fieldsFunction(record, fields) {
+
+  return fields.map(field => {
+
+    if (!field.field) return;
+
+    // Escape quotes in string value.
+    if (typeof record[field.field] === 'string' && field.string) {
+
+      return `"${record[field.field].replace('"', '\\"')}"`
+    }
+
+    // Format number toLocaleString
+    if (field.formatter === 'toLocaleString') {
+
+      let val = parseFloat(record[field.field])
+
+      if (isNaN(val)) return;
+
+      return `"${val.toLocaleString(field.locale || navigator.language, field.options)}"`
+    }
+
+    return record[field.field]
+
+  })
 }

--- a/lib/utils/csvDownload.mjs
+++ b/lib/utils/csvDownload.mjs
@@ -52,7 +52,7 @@ function fieldsFunction(record, fields) {
     // Escape quotes in string value.
     if (typeof record[field.field] === 'string' && field.string) {
 
-      return `"${record[field.field].replace('"', '\\"')}"`
+      return `"${record[field.field].replaceAll('"', '\\"')}"`
     }
 
     // Format number toLocaleString

--- a/lib/utils/csvDownload.mjs
+++ b/lib/utils/csvDownload.mjs
@@ -1,24 +1,69 @@
-export default function csvDownload(arr, params = {}) {
+export default function csvDownload(data, params = {}) {
 
-    if (!Array.isArray(arr)) {
-        console.warn('Array argument for csvDownload must be an array')
-        return;
+  if (!Array.isArray(data)) {
+    console.warn('Array argument for csvDownload must be an array')
+    return;
+  }
+
+  // Set comma as default separator.
+  params.separator ??= ','
+
+  const rows = data.map(record => {
+
+    if (Array.isArray(params.fields)) {
+
+      let row = params.fields.map(field => {
+
+        if (!field.field) return;
+
+        // Escape quotes in string value.
+        if (typeof record[field.field] === 'string' && field.string) {
+
+          return `"${record[field.field].replace(`"`, `\\"`)}"`
+        }
+
+        // Format number toLocaleString
+        if (field.formatter === 'toLocaleString') {
+
+          let val = parseFloat(record[field.field])
+
+          if (isNaN(val)) return;
+      
+          return `"${val.toLocaleString(field.locale || navigator.language, field.options)}"`
+        }
+
+        return record[field.field]
+
+      })
+
+      return row.join(params.separator)
     }
 
-    const rows = arr.map(record => {
+    return Object.values(record).join(params.separator)
+  })
 
-        return Object.values(record).join(',')
-    })
+  // Set default type for the blob.
+  params.type ??= 'text/csv;charset=utf-8;'
 
-    const blob = new Blob([rows.join('\r\n')], { type: 'text/csv;charset=utf-8;' })
+  params.join ??= '\r\n'
 
-    const link = document.createElement('a')
+  params.title ??= 'file'
 
-    link.download = `${params.title || 'file'}.csv`
-    link.href = URL.createObjectURL(blob)
-    link.dataset.downloadurl = ['csv', link.download, link.href].join(':')
-    link.style.display = 'none'
-    document.body.append(link)
-    link.click()
-    link.remove()
+  if (params.header && Array.isArray(params.fields)) {
+
+    // Unshift the header row with either the title or field names.
+    rows.unshift(params.fields.map(field => field.title || field.field))
+  }
+
+  const blob = new Blob([rows.join(params.join)], { type: params.type })
+
+  const link = document.createElement('a')
+
+  link.download = `${params.title}.csv`
+  link.href = URL.createObjectURL(blob)
+  link.dataset.downloadurl = ['csv', link.download, link.href].join(':')
+  link.style.display = 'none'
+  document.body.append(link)
+  link.click()
+  link.remove()
 }


### PR DESCRIPTION
The tabulatorUtils formatter method `toLocalString` has been renamed `toLocaleString` in order to be caught by the column check method.

The toolbar element method for downloads will pass the data and params to the csvDownload utility method.

The csvDownload utility assign default parameter for the seprator, join, and blob type which can be overridden.

```js
params = {
  join: '\r\n',
  separator: ',',
  type: 'text/csv;charset=utf-8;'
}
```

The fields config will allow a `toLocalString` formatter which will return the record value as a formatted string.

The `navigator.language` is assumed as the default locale instead of `en-GB`.