### PR TITLE
Distinct in/ni filter

### DIFF
--- a/lib/ui/layers/filters.mjs
+++ b/lib/ui/layers/filters.mjs
@@ -144,7 +144,7 @@ async function filter_numeric(layer, filter){
 
 async function filter_in(layer, filter) {
 
-  if (filter.distinct) {
+  if (!Array.isArray(filter[filter.type])) {
 
     // Query distinct field values from the layer table.
     const response = await mapp.utils.xhr(`${layer.mapview.host}/api/query?` +


### PR DESCRIPTION
The `distinct:true` flag shouldn't be required for `in` and `ni` type filter.

Having a filter of this type without a values array a no `distinct:true` flag will crash the filter.mjs module.

This PR addresses the issue by running the distinct query when no values array is provided in the filter config.