### PR TITLE
Failed to load workspace

### DIFF
--- a/mod/provider/file.js
+++ b/mod/provider/file.js
@@ -19,6 +19,6 @@ module.exports = async ref => {
 
   } catch (err) {
     console.error(err)
-    return;
+    return err;
   }
 }

--- a/mod/provider/getFrom.js
+++ b/mod/provider/getFrom.js
@@ -7,27 +7,27 @@ const file = require('../provider/file')
 const mongodb = require('../provider/mongodb')
 
 module.exports = {
-    https: async url => {
+  https: async url => {
 
-        try {
+    try {
 
-            const response = await fetch(url)
+      const response = await fetch(url)
 
-            logger(`${response.status} - ${url}`, 'fetch')
+      logger(`${response.status} - ${url}`, 'fetch')
 
-            if (url.match(/\.json$/i)) {
-                return await response.json()
-            }
+      if (url.match(/\.json$/i)) {
+        return await response.json()
+      }
 
-            return await response.text()
+      return await response.text()
 
-        } catch (err) {
-            console.error(err)
-            return;
-        }
+    } catch (err) {
+      console.error(err)
+      return;
+    }
 
-    },
-    file: ref => file(ref.split(':')[1]),
-    cloudfront: ref => cloudfront(ref.split(':')[1]),
-    mongodb: ref => mongodb(ref.split(/:(.*)/s)[1])
+  },
+  file: ref => file(ref.split(':')[1]),
+  cloudfront: ref => cloudfront(ref.split(':')[1]),
+  mongodb: ref => mongodb(ref.split(/:(.*)/s)[1])
 }

--- a/mod/query.js
+++ b/mod/query.js
@@ -19,6 +19,10 @@ module.exports = async (req, res) => {
   // Get workspace from cache.
   const workspace = await workspaceCache()
 
+  if (workspace instanceof Error) {
+    return res.status(500).send('Failed to load workspace.')
+  }
+
   // Check whether query template exists.
   if (!Object.hasOwn(workspace.templates, req.params.template)) {
 

--- a/mod/utils/languageTemplates.js
+++ b/mod/utils/languageTemplates.js
@@ -13,6 +13,10 @@ module.exports = async (params) => {
 
   const workspace = await workspaceCache()
 
+  if (workspace instanceof Error) {
+    return 'Failed to load workspace.'
+  }
+
   if (!Object.hasOwn(workspace.templates, params.template)) {
 
     console.warn(`Template ${params.template} not found.`)

--- a/mod/workspace/_workspace.js
+++ b/mod/workspace/_workspace.js
@@ -12,6 +12,10 @@ module.exports = async (req, res) => {
 
   workspace = await workspaceCache()
 
+  if (workspace instanceof Error) {
+    return res.status(500).send('Failed to load workspace.')
+  }
+
   const keys = {
     layer,
     locale,

--- a/mod/workspace/cache.js
+++ b/mod/workspace/cache.js
@@ -37,15 +37,19 @@ const msg_templates = require('./templates/_msgs')
 
 const query_templates = require('./templates/_queries')
 
+const workspace_src = process.env.WORKSPACE.split(':')[0]
+
 async function cacheWorkspace() {
 
+  let workspace;
+
   // Get workspace from source.
-  const workspace = process.env.WORKSPACE ?
-    await getFrom[process.env.WORKSPACE.split(':')[0]](process.env.WORKSPACE) : {}
+  workspace = Object.hasOwn(getFrom, workspace_src) ?
+    await getFrom[workspace_src](process.env.WORKSPACE) : {}
 
   // Return error if source failed.
   if (workspace instanceof Error) {
-    return {};
+    workspace = {};
   }
 
   const custom_templates = process.env.CUSTOM_TEMPLATES

--- a/mod/workspace/cache.js
+++ b/mod/workspace/cache.js
@@ -49,7 +49,7 @@ async function cacheWorkspace() {
 
   // Return error if source failed.
   if (workspace instanceof Error) {
-    workspace = {};
+    return workspace
   }
 
   const custom_templates = process.env.CUSTOM_TEMPLATES

--- a/mod/workspace/getLayer.js
+++ b/mod/workspace/getLayer.js
@@ -12,6 +12,10 @@ module.exports = async (params) => {
 
   const workspace = await workspaceCache()
 
+  if (workspace instanceof Error) {
+    return workspace
+  }
+
   if (!Object.hasOwn(workspace.locales, params.locale)) {
     return new Error('Unable to validate locale param.')
   }

--- a/mod/workspace/getLocale.js
+++ b/mod/workspace/getLocale.js
@@ -10,6 +10,10 @@ module.exports = async (params) => {
 
   const workspace = await workspaceCache()
 
+  if (workspace instanceof Error) {
+    return workspace
+  }
+
   if (!Object.hasOwn(workspace.locales, params.locale)) {
     return new Error('Unable to validate locale param.')
   }


### PR DESCRIPTION
A 500 'Failed to load workspace.' error should be returned instead of the zero/OSM only workspace if the workspace cache fails.

The instance should not crash.

The error should be logged to the node console.