### PR TITLE
syncFields check

### DIFF
--- a/lib/location/decorate.mjs
+++ b/lib/location/decorate.mjs
@@ -97,9 +97,9 @@ async function syncFields(fields) {
       id: this.id,
       fields: fields.join(),
     }));
-
-  // If response is null, return. 
-  if (!response) return;
+  
+  // Return if response is falsy or error.
+  if (!response || response instanceof Error) return;
 
   this.infoj
     .filter(entry => typeof response[entry.field] !== 'undefined')

--- a/lib/location/decorate.mjs
+++ b/lib/location/decorate.mjs
@@ -75,7 +75,7 @@ async function update() {
     })
     .flat()
     .filter(dependents => dependents !== undefined)
-  
+
   // sync dependent fields
   if (dependents.length) await this.syncFields([...new Set(dependents)])
 
@@ -98,6 +98,9 @@ async function syncFields(fields) {
       fields: fields.join(),
     }));
 
+  // If response is null, return. 
+  if (!response) return;
+
   this.infoj
     .filter(entry => typeof response[entry.field] !== 'undefined')
     .forEach(entry => {
@@ -105,7 +108,7 @@ async function syncFields(fields) {
     })
 }
 
-function flyTo (maxZoom) {
+function flyTo(maxZoom) {
 
   const sourceVector = new ol.source.Vector();
 
@@ -117,14 +120,14 @@ function flyTo (maxZoom) {
       && sourceVector.addFeatures(source.getFeatures())
   })
 
-  this.layer.mapview.fitView(sourceVector.getExtent(),{
+  this.layer.mapview.fitView(sourceVector.getExtent(), {
     maxZoom
   });
 }
 
 async function trash() {
 
-  if(!confirm(mapp.dictionary.confirm_delete)) return;
+  if (!confirm(mapp.dictionary.confirm_delete)) return;
 
   await mapp.utils.xhr(`${this.layer.mapview.host}/api/query?` +
     mapp.utils.paramString({


### PR DESCRIPTION
This PR adds a single line of code to address a small bug. 
If syncFields is called for dependents that do not yet have a value - the response will be null. 
If the response is null, then 
``` js 
this.infoj
    .filter(entry => typeof response[entry.field] !== 'undefined')
``` 
will error as the response contains nothing. 
As such, I simply added a check on if response is null, just return before the filtering to remove this error. 