### PR TITLE
Basic authorization header

### DIFF
--- a/api/api.js
+++ b/api/api.js
@@ -123,6 +123,11 @@ module.exports = async (req, res) => {
   // The authentication method returns an error.
   if (user && user instanceof Error) {
 
+    if (req.headers.authorization) {
+
+      return res.status(401).send(user.message)
+    }
+
     // Remove cookie.
     res.setHeader('Set-Cookie', `${process.env.TITLE}=null;HttpOnly;Max-Age=0;Path=${process.env.DIR || '/'};SameSite=Strict${!req.headers.host.includes('localhost') && ';Secure' || ''}`)
 

--- a/mod/user/_user.js
+++ b/mod/user/_user.js
@@ -52,7 +52,7 @@ const methods = {
   }
 }
 
-module.exports = (req, res) => {
+module.exports = async (req, res) => {
 
   const method = methods[req.params.method]
 

--- a/mod/user/acl.js
+++ b/mod/user/acl.js
@@ -2,37 +2,30 @@ const { Pool } = require('pg');
 
 const connection = process.env.PRIVATE?.split('|') || process.env.PUBLIC?.split('|')
 
-let pool = null
+if(!connection || !connection[1]) return
 
-module.exports = () => {
+const acl_table = connection[1].split('.').pop()
 
-  if(!connection || !connection[1]) return
+const acl_schema = connection[1].split('.')[0] === acl_table ? 'public' : connection[1].split('.')[0]
 
-  const acl_table = connection[1].split('.').pop()
+const pool = new Pool({
+  connectionString: connection[0]
+})
 
-  const acl_schema = connection[1].split('.')[0] === acl_table ? 'public' : connection[1].split('.')[0]
+module.exports = async (q, arr) => {
 
-  // Create PostgreSQL connection pool for ACL table.
-  pool ??= new Pool({
-    connectionString: connection[0]
-  })
+  try {
 
-  // Method to query ACL. arr must be empty array by default.
-  return async (q, arr) => {
+    const client = await pool.connect()
 
-    try {
+    const { rows } = await client.query(q.replace(/acl_table/g, acl_table).replace(/acl_schema/g, acl_schema), arr)
 
-      const client = await pool.connect()
+    client.release()
 
-      const { rows } = await client.query(q.replace(/acl_table/g, acl_table).replace(/acl_schema/g, acl_schema), arr)
+    return rows
 
-      client.release()
-      
-      return rows
-    
-    } catch (err) {
-      console.error(err)
-      return err
-    }
+  } catch (err) {
+    console.error(err)
+    return err
   }
 }

--- a/mod/user/add.js
+++ b/mod/user/add.js
@@ -1,4 +1,4 @@
-const acl = require('./acl')()
+const acl = require('./acl')
 
 module.exports = async (req, res) => {
 

--- a/mod/user/auth.js
+++ b/mod/user/auth.js
@@ -1,8 +1,15 @@
 const jwt = require('jsonwebtoken')
 
-const acl = require('./acl')()
+const acl = require('./acl')
+
+const fromACL = require('./fromACL')
 
 module.exports = async (req, res) => {
+
+  if (req.headers.authorization) {
+
+    return await fromACL(req)
+  }
 
   // Get token from params or cookie.
   const token = req.params.token || req.cookies && req.cookies[process.env.TITLE]

--- a/mod/user/delete.js
+++ b/mod/user/delete.js
@@ -1,4 +1,4 @@
-const acl = require('./acl')()
+const acl = require('./acl')
 
 const mailer = require('../utils/mailer')
 

--- a/mod/user/fromACL.js
+++ b/mod/user/fromACL.js
@@ -1,0 +1,211 @@
+const bcrypt = require('bcryptjs')
+
+const crypto = require('crypto')
+
+const mailer = require('../utils/mailer')
+
+const languageTemplates = require('../utils/languageTemplates')
+
+const acl = require('./acl')
+
+const { nanoid } = require('nanoid')
+
+module.exports = async (req) => {
+
+  let email = req.body?.email
+
+  let password = req.body?.password
+
+  if (req.headers.authorization) {
+
+    let user_string = Buffer.from(req.headers.authorization.split(" ")[1], 'base64').toString()
+
+    let email_password = user_string.split(':')
+
+    email ??= email_password[0]
+
+    password ??= email_password[1]
+  }
+
+  const remote_address = req.headers['x-forwarded-for']
+    && /^[A-Za-z0-9.,_-\s]*$/.test(req.headers['x-forwarded-for']) ? req.headers['x-forwarded-for'] : 'invalid'
+    || 'unknown';
+
+  if (!email) return new Error(await languageTemplates({
+    template: 'missing_email',
+    language: req.params.language
+  }))
+
+  if (!password) return new Error(await languageTemplates({
+    template: 'missing_password',
+    language: req.params.language
+  }))
+
+  const date = new Date()
+
+  // Get the host for the account verification email.
+  const host = `${req.headers.origin
+    || req.headers.referer && new URL(req.headers.referer).origin
+    || 'https://' + (process.env.ALIAS || req.headers.host)}${process.env.DIR}`
+
+  // Update access_log and return user record matched by email.
+  let rows = await acl(`
+    UPDATE acl_schema.acl_table
+    SET access_log = array_append(access_log, '${date.toISOString().replace(/\..*/, '')}@${remote_address}')
+    WHERE lower(email) = lower($1)
+    RETURNING email, roles, language, blocked, approved, approved_by, verified, admin, password ${process.env.APPROVAL_EXPIRY ? ', expires_on;' : ';'}`,
+    [email])
+
+  if (rows instanceof Error) return new Error(await languageTemplates({
+    template: 'failed_query',
+    language: req.params.language
+  }))
+
+  // Get user record from first row.
+  const user = rows[0]
+
+  if (!user) return new Error('auth_failed')
+
+  // Blocked user cannot login.
+  if (user.blocked) return new Error(await languageTemplates({
+    template: 'user_blocked',
+    language: user.language || req.params.language
+  }))
+
+  // Non admin accounts may expire.
+  if (!user.admin && process.env.APPROVAL_EXPIRY) {
+
+    // User account has expired.
+    if (user.expires_on !== null && user.expires_on < new Date() / 1000) {
+
+      // Remove user approval.
+      if (user.approved) {
+
+        // Remove approval of expired user account.
+        rows = await acl(`
+          UPDATE acl_schema.acl_table
+          SET approved = false
+          WHERE lower(email) = lower($1);`,
+          [email])
+
+        if (rows instanceof Error) return new Error(await languageTemplates({
+          template: 'failed_query',
+          language: req.params.language
+        }))
+      }
+
+      return new Error(await languageTemplates({
+        template: 'user_expired',
+        language: user.language
+      }))
+
+    }
+
+  }
+
+  // Accounts must be verified and approved for login
+  if (!user.verified || !user.approved) {
+
+    await mailer({
+      template: 'failed_login',
+      language: user.language,
+      to: user.email,
+      host: host,
+      remote_address
+    })
+
+    return new Error('user_not_verified')
+  }
+
+  // Check password from post body against encrypted password from ACL.
+  if (bcrypt.compareSync(password, user.password)) {
+
+    // password must be removed after check
+    delete user.password
+
+    if (process.env.NANO_SESSION) {
+
+      const nano_session = nanoid()
+
+      user.session = nano_session
+
+      rows = await acl(`
+        UPDATE acl_schema.acl_table
+        SET session = '${nano_session}'
+        WHERE lower(email) = lower($1)`,
+        [email])
+
+      if (rows instanceof Error) return new Error(await languageTemplates({
+        template: 'failed_query',
+        language: req.params.language
+      }))
+
+    }
+
+    return user
+  }
+
+  // password must be removed after check
+  delete user.password
+
+  // FAILED LOGIN
+  // Password from login form does NOT match encrypted password in ACL!
+
+  // Increase failed login attempts counter by 1.
+  rows = await acl(`
+    UPDATE acl_schema.acl_table
+    SET failedattempts = failedattempts + 1
+    WHERE lower(email) = lower($1)
+    RETURNING failedattempts;`, [email])
+
+  if (rows instanceof Error) return new Error(await languageTemplates({
+    template: 'failed_query',
+    language: req.params.language
+  }))
+
+  // Check whether failed login attempts exceeds limit.
+  if (rows[0].failedattempts >= parseInt(process.env.FAILED_ATTEMPTS || 3)) {
+
+    // Create a verificationtoken.
+    const verificationtoken = crypto.randomBytes(20).toString('hex')
+
+    // Store verificationtoken and remove verification status.
+    rows = await acl(`
+      UPDATE acl_schema.acl_table
+      SET
+        verified = false,
+        verificationtoken = '${verificationtoken}'
+      WHERE lower(email) = lower($1);`, [email])
+
+    if (rows instanceof Error) return new Error(await languageTemplates({
+      template: 'failed_query',
+      language: req.params.language
+    }))
+
+    await mailer({
+      template: 'locked_account',
+      language: user.language,
+      to: user.email,
+      host: host,
+      failed_attempts: parseInt(process.env.FAILED_ATTEMPTS) || 3,
+      verificationtoken: verificationtoken,
+      remote_address
+    })
+
+    return new Error(await languageTemplates({
+      template: 'user_locked',
+      language: user.language
+    }))
+  }
+
+  // Login has failed but account is not locked (yet).
+  await mailer({
+    template: 'login_incorrect',
+    language: user.language,
+    to: user.email,
+    host: host,
+    remote_address
+  })
+
+  return new Error('auth_failed')
+}

--- a/mod/user/fromACL.js
+++ b/mod/user/fromACL.js
@@ -27,9 +27,8 @@ module.exports = async (req) => {
     password ??= email_password[1]
   }
 
-  const remote_address = req.headers['x-forwarded-for']
-    && /^[A-Za-z0-9.,_-\s]*$/.test(req.headers['x-forwarded-for']) ? req.headers['x-forwarded-for'] : 'invalid'
-    || 'unknown';
+  const remote_address = /^[A-Za-z0-9.,_-\s]*$/.test(req.headers['x-forwarded-for'])
+   ? req.headers['x-forwarded-for'] : undefined;
 
   if (!email) return new Error(await languageTemplates({
     template: 'missing_email',

--- a/mod/user/fromACL.js
+++ b/mod/user/fromACL.js
@@ -21,9 +21,9 @@ module.exports = async (req) => {
 
   if (req.headers.authorization) {
 
-    let user_string = Buffer.from(req.headers.authorization.split(" ")[1], 'base64').toString()
+    const user_string = Buffer.from(req.headers.authorization.split(" ")[1], 'base64').toString()
 
-    let email_password = user_string.split(':')
+    const email_password = user_string.split(':')
 
     request.email = email_password[0]
 

--- a/mod/user/key.js
+++ b/mod/user/key.js
@@ -13,7 +13,9 @@ module.exports = async (req, res) => {
   
   const user = rows[0]
   
-  if (!user || !user.api || user.api === 'false' || !user.verified || !user.approved || user.blocked) return res.status(401).send('Invalid token.')
+  if (!user || user.api === 'false' || !user.verified || !user.approved || user.blocked) {
+    return res.status(401).send('Invalid token.')
+  }
   
   // Create signed api_token
   const api_user = {
@@ -33,5 +35,4 @@ module.exports = async (req, res) => {
   
   // Send ACL token.
   res.send(key)
-
 }

--- a/mod/user/key.js
+++ b/mod/user/key.js
@@ -1,4 +1,4 @@
-const acl = require('./acl')()
+const acl = require('./acl')
 
 const jwt = require('jsonwebtoken')
 
@@ -13,8 +13,8 @@ module.exports = async (req, res) => {
   
   const user = rows[0]
   
-  if (!user || user.api === 'false' || !user.verified || !user.approved || user.blocked) {
-    return res.status(401).send('Invalid token.')
+  if (!user || !user.api || !user.verified || !user.approved || user.blocked) {
+    return res.status(401).send('Unauthorized access.')
   }
   
   // Create signed api_token

--- a/mod/user/list.js
+++ b/mod/user/list.js
@@ -1,4 +1,4 @@
-const acl = require('./acl')()
+const acl = require('./acl')
 
 module.exports = async (req, res) => {
 

--- a/mod/user/log.js
+++ b/mod/user/log.js
@@ -1,4 +1,4 @@
-const acl = require('./acl')()
+const acl = require('./acl')
 
 module.exports = async (req, res) => {
 

--- a/mod/user/login.js
+++ b/mod/user/login.js
@@ -1,26 +1,14 @@
-const bcrypt = require('bcryptjs')
-
-const crypto = require('crypto')
-
 const jwt = require('jsonwebtoken')
 
-const acl = require('./acl')()
-
-const mailer = require('../utils/mailer')
-
-const languageTemplates = require('../utils/languageTemplates')
+const fromACL = require('./fromACL')
 
 const view = require('../view')
 
-const { nanoid } = require('nanoid')
-
 module.exports = async (req, res) => {
-
-  if (!acl) return res.status(500).send('ACL unavailable.')
 
   if (req.body) {
 
-    const user = await post(req)
+    const user = await fromACL(req)
 
     const redirect = req.cookies && req.cookies[`${process.env.TITLE}_redirect`]
 
@@ -55,7 +43,6 @@ module.exports = async (req, res) => {
     res.setHeader('location', `${redirect && redirect.replace(/([?&]{1})msg={1}[^&]+(&|$)/,'') || process.env.DIR}`)
 
     return res.status(302).send()
-
   }
 
   if (!req.params.msg && req.params.user) {
@@ -82,189 +69,4 @@ async function loginView(req, res) {
   req.params.template = 'login_view'
 
   view(req, res)
-}
-
-async function post(req, res) {
-
-  const remote_address = req.headers['x-forwarded-for']
-    && /^[A-Za-z0-9.,_-\s]*$/.test(req.headers['x-forwarded-for']) ? req.headers['x-forwarded-for'] : 'invalid'
-    || 'unknown';
-
-  if (!req.body.email) return new Error(await languageTemplates({
-    template: 'missing_email',
-    language: req.params.language
-  }))
-  
-  if (!req.body.password) return new Error(await languageTemplates({
-    template: 'missing_password',
-    language: req.params.language
-  }))
-
-  const date = new Date()
-
-  // Get the host for the account verification email.
-  const host = `${req.headers.origin 
-    || req.headers.referer && new URL(req.headers.referer).origin 
-    || 'https://' + (process.env.ALIAS || req.headers.host)}${process.env.DIR}`
-
-  // Update access_log and return user record matched by email.
-  let rows = await acl(`
-    UPDATE acl_schema.acl_table
-    SET access_log = array_append(access_log, '${date.toISOString().replace(/\..*/,'')}@${remote_address}')
-    WHERE lower(email) = lower($1)
-    RETURNING email, roles, language, blocked, approved, approved_by, verified, admin, password ${process.env.APPROVAL_EXPIRY ? ', expires_on;' : ';'}`,
-    [req.body.email])
-
-  if (rows instanceof Error) return new Error(await languageTemplates({
-    template: 'failed_query',
-    language: req.params.language
-  }))
-
-  // Get user record from first row.
-  const user = rows[0]
-
-  if (!user) return new Error('auth_failed')
-
-  // Blocked user cannot login.
-  if (user.blocked) return new Error(await languageTemplates({
-    template: 'user_blocked',
-    language: user.language || req.params.language
-  }))
-  
-  // Non admin accounts may expire.
-  if (!user.admin && process.env.APPROVAL_EXPIRY) {
-
-    // User account has expired.
-    if (user.expires_on !== null && user.expires_on < new Date()/1000) {
-
-      // Remove user approval.
-      if (user.approved) {
-
-        // Remove approval of expired user account.
-        rows = await acl(`
-          UPDATE acl_schema.acl_table
-          SET approved = false
-          WHERE lower(email) = lower($1);`,
-          [req.body.email])
-          
-        if (rows instanceof Error) return new Error(await languageTemplates({
-          template: 'failed_query',
-          language: req.params.language
-        }))
-      }
-
-      return new Error(await languageTemplates({
-        template: 'user_expired',
-        language: user.language
-      }))
-
-    }
-
-  }
-
-  // Accounts must be verified and approved for login
-  if (!user.verified || !user.approved) {
- 
-    await mailer({
-      template: 'failed_login',
-      language: user.language,
-      to: user.email,
-      host: host,
-      remote_address
-    })
-
-    return new Error('user_not_verified')
-  }
-
-  // Check password from post body against encrypted password from ACL.
-  if (bcrypt.compareSync(req.body.password, user.password)) {
-
-    // password must be removed after check
-    delete user.password
-
-    if (process.env.NANO_SESSION) {
-
-      const nano_session = nanoid()
-
-      user.session = nano_session
-
-      rows = await acl(`
-      UPDATE acl_schema.acl_table
-      SET session = '${nano_session}'
-      WHERE lower(email) = lower($1)`,
-      [req.body.email])
-  
-      if (rows instanceof Error) return new Error(await languageTemplates({
-        template: 'failed_query',
-        language: req.params.language
-      }))
-
-    }
-
-    return user
-  }
-
-  // password must be removed after check
-  delete user.password
-
-  // FAILED LOGIN
-  // Password from login form does NOT match encrypted password in ACL!
-
-  // Increase failed login attempts counter by 1.
-  rows = await acl(`
-    UPDATE acl_schema.acl_table
-    SET failedattempts = failedattempts + 1
-    WHERE lower(email) = lower($1)
-    RETURNING failedattempts;`, [req.body.email])
-
-  if (rows instanceof Error) return new Error(await languageTemplates({
-    template: 'failed_query',
-    language: req.params.language
-  }))
-
-  // Check whether failed login attempts exceeds limit.
-  if (rows[0].failedattempts >= parseInt(process.env.FAILED_ATTEMPTS || 3)) {
-
-    // Create a verificationtoken.
-    const verificationtoken = crypto.randomBytes(20).toString('hex')
-
-    // Store verificationtoken and remove verification status.
-    rows = await acl(`
-      UPDATE acl_schema.acl_table
-      SET
-        verified = false,
-        verificationtoken = '${verificationtoken}'
-      WHERE lower(email) = lower($1);`, [req.body.email])
-
-    if (rows instanceof Error) return new Error(await languageTemplates({
-      template: 'failed_query',
-      language: req.params.language
-    }))
- 
-    await mailer({
-      template: 'locked_account',
-      language: user.language,
-      to: user.email,
-      host: host,
-      failed_attempts: parseInt(process.env.FAILED_ATTEMPTS) || 3,
-      verificationtoken: verificationtoken,
-      remote_address
-    })
-
-    return new Error(await languageTemplates({
-      template: 'user_locked',
-      language: user.language
-    }))
-  }
-
-  // Login has failed but account is not locked (yet).
-  await mailer({
-    template: 'login_incorrect',
-    language: user.language,
-    to: user.email,
-    host: host,
-    remote_address
-  })
-
-  return new Error('auth_failed')
 }

--- a/mod/user/register.js
+++ b/mod/user/register.js
@@ -2,7 +2,7 @@ const bcrypt = require('bcryptjs')
 
 const crypto = require('crypto')
 
-const acl = require('./acl')()
+const acl = require('./acl')
 
 const mailer = require('../utils/mailer')
 

--- a/mod/user/saml.js
+++ b/mod/user/saml.js
@@ -11,7 +11,7 @@ try {
 
   const { readFileSync } = require('fs');
 
-  acl = require('./acl')();
+  acl = require('./acl');
 
   sp = new saml2.ServiceProvider({
     entity_id: process.env.SAML_ENTITY_ID,

--- a/mod/user/update.js
+++ b/mod/user/update.js
@@ -1,4 +1,4 @@
-const acl = require('./acl')()
+const acl = require('./acl')
 
 const mailer = require('../utils/mailer')
 

--- a/mod/user/verify.js
+++ b/mod/user/verify.js
@@ -1,4 +1,4 @@
-const acl = require('./acl')()
+const acl = require('./acl')
 
 const mailer = require('../utils/mailer')
 


### PR DESCRIPTION
It should be possible to provide a base64 encoded authentication header `--user` with a request.

eg.

```console
curl http://localhost:3000/api/user/key --user "dennis.bauszus@geolytix.co.uk:mypassword"
```

The `auth.js` module will short circuit and await the `fromACL.js` response which is either a user object or error.

The `fromACL.js` module is taken from the post method from the login module which now requires the `fromACL` module.

The ACL module itself has been formatted to return the ACL query method.

The ACL module can now be required without having to be executed.