### PR TITLE
Move default btn methods to plugins

### DIFF
--- a/lib/plugins.mjs
+++ b/lib/plugins.mjs
@@ -19,3 +19,93 @@ export async function svg_templates(plugin) {
 
   await Promise.all(promises)
 }
+
+export function locator(plugin, mapview) {
+
+  const btnColumn = document.getElementById('mapButton');
+
+  // the btnColumn element only exist in the default mapp view.
+  if (!btnColumn) return;
+
+  plugin.btn = mapp.utils.html.node`
+  <button
+    title=${mapp.dictionary.toolbar_current_location}
+    onclick=${(e) => {
+      e.target.classList.toggle('active');
+      mapview.locate();
+    }}><div class="mask-icon gps-not-fixed">`
+
+  btnColumn.append(plugin.btn)
+}
+
+export function fullscreen(plugin, mapview) {
+
+  const btnColumn = document.getElementById('mapButton');
+
+  // the btnColumn element only exist in the default mapp view.
+  if (!btnColumn) return;
+
+  function toggleFullscreen(e) {
+
+    e.target.classList.toggle('active');
+    document.body.classList.toggle('fullscreen');
+    mapview.Map.updateSize();
+    Object.values(mapview.layers)
+      .forEach((layer) => layer.mbMap?.resize());
+  }
+
+  plugin.btn = mapp.utils.html.node`
+  <button
+    class="mobile-display-none"
+    title=${mapp.dictionary.toolbar_fullscreen}
+    onclick=${toggleFullscreen}>
+    <div class="mask-icon map">`
+
+  btnColumn.append(plugin.btn)
+}
+
+export function zoomToArea(plugin, mapview) {
+
+  const btnColumn = document.getElementById('mapButton');
+
+  // the btnColumn element only exist in the default mapp view.
+  if (!btnColumn) return;
+
+  function toggleZoomInteraction(e) {
+
+    // If active cancel zoom and enable highlight interaction.
+    if (e.target.classList.contains('active')) {
+
+      // Will remove the 'active' class in callback of zoom interaction.
+      mapview.interactions.highlight()
+      return;
+    }
+
+    // Add active class
+    e.target.classList.add('active')
+
+    // Make zoom interaction current.
+    mapview.interactions.zoom({
+
+      // The interaction callback is executed on cancel or finish.
+      callback: () => {
+        e.target.classList.remove('active');
+        delete mapview.interaction
+
+        // Set highlight interaction if no other interaction is current after 400ms.
+        setTimeout(() => {
+          !mapview.interaction && mapview.interactions.highlight()
+        }, 400)
+      }
+    })
+  }
+
+  plugin.btn = mapp.utils.html.node`
+  <button
+    class="mobile-display-none"
+    title=${mapp.dictionary.toolbar_zoom_to_area}
+    onclick=${toggleZoomInteraction}>
+    <div class="mask-icon pageview">`
+
+  btnColumn.append(plugin.btn)  
+}

--- a/lib/plugins.mjs
+++ b/lib/plugins.mjs
@@ -27,7 +27,7 @@ export function locator(plugin, mapview) {
   // the btnColumn element only exist in the default mapp view.
   if (!btnColumn) return;
 
-  plugin.btn = mapp.utils.html.node`
+  const btn = mapp.utils.html.node`
   <button
     title=${mapp.dictionary.toolbar_current_location}
     onclick=${(e) => {
@@ -35,7 +35,7 @@ export function locator(plugin, mapview) {
       mapview.locate();
     }}><div class="mask-icon gps-not-fixed">`
 
-  btnColumn.append(plugin.btn)
+  btnColumn.append(btn)
 }
 
 export function fullscreen(plugin, mapview) {
@@ -54,14 +54,14 @@ export function fullscreen(plugin, mapview) {
       .forEach((layer) => layer.mbMap?.resize());
   }
 
-  plugin.btn = mapp.utils.html.node`
+  const btn = mapp.utils.html.node`
   <button
     class="mobile-display-none"
     title=${mapp.dictionary.toolbar_fullscreen}
     onclick=${toggleFullscreen}>
     <div class="mask-icon map">`
 
-  btnColumn.append(plugin.btn)
+  btnColumn.append(btn)
 }
 
 export function zoomToArea(plugin, mapview) {
@@ -100,12 +100,12 @@ export function zoomToArea(plugin, mapview) {
     })
   }
 
-  plugin.btn = mapp.utils.html.node`
+  const btn = mapp.utils.html.node`
   <button
     class="mobile-display-none"
     title=${mapp.dictionary.toolbar_zoom_to_area}
     onclick=${toggleZoomInteraction}>
     <div class="mask-icon pageview">`
 
-  btnColumn.append(plugin.btn)  
+  btnColumn.append(btn)  
 }

--- a/public/views/_default.js
+++ b/public/views/_default.js
@@ -338,65 +338,9 @@ window.onload = async () => {
     btnZoomOut.disabled = z <= mapview.locale.minZoom;
   });
 
-  // Add zoom to area button.
-  btnColumn.append(mapp.utils.html.node`
-    <button
-      class="mobile-display-none"
-      title=${mapp.dictionary.toolbar_zoom_to_area}
-      onclick=${(e) => {
-
-      // If active cancel zoom and enable highlight interaction.
-      if (e.target.classList.contains('active')) {
-
-        // Will remove the 'active' class in callback of zoom interaction.
-        mapview.interactions.highlight()
-        return;
-      }
-
-      // Add active class
-      e.target.classList.add('active')
-
-      // Make zoom interaction current.
-      mapview.interactions.zoom({
-
-        // The interaction callback is executed on cancel or finish.
-        callback: () => {
-          e.target.classList.remove('active');
-          delete mapview.interaction
-
-          // Set highlight interaction if no other interaction is current after 400ms.
-          setTimeout(() => {
-            !mapview.interaction && mapview.interactions.highlight()
-          }, 400)
-        }
-      })
-
-    }}>
-      <div class="mask-icon pageview">`)
-
-  // Add locator button.
-  mapview.locale.locator && btnColumn.appendChild(mapp.utils.html.node`
-    <button
-      title=${mapp.dictionary.toolbar_current_location}
-      onclick=${(e) => {
-      mapview.locate();
-      e.target.classList.toggle('active');
-    }}>
-      <div class="mask-icon gps-not-fixed">`);
-
-  // Add fullscreen button.
-  btnColumn.appendChild(mapp.utils.html.node`
-    <button
-      class="mobile-display-none"
-      title=${mapp.dictionary.toolbar_fullscreen}
-      onclick=${(e) => {
-      e.target.classList.toggle('active');
-      document.body.classList.toggle('fullscreen');
-      mapview.Map.updateSize();
-      Object.values(mapview.layers)
-        .forEach((layer) => layer.mbMap?.resize());
-    }}>
-      <div class="mask-icon map">`);
+  // Default plugins
+  mapview.locale.zoomToArea ??= {}
+  mapview.locale.fullscreen ??= {}
 
   // Load plugins
   await mapp.utils.loadPlugins(locale.plugins);

--- a/public/views/_default.js
+++ b/public/views/_default.js
@@ -341,10 +341,6 @@ window.onload = async () => {
     btnZoomOut.disabled = z <= mapview.locale.minZoom;
   });
 
-  // Default plugins
-  mapview.locale.zoomToArea = true
-  mapview.locale.fullscreen = true
-
   // Load JSON layers from Workspace API.
   const layers = locale.layers.length ? await mapp.utils.promiseAll(locale.layers.map(
     layer => mapp.utils.xhr(`${mapp.host}/api/workspace/layer?`

--- a/public/views/_default.js
+++ b/public/views/_default.js
@@ -339,8 +339,8 @@ window.onload = async () => {
   });
 
   // Default plugins
-  mapview.locale.zoomToArea ??= {}
-  mapview.locale.fullscreen ??= {}
+  mapview.locale.zoomToArea = true
+  mapview.locale.fullscreen = true
 
   // Load plugins
   await mapp.utils.loadPlugins(locale.plugins);


### PR DESCRIPTION
locator, zoomToArea, and fullscreen behave exactly like plugins.

These 'default' plugins have been moved to the plugins module from the default view to clean up the default view.

Methods have been moved out of the <button> tag for better maintenance and linting.