### PR TITLE
Clear highlight interaction on mouseout.

### DIFF
--- a/lib/mapview/interactions/highlight.mjs
+++ b/lib/mapview/interactions/highlight.mjs
@@ -51,6 +51,8 @@ export default function (params) {
 
   mapview.Map.getTargetElement().addEventListener('mouseup', mouseUp)
 
+  mapview.Map.getTargetElement().addEventListener('mouseout', clear)
+
   // Prevent mouseDown event on touch input.
   function touchStart(e) {
     e.preventDefault()
@@ -284,6 +286,9 @@ export default function (params) {
     // Delete the highlight id from current layer.
     delete mapview.interaction.current.layer.highlight
 
+    // Reset candidateKeys
+    mapview.interaction.candidateKeys = new Set();
+
     // Style the feature itself if possible.
     if (mapview.interaction.current.layer.format !== 'mvt'
       && typeof mapview.interaction.current.F.setStyle === 'function') {
@@ -385,6 +390,7 @@ export default function (params) {
     mapview.Map.getTargetElement().removeEventListener('mousedown', mouseDown)
     mapview.Map.getTargetElement().removeEventListener('touchstart', touchStart)
     mapview.Map.getTargetElement().removeEventListener('mouseup', mouseUp)
+    mapview.Map.getTargetElement().removeEventListener('mouseout', clear)
 
     mapview.interaction.callback?.()
   }


### PR DESCRIPTION
The mousout event to clear the highlight is added to the highlight interaction and removed when the interaction finishes.