### PR TITLE
Update to verify the absence of a user in the Access Control List (ACL).

### DIFF
--- a/mod/user/fromACL.js
+++ b/mod/user/fromACL.js
@@ -181,7 +181,7 @@ async function failedLogin(request) {
   }))
 
   // Check whether failed login attempts exceeds limit.
-  if (rows[0].failedattempts >= parseInt(process.env.FAILED_ATTEMPTS || 3)) {
+  if (rows[0]?.failedattempts >= parseInt(process.env.FAILED_ATTEMPTS || 3)) {
 
     // Create a verificationtoken.
     const verificationtoken = crypto.randomBytes(20).toString('hex')


### PR DESCRIPTION
### Update: User Authentication Enhancement

Just wanted to give you a heads up about a discovery. If you happen to provide login details for a user not present in the Access Control List (ACL), it might lead to the error bellow. 🤔

Here's a quick snippet of the issue encountered:

```javascript
if (rows[0].failedattempts >= parseInt(process.env.FAILED_ATTEMPTS || 3)) {
              ^
TypeError: Cannot read properties of undefined (reading 'failedattempts')
