### PR TITLE
provide string array argument as filter for ui.location.infoj(loc, [])

### DIFF
--- a/lib/ui/locations/infoj.mjs
+++ b/lib/ui/locations/infoj.mjs
@@ -8,8 +8,21 @@ export default (location, infoj) => {
   // Create object to hold view groups.
   const groups = {}
 
+  if (Array.isArray(infoj)) infoj.forEach(entry => {
+    if (typeof entry === 'string') {
+
+      entry = location.infoj.find(_entry => entry.field === _entry.field)
+    }
+  })
+
   // Iterate through info fields and add to info table.
-  for (const entry of infoj || location.infoj) {
+  for (let entry of infoj || location.infoj) {
+
+    if (typeof entry === 'string') {
+      entry = location.infoj.find(_entry => _entry.field === entry)
+
+      if (!entry) continue;
+    }
 
     // The location view entries should not be processed if the view is disabled.
     if (location.view && location.view.classList.contains('disabled')) break;

--- a/lib/ui/locations/infoj.mjs
+++ b/lib/ui/locations/infoj.mjs
@@ -8,21 +8,18 @@ export default (location, infoj) => {
   // Create object to hold view groups.
   const groups = {}
 
-  if (Array.isArray(infoj)) infoj.forEach(entry => {
+  // infoj argument is provided as an array of strings to filter the location infoj entries.
+  if (Array.isArray(infoj)) infoj = infoj.map(entry => {
     if (typeof entry === 'string') {
 
-      entry = location.infoj.find(_entry => entry.field === _entry.field)
+      return location.infoj.find(_entry => _entry.field === entry)
     }
+
+    return entry
   })
 
   // Iterate through info fields and add to info table.
-  for (let entry of infoj || location.infoj) {
-
-    if (typeof entry === 'string') {
-      entry = location.infoj.find(_entry => _entry.field === entry)
-
-      if (!entry) continue;
-    }
+  for (const entry of infoj || location.infoj) {
 
     // The location view entries should not be processed if the view is disabled.
     if (location.view && location.view.classList.contains('disabled')) break;


### PR DESCRIPTION
If the infoj argument is provided as an array of strings a lookup for the entry with matching field will be attempted at the beginning of the iteration.

This does not backwards compatibility where the infoj argument is provided as an array of objects.

![image](https://github.com/GEOLYTIX/xyz/assets/22201617/c7aa37a9-a7e9-43a5-af29-198e6a04f321)
