### PR TITLE
wkt_properties feature format and mvt queries

### DIFF
--- a/lib/layer/Style.mjs
+++ b/lib/layer/Style.mjs
@@ -18,7 +18,18 @@ export default layer => {
       if (Styles) return Styles
     }
 
-    feature.properties = feature.getProperties()
+    if (layer.featuresObject) {
+
+      let id = feature.get('id').toString()
+
+      feature.properties = layer.featuresObject[id]
+
+      if (!feature.properties) return;
+
+    } else {
+
+      feature.properties = feature.getProperties()
+    }
 
     // Geojson features have a properties property
     if (feature.properties.properties) {

--- a/lib/layer/format/mvt.mjs
+++ b/lib/layer/format/mvt.mjs
@@ -58,47 +58,27 @@ export default layer => {
 
   // Assign wkt properties load method.
   if (layer.wkt_properties) {
-    layer.source.setTileUrlFunction(wktTileUrlFunction)
-    layer.mapview.Map.getTargetElement().addEventListener('changeEnd', changeEndLoad);
+    layer.source.setTileUrlFunction(wktTileUrlFunction(layer))
+    layer.mapview.Map.getTargetElement().addEventListener('changeEnd', () => changeEndLoad(layer));
 
   } else {
 
-    layer.source.setTileUrlFunction(tileUrlFunction)
+    layer.source.setTileUrlFunction(tileUrlFunction(layer))
   }
 
-  function tileUrlFunction(tileCoord) {
+  layer.L = new ol.layer.VectorTile({
+    key: layer.key,
+    source: layer.source,
+    renderBuffer: 200,
+    //renderMode: 'vector',
+    zIndex: layer.style?.zIndex || 1,
+    style: mapp.layer.Style(layer)
+  })
+}
 
-    const table = layer.tableCurrent()
+function wktTileUrlFunction(layer) {
 
-    if ((!table || !layer.display) && !layer.clones?.size) return layer.source.clear()
-
-    const geom = layer.geomCurrent()
-
-    // Create a set of feature properties for styling.
-    layer.params.fields = [...new Set([
-      Array.isArray(layer.style.theme?.fields) ?
-        layer.style.theme.fields : layer.style.theme?.field,
-      layer.style.theme?.field,
-      layer.style.label?.field
-    ].flat().filter(field => !!field))]
-
-    const url = `${layer.mapview.host}/api/query?${mapp.utils.paramString({
-      template: 'mvt',
-      z: tileCoord[0],
-      x: tileCoord[1],
-      y: tileCoord[2],
-      locale: layer.mapview.locale.key,
-      layer: layer.key,
-      table,
-      geom,
-      filter: layer.filter?.current,
-      ...layer.params
-    })}`
-
-    return url
-  }
-
-  function wktTileUrlFunction(tileCoord) {
+  return tileCoord => {
 
     const table = layer.tableCurrent()
 
@@ -120,19 +100,11 @@ export default layer => {
 
     return url
   }
+}
 
-  layer.L = new ol.layer.VectorTile({
-    key: layer.key,
-    source: layer.source,
-    renderBuffer: 200,
-    //renderMode: 'vector',
-    zIndex: layer.style?.zIndex || 1,
-    style: mapp.layer.Style(layer)
-  })
+function tileUrlFunction(layer) {
 
-  function changeEndLoad() {
-
-    layer.xhr?.abort()
+  return tileCoord => {
 
     const table = layer.tableCurrent()
 
@@ -148,45 +120,80 @@ export default layer => {
       layer.style.label?.field
     ].flat().filter(field => !!field))]
 
-    const bounds = layer.mapview.getBounds()
-
-    // Assign current viewport if queryparam is truthy.
-    let viewport = [bounds.west, bounds.south, bounds.east, bounds.north, layer.mapview.srid];
-
-    // Assign current viewport if queryparam is truthy.
-    let z = layer.mapview.Map.getView().getZoom();
-
-    layer.xhr = new XMLHttpRequest()
-
-    layer.xhr.responseType = 'json'
-
-    layer.xhr.onload = e => {
-
-      layer.featuresObject = {}
-
-      if (!e.target?.response) {
-        layer.L.changed()
-        return;
-      }
-
-      mapp.utils.featureFormats.wkt_properties(layer, e.target.response)
-
-      layer.L.changed()
-    }
-
-    layer.xhr.open('GET', `${layer.mapview.host}/api/query?${mapp.utils.paramString({
-      template: 'wkt',
+    const url = `${layer.mapview.host}/api/query?${mapp.utils.paramString({
+      template: 'mvt',
+      z: tileCoord[0],
+      x: tileCoord[1],
+      y: tileCoord[2],
       locale: layer.mapview.locale.key,
       layer: layer.key,
       table,
       geom,
-      no_geom: true,
-      viewport,
-      z,
       filter: layer.filter?.current,
       ...layer.params
-    })}`)
+    })}`
 
-    layer.xhr.send()
+    return url
   }
+
+}
+
+function changeEndLoad(layer) {
+
+  layer.xhr?.abort()
+
+  const table = layer.tableCurrent()
+
+  if ((!table || !layer.display) && !layer.clones?.size) return layer.source.clear()
+
+  const geom = layer.geomCurrent()
+
+  // Create a set of feature properties for styling.
+  layer.params.fields = [...new Set([
+    Array.isArray(layer.style.theme?.fields) ?
+      layer.style.theme.fields : layer.style.theme?.field,
+    layer.style.theme?.field,
+    layer.style.label?.field
+  ].flat().filter(field => !!field))]
+
+  const bounds = layer.mapview.getBounds()
+
+  // Assign current viewport if queryparam is truthy.
+  let viewport = [bounds.west, bounds.south, bounds.east, bounds.north, layer.mapview.srid];
+
+  // Assign current viewport if queryparam is truthy.
+  let z = layer.mapview.Map.getView().getZoom();
+
+  layer.xhr = new XMLHttpRequest()
+
+  layer.xhr.responseType = 'json'
+
+  layer.xhr.onload = e => {
+
+    layer.featuresObject = {}
+
+    if (!e.target?.response) {
+      layer.L.changed()
+      return;
+    }
+
+    mapp.utils.featureFormats.wkt_properties(layer, e.target.response)
+
+    layer.L.changed()
+  }
+
+  layer.xhr.open('GET', `${layer.mapview.host}/api/query?${mapp.utils.paramString({
+    template: 'wkt',
+    locale: layer.mapview.locale.key,
+    layer: layer.key,
+    table,
+    geom,
+    no_geom: true,
+    viewport,
+    z,
+    filter: layer.filter?.current,
+    ...layer.params
+  })}`)
+
+  layer.xhr.send()
 }

--- a/lib/layer/format/mvt.mjs
+++ b/lib/layer/format/mvt.mjs
@@ -26,7 +26,7 @@ export default layer => {
   layer.reload = () => {
 
     if (layer.wkt_properties) {
-      () => changeEndLoad(layer)
+      changeEndLoad(layer)
       return;
     }
 

--- a/lib/layer/format/mvt.mjs
+++ b/lib/layer/format/mvt.mjs
@@ -26,7 +26,7 @@ export default layer => {
   layer.reload = () => {
 
     if (layer.wkt_properties) {
-      changeEndLoad()
+      () => changeEndLoad(layer)
       return;
     }
 

--- a/lib/layer/format/mvt.mjs
+++ b/lib/layer/format/mvt.mjs
@@ -8,7 +8,7 @@ export default layer => {
     console.warn(`Layer ${layer.key} must be set to use SRID 3857.`)
     return;
   }
-  
+
   // Assign empty style object if nullish.
   layer.style ??= {}
 
@@ -25,9 +25,13 @@ export default layer => {
 
   layer.reload = () => {
 
+    if (layer.wkt_properties) {
+      changeEndLoad()
+      return;
+    }
+
     layer.source.clear()
     layer.source.refresh()
-    layer.tilesLoaded = []
     layer.featureSource.refresh()
   }
 
@@ -44,14 +48,23 @@ export default layer => {
     cacheSize: 0,
     tileUrlFunction
   })
- 
+
   // Define source for mvt layer.
   layer.source = new ol.source.VectorTile({
     format: new ol.format.MVT(),
-    transition: 0,
-    cacheSize: 0,
-    tileUrlFunction
+    transition: layer.transition,
+    cacheSize: layer.cacheSize
   })
+
+  // Assign wkt properties load method.
+  if (layer.wkt_properties) {
+    layer.source.setTileUrlFunction(wktTileUrlFunction)
+    layer.mapview.Map.getTargetElement().addEventListener('changeEnd', changeEndLoad);
+
+  } else {
+
+    layer.source.setTileUrlFunction(tileUrlFunction)
+  }
 
   function tileUrlFunction(tileCoord) {
 
@@ -76,11 +89,33 @@ export default layer => {
       y: tileCoord[2],
       locale: layer.mapview.locale.key,
       layer: layer.key,
-      srid: layer.mapview.srid,
       table,
       geom,
       filter: layer.filter?.current,
       ...layer.params
+    })}`
+
+    return url
+  }
+
+  function wktTileUrlFunction(tileCoord) {
+
+    const table = layer.tableCurrent()
+
+    if ((!table || !layer.display) && !layer.clones?.size) return layer.source.clear()
+
+    const geom = layer.geomCurrent()
+
+    const url = `${layer.mapview.host}/api/query?${mapp.utils.paramString({
+      template: 'mvt',
+      z: tileCoord[0],
+      x: tileCoord[1],
+      y: tileCoord[2],
+      locale: layer.mapview.locale.key,
+      layer: layer.key,
+      srid: layer.mapview.srid,
+      table,
+      geom
     })}`
 
     return url
@@ -95,4 +130,63 @@ export default layer => {
     style: mapp.layer.Style(layer)
   })
 
+  function changeEndLoad() {
+
+    layer.xhr?.abort()
+
+    const table = layer.tableCurrent()
+
+    if ((!table || !layer.display) && !layer.clones?.size) return layer.source.clear()
+
+    const geom = layer.geomCurrent()
+
+    // Create a set of feature properties for styling.
+    layer.params.fields = [...new Set([
+      Array.isArray(layer.style.theme?.fields) ?
+        layer.style.theme.fields : layer.style.theme?.field,
+      layer.style.theme?.field,
+      layer.style.label?.field
+    ].flat().filter(field => !!field))]
+
+    const bounds = layer.mapview.getBounds()
+
+    // Assign current viewport if queryparam is truthy.
+    let viewport = [bounds.west, bounds.south, bounds.east, bounds.north, layer.mapview.srid];
+
+    // Assign current viewport if queryparam is truthy.
+    let z = layer.mapview.Map.getView().getZoom();
+
+    layer.xhr = new XMLHttpRequest()
+
+    layer.xhr.responseType = 'json'
+
+    layer.xhr.onload = e => {
+
+      layer.featuresObject = {}
+
+      if (!e.target?.response) {
+        layer.L.changed()
+        return;
+      }
+
+      mapp.utils.featureFormats.wkt_properties(layer, e.target.response)
+
+      layer.L.changed()
+    }
+
+    layer.xhr.open('GET', `${layer.mapview.host}/api/query?${mapp.utils.paramString({
+      template: 'wkt',
+      locale: layer.mapview.locale.key,
+      layer: layer.key,
+      table,
+      geom,
+      no_geom: true,
+      viewport,
+      z,
+      filter: layer.filter?.current,
+      ...layer.params
+    })}`)
+
+    layer.xhr.send()
+  }
 }

--- a/lib/layer/format/mvt.mjs
+++ b/lib/layer/format/mvt.mjs
@@ -82,7 +82,17 @@ function wktTileUrlFunction(layer) {
 
     const table = layer.tableCurrent()
 
-    if ((!table || !layer.display) && !layer.clones?.size) return layer.source.clear()
+    // The layer has no data for this zoom level.
+    if (!table) {
+      layer.source.clear();
+      return;
+    }
+
+    // The layer does not display and doesn't have clones.
+    if (!layer.display && !layer.clones?.size) {
+      layer.source.clear();
+      return;
+    }
 
     const geom = layer.geomCurrent()
 
@@ -108,7 +118,17 @@ function tileUrlFunction(layer) {
 
     const table = layer.tableCurrent()
 
-    if ((!table || !layer.display) && !layer.clones?.size) return layer.source.clear()
+    // The layer has no data for this zoom level.
+    if (!table) {
+      layer.source.clear();
+      return;
+    }
+
+    // The layer does not display and doesn't have clones.
+    if (!layer.display && !layer.clones?.size) {
+      layer.source.clear();
+      return;
+    }
 
     const geom = layer.geomCurrent()
 

--- a/lib/utils/featureFormats.mjs
+++ b/lib/utils/featureFormats.mjs
@@ -1,100 +1,121 @@
 function initializeFieldStats(layer) {
-    if (layer.style?.theme?.field_stats) {
-        layer.style.theme.updated = true;
-        layer.style.theme.field_stats[layer.style.theme.field] = {
-            values: []
-        };
-    }
+  if (layer.style?.theme?.field_stats) {
+    layer.style.theme.updated = true;
+    layer.style.theme.field_stats[layer.style.theme.field] = {
+      values: []
+    };
+  }
 }
 
 export function geojson(layer, features) {
 
-    const formatGeojson = new ol.format.GeoJSON
+  const formatGeojson = new ol.format.GeoJSON
 
-    initializeFieldStats(layer);
+  initializeFieldStats(layer);
 
-    return features.map((feature) => {
+  return features.map((feature) => {
 
-        const properties = feature.properties
+    const properties = feature.properties
 
-        if (layer.style?.theme?.field_stats) {
+    if (layer.style?.theme?.field_stats) {
 
-            layer.style.theme.field_stats[layer.style.theme.field].values.push(parseFloat(properties[layer.style.theme.field]));
-        }
+      layer.style.theme.field_stats[layer.style.theme.field].values.push(parseFloat(properties[layer.style.theme.field]));
+    }
 
-        return new ol.Feature({
-            id: feature.id,
-            geometry: formatGeojson.readGeometry(feature.geometry, {
-                dataProjection: 'EPSG:' + layer.srid,
-                featureProjection: 'EPSG:' + layer.mapview.srid,
-            }),
-            properties
-        })
-
+    return new ol.Feature({
+      id: feature.id,
+      geometry: formatGeojson.readGeometry(feature.geometry, {
+        dataProjection: 'EPSG:' + layer.srid,
+        featureProjection: 'EPSG:' + layer.mapview.srid,
+      }),
+      properties
     })
+
+  })
 }
 
 export function wkt(layer, features) {
 
-    const formatWKT = new ol.format.WKT
+  const formatWKT = new ol.format.WKT
 
-    initializeFieldStats(layer);
+  initializeFieldStats(layer);
 
-    return features.map((feature) => {
+  return features.map((feature) => {
 
-        const properties = {}
+    const properties = {}
 
-        // Assign field key and value to properties object
-        layer.params.fields?.forEach((field, i) => {
+    // Assign field key and value to properties object
+    layer.params.fields?.forEach((field, i) => {
 
-            if (layer.style?.theme?.field_stats?.[field]) {
+      if (layer.style?.theme?.field_stats?.[field]) {
 
-                layer.style?.theme?.field_stats?.[field].values.push(parseFloat(feature[i + 2]));
-            }
+        layer.style?.theme?.field_stats?.[field].values.push(parseFloat(feature[i + 2]));
+      }
 
-            properties[field] = feature[i + 2]
-        })
-
-        // Return feature from geometry with properties.
-        return new ol.Feature({
-            id: feature.shift(),
-            geometry: formatWKT.readGeometry(feature.shift(), {
-                dataProjection: 'EPSG:' + layer.srid,
-                featureProjection: 'EPSG:' + layer.mapview.srid,
-            }),
-            properties
-        })
-
+      properties[field] = feature[i + 2]
     })
 
+    // Return feature from geometry with properties.
+    return new ol.Feature({
+      id: feature.shift(),
+      geometry: formatWKT.readGeometry(feature.shift(), {
+        dataProjection: 'EPSG:' + layer.srid,
+        featureProjection: 'EPSG:' + layer.mapview.srid,
+      }),
+      properties
+    })
+
+  })
+}
+
+export function wkt_properties(layer, features) {
+
+  initializeFieldStats(layer);
+
+  for (const feature of features) {
+
+    const properties = {}
+
+    // Assign field key and value to properties object
+    layer.params.fields?.forEach((field, i) => {
+
+      if (layer.style?.theme?.field_stats?.[field]) {
+
+        layer.style?.theme?.field_stats?.[field].values.push(parseFloat(feature[i + 1]));
+      }
+
+      properties[field] = feature[i + 1]
+    })
+
+    layer.featuresObject[feature.shift()] = properties
+  }
 }
 
 export function cluster(layer, features) {
 
-    layer.max_size = 1
+  layer.max_size = 1
 
-    return features.map((vals, i) => {
+  return features.map((vals, i) => {
 
-        const geometry = new ol.geom.Point(vals.shift())
+    const geometry = new ol.geom.Point(vals.shift())
 
-        const count = vals.shift()
+    const count = vals.shift()
 
-        layer.max_size = layer.max_size > count ? layer.max_size: count;
+    layer.max_size = layer.max_size > count ? layer.max_size : count;
 
-        const id = vals.shift()
+    const id = vals.shift()
 
-        const properties = {count}
-        
-        layer.params.fields.forEach((field, i) => {
-            properties[field] = vals[i]
-        })
+    const properties = { count }
 
-        return new ol.Feature({
-            id,
-            geometry,
-            ...properties
-        })
-
+    layer.params.fields.forEach((field, i) => {
+      properties[field] = vals[i]
     })
 
+    return new ol.Feature({
+      id,
+      geometry,
+      ...properties
+    })
+
+  })
 }

--- a/mod/workspace/templates/_queries.js
+++ b/mod/workspace/templates/_queries.js
@@ -57,5 +57,9 @@ module.exports = {
   mvt: {
     render: require('./mvt'),
     value_only: true
+  },
+  mvt_geom: {
+    render: require('./mvt_geom'),
+    value_only: true
   }
 }

--- a/mod/workspace/templates/mvt_geom.js
+++ b/mod/workspace/templates/mvt_geom.js
@@ -1,13 +1,5 @@
 module.exports = _ => {
 
-  // Get fields array from query params.
-  const fields = _.fields?.split(',')
-    .map(field => `${_.workspace.templates[field]?.template || field} AS ${field}`)
-    .filter(field => !!field)
-
-  // Push label (cluster) into fields
-  _.label && fields.push(`${_.workspace.templates[_.label]?.template || _.label} AS ${_.label}`)
-
   let
     x = parseInt(_.x),
     y = parseInt(_.y),
@@ -19,7 +11,6 @@ module.exports = _ => {
     FROM (
       SELECT
         ${_.layer.qID || null} as id,
-        ${Array.isArray(fields) ? fields.toString() + ',' : ''}
         ST_AsMVTGeom(
           ${_.geom},
           ST_TileEnvelope(${z},${x},${y}),
@@ -29,11 +20,9 @@ module.exports = _ => {
         ) geom
       FROM ${_.table}
       WHERE
-        ${_.layer.z_field && `${_.layer.z_field} < ${z} AND` || ''}
         ST_Intersects(
           ST_TileEnvelope(${z},${x},${y}),
           ${_.geom}
         )
-        \${filter}
       ) tile`
 }


### PR DESCRIPTION
It should be possible to request feature properties for the viewport separate from the tile (geometries).

The `wkt_properties()` featureFormat method processes wkt features without geometries. The feature properties are assigned with the feature [id] key to the `layer.featuresObject{}`.

The openlayers `layer.L.changed()` is used to re-style the layer after the feature properties are loaded. The removes the need to hook into the tile load and rendered methods.

Only the feature properties need to be loaded if the current layer filter are changed.

Having filter statistics will allow to create dynamic themes and legends which can use viewport statistics of loaded features.

The `mvt_geom` query will ignore the any filters. This will allow to create tile caches for shared geometries.

The `wkt_properties:true` flag will enable this mode for mvt layer.

The [tile] `cachSize` can be configured as an integer on the layer.