### PR TITLE
layer.geomCurrent method

### DIFF
--- a/lib/layer/decorate.mjs
+++ b/lib/layer/decorate.mjs
@@ -9,6 +9,7 @@ export default async layer => {
     hide,
     hideCallbacks: [],
     tableCurrent,
+    geomCurrent,
     tableMax,
     tableMin,
     zoomToExtent,
@@ -327,6 +328,37 @@ function tableCurrent() {
   table = zoom > maxZoomKey ? this.tables[maxZoomKey] : table;
 
   return table;
+}
+
+function geomCurrent() {
+
+  // Return the current table if it exists.
+
+  // A layer must have either a table or tables configuration.
+  if (!this.geoms) return this.geom;
+
+  let geom;
+
+  // Get current zoom level from mapview.
+  const zoom = parseInt(this.mapview.Map.getView().getZoom());
+
+  // Get zoom level keys from layer.tables object.
+  const zoomKeys = Object.keys(this.geoms);
+
+  // Get first zoom level key from array.
+  const minZoomKey = parseInt(zoomKeys[0]);
+  const maxZoomKey = parseInt(zoomKeys[zoomKeys.length - 1]);
+
+  // Get the table for the current zoom level.
+  geom = this.geoms[zoom];
+
+  // Get the first table if the current zoom level is smaller than the min.
+  geom = zoom < minZoomKey ? this.geoms[minZoomKey] : geom;
+
+  // Get the last table if the current zoom level is larger than the max.
+  geom = zoom > maxZoomKey ? this.geoms[maxZoomKey] : geom;
+
+  return geom;
 }
 
 function tableMax() {

--- a/lib/layer/format/mvt.mjs
+++ b/lib/layer/format/mvt.mjs
@@ -55,9 +55,11 @@ export default layer => {
 
   function tileUrlFunction(tileCoord) {
 
-    const tableZ = layer.tableCurrent()
+    const table = layer.tableCurrent()
 
-    if ((!tableZ || !layer.display) && !layer.clones?.size) return layer.source.clear()
+    if ((!table || !layer.display) && !layer.clones?.size) return layer.source.clear()
+
+    const geom = layer.geomCurrent()
 
     // Create a set of feature properties for styling.
     layer.params.fields = [...new Set([
@@ -75,7 +77,8 @@ export default layer => {
       locale: layer.mapview.locale.key,
       layer: layer.key,
       srid: layer.mapview.srid,
-      table: tableZ,
+      table,
+      geom,
       filter: layer.filter?.current,
       ...layer.params
     })}`

--- a/lib/layer/format/vector.mjs
+++ b/lib/layer/format/vector.mjs
@@ -60,6 +60,8 @@ export default layer => {
 
     if (!table) return;
 
+    const geom = layer.geomCurrent()
+
     if (layer.fade) mapp.layer.fade(layer, true)
 
     // Create a set of feature properties for styling.
@@ -90,6 +92,7 @@ export default layer => {
           locale: layer.mapview.locale.key,
           layer: layer.key,
           table,
+          geom,
           srid: layer.srid,
           filter: layer.filter?.current,
           ...layer.params


### PR DESCRIPTION
A layer.geomCurrent method is required to provide the current geometry from the geoms object.