### PR TITLE
Editing Geometry Fix

### DIFF
--- a/lib/ui/locations/entries/geometry.mjs
+++ b/lib/ui/locations/entries/geometry.mjs
@@ -251,7 +251,8 @@ function modify(e, entry) {
 
         // Assign feature geometry as new value.
         entry.value = feature.geometry
-
+        // Remove entry.geometry. 
+        delete entry.geometry; 
         update(entry)
 
         return;


### PR DESCRIPTION
**What**
This PR addresses a bug whereby editing a location `entry` of type `geometry` would save the changes to the db but not update the geometry shown on the map. 

**Solution**
By adding delete entry.geometry before the update call, this forces the geometry to be re-created and thus re-drawn to the map, fixing the described issue. 
