### PR TITLE
Allow entry.query and entry.query for dataviews

### DIFF
--- a/lib/ui/locations/infoj.mjs
+++ b/lib/ui/locations/infoj.mjs
@@ -120,9 +120,41 @@ export default (location, infoj) => {
         entry.location.layer.queryparams || {},
         entry.location.layer.mapview.locale.queryparams || {})
 
-      // Check whether query returns data.
-      if (entry.queryCheck || entry.run === true) {
+      // Check if the query is attached to type dataview 
+      if (entry.type === 'dataview') {
+        // Check whethe query returns data.
+        if (entry.queryCheck || entry.run === true) {
 
+          // Stringify paramString from object.
+          const paramString = mapp.utils.paramString(mapp.utils.queryParams(entry))
+
+          // Run the entry query.
+          mapp.utils
+            .xhr(`${entry.host || entry.location.layer.mapview.host}/api/query?${paramString}`)
+            .then(response => {
+
+              // Assign query response as entry value.
+              entry.value = response;
+
+              // Check whether entry should be skipped.
+              if (skipEntry(entry)) {
+
+                // Remove the entry.node from location view.
+                entry.node.remove();
+                return;
+              }
+
+              // Create element to be appended into empty entry.node
+              const el = mapp.ui.locations.entries[entry.type]?.(entry)
+
+              el && entry.node.append(el)
+            })
+
+          continue;
+        }
+      } else {
+
+        // If the query is just attached to the entry, run it and store the response[field] in entry.value.
         // Stringify paramString from object.
         const paramString = mapp.utils.paramString(mapp.utils.queryParams(entry))
 
@@ -131,8 +163,12 @@ export default (location, infoj) => {
           .xhr(`${entry.host || entry.location.layer.mapview.host}/api/query?${paramString}`)
           .then(response => {
 
+            // Check if response is null or if the response[field] is null.
+            if (response === null || response[entry.field] === null) {
+              return;
+            }
             // Assign query response as entry value.
-            entry.value = response;
+            entry.value = response[entry.field];
 
             // Check whether entry should be skipped.
             if (skipEntry(entry)) {
@@ -147,8 +183,6 @@ export default (location, infoj) => {
 
             el && entry.node.append(el)
           })
-
-        continue;
       }
 
     }


### PR DESCRIPTION
**What this PR Fixes**
An `entry.query` of the configuration below will not error or warn but will not return a value. 
This is as the current set up assumes all `entry.query` are part of a `dataview`, so assigns the query `response` as `entry.value`. 
``` json 
 {
                        "title": "Field",
                        "field": "field_name",
                        "query": "get_field_name",
                        "queryparams": {
                            "id": true
                        },
                        "inline": true,
                        "skipNullValue": true
                    }
```

**How this has been done**
To fix this, I have updated `infoj.mjs` to have a code block specifically for `entry.query && entry.dataview` which works in the current way. 
I then added a new block of code specifically for `entry.query` that is for the entry. This new code block runs the query, and then assigns `response[entry.field]` to `entry.value` - ensuring that the above configuration will work.