### PR TITLE
entry type:tab chkbox

### DIFF
--- a/lib/ui/locations/entries/tab.mjs
+++ b/lib/ui/locations/entries/tab.mjs
@@ -13,7 +13,7 @@ export default entry => {
   // Show the tab if display is true.
   entry.display && entry.show()
 
-  const chkbox = mapp.ui.elements.chkbox({
+  return mapp.ui.elements.chkbox({
     label: entry.label,
     checked: !!entry.display,
     onchange: (checked) => {
@@ -27,6 +27,4 @@ export default entry => {
   
     }
   })
-  
-  return mapp.utils.html.node`${chkbox}`
 }


### PR DESCRIPTION
The entry `type:tab` should return the chkbox element not a document fragment containing the chkbox. The chkbox element util returns a node.