### PR TITLE
Provide fallback when host is empty string

### DIFF
--- a/lib/ui/Dataview.mjs
+++ b/lib/ui/Dataview.mjs
@@ -36,7 +36,7 @@ export default async (_this) => {
 
     // Query data as response from query.
     const response = await mapp.utils.xhr(
-      `${_this.host || _this.location.layer.mapview.host
+      `${_this.host || _this.location?.layer?.mapview?.host || mapp.host
       }/api/query?${paramString}`
     );
 

--- a/lib/ui/locations/entries/dataview.mjs
+++ b/lib/ui/locations/entries/dataview.mjs
@@ -16,7 +16,7 @@ export default entry => {
 
   // Dataview methods require the layer and host to be defined on the entry.
   entry.layer = entry.location.layer
-  entry.host = entry.host || entry.location.layer.mapview.host
+  entry.host = entry.host || entry.location?.layer?.mapview?.host || mapp.host
 
   // An entry which depend on another entry field will not be displayed if that field value is falsy.
   if (entry.dependents && entry.dependents.some(

--- a/lib/ui/locations/entries/mvt_clone.mjs
+++ b/lib/ui/locations/entries/mvt_clone.mjs
@@ -67,7 +67,7 @@ export default entry => {
     const paramString = mapp.utils.paramString(mapp.utils.queryParams(entry))
 
     // Query the featureLookup.
-    entry.featureLookup = await mapp.utils.xhr(`${entry.host || entry.mapview.host}/api/query?${paramString}`)
+    entry.featureLookup = await mapp.utils.xhr(`${entry.host || entry.mapview?.host || mapp.host}/api/query?${paramString}`)
 
     // The query does not return a response.
     if (entry.featureLookup === null) {

--- a/lib/ui/locations/entries/vector_layer.mjs
+++ b/lib/ui/locations/entries/vector_layer.mjs
@@ -63,7 +63,7 @@ async function show(entry) {
   const paramString = mapp.utils.paramString(mapp.utils.queryParams(entry))
 
   // Query the featureLookup.
-  entry.features = await mapp.utils.xhr(`${entry.host || entry.mapview.host}/api/query?${paramString}`)
+  entry.features = await mapp.utils.xhr(`${entry.host || entry.mapview?.host || mapp.host}/api/query?${paramString}`)
 
   mapp.layer.formats[entry.format](entry)
 

--- a/lib/ui/locations/infoj.mjs
+++ b/lib/ui/locations/infoj.mjs
@@ -128,7 +128,7 @@ export default (location, infoj) => {
 
         // Run the entry query.
         mapp.utils
-          .xhr(`${entry.host || entry.location.layer.mapview.host}/api/query?${paramString}`)
+          .xhr(`${entry.host || entry.location?.layer?.mapview?.host || mapp.host}/api/query?${paramString}`)
           .then(response => {
 
             // Assign query response as entry value.


### PR DESCRIPTION
Prevents an issue where the location.layer.mapview is not available and the DIR/HOST is falsy, e.g. empty string.