### PR TITLE
Get scale_bar from locale

### DIFF
--- a/lib/mapview/_mapview.mjs
+++ b/lib/mapview/_mapview.mjs
@@ -181,7 +181,7 @@ export default (mapview) => {
 
   // Scalebar
   mapview.locale.scalebar && mapview.Map.addControl(new ol.control.ScaleLine({
-    units: mapview.locale.scalebar
+    units: mapview.locale.scalebar === 'imperial' ? 'imperial' : 'metric',
   }))
 
   // Attribution

--- a/lib/mapview/_mapview.mjs
+++ b/lib/mapview/_mapview.mjs
@@ -180,8 +180,8 @@ export default (mapview) => {
   }
 
   // Scalebar
-  mapview.scalebar && mapview.Map.addControl(new ol.control.ScaleLine({
-    units: mapview.scalebar
+  mapview.locale.scalebar && mapview.Map.addControl(new ol.control.ScaleLine({
+    units: mapview.locale.scalebar
   }))
 
   // Attribution

--- a/lib/mapview/_mapview.mjs
+++ b/lib/mapview/_mapview.mjs
@@ -180,8 +180,8 @@ export default (mapview) => {
   }
 
   // ScaleBar
-  mapview.locale.scaleBar && mapview.Map.addControl(new ol.control.ScaleLine({
-    units: mapview.locale.scaleBar === 'imperial' ? 'imperial' : 'metric',
+  mapview.locale.ScaleLine && mapview.Map.addControl(new ol.control.ScaleLine({
+    units: mapview.locale.ScaleLine === 'imperial' ? 'imperial' : 'metric',
   }))
 
   // Attribution

--- a/lib/mapview/_mapview.mjs
+++ b/lib/mapview/_mapview.mjs
@@ -179,9 +179,9 @@ export default (mapview) => {
     }))
   }
 
-  // Scalebar
-  mapview.locale.scalebar && mapview.Map.addControl(new ol.control.ScaleLine({
-    units: mapview.locale.scalebar === 'imperial' ? 'imperial' : 'metric',
+  // ScaleBar
+  mapview.locale.scaleBar && mapview.Map.addControl(new ol.control.ScaleLine({
+    units: mapview.locale.scaleBar === 'imperial' ? 'imperial' : 'metric',
   }))
 
   // Attribution

--- a/public/views/_default.js
+++ b/public/views/_default.js
@@ -230,7 +230,7 @@ window.onload = async () => {
     locale: locale,
     hooks: true,
     scrollWheelZoom: true,
-    scalebar: locale.scaleBar || 'metric', //'imperial'
+    scalebar: locale.scaleBar === 'imperial' ? 'imperial' : 'metric',
     attribution: {
       target: document.querySelector('#Attribution > .attribution-links'),
       links: {

--- a/public/views/_default.js
+++ b/public/views/_default.js
@@ -230,7 +230,7 @@ window.onload = async () => {
     locale: locale,
     hooks: true,
     scrollWheelZoom: true,
-    scalebar: 'metric', //'imperial'
+    scalebar: locale.scaleBar || 'metric', //'imperial'
     attribution: {
       target: document.querySelector('#Attribution > .attribution-links'),
       links: {

--- a/public/views/_default.js
+++ b/public/views/_default.js
@@ -230,7 +230,6 @@ window.onload = async () => {
     locale: locale,
     hooks: true,
     scrollWheelZoom: true,
-    scalebar: locale.scaleBar === 'imperial' ? 'imperial' : 'metric',
     attribution: {
       target: document.querySelector('#Attribution > .attribution-links'),
       links: {


### PR DESCRIPTION
# Pull Request: Get `scale_bar` from locale 🌐📏

## Description
This pull request addresses the need to retrieve the `scale_bar` information from the locale. The changes aim to improve the localization of the scale bar in our application, enhancing the user experience by dynamically obtaining this information based on the user's locale.

## Changes Made
- Updated the `scale_bar` property in the default mapview to take the `scaleBar` property from the locales configuration. 🗺️🔄

## Testing Done
- [x] Tested against a workspace with multiple locales. One with 'imperial', 'Metric' and default (no scaleBar). ✔️🌍