### PR TITLE
Merge locale into template

### DIFF
--- a/mod/workspace/_workspace.js
+++ b/mod/workspace/_workspace.js
@@ -104,6 +104,11 @@ async function locale(req, res) {
   
   // Check layer access.
   locale.layers = locale.layers && Object.entries(locale.layers)
+
+    // filter layers which are null
+    .filter(layer => layer[1] !== null)
+
+    // check layer for user roles
     .filter(layer => !!Roles.check(layer[1], roles))
     .map(layer => layer[0])
 

--- a/mod/workspace/cache.js
+++ b/mod/workspace/cache.js
@@ -77,17 +77,21 @@ async function cacheWorkspace() {
   // Loop through locale keys in workspace.
   Object.keys(workspace.locales).forEach(locale_key => {
 
-    // Get locale object from key.
-    const locale = workspace.locales[locale_key]
+    // workspace has a locale prototype.
+    if (workspace.locale) {
 
-    // Merge the workspace template into workspace.
-    merge(locale, workspace.locale)
+      const locale = structuredClone(workspace.locale)
+
+      merge(locale, workspace.locales[locale_key])
+
+      workspace.locales[locale_key] = locale
+    }
 
     // Assign key value as key on locale object.
-    locale.key = locale_key
+    workspace.locales[locale_key].key = locale_key
 
     // Assign locale key as name with no existing name on locale object.
-    locale.name ??= locale_key
+    workspace.locales[locale_key].name ??= locale_key
   })
 
   if (workspace.plugins) {


### PR DESCRIPTION
The template being merged into the locale means it is impossible to override anything in the template with locale specific config.

It should be possible to null an object entry in the workspace.locale.

A layer which is null should not be returned in the locale layer array.