### PR TITLE
Draw on layer without infoj

### DIFF
--- a/lib/location/get.mjs
+++ b/lib/location/get.mjs
@@ -53,7 +53,10 @@ export default async function (location, list = location.layer.mapview.locations
     return;
   }
 
-  const infoj = location.layer.infoj.map(_entry => {
+  // Assign qID as default field if layer has no infoj.
+  location.layer.infoj ??= [{field:location.layer.qID}]
+
+  const infoj = location.layer.infoj?.map(_entry => {
 
     const entry = mapp.utils.clone(_entry)
 
@@ -65,7 +68,7 @@ export default async function (location, list = location.layer.mapview.locations
 
     return entry
   })
-
+  
   mapp.location.decorate(Object.assign(location, { infoj }))
 
   // Assign location to mapview.

--- a/mod/workspace/templates/location_get.js
+++ b/mod/workspace/templates/location_get.js
@@ -1,9 +1,6 @@
 module.exports = _ => {
 
-  const fields = _.layer.infoj
-
-    // Entry must NOT have a query defined.
-    .filter(entry => !entry.query)
+  const fields = _.layer.infoj?.filter(entry => !entry.query)
 
     // Entry must have a field defined.
     .filter(entry => entry.field)
@@ -13,6 +10,9 @@ module.exports = _ => {
 
     // Map either fieldfx or template SQL if available.
     .map(entry => `(${entry.fieldfx || _.workspace.templates[entry.field]?.template || entry.field}) AS ${entry.field}`)
+
+    // Assign qID as default field without layer.infoj
+    || [_.layer.qID]
 
   return `
     SELECT ${fields.join()}

--- a/mod/workspace/templates/mvt.js
+++ b/mod/workspace/templates/mvt.js
@@ -20,7 +20,7 @@ module.exports = _ => {
     FROM (
       SELECT
         ${_.layer.qID || null} as id,
-        ${Array.isArray(fields) ? fields.toString() + ',' : ''}
+        ${fields.length ? fields.toString() + ',' : ''}
         ST_AsMVTGeom(
           ${_.geom},
           ST_TileEnvelope(${z},${x},${y}),
@@ -36,5 +36,5 @@ module.exports = _ => {
           ${_.geom}
         )
         \${filter}
-      ) tile`
+  ) tile`
 }


### PR DESCRIPTION
Drawing on a layer will create a new location.

The mapp library will attempt to get the location from the `location_get` query template. This template fails without a layer.infoj array.

The `location_get` query will assign just the qID as field in the fields array if the layer has no infoj configuration.

The location.get mapp method will assign the qID as only field entry in the location.layer.infoj if undefined.

```js
location.layer.infoj ??= [{field:location.layer.qID}]
```