### PR TITLE
Allow object default layer filter

### DIFF
--- a/mod/query.js
+++ b/mod/query.js
@@ -245,8 +245,8 @@ async function layerQuery(req, res) {
   const roles = Roles.filter(req.params.layer, req.params.user?.roles)
 
   // Create params filter string from roleFilter filter params.
-  req.params.filter =
-    ` ${req.params.layer.filter?.default && 'AND ' + req.params.layer.filter?.default || ''}
+  req.params.filter = `
+    ${req.params.layer.filter?.default && `AND ${sqlFilter(req.params.layer.filter.default, req.params.SQL)}` || ''}
     ${req.params.filter && `AND ${sqlFilter(JSON.parse(req.params.filter), req.params.SQL)}` || ''}
     ${roles && Object.values(roles).some(r => !!r)
       ? `AND ${sqlFilter(Object.values(roles).filter(r => !!r), req.params.SQL)}`

--- a/mod/utils/sqlFilter.js
+++ b/mod/utils/sqlFilter.js
@@ -38,6 +38,8 @@ function addValues(val) {
 
 module.exports = function sqlfilter(filter, params) {
 
+  if (typeof filter === 'string') return filter;
+
   SQLparams = params
 
   // Filter in an array will be conditional OR


### PR DESCRIPTION
Previously the layer.filter.default had to be defined as a SQL string.

It is now possible to define the default filter as a filter object.

The SQL filter module will check for the filter type and return the filter argument if string.

https://github.com/GEOLYTIX/xyz/wiki/Workspace-Configuration#default