### PR TITLE
Email true queryparams

### DIFF
--- a/lib/utils/queryParams.mjs
+++ b/lib/utils/queryParams.mjs
@@ -46,6 +46,9 @@ export default _this => {
     // ID will be taken if a location object is provided with the params.
     id: _this.queryparams.id ? _this.location?.id : undefined,
 
+    // Email will be taken if a location object is provided with the params.
+    email: _this.queryparams.email ? mapp.user.email : undefined,
+
     // lat lng must be explicit or the center flag param must be set.
     lat: center && center[1],
     lng: center && center[0],


### PR DESCRIPTION
Just a little change here - I've added the ability to pass `email:true` in the queryparams object and this is then passed to the query as `%{email}`, the same way as `id: true` works. 