### PR TITLE
Get array of layer objects instead of layer keys

### DIFF
--- a/mod/workspace/_workspace.js
+++ b/mod/workspace/_workspace.js
@@ -105,6 +105,28 @@ async function locale(req, res) {
     JSON.stringify(locale).replace(/\$\{(.*?)\}/g,
       matched => process.env[`SRC_${matched.replace(/(^\${)|(}$)/g, '')}`])
   )
+
+  // Return layer object instead of array of layer keys
+  if (req.params.layers) {
+
+    const layers = []
+
+    for (const key of Object.keys(locale.layers)) {
+
+      const layer = await getLayer({
+        locale: req.params.locale,
+        layer: key
+      })
+
+      if (!Roles.check(layer, roles)) continue;
+
+      layers.push(layer)
+    }
+
+    locale.layers = layers
+
+    return res.json(locale)
+  }
   
   // Check layer access.
   locale.layers = locale.layers && Object.entries(locale.layers)

--- a/public/views/_default.js
+++ b/public/views/_default.js
@@ -344,23 +344,6 @@ window.onload = async () => {
     btnZoomOut.disabled = z <= mapview.locale.minZoom;
   });
 
-  // Load JSON layers from Workspace API.
-  const layers = locale.layers.length ? await mapp.utils.promiseAll(locale.layers.map(
-    layer => mapp.utils.xhr(`${mapp.host}/api/workspace/layer?`
-      + `locale=${locale.key}&layer=${layer}`)))
-    : [{
-      key: 'OSM',
-      display: true,
-      format: 'tiles',
-      URI: 'https://{a-c}.tile.openstreetmap.org/{z}/{x}/{y}.png',
-      style: {
-        hidden: true
-      }
-    }]
-
-  // Add layers to mapview.
-  await mapview.addLayer(layers);
-
   if (mapview.locale.gazetteer) {
 
     mapp.ui.Gazetteer(Object.assign(mapview.locale.gazetteer, {

--- a/public/views/_default.js
+++ b/public/views/_default.js
@@ -261,7 +261,7 @@ window.onload = async () => {
 
   // Get locale with list of layers from Workspace API.
   const locale = await mapp.utils.xhr(
-    `${mapp.host}/api/workspace/locale?locale=${mapp.hooks.current.locale || locales[0].key}`);
+    `${mapp.host}/api/workspace/locale?locale=${mapp.hooks.current.locale || locales[0].key}&layers=true`);
 
   if (locale instanceof Error) {
 
@@ -307,6 +307,9 @@ window.onload = async () => {
     // mapp.Mapview must be awaited.
     loadPlugins: true
   });
+
+  // Add layers to mapview.
+  await mapview.addLayer(locale.layers);
 
   // Add zoomIn button.
   const btnZoomIn = btnColumn.appendChild(mapp.utils.html.node`
@@ -400,23 +403,6 @@ window.onload = async () => {
         .forEach((layer) => layer.mbMap?.resize());
     }}>
       <div class="mask-icon map">`);
-
-  // Load JSON layers from Workspace API.
-  const layers = locale.layers.length ? await mapp.utils.promiseAll(locale.layers.map(
-    layer => mapp.utils.xhr(`${mapp.host}/api/workspace/layer?`
-      + `locale=${locale.key}&layer=${layer}`)))
-    : [{
-      key: 'OSM',
-      display: true,
-      format: 'tiles',
-      URI: 'https://{a-c}.tile.openstreetmap.org/{z}/{x}/{y}.png',
-      style: {
-        hidden: true
-      }
-    }]
-
-  // Add layers to mapview.
-  await mapview.addLayer(layers);
 
   if (mapview.locale.gazetteer) {
 


### PR DESCRIPTION
Setting `layers=true` request param for the `/api/workspace/locale` endpoint will return an array of layer objects instead of layer keys.

Fewer requests have to be made to the workspace endpoints and the default script is shorter.

The hidden osm layer should not be assigned at this stage but when trying to create a mapview with an empty layers array.