### PR TITLE
mvt and wkt query break with no fields being requested / vector format SRID warning

### DIFF
--- a/lib/layer/format/vector.mjs
+++ b/lib/layer/format/vector.mjs
@@ -1,7 +1,10 @@
 export default layer => {
 
-  // 3857 is assumed to be the default SRID for all vector format layer.
-  layer.srid ??= '3857'
+  if (!layer.srid) {
+
+    console.warn(`Layer: ${layer.key} has no SRID defintion.`)
+    return;
+  }
 
   if (layer.properties) {
     console.warn(`Layer: ${layer.key}, layer.properties{} are no longer required for wkt & geojson datasets.`)

--- a/lib/layer/format/vector.mjs
+++ b/lib/layer/format/vector.mjs
@@ -2,7 +2,7 @@ export default layer => {
 
   if (!layer.srid) {
 
-    console.warn(`Layer: ${layer.key} has no SRID defintion.`)
+    console.warn(`Vector Layer: ${layer.key} missing SRID.`)
     return;
   }
 

--- a/mod/workspace/templates/mvt.js
+++ b/mod/workspace/templates/mvt.js
@@ -4,6 +4,7 @@ module.exports = _ => {
   const fields = _.fields?.split(',')
     .map(field => `${_.workspace.templates[field]?.template || field} AS ${field}`)
     .filter(field => !!field)
+    || []
 
   // Push label (cluster) into fields
   _.label && fields.push(`${_.workspace.templates[_.label]?.template || _.label} AS ${_.label}`)

--- a/mod/workspace/templates/wkt.js
+++ b/mod/workspace/templates/wkt.js
@@ -4,6 +4,7 @@ module.exports = _ => {
   const fields = _.fields?.split(',')
     .map(field => `${_.workspace.templates[field]?.template || field} AS ${field}`)
     .filter(field => !!field)
+    || []
 
   // Unshift the geom field into the array.
   if (_.geom && !_.no_geom) {


### PR DESCRIPTION
Requesting a wkt or mvt layer with no theme or label is bugged due to the fields array being undefined.

Vector format layer require an SRID configuration.