### PR TITLE
Feat dropdown shadow

### DIFF
--- a/public/css/_inputs.css
+++ b/public/css/_inputs.css
@@ -107,7 +107,7 @@ label.checkbox {
   overflow: visible;
   position: relative;
   background-color: white;
-  box-shadow: 1px 1px 3px var(--color-primary-light);
+  box-shadow: var(--color-mid) 0px 8px 24px;
 
   &:disabled {
     pointer-events: none;

--- a/public/css/ui.css
+++ b/public/css/ui.css
@@ -1031,7 +1031,7 @@ label.checkbox {
   overflow: visible;
   position: relative;
   background-color: white;
-  box-shadow: 1px 1px 3px var(--color-primary-light);
+  box-shadow: var(--color-mid) 0px 8px 24px;
   &:disabled {
     pointer-events: none;
     opacity: 0.4;
@@ -1068,11 +1068,11 @@ label.checkbox {
       padding: 5px;
     }
     & > li:hover {
-      background-color: var(--color-mid);
+      background-color: var(--color-light);
       cursor: pointer;
     }
     & > li.selected {
-      background-color: var(--color-mid);
+      background-color: var(--color-light-secondary);
     }
     & .label {
       padding: 0 6px;


### PR DESCRIPTION
Softened the box shadow on dropdown elements to fit it better with the rest of the UI.

Screenshots below for comparison:
<img width="183" alt="image" src="https://github.com/GEOLYTIX/xyz/assets/64873688/fdf8bb32-21fb-456e-90dc-328b2b14674d">
<img width="186" alt="image" src="https://github.com/GEOLYTIX/xyz/assets/64873688/2ab84fc0-e162-4396-a333-617be529c91f">

<img width="241" alt="image" src="https://github.com/GEOLYTIX/xyz/assets/64873688/d5b11bff-dc1e-4492-a438-c48113567ecd">
<img width="239" alt="image" src="https://github.com/GEOLYTIX/xyz/assets/64873688/3bbaf40f-b487-41e7-9091-f0a9f30c8305">



