### PR TITLE
GeoJSON Feature Formats Bug

### DIFF
--- a/lib/layer/featureFormats.mjs
+++ b/lib/layer/featureFormats.mjs
@@ -8,7 +8,7 @@ export function geojson(layer, features) {
 
     const properties = feature.properties
 
-    if (layer.featureFields[layer.style.theme.field]) {
+    if (layer.featureFields[layer.style?.theme?.field]) {
 
       layer.featureFields[layer.style.theme.field].values.push(properties[layer.style.theme.field]);
     }


### PR DESCRIPTION
I noticed that if you provide a `geojson` format layer without a `style.theme` property - the geojson function in `featureFormats.mjs` fails with this error 
`featureFormats.mjs:11 Uncaught (in promise) TypeError: Cannot read properties of undefined (reading 'field')
    at featureFormats.mjs:11:47
    at Array.map (<anonymous>)
    at Object.mi (featureFormats.mjs:7:19)
    at W.e.setSource (vector.mjs:33:55)`

This PR simply adds optional chaining to protect against the scenario when we apply styling to a geojson layer that does not include a thematic. 
``` js
 if (layer.featureFields[layer.style?.theme?.field]) {

      layer.featureFields[layer.style.theme.field].values.push(properties[layer.style.theme.field]);
    }
```