### PR TITLE
Spelling mistake

### DIFF
--- a/lib/ui/locations/view.mjs
+++ b/lib/ui/locations/view.mjs
@@ -229,7 +229,7 @@ export default location => {
 
       if (location.infoj.some(entry => typeof entry.newValue !== 'undefined')) {
 
-        if (confirm(`${mappe.dictionary.location_save_changes}`)) {
+        if (confirm(`${mapp.dictionary.location_save_changes}`)) {
 
           await location.update()
 


### PR DESCRIPTION
Accidental spelling mistake of `mappe` not `mapp`.