### PR TITLE
Update mapview.geoJSON method

### DIFF
--- a/lib/layer/featureFormats.mjs
+++ b/lib/layer/featureFormats.mjs
@@ -1,6 +1,8 @@
-export function geojson(layer, features) {
+const formatGeojson = new ol.format.GeoJSON
 
-  const formatGeojson = new ol.format.GeoJSON
+const formatWKT = new ol.format.WKT
+
+export function geojson(layer, features) {
 
   mapp.layer.featureFields.reset(layer);
 
@@ -25,9 +27,7 @@ export function geojson(layer, features) {
   })
 }
 
-export function wkt(layer, features) {
-
-  const formatWKT = new ol.format.WKT
+export function wkt(layer, features) {  
 
   mapp.layer.featureFields.reset(layer);
 

--- a/lib/mapview/geoJSON.mjs
+++ b/lib/mapview/geoJSON.mjs
@@ -1,17 +1,23 @@
-export default function (params){
+const geoJSON = new ol.format.GeoJSON();
 
-  const geoJSON = new ol.format.GeoJSON();
+export default function (params) {
 
   let feature;
+
+  // Parse geometry from string value if not provided.
+  params.geometry ??= typeof params.value === 'string' ? JSON.parse(params.value) : params.value
+
+  // Create OL style object from params.style if not provided.
+  params.Style ??= mapp.utils.style(params.style)
 
   try {
 
     feature = params.geometry && geoJSON.readFeature({
       type: 'Feature',
       geometry: params.geometry
-    },{ 
-      dataProjection: `EPSG:${params.dataProjection || this.srid}`,
-      featureProjection:`EPSG:${this.srid}`
+    }, {
+      dataProjection: `EPSG:${params.dataProjection || params.srid || this.srid}`,
+      featureProjection: `EPSG:${this.srid}`
     });
 
   } catch (err) {
@@ -29,8 +35,8 @@ export default function (params){
     zIndex: params.zIndex,
     style: params.Style
   })
-  
+
   this.Map.addLayer(layerVector)
-  
+
   return layerVector
 }

--- a/lib/ui/locations/entries/geometry.mjs
+++ b/lib/ui/locations/entries/geometry.mjs
@@ -38,6 +38,9 @@ mapp.utils.merge(mapp.dictionaries, {
 
 export default entry => {
 
+  // Assigning the mapview to the entry makes the entry behave like a layer object for draw and modify interactions.
+  entry.mapview ??= entry.location?.layer?.mapview
+
   // The geometry value must be JSON.
   entry.value = typeof entry.value === 'string' && JSON.parse(entry.value) || entry.value
 
@@ -57,9 +60,6 @@ export default entry => {
 
   // Return if entry has no geometry value and cannot be drawn in to.
   if (!entry.value && !entry.draw) return;
-
-  // Assigning the mapview to the entry makes the entry behave like a layer object for draw and modify interactions.
-  entry.location.layer.mapview = entry.location.layer.mapview
 
   // Assign entry.style to location.style
   entry.style = { ...entry.location?.style, ...entry.style }

--- a/lib/ui/locations/entries/geometry.mjs
+++ b/lib/ui/locations/entries/geometry.mjs
@@ -41,6 +41,8 @@ export default entry => {
   // The geometry value must be JSON.
   entry.value = typeof entry.value === 'string' && JSON.parse(entry.value) || entry.value
 
+  entry.srid ??= entry.location?.layer?.srid
+
   // Turn off display with no geometry to display.
   entry.display = (entry.display && entry.value)
 
@@ -195,13 +197,10 @@ function show() {
     delete this.L
   }
 
+  this.zIndex ??= 99
+
   // Create new geometry layer from entry value
-  this.L = this.location.layer.mapview.geoJSON({
-    zIndex: this.zIndex || 99,
-    geometry: this.value,
-    Style: this.Style,
-    dataProjection: this.srid || this.location?.layer?.srid
-  })
+  this.L = this.location.layer.mapview.geoJSON(entry)
 
   // Removes layer from mapview when location is removed.
   this.location.Layers.push(this.L)

--- a/lib/ui/locations/entries/geometry.mjs
+++ b/lib/ui/locations/entries/geometry.mjs
@@ -200,7 +200,7 @@ function show() {
   this.zIndex ??= 99
 
   // Create new geometry layer from entry value
-  this.L = this.location.layer.mapview.geoJSON(entry)
+  this.L = this.location.layer.mapview.geoJSON(this)
 
   // Removes layer from mapview when location is removed.
   this.location.Layers.push(this.L)

--- a/lib/ui/locations/entries/geometry.mjs
+++ b/lib/ui/locations/entries/geometry.mjs
@@ -59,7 +59,7 @@ export default entry => {
   if (!entry.value && !entry.draw) return;
 
   // Assigning the mapview to the entry makes the entry behave like a layer object for draw and modify interactions.
-  entry.mapview = entry.location.layer.mapview
+  entry.location.layer.mapview = entry.location.layer.mapview
 
   // Assign entry.style to location.style
   entry.style = { ...entry.location?.style, ...entry.style }
@@ -215,7 +215,7 @@ function modify(e, entry) {
   if (btn.classList.contains('active')) {
 
     // Cancel modify interaction.
-    entry.mapview.interactions.highlight()
+    entry.location.layer.mapview.interactions.highlight()
     return;
   }
 
@@ -229,7 +229,7 @@ function modify(e, entry) {
 
   const feature = entry.L.getSource().getFeatures()[0]
 
-  entry.mapview.interactions.modify({
+  entry.location.layer.mapview.interactions.modify({
     Feature: feature.clone(),
     layer: entry.location.layer,
     snap: entry.edit.snap,
@@ -239,11 +239,11 @@ function modify(e, entry) {
       // Reset interaction and button
       btn.classList.remove('active')
 
-      delete entry.mapview.interaction
+      delete entry.location.layer.mapview.interaction
 
       // Set highlight interaction if no other interaction is current after 400ms.
       setTimeout(() => {
-        !entry.mapview.interaction && entry.mapview.interactions.highlight()
+        !entry.location.layer.mapview.interaction && entry.location.layer.mapview.interactions.highlight()
       }, 400)
 
       // The callback returns a feature as geojson.

--- a/lib/ui/locations/entries/pin.mjs
+++ b/lib/ui/locations/entries/pin.mjs
@@ -36,21 +36,28 @@ mapp.utils.merge(mapp.dictionaries, {
 
 export default entry => {
 
+  if (!Array.isArray(entry.value)) {
+
+    console.warn(`Entry type pin requires a value array.`)
+    return;
+  }
+
   // Assign srid from location.layer if not implicit.
   entry.srid ??= entry.location.layer.srid
 
   // Remove existing pin layer
   entry.location.layer.mapview.Map.removeLayer(entry.L)
 
-  entry.L = entry.location.layer.mapview.geoJSON({
-    zIndex: Infinity,
-    geometry: {
-      type: 'Point',
-      coordinates: entry.value,
-    },
-    dataProjection: entry.srid,
-    Style: entry.style && mapp.utils.style(entry.style) || entry.Style || entry.location.pinStyle
-  })
+  entry.zIndex ??= Infinity
+
+  entry.Style ??= entry.style ? mapp.utils.style(entry.style) : entry.location.pinStyle
+
+  entry.geometry = {
+    type: 'Point',
+    coordinates: entry.value,
+  }
+
+  entry.L = entry.location.layer.mapview.geoJSON(entry)
 
   entry.location.layer.display && entry.location.layer.L?.changed()
 


### PR DESCRIPTION
The geojson format should be defined outside the function closure to not be re-assigned on every execution.

The geometry should be parsed from value if not provided.

The `Style` should be created from a `style` object if not provided.

`srid` should be fallback for the dataProjection.