### PR TITLE
Abort dataset gazetteer XHR

### DIFF
--- a/lib/ui/Gazetteer.mjs
+++ b/lib/ui/Gazetteer.mjs
@@ -41,7 +41,7 @@ export default gazetteer => {
             lat: ll[0]
           })
 
-        }}><span>Latitutde:${ll[0]}, Longitude:${ll[1]}`)
+        }}><span>Latitude:${ll[0]}, Longitude:${ll[1]}`)
 
       // Do not search if coordinates are provided.
       return;

--- a/lib/utils/gazetteer.mjs
+++ b/lib/utils/gazetteer.mjs
@@ -1,152 +1,153 @@
 export function datasets(term, gazetteer) {
 
-    if (!gazetteer.provider) {
+  if (!gazetteer.provider) {
 
-        // The default gazetteer config is for a dataset search.
-        gazetteer.qterm && search(gazetteer)
+    // The default gazetteer config is for a dataset search.
+    gazetteer.qterm && search(gazetteer)
+  }
+
+  // Search additional datasets.
+  gazetteer.datasets?.forEach(dataset => {
+
+    // Abort current dataset query. Onload will not be called.
+    dataset.xhr?.abort()
+    dataset.xhr = new XMLHttpRequest()
+
+    search({
+      layer: gazetteer.layer,
+      table: gazetteer.table,
+      query: gazetteer.query,
+      qterm: gazetteer.qterm,
+      label: gazetteer.label,
+      title: gazetteer.title,
+      limit: gazetteer.limit,
+      no_result: gazetteer.no_result,
+      leading_wildcard: gazetteer.leading_wildcard,
+      callback: gazetteer.callback,
+      maxZoom: gazetteer.maxZoom,
+      ...dataset
+    })
+  })
+
+  function search(dataset) {
+
+    const layer = gazetteer.mapview.layers[dataset.layer]
+
+    // Skip if layer defined in datasets is not added to the mapview
+    if (!layer) {
+
+      console.warn('No layer definition for gazetteer search.')
+      return;
     }
 
-    // Search additional datasets.
-    gazetteer.datasets?.forEach(dataset => search({
-        layer: gazetteer.layer,
-        table: gazetteer.table,
-        query: gazetteer.query,
-        qterm: gazetteer.qterm,
-        label: gazetteer.label,
-        title: gazetteer.title,
-        limit: gazetteer.limit,
-        no_result: gazetteer.no_result,
-        leading_wildcard: gazetteer.leading_wildcard,
-        callback: gazetteer.callback,
-        maxZoom: gazetteer.maxZoom,
-        ...dataset}))
+    // Skip if layer table is not defined and no table is defined in dataset or gazetteer.
+    if (!layer.table && !dataset.table) {
 
-    function search(dataset) {
+      console.warn('No table definition for gazetteer search.')
+      return;
+    };
 
-        const layer = gazetteer.mapview.layers[dataset.layer]
+    dataset.xhr.open('GET', gazetteer.mapview.host + '/api/query?' +
+      mapp.utils.paramString({
+        template: dataset.query || 'gaz_query',
+        label: dataset.label || dataset.qterm,
+        qterm: dataset.qterm,
+        qID: layer.qID,
+        locale: gazetteer.mapview.locale.key,
+        layer: layer.key,
+        filter: layer.filter?.current,
+        table: dataset.table || layer.table,
+        wildcard: '*',
+        term: `${dataset.leading_wildcard ? '*' : ''}${term}*`,
+        limit: dataset.limit || 10
+      }))
 
-        // Skip if layer defined in datasets is not added to the mapview
-        if (!layer) {
+    dataset.xhr.setRequestHeader('Content-Type', 'application/json')
+    dataset.xhr.responseType = 'json'
+    dataset.xhr.onload = e => {
 
-            console.warn('No layer definition for gazetteer search.')
-            return;
-        }
+      // The gazetteer input may have been cleared prior to the onload event.
+      if (!gazetteer.input.value.length) return;
 
-        // Skip if layer table is not defined and no table is defined in dataset or gazetteer.
-        if (!layer.table && !dataset.table) {
+      if (e.target.status >= 300) return;
 
-            console.warn('No table definition for gazetteer search.')
-            return;
-        };
-        
-        // Abort current dataset query. Onload will not be called.
-        dataset.xhr?.abort()
+      // No results
+      if (!e.target.response) {
+        if (dataset.no_result === null) return;
+        gazetteer.list.append(mapp.utils.html.node`
+          <li>
+            <span class="label">${dataset.title || layer.name}</span>
+            <span>${dataset.no_result || mapp.dictionary.no_results}</span>`)
+        return;
+      }
 
-        dataset.xhr = new XMLHttpRequest()
+      // Ensure that response if a flat array.
+      [e.target.response].flat().forEach(row => {
 
-        dataset.xhr.open('GET', gazetteer.mapview.host + '/api/query?' +
-            mapp.utils.paramString({
-                template: dataset.query || 'gaz_query',
-                label: dataset.label || dataset.qterm,
-                qterm: dataset.qterm,
-                qID: layer.qID,
-                locale: gazetteer.mapview.locale.key,
-                layer: layer.key,
-                filter: layer.filter?.current,
-                table: dataset.table || layer.table,
-                wildcard: '*',
-                term: `${dataset.leading_wildcard ? '*' : ''}${term}*`,
-                limit: dataset.limit || 10
-            }))
+        gazetteer.list.append(mapp.utils.html.node`
+          <li onclick=${e => {
 
-        dataset.xhr.setRequestHeader('Content-Type', 'application/json')
-        dataset.xhr.responseType = 'json'
-        dataset.xhr.onload = e => {
+            if (dataset.callback) return dataset.callback(row, dataset);
 
-            // The gazetteer input may have been cleared prior to the onload event.
-            if (!gazetteer.input.value.length) return;
+            mapp.location.get({
+              layer,
+              id: row.id
+            }).then(loc => loc?.flyTo?.(dataset.maxZoom))
 
-            if (e.target.status >= 300) return;
-            
-            // No results
-            if (!e.target.response) {
-                if (dataset.no_result === null) return;
-                gazetteer.list.append(mapp.utils.html.node`
-                    <li>
-                        <span class="label">${dataset.title || layer.name}</span>
-                        <span>${dataset.no_result || mapp.dictionary.no_results}</span>`)
-                return;
-            }
-
-            // Ensure that response if a flat array.
-            [e.target.response].flat().forEach(row => {
-
-                gazetteer.list.append(mapp.utils.html.node`
-                    <li
-                        onclick=${e => {
-
-                            if (dataset.callback) return dataset.callback(row, dataset);
-
-                            mapp.location.get({
-                                layer,
-                                id: row.id
-                            }).then(loc => loc?.flyTo?.(dataset.maxZoom))
-
-                        }}>
-                        <span class="label">${dataset.title || layer.name}</span>
-                        <span>${row.label}</span>`)
-            })
-
-        }
-
-        dataset.xhr.send()
+          }}>
+            <span class="label">${dataset.title || layer.name}</span>
+            <span>${row.label}</span>`)
+      })
 
     }
+
+    dataset.xhr.send()
+  }
 }
 
 export function getLocation(location, gazetteer) {
 
-    if (typeof gazetteer.callback === 'function') {
-        gazetteer.callback(location)
-        return;
-    }
+  if (typeof gazetteer.callback === 'function') {
+    gazetteer.callback(location)
+    return;
+  }
 
-    Object.assign(location, {
-        layer: {
-            mapview: gazetteer.mapview
-        },
-        Layers: [],
-        hook: location.label
+  Object.assign(location, {
+    layer: {
+      mapview: gazetteer.mapview
+    },
+    Layers: [],
+    hook: location.label
+  })
+
+  const infoj = [
+    {
+      title: location.label,
+      value: location.source,
+      inline: true
+    },
+    {
+      type: 'pin',
+      value: [location.lng, location.lat],
+      srid: '4326',
+      class: 'display-none',
+      location
+    }
+  ]
+
+  if (gazetteer.streetview) {
+
+    gazetteer.streetview.key && infoj.push({
+      type: 'streetview',
+      key: gazetteer.streetview.key,
+      location
     })
 
-    const infoj = [
-        {
-            title: location.label,
-            value: location.source,
-            inline: true
-        },
-        {
-            type: 'pin',
-            value: [location.lng, location.lat],
-            srid: '4326',
-            class: 'display-none',
-            location
-        }
-    ]
+  }
 
-    if (gazetteer.streetview) {
+  mapp.location.decorate(Object.assign(location, { infoj }))
 
-        gazetteer.streetview.key && infoj.push({
-            type: 'streetview',
-            key: gazetteer.streetview.key,
-            location
-        })
+  gazetteer.mapview.locations[location.hook] = location
 
-    }   
-
-    mapp.location.decorate(Object.assign(location, { infoj }))
-
-    gazetteer.mapview.locations[location.hook] = location
-
-    location.flyTo(gazetteer.maxZoom)
+  location.flyTo(gazetteer.maxZoom)
 }


### PR DESCRIPTION
The abort was previously inside the search method which has no reference to the dataset on subsequent iterations.