### PR TITLE
Load plugins in mapview creation

### DIFF
--- a/lib/mapview/_mapview.mjs
+++ b/lib/mapview/_mapview.mjs
@@ -279,5 +279,21 @@ export default (mapview) => {
     mapview.Map.getTargetElement().dispatchEvent(new CustomEvent('changeEnd'))
   }, 500)
 
+  if (mapview.loadPlugins) {
+
+    return (async function(){
+
+      await mapp.utils.loadPlugins(mapview.locale.plugins);
+
+      mapview.plugins = Object.keys(mapview.locale)
+      .filter((key) => typeof mapp.plugins[key] === 'function')
+      .map((key) => mapp.plugins[key](mapview.locale[key], mapview));
+
+      await Promise.all(mapview.plugins)
+
+      return mapview
+    })()
+  }
+
   return mapview
 }

--- a/lib/mapview/_mapview.mjs
+++ b/lib/mapview/_mapview.mjs
@@ -281,7 +281,7 @@ export default (mapview) => {
 
   if (mapview.loadPlugins) {
 
-    return (async function(){
+    return (async (mapview)=>{
 
       await mapp.utils.loadPlugins(mapview.locale.plugins);
 
@@ -292,7 +292,7 @@ export default (mapview) => {
       await Promise.all(mapview.plugins)
 
       return mapview
-    })()
+    })(mapview)
   }
 
   return mapview

--- a/public/views/_default.js
+++ b/public/views/_default.js
@@ -291,7 +291,7 @@ window.onload = async () => {
   if (!window.ol) await mapp.utils.olScript()
 
   // Create mapview
-  const mapview = mapp.Mapview({
+  const mapview = await mapp.Mapview({
     host: host,
     target: OL,
     locale: locale,
@@ -304,7 +304,10 @@ window.onload = async () => {
         ['SHA']: `https://github.com/GEOLYTIX/xyz/commit/${mapp.hash}`,
         Openlayers: 'https://openlayers.org',
       },
-    }
+    },
+    
+    // mapp.Mapview must be awaited.
+    loadPlugins: true
   });
 
   // Add zoomIn button.
@@ -399,18 +402,6 @@ window.onload = async () => {
         .forEach((layer) => layer.mbMap?.resize());
     }}>
       <div class="mask-icon map">`);
-
-  // Load plugins
-  await mapp.utils.loadPlugins(locale.plugins);
-
-  // Execute plugins with matching keys in locale.
-  const plugins = Object.keys(locale).map((key) => {
-    // Check if mapp.plugins[key] is a function before executing it
-    return typeof mapp.plugins[key] === 'function' && mapp.plugins[key](locale[key], mapview);
-  });
-
-  // Ensure that all plugin promises are resolved
-  await Promise.all(plugins)
 
   // Load JSON layers from Workspace API.
   const layers = locale.layers.length ? await mapp.utils.promiseAll(locale.layers.map(


### PR DESCRIPTION
With the `loadPlugins: true` option the `mapp.Mapview()` method becomes async and must be awaited.

Plugins from the locale are loaded and executed.