### PR TITLE
Check whether a plugin string endsWith some value from an array

### DIFF
--- a/lib/utils/loadPlugins.mjs
+++ b/lib/utils/loadPlugins.mjs
@@ -1,26 +1,28 @@
-export default plugins => {
+export default (plugins, endsWith = ['.js','.mjs']) => {
 
   if (!Array.isArray(plugins)) return;
-  
-  return new Promise(resolveAll=>{
 
-    const promises = plugins.map(
-      plugin => 
-        new Promise((resolve, reject) => 
-          import(plugin)
-          .then(mod=> {
-            resolve(mod)
-          })
-          .catch(()=> {
-            reject()
-          })))
+  return new Promise(resolveAll => {
+
+    const promises = plugins
+      .filter(plugin => endsWith.some(_this => plugin.endsWith(_this)))
+      .map(
+        plugin =>
+          new Promise((resolve, reject) =>
+            import(plugin)
+              .then(mod => {
+                resolve(mod)
+              })
+              .catch(() => {
+                reject()
+              })))
 
     Promise
       .allSettled(promises)
-      .then(()=>{
+      .then(() => {
         resolveAll()
       })
-      .catch(err=>{
+      .catch(err => {
         console.error(err)
         resolveAll()
       })


### PR DESCRIPTION
An optional array argument endsWith which defaults to `['.js','.mjs']` can be provided to the loadPlugins method to limit which plugins should be loaded.

```js
// Load the ui_elements googleMaps plugins if defined in the locale.plugins
await mapp.utils.loadPlugins(locale.plugins, ['ui_elements.js','googleMaps.js']);
```