### PR TITLE
Provide layer key as snap option

### DIFF
--- a/lib/mapview/interactions/snap.mjs
+++ b/lib/mapview/interactions/snap.mjs
@@ -25,6 +25,12 @@ export default function(mapview) {
     ...mapview.interaction.snap
   }
 
+  // Check if snap layer exists in mapview.layers.
+  if (!mapview.layers[mapview.interaction.snap.layer]) {
+  console.warn(`Unable to snap to layer:${mapview.interaction.snap.layer} as it is not found in mapview.layers.`)
+  return;
+  }
+
   // Assign snap layer from key if defined.
   mapview.interaction.snap.layer &&= mapview.layers[mapview.interaction.snap.layer] || mapview.interaction.layer
 

--- a/lib/mapview/interactions/snap.mjs
+++ b/lib/mapview/interactions/snap.mjs
@@ -20,8 +20,16 @@ export default function(mapview) {
       }
 
       mapview.Map.removeInteraction(mapview.interaction.snap.interaction)
-    }
+    },
+
+    ...mapview.interaction.snap
   }
+
+  // Assign snap layer from key if defined.
+  mapview.interaction.snap.layer &&= mapview.layers[mapview.interaction.snap.layer] || mapview.interaction.layer
+
+  // Assign interaction as snap layer if undefined.
+  mapview.interaction.snap.layer ??= mapview.interaction.layer
 
   function tileloadend(e) {
 
@@ -30,16 +38,16 @@ export default function(mapview) {
   }
 
   // Only MVT layer have a snapSource.
-  if (mapview.interaction.layer.featureSource) {
+  if (mapview.interaction.snap.layer.featureSource) {
 
     // Create new Vector source for snap features.
     mapview.interaction.snap.source = new ol.source.Vector()
 
     // Assign loadend event to MVT layer featureSource.
-    mapview.interaction.layer.featureSource.on('tileloadend', tileloadend)
+    mapview.interaction.snap.layer.featureSource.on('tileloadend', tileloadend)
 
     mapview.interaction.snap.vectorTileLayer = new ol.layer.VectorTile({
-      source: mapview.interaction.layer.featureSource,
+      source: mapview.interaction.snap.layer.featureSource,
       opacity: 0
     })
   
@@ -49,7 +57,7 @@ export default function(mapview) {
   } else {
 
     // Assign vector source as snap source for vector layer.
-    mapview.interaction.snap.source = mapview.interaction.layer.L.getSource()
+    mapview.interaction.snap.source = mapview.interaction.snap.layer.L.getSource()
   }
 
   // Create snap interaction with snap.source.


### PR DESCRIPTION
Instead of `snap:true` it should be possible to provide a layer key.

```js
"polygon": {
  "snap": {
    "layer": "iuc"
  }
}
```
https://github.com/GEOLYTIX/xyz/wiki/Workspace-Configuration#snap