### PR TITLE
Enable legend.dynamic for categorical themes.

### DIFF
--- a/lib/layer/themes/categorized.mjs
+++ b/lib/layer/themes/categorized.mjs
@@ -4,12 +4,16 @@ export default function (theme, feature) {
 
   const catValue = feature.properties.cat || feature.properties[theme.field]
 
-  const catStyle = theme.cat[encodeURIComponent(catValue)]?.style
-    || theme.cat[catValue]?.style
-    || theme.cat[encodeURIComponent(catValue)]
-    || theme.cat[catValue]
+  const cat = theme.cat[encodeURIComponent(catValue)] || theme.cat[catValue]
+
+  const catStyle = cat.style || cat
 
   if (typeof catStyle === 'undefined') return;
+
+  if (theme.legend?.dynamic && cat.node) {
+
+    cat.display = 'contents'
+  }
 
   if (feature.geometryType === 'Point') {
 

--- a/lib/ui/layers/legends/categorized.mjs
+++ b/lib/ui/layers/legends/categorized.mjs
@@ -1,25 +1,23 @@
+// Assign and returns legend to the layer.style object.
 export default (layer) => {
-  /**
-  * Creates a map legend for the given map layer
-  * @param {Object} layer - Map layer the legend is for
-  */
-
-  //legend.layout - Container display layout, "grid" | "flex"
-  //legend.alignContents - How the contents are aligned, "left" | "center" | "row"
-  const legendOptions = layer.style.theme.legend;
 
   const theme = layer.style.theme
 
-  const grid = []
+  theme.legend ??= {}
 
-  const contentsClass = ['contents'];
-  
-  contentsClass.push(legendOptions?.alignContents)
+  // Apply dynamic legend methods.
+  dynamicLegend(layer)
+
+  theme.legend.grid = []
+
+  // Make 'left' default alignment.
+  theme.legend.alignContents ??= 'left'
+  theme.legend.alignContents += ' contents'
 
   let timeout;
 
   // Switch all control
-  const switchControl = layer.filter &&
+  theme.legend.switch = layer.filter &&
     mapp.utils.html`
       <div
         class="switch-all"
@@ -70,9 +68,10 @@ export default (layer) => {
     let icon = mapp.utils.html`
       <div
         style="height: 24px; width: 24px; grid-column: 1;">
-        ${mapp.ui.elements.legendIcon(
-          Object.assign({ width: 24, height: 24 }, cat_style)
-        )}`;
+        ${mapp.ui.elements.legendIcon({
+          width: 24,
+          height: 24,
+          ...cat_style})}`;
 
     // Cat label with filter function.
     let label = mapp.utils.html`
@@ -80,7 +79,7 @@ export default (layer) => {
         class=${`label ${layer.filter && 'switch' ||''} ${
 
           // Check whether cat is in current filter.
-          layer.filter?.current[theme.field]?.ni?.indexOf(cat[0]) > 0 ? 'disabled' : ''
+          layer.filter?.current[theme.field]?.ni?.indexOf(cat[0]) >= 0 ? 'disabled' : ''
         }`}
         style="grid-column: 2;"
         onclick=${e => {
@@ -153,12 +152,14 @@ export default (layer) => {
 
         }}>${cat[1].label || cat[0]}`
 
-    // Push icon and label into legend grid.
-    grid.push(mapp.utils.html`
-    <div 
+    cat[1].node = mapp.utils.html.node`
+    <div
       data-id=${cat[0]}
-      class="${contentsClass.join(' ')}">
-      ${icon}${label}`)
+      class="${theme.legend.alignContents}">
+      ${icon}${label}`
+
+    // Push icon and label into legend grid.
+    theme.legend.grid.push(cat[1].node)
   })
 
   // Attach row for cluster locations.
@@ -168,10 +169,12 @@ export default (layer) => {
     let icon = mapp.utils.html`
       <div
         style="height: 40px; width: 40px;">
-        ${mapp.ui.elements.legendIcon(Object.assign({
+        ${mapp.ui.elements.legendIcon({
           width: 40,
-          height: 40
-        }, layer.style.default, layer.style.cluster))}`
+          height: 40,
+          ...layer.style.default,
+          ...layer.style.cluster
+        })}`
    
     // Create cluster label.
     let label = mapp.utils.html`
@@ -180,19 +183,63 @@ export default (layer) => {
         ${mapp.dictionary.layer_style_cluster}`
 
     // Push icon and label into legend grid.
-    grid.push(mapp.utils.html`
+    theme.legend.grid.push(mapp.utils.html`
       <div 
         data-id="cluster"
-        class=${contentsClass.join(' ')}>
+        class=${theme.legend.alignContents}>
         ${icon}${label}`)
   }
 
-  layer.style.legend = mapp.utils.html.node`
+  // Default layout to 'grid'
+  theme.legend.layout ??= 'grid'
+
+  theme.legend.node = mapp.utils.html.node`
     <div class="legend-wrapper">
-      ${switchControl || ''}
-      <div class=${`contents-wrapper ${legendOptions?.layout || 'grid'}`}>
-        ${grid}
-  `
-  
+      ${theme.legend.switch || ''}
+      <div class=${`contents-wrapper ${theme.legend.layout}`}>
+        ${theme.legend.grid}`
+
+  layer.style.legend = theme.legend.node
+
   return layer.style.legend;
+}
+
+function dynamicLegend(layer) {
+
+  // shortcircuit if legend is not dynamic.
+  if (!layer.style.theme?.legend?.dynamic) return;
+
+  layer.L.once('prerender', prerender)
+
+  function prerender() {
+
+    // shortcircuit if legend is no longer dynamic.
+    if (!layer.style.theme?.legend?.dynamic) return;
+
+    // Do not display cat which are disabled/filtered.
+    Object.values(layer.style.theme.cat).forEach(cat => {
+      if (cat.node.querySelector('.disabled')) return;
+      cat.display = 'none'
+    })
+
+    layer.L.once('postrender', () => {
+
+      // timeout to allow for the render method to process categories.
+      setTimeout(() => {
+
+        // shortcircuit if legend is no longer dynamic.
+        if (!layer.style.theme?.legend?.dynamic) return;
+
+        Object.values(layer.style.theme.cat).forEach(cat => {
+          cat.node.style.display = cat.display
+        })
+        
+        layer.L.once('prerender', prerender)
+
+      }, 400)
+    })
+
+    // Will trigger styling/(post)render
+    layer.L.changed()
+  }
 }


### PR DESCRIPTION
A categorical theme with the `legend.dynamic` flag will use pre and post render methods to update the display status of cat entries which have not been flagged by the categorical theme method to be displayed.

This must be tested with MVT and Vector layer, with multiple themes and theme switching.
