### PR TITLE
Add error for 4326 mvt layer

### DIFF
--- a/lib/layer/format/mvt.mjs
+++ b/lib/layer/format/mvt.mjs
@@ -1,13 +1,14 @@
 export default layer => {
 
-  // If 4326, return an error as this is not supported anymore. 
-  if (layer.srid === '4326') {
-    return console.error(`Layer ${layer.key} is using SRID 4326 which is not supported anymore for format:mvt. This must be changed to 3857.`)
-  }
-  
   // Assign default SRID if nullish.
   layer.srid ??= '3857'
 
+  // If 4326, return an error as this is not supported anymore. 
+  if (layer.srid !== '3857') {
+    console.warn(`Layer ${layer.key} must be set to use SRID 3857.`)
+    return;
+  }
+  
   // Assign empty style object if nullish.
   layer.style ??= {}
 

--- a/lib/layer/format/mvt.mjs
+++ b/lib/layer/format/mvt.mjs
@@ -1,5 +1,10 @@
 export default layer => {
 
+  // If 4326, return an error as this is not supported anymore. 
+  if (layer.srid === '4326') {
+    return console.error(`Layer ${layer.key} is using SRID 4326 which is not supported anymore for format:mvt. This must be changed to 3857.`)
+  }
+  
   // Assign default SRID if nullish.
   layer.srid ??= '3857'
 


### PR DESCRIPTION
Adding a check on srid and returning an error if its 4326 as no longer supported.