### PR TITLE
numeric input formatter

### DIFF
--- a/lib/ui/locations/entries/numeric.mjs
+++ b/lib/ui/locations/entries/numeric.mjs
@@ -58,11 +58,9 @@ function createNumberInput(entry) {
 
 function createFormatterNumberInput(entry) {
 
-  let val = `${entry.prefix||''}${parseFloat(entry.newValue || entry.value).toLocaleString(entry.formatterParams.locale || 'en-GB', entry.formatterParams.options)}${entry.suffix||''}`
-
   return mapp.utils.html.node`
     <input
-      value=${val}
+      value=${getVal(entry)}
       onFocus=${e => onFocus(e, entry)}
       onBlur=${e => onBlur(e, entry)}
       placeholder=${entry.edit.placeholder}
@@ -75,16 +73,31 @@ function onFocus(e, entry) {
 }
 
 function onBlur(e, entry) {
-  e.target.type='';
-  e.target.value=`${entry.prefix||''}${parseFloat(entry.newValue || entry.value).toLocaleString(entry.formatterParams.locale || 'en-GB', entry.formatterParams.options)}${entry.suffix||''}`
+  e.target.type = '';
+  e.target.value = getVal(entry)
+}
+
+function getVal(entry) {
+
+  return isNaN(parseFloat(entry.newValue || entry.value))
+    ? `${entry.prefix || ''}   ${entry.suffix || ''}`
+    : `${entry.prefix || ''}${parseFloat(entry.newValue || entry.value).toLocaleString(entry.formatterParams.locale || 'en-GB', entry.formatterParams.options)}${entry.suffix || ''}`
 }
 
 function handleKeyUp(e, entry) {
+
   if (entry.type === 'integer') {
     e.target.value = parseInt(e.target.value);
   }
 
-  entry.newValue = e.target.value;
+  if (!e.target.value) {
+
+    delete entry.newValue
+  } else {
+
+    entry.newValue = e.target.value;
+  }
+  
   entry.location.view?.dispatchEvent(
     new CustomEvent('valChange', { detail: entry })
   );

--- a/lib/ui/locations/entries/numeric.mjs
+++ b/lib/ui/locations/entries/numeric.mjs
@@ -10,6 +10,10 @@ export default entry => {
       return createSlider(entry);
     }
 
+    if (entry.formatterParams.input) {
+      return createFormatterNumberInput(entry);
+    }
+
     return createNumberInput(entry);
   }
 
@@ -50,6 +54,29 @@ function createNumberInput(entry) {
       value=${entry.newValue || entry.value}
       placeholder=${entry.edit.placeholder}
       onkeyup=${e => handleKeyUp(e, entry)}>`;
+}
+
+function createFormatterNumberInput(entry) {
+
+  let val = `${entry.prefix||''}${parseFloat(entry.newValue || entry.value).toLocaleString(entry.formatterParams.locale || 'en-GB', entry.formatterParams.options)}${entry.suffix||''}`
+
+  return mapp.utils.html.node`
+    <input
+      value=${val}
+      onFocus=${e => onFocus(e, entry)}
+      onBlur=${e => onBlur(e, entry)}
+      placeholder=${entry.edit.placeholder}
+      onkeyup=${e => handleKeyUp(e, entry)}>`;
+}
+
+function onFocus(e, entry) {
+  e.target.value=parseFloat(entry.newValue || entry.value)
+  e.target.type='number';
+}
+
+function onBlur(e, entry) {
+  e.target.type='';
+  e.target.value=`${entry.prefix||''}${parseFloat(entry.newValue || entry.value).toLocaleString(entry.formatterParams.locale || 'en-GB', entry.formatterParams.options)}${entry.suffix||''}`
 }
 
 function handleKeyUp(e, entry) {


### PR DESCRIPTION
Setting the `formatterParams.input` flag will enable value formatting for the numeric input element on focus/blur.

```js
{
  "title": "numeric_field",
  "type": "numeric",
  "field": "numeric_field",
  "edit": true,
  "formatterParams": {
    "input": true,
    "options": {
      "maximumFractionDigits": 5
    },
    "locale": "en-GB"
  },
  "inline": true,
  "prefix": "£"
},
```