### PR TITLE
Typeof `function` check

### DIFF
--- a/lib/layer/decorate.mjs
+++ b/lib/layer/decorate.mjs
@@ -247,10 +247,10 @@ export default async layer => {
   Object.keys(layer).forEach((key) => {
 
     // Check for layer method matching the layer key.
-    mapp.layer[key]?.(layer);
+    typeof mapp.layer[key] === 'function' && mapp.layer[key]?.(layer);
 
     // Or plugin method and provide the layer object as argument.
-    mapp.plugins[key]?.(layer);
+    typeof mapp.plugins[key] === 'function' && mapp.plugins[key]?.(layer);
 
     // It is possible to have a plugin method of the same name as a layer method.
   });

--- a/public/views/_default.js
+++ b/public/views/_default.js
@@ -405,7 +405,8 @@ window.onload = async () => {
 
   // Execute plugins with matching keys in locale.
   const plugins = Object.keys(locale).map((key) => {
-    return mapp.plugins[key] && mapp.plugins[key](locale[key], mapview);
+    // Check if mapp.plugins[key] is a function before executing it
+    return typeof mapp.plugins[key] === 'function' && mapp.plugins[key](locale[key], mapview);
   });
 
   // Ensure that all plugin promises are resolved


### PR DESCRIPTION
## TypeOf 'Function' PR Summary 📖 
### Changes Made

This pull request introduces improvements to our codebase by incorporating the `typeof` check to ensure that certain properties are functions before attempting to execute them in the layer decorate and in the default view's javascript.

1. **Handling Layer and Plugin Methods**
   - In the code responsible for handling layer and plugin methods, we have added `typeof` checks to verify whether the properties are functions before attempting to execute them. This enhancement aims to prevent potential errors when invoking methods that might not be functions.

   ```javascript
   Object.keys(layer).forEach((key) => {
           // Check if mapp.layer[key] is a function before executing it
           typeof mapp.layer[key] === 'function' && mapp.layer[key](layer);

           // Or plugin method and provide the layer object as an argument.
           typeof mapp.plugins[key] === 'function' && mapp.plugins[key](layer);

           // It is possible to have a plugin method of the same name as a layer method.
       }
   });
   ```

### Motivation

The motivation behind these changes is to enhance the robustness of the code by explicitly checking the types of properties before executing them. By ensuring that methods are functions, we reduce the risk of potential runtime errors in the codebase and other custom views.
