### PR TITLE
Layer failing to decorate must not be added to list

### DIFF
--- a/lib/layer/decorate.mjs
+++ b/lib/layer/decorate.mjs
@@ -3,6 +3,8 @@ export default async layer => {
   // Decorate layer format methods.
   await mapp.layer.formats[layer.format](layer);
 
+  if (!layer.L) return;
+
   Object.assign(layer, {
     show,
     showCallbacks: [],

--- a/lib/mapview/addLayer.mjs
+++ b/lib/mapview/addLayer.mjs
@@ -29,6 +29,8 @@ export default async function (layers) {
 
     await mapp.layer.decorate(layer);
 
+    if (!layer.L) continue;
+
     this.layers[layer.key] = layer;
 
     layer.display && layer.show();


### PR DESCRIPTION
A layer must not be added to the layers list if it fails to decorate from the format method, e.g. wrong srid.