### PR TITLE
Update location_get query

### DIFF
--- a/lib/location/get.mjs
+++ b/lib/location/get.mjs
@@ -42,6 +42,9 @@ export default async function (location, list = location.layer.mapview.locations
       table: location.table,
       id: location.id,
     }));
+  
+  // Error will be logged from xhr utils.
+  if (response instanceof Error) return;
 
   if (!response) {
 

--- a/mod/workspace/templates/location_get.js
+++ b/mod/workspace/templates/location_get.js
@@ -1,11 +1,15 @@
 module.exports = _ => {
 
   const fields = _.layer.infoj
-    .filter(entry => !_.fields || _.fields?.split(',').includes(entry.field))
-    .filter(entry => !entry.query)
-    .filter(entry => entry.type !== 'key')
+
+    // Entry must have a field defined.
     .filter(entry => entry.field)
-    .map(entry => `(${entry.fieldfx || entry.field}) AS ${entry.field}`)
+
+    // Entry must NOT have a query defined.
+    .filter(entry => !entry.query)
+
+    // Map either fieldfx or template SQL if available.
+    .map(entry => `(${entry.fieldfx || _.workspace.templates[entry.field]?.template || entry.field}) AS ${entry.field}`)
 
   return `
     SELECT ${fields.join()}

--- a/mod/workspace/templates/location_get.js
+++ b/mod/workspace/templates/location_get.js
@@ -2,11 +2,14 @@ module.exports = _ => {
 
   const fields = _.layer.infoj
 
+    // Entry must NOT have a query defined.
+    .filter(entry => !entry.query)
+
     // Entry must have a field defined.
     .filter(entry => entry.field)
 
-    // Entry must NOT have a query defined.
-    .filter(entry => !entry.query)
+    // Only include fields from the fields[] array param.
+    .filter(entry => !_.fields || _.fields?.split(',').includes(entry.field))
 
     // Map either fieldfx or template SQL if available.
     .map(entry => `(${entry.fieldfx || _.workspace.templates[entry.field]?.template || entry.field}) AS ${entry.field}`)


### PR DESCRIPTION
The fields param and entry.key check in the `location_get` query template were legacy and not actually used.

The `location_get` query should check for templates matching the field name.

The location `get()` method should return if the location_get query fails.