### PR TITLE
Don't merge workspace.locale with itself

### DIFF
--- a/mod/workspace/cache.js
+++ b/mod/workspace/cache.js
@@ -78,7 +78,8 @@ async function cacheWorkspace() {
   Object.keys(workspace.locales).forEach(locale_key => {
 
     // workspace has a locale prototype.
-    if (workspace.locale) {
+    // don't merge workspace.locale with itself.
+    if (workspace.locale && locale_key !== 'locale') {
 
       const locale = structuredClone(workspace.locale)
 


### PR DESCRIPTION
Bug happens when a workspace is loaded with only workspace.locale and no locales.