### PR TITLE
round shorthand for formatterParams.options.maximumFractionDigits

### DIFF
--- a/lib/ui/locations/entries/numeric.mjs
+++ b/lib/ui/locations/entries/numeric.mjs
@@ -22,6 +22,9 @@ export default entry => {
   if (entry.type === 'integer') {
 
     entry.formatterParams.options.maximumFractionDigits = 0
+  } else {
+
+    entry.formatterParams.options.maximumFractionDigits ??= entry.round || 2
   }
 
   return mapp.utils.html.node`


### PR DESCRIPTION
I have a feeling that formatting is often done in the query fieldfx rather than in the infoj entry config because of the formatterParams being rather verbose to match the [toLocaleString()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number/toLocaleString) config.

This PR provides a shorthand `round:int` for the type:numeric entry config.

```js
{
  "title": "Aged <18",
  "type": "numeric",
  "round": 1,
  "field": "age0to18_perc",
  "suffix": "%",
  "inline": true
}
```