### PR TITLE
Edit Options Query

### DIFF
--- a/lib/ui/locations/entries/text.mjs
+++ b/lib/ui/locations/entries/text.mjs
@@ -1,5 +1,12 @@
 export default entry => {
 
+  mapp.utils.merge(mapp.dictionaries, {
+    en: {
+      no_options_available: 'No options available.'
+    }
+  }
+  )
+
   // Short circuit if not editable without a value.
   if (!entry.edit && !entry.value) return;
 
@@ -43,9 +50,15 @@ function edit(entry) {
           layer: entry.location.layer.key,
           filter: entry.location.layer.filter?.current,
           table: entry.location.layer.tableCurrent(),
-          field: entry.field
+          field: entry.field,
+          id: entry.location.id
         })).then(response => {
 
+          // If response is null, we can not create a dropdown, so we return a message.
+          if (response === null) {
+            entry.container.innerHTML = `${mapp.dictionary.no_options_available}`
+            return;
+          }
           // Return first value from object row as options array.
           entry.edit.options = [response].flat().map(row => {
             return Object.values(row)[0]


### PR DESCRIPTION
Minor change here. 
1. Added id to the params for the query for edit.options.query
2. Added a no result message as previously this would fail
3. Added a translation for the no result message.