### PR TITLE
Review ui.elements.modal

### DIFF
--- a/lib/ui/elements/modal.mjs
+++ b/lib/ui/elements/modal.mjs
@@ -1,25 +1,26 @@
 export default (params) => {
+
   // Ensure the target is an HTMLElement before proceeding
   if (!(params.target instanceof HTMLElement)) return;
+
+  const closeBtn = params.close && mapp.utils.html.node`
+    <button
+      data-id=close
+      class="mask-icon close"
+      onclick=${closeModal}>`
+
+  const header = params.header?
+    mapp.utils.html.node`<h3>${params.header}${closeBtn}`
+    : closeBtn
 
   // Construct the modal element and append it to the target element
   params.modal = params.target.appendChild(mapp.utils.html.node`
     <div 
-      style="top: 10px; right: 10px; overflow: auto;"
+      style="top: 10px; right: 10px;"
       data-id=${params.data_id || 'modal'}
       class="modal">
-      <div class="header bold">
-        <span>${params.header}</span>
-        <button
-          data-id=close
-          class="mask-icon close"
-          onclick=${closeModal}>
-      </div>
+      ${header}
       ${params.content}`);
-
-  //set the width and height of the modal from where it gets defined.    
-  params.modal.style.width = params.width || '50%';
-  params.modal.style.height = params.height || '50%';
 
   // Function to handle the modal closure
   function closeModal(e) {
@@ -51,7 +52,6 @@ export default (params) => {
     window.addEventListener(endEvent, stopShift);
   }
 
-
   // Function to end the drag event, resetting cursor style and removing the move and end event listeners
   function stopShift() {
     params.modal.style.cursor = 'grab';
@@ -69,6 +69,10 @@ export default (params) => {
 
   // Function to handle the move event during a drag, updating the position of the modal while keeping it within the window bounds
   function shiftEvent(e) {
+
+    console.log(e.pageX)
+    console.log(e.pageY)
+
     // Retrieve the current touch or mouse position
     const pageX = (e.touches && e.touches[0].pageX) || e.pageX;
     const pageY = (e.touches && e.touches[0].pageY) || e.pageY;

--- a/lib/ui/elements/modal.mjs
+++ b/lib/ui/elements/modal.mjs
@@ -95,13 +95,13 @@ export default (modal) => {
 
     if (modal.contained) {
 
-      shiftContained(leftShift, topShift)
+      shiftContained(modal, leftShift, topShift)
       return;
     }
 
     if (modal.containedCentre) {
 
-      shiftContainedCentre(leftShift, topShift)
+      shiftContainedCentre(modal, leftShift, topShift)
       return
     }
 
@@ -111,82 +111,80 @@ export default (modal) => {
     // top shift
     modal.node.style.top = `${modal.node.offsetTop + topShift}px`
   }
+};
 
-  function shiftContained(leftShift, topShift) {
+function shiftContained(modal, leftShift, topShift) {
 
-    console.log([leftShift, topShift])
+  // Exceeds left offset
+  if ((modal.node.offsetLeft + leftShift) < 0) {
 
-    // Exceeds left offset
-    if ((modal.node.offsetLeft + leftShift) < 0) {
+    modal.node.style.left = 0
+  
+  // Shifts left
+  } else if (leftShift < 0) {
 
-      modal.node.style.left = 0
-    
+    modal.node.style.left = `${modal.node.offsetLeft + leftShift}px`
+
+  // Does NOT exceed right offset
+  } else if ((modal.target.offsetWidth - modal.node.offsetWidth - modal.node.offsetLeft) > 0) {
+
+    // Shifts right
+    modal.node.style.left = `${modal.node.offsetLeft + leftShift}px`
+  }
+
+
+  // Exceeds top offset
+  if ((modal.node.offsetTop + topShift) < 0) {
+
+    modal.node.style.top = 0
+  
+  // Shift top
+  } else if (topShift < 0) {
+
+    modal.node.style.top = `${modal.node.offsetTop + topShift}px`
+
+  // Does NOT exceed bottom offset
+  } else if ((modal.target.offsetHeight - modal.node.offsetHeight - modal.node.offsetTop) > 0) {
+
+    // Shift bottom
+    modal.node.style.top = `${modal.node.offsetTop + topShift}px`
+  }
+}
+
+function shiftContainedCentre(modal, leftShift, topShift) {
+
+  // Exceeds left offset
+  if ((modal.node.offsetLeft + parseInt(modal.node.offsetWidth / 2) + leftShift) < 0) {
+
+    return;
+
     // Shifts left
-    } else if (leftShift < 0) {
+  } else if (leftShift < 0) {
 
-      modal.node.style.left = `${modal.node.offsetLeft + leftShift}px`
+    modal.node.style.left = `${modal.node.offsetLeft + leftShift}px`
 
     // Does NOT exceed right offset
-    } else if ((modal.target.offsetWidth - modal.node.offsetWidth - modal.node.offsetLeft) > 0) {
+  } else if ((modal.target.offsetWidth - parseInt(modal.node.offsetWidth / 2) - modal.node.offsetLeft) > 0) {
 
-      // Shifts right
-      modal.node.style.left = `${modal.node.offsetLeft + leftShift}px`
-    }
+    // Shifts right
+    modal.node.style.left = `${modal.node.offsetLeft + leftShift}px`
+  }
 
 
-    // Exceeds top offset
-    if ((modal.node.offsetTop + topShift) < 0) {
+  // Exceeds top offset
+  if ((modal.node.offsetTop + parseInt(modal.node.offsetHeight / 2) + topShift) < 0) {
 
-      modal.node.style.top = 0
-    
+    return;
+
     // Shift top
-    } else if (topShift < 0) {
+  } else if (topShift < 0) {
 
-      modal.node.style.top = `${modal.node.offsetTop + topShift}px`
+    modal.node.style.top = `${modal.node.offsetTop + topShift}px`
 
     // Does NOT exceed bottom offset
-    } else if ((modal.target.offsetHeight - modal.node.offsetHeight - modal.node.offsetTop) > 0) {
+  } else if ((modal.target.offsetHeight - parseInt(modal.node.offsetHeight / 2) - modal.node.offsetTop) > 0) {
 
-      // Shift bottom
-      modal.node.style.top = `${modal.node.offsetTop + topShift}px`
-    }
+    // Shift bottom
+    modal.node.style.top = `${modal.node.offsetTop + topShift}px`
   }
-
-  function shiftContainedCentre(leftShift, topShift) {
-
-    // Exceeds left offset
-    if ((modal.node.offsetLeft + parseInt(modal.node.offsetWidth / 2) + leftShift) < 0) {
-
-      return;
-
-      // Shifts left
-    } else if (leftShift < 0) {
-
-      modal.node.style.left = `${modal.node.offsetLeft + leftShift}px`
-
-      // Does NOT exceed right offset
-    } else if ((modal.target.offsetWidth - parseInt(modal.node.offsetWidth / 2) - modal.node.offsetLeft) > 0) {
-
-      // Shifts right
-      modal.node.style.left = `${modal.node.offsetLeft + leftShift}px`
-    }
-
-
-    // Exceeds top offset
-    if ((modal.node.offsetTop + parseInt(modal.node.offsetHeight / 2) + topShift) < 0) {
-
-      return;
-
-      // Shift top
-    } else if (topShift < 0) {
-
-      modal.node.style.top = `${modal.node.offsetTop + topShift}px`
-
-      // Does NOT exceed bottom offset
-    } else if ((modal.target.offsetHeight - parseInt(modal.node.offsetHeight / 2) - modal.node.offsetTop) > 0) {
-
-      // Shift bottom
-      modal.node.style.top = `${modal.node.offsetTop + topShift}px`
-    }
-  }
-};
+}

--- a/lib/ui/elements/modal.mjs
+++ b/lib/ui/elements/modal.mjs
@@ -1,26 +1,31 @@
-export default (params) => {
+export default (modal) => {
 
   // Ensure the target is an HTMLElement before proceeding
-  if (!(params.target instanceof HTMLElement)) return;
+  if (!(modal.target instanceof HTMLElement)) return;
 
-  const closeBtn = params.close && mapp.utils.html.node`
+  const closeBtn = modal.close && mapp.utils.html.node`
     <button
       data-id=close
       class="mask-icon close"
       onclick=${closeModal}>`
 
-  const header = params.header?
-    mapp.utils.html.node`<h3>${params.header}${closeBtn}`
+  const header = modal.header?
+    mapp.utils.html.node`<h3>${modal.header}${closeBtn}`
     : closeBtn
 
+  modal.data_id ??= 'modal'
+
+  // Modal must have inline style for top and left offset.
+  const css_style = `${modal.css_style || ''} top: 0; left: 0;`
+
   // Construct the modal element and append it to the target element
-  params.modal = params.target.appendChild(mapp.utils.html.node`
+  modal.node = modal.target.appendChild(mapp.utils.html.node`
     <div 
-      style="top: 10px; right: 10px;"
-      data-id=${params.data_id || 'modal'}
+      style=${css_style}
+      data-id=${modal.data_id}
       class="modal">
       ${header}
-      ${params.content}`);
+      ${modal.content}`);
 
   // Function to handle the modal closure
   function closeModal(e) {
@@ -30,88 +35,152 @@ export default (params) => {
 
   // Function to add event listeners for drag functionality
   function addEventListeners() {
-    params.modal.addEventListener('mousedown', handleStartEvent);
-    params.modal.addEventListener('touchstart', handleStartEvent);
+    modal.node.addEventListener('mousedown', handleStartEvent);
+    modal.node.addEventListener('touchstart', handleStartEvent);
   }
 
   // Function to handle the start of a drag event, setting up the necessary event listeners for moving and ending the drag
   function handleStartEvent(e) {
 
-    if (e.target.matches('input, textarea')) return;
-
-    params.modal.style.cursor = 'grabbing';
+    modal.node.style.cursor = 'grabbing';
 
     const eventsMap = {
-      mousedown: { move: 'mousemove', end: 'mouseup' },
-      touchstart: { move: 'touchmove', end: 'touchend' },
+      mousedown: {
+        move: 'mousemove',
+        end: 'mouseup'
+      },
+      touchstart: {
+        move: 'touchmove',
+        end: 'touchend'
+      },
     };
 
     const { move: moveEvent, end: endEvent } = eventsMap[e.type];
 
-    window.addEventListener(moveEvent, shiftEvent);
+    modal.target.addEventListener(moveEvent, shiftEvent);
     window.addEventListener(endEvent, stopShift);
   }
 
   // Function to end the drag event, resetting cursor style and removing the move and end event listeners
   function stopShift() {
-    params.modal.style.cursor = 'grab';
+    modal.node.style.cursor = 'grab';
 
-    x = undefined;
-    y = undefined;
-    window.removeEventListener('mousemove', shiftEvent);
-    window.removeEventListener('touchmove', shiftEvent);
-    window.removeEventListener('mouseup', stopShift);
-    window.removeEventListener('touchend', stopShift);
+    modal.target.removeEventListener('mousemove', shiftEvent);
+    modal.target.removeEventListener('touchmove', shiftEvent);
+    modal.target.removeEventListener('mouseup', stopShift);
+    modal.target.removeEventListener('touchend', stopShift);
   }
-
-  // Variables to hold the current position during a drag event
-  let x, y;
 
   // Function to handle the move event during a drag, updating the position of the modal while keeping it within the window bounds
   function shiftEvent(e) {
 
-    console.log(e.pageX)
-    console.log(e.pageY)
+    // Set initial x
+    modal.x ??= e.x
 
-    // Retrieve the current touch or mouse position
-    const pageX = (e.touches && e.touches[0].pageX) || e.pageX;
-    const pageY = (e.touches && e.touches[0].pageY) || e.pageY;
+    const leftShift = e.x - modal.x
 
-    // If x and y are not defined, it is the first move event; store the current positions and exit
-    if (!x || !y) {
-      x = pageX;
-      y = pageY;
+    modal.x = e.x
+
+    // Set initial y
+    modal.y ??= e.y
+
+    const topShift = e.y - modal.y
+
+    modal.y = e.y
+
+    if (modal.contained) {
+
+      shiftContained(leftShift, topShift)
       return;
     }
 
-    // Calculate the new position of the modal based on the drag distance
-    let newRight = parseInt(params.modal.style.right) + (x - pageX);
-    let newTop = parseInt(params.modal.style.top) + (pageY - y);
+    if (modal.containedCentre) {
 
-    // Retrieve the dimensions of the entire HTML page
-    const targetBounds = document.documentElement.getBoundingClientRect();
-
-    // Calculate the central anchor point of the modal (center in X and Y coordinates)
-    const modalCenterX = window.innerWidth - newRight - (params.modal.offsetWidth / 2);
-    const modalCenterY = newTop + (params.modal.offsetHeight / 2);
-
-    // If the central anchor point of the modal goes outside the HTML page's boundaries, prevent the move
-    if (
-      modalCenterX < targetBounds.left ||
-      modalCenterX > targetBounds.right ||
-      modalCenterY < targetBounds.top ||
-      modalCenterY > targetBounds.bottom
-    ) {
-      return;
+      shiftContainedCentre(leftShift, topShift)
+      return
     }
 
-    // If within boundaries, update the modal's position based on the drag
-    params.modal.style.right = newRight + 'px';
-    params.modal.style.top = newTop + 'px';
+    // left shift
+    modal.node.style.left = `${modal.node.offsetLeft + leftShift}px`
 
-    // Store the current positions for use in the next move event
-    x = pageX;
-    y = pageY;
+    // top shift
+    modal.node.style.top = `${modal.node.offsetTop + topShift}px`
+  }
+
+  function shiftContained(leftShift, topShift) {
+
+    // Exceeds left offset
+    if ((modal.node.offsetLeft + leftShift) < 0) {
+
+      modal.node.style.left = 0
+    
+    // Shifts left
+    } else if (leftShift < 0) {
+
+      modal.node.style.left = `${modal.node.offsetLeft + leftShift}px`
+
+    // Does NOT exceed right offset
+    } else if ((modal.target.offsetWidth - modal.node.offsetWidth - modal.node.offsetLeft) > 0) {
+
+      // Shifts right
+      modal.node.style.left = `${modal.node.offsetLeft + leftShift}px`
+    }
+
+
+    // Exceeds top offset
+    if ((modal.node.offsetTop + topShift) < 0) {
+
+      modal.node.style.top = 0
+    
+    // Shift top
+    } else if (topShift < 0) {
+
+      modal.node.style.top = `${modal.node.offsetTop + topShift}px`
+
+    // Does NOT exceed bottom offset
+    } else if ((modal.target.offsetHeight - modal.node.offsetHeight - modal.node.offsetTop) > 0) {
+
+      // Shift bottom
+      modal.node.style.top = `${modal.node.offsetTop + topShift}px`
+    }
+  }
+
+  function shiftContainedCentre(leftShift, topShift) {
+
+    // Exceeds left offset
+    if ((modal.node.offsetLeft + parseInt(modal.node.offsetWidth / 2) + leftShift) < 0) {
+
+      return;
+
+      // Shifts left
+    } else if (leftShift < 0) {
+
+      modal.node.style.left = `${modal.node.offsetLeft + leftShift}px`
+
+      // Does NOT exceed right offset
+    } else if ((modal.target.offsetWidth - parseInt(modal.node.offsetWidth / 2) - modal.node.offsetLeft) > 0) {
+
+      // Shifts right
+      modal.node.style.left = `${modal.node.offsetLeft + leftShift}px`
+    }
+
+
+    // Exceeds top offset
+    if ((modal.node.offsetTop + parseInt(modal.node.offsetHeight / 2) + topShift) < 0) {
+
+      return;
+
+      // Shift top
+    } else if (topShift < 0) {
+
+      modal.node.style.top = `${modal.node.offsetTop + topShift}px`
+
+      // Does NOT exceed bottom offset
+    } else if ((modal.target.offsetHeight - parseInt(modal.node.offsetHeight / 2) - modal.node.offsetTop) > 0) {
+
+      // Shift bottom
+      modal.node.style.top = `${modal.node.offsetTop + topShift}px`
+    }
   }
 
   // Initialize the event listeners when the module is executed

--- a/lib/ui/elements/modal.mjs
+++ b/lib/ui/elements/modal.mjs
@@ -36,7 +36,7 @@ export default (modal) => {
   // Function to handle the modal closure
   function closeModal(e) {
     e.target.closest('.modal').remove();
-    params?.close?.(e);
+    modal?.close?.(e);
   }
 
   // Function to handle the start of a drag event, setting up the necessary event listeners for moving and ending the drag

--- a/lib/ui/elements/modal.mjs
+++ b/lib/ui/elements/modal.mjs
@@ -9,23 +9,29 @@ export default (modal) => {
       class="mask-icon close"
       onclick=${closeModal}>`
 
-  const header = modal.header?
-    mapp.utils.html.node`<h3>${modal.header}${closeBtn}`
-    : closeBtn
-
   modal.data_id ??= 'modal'
-
-  // Modal must have inline style for top and left offset.
-  const css_style = `${modal.css_style || ''} top: 0; left: 0;`
 
   // Construct the modal element and append it to the target element
   modal.node = modal.target.appendChild(mapp.utils.html.node`
     <div 
-      style=${css_style}
+      style=${modal.css_style}
       data-id=${modal.data_id}
       class="modal">
-      ${header}
+      ${closeBtn}
+      ${modal.header}
       ${modal.content}`);
+
+  if (modal.right) {
+
+    // Calc left from right and offSetWidth
+    modal.left = modal.target.offsetWidth - modal.node.offsetWidth - parseInt(modal.right)
+  }
+  
+  modal.node.style.top = `${modal.top || 0}px`
+  modal.node.style.left = `${modal.left || 0}px`
+
+  modal.node.addEventListener('mousedown', handleStartEvent);
+  modal.node.addEventListener('touchstart', handleStartEvent);      
 
   // Function to handle the modal closure
   function closeModal(e) {
@@ -33,14 +39,11 @@ export default (modal) => {
     params?.close?.(e);
   }
 
-  // Function to add event listeners for drag functionality
-  function addEventListeners() {
-    modal.node.addEventListener('mousedown', handleStartEvent);
-    modal.node.addEventListener('touchstart', handleStartEvent);
-  }
-
   // Function to handle the start of a drag event, setting up the necessary event listeners for moving and ending the drag
   function handleStartEvent(e) {
+
+    // Don't trigger shift on right click
+    if (e.which === 3) return;
 
     modal.node.style.cursor = 'grabbing';
 
@@ -63,8 +66,10 @@ export default (modal) => {
 
   // Function to end the drag event, resetting cursor style and removing the move and end event listeners
   function stopShift() {
-    modal.node.style.cursor = 'grab';
+    delete modal.x
+    delete modal.y
 
+    modal.node.style.cursor = 'grab';
     modal.target.removeEventListener('mousemove', shiftEvent);
     modal.target.removeEventListener('touchmove', shiftEvent);
     modal.target.removeEventListener('mouseup', stopShift);
@@ -108,6 +113,8 @@ export default (modal) => {
   }
 
   function shiftContained(leftShift, topShift) {
+
+    console.log([leftShift, topShift])
 
     // Exceeds left offset
     if ((modal.node.offsetLeft + leftShift) < 0) {
@@ -182,7 +189,4 @@ export default (modal) => {
       modal.node.style.top = `${modal.node.offsetTop + topShift}px`
     }
   }
-
-  // Initialize the event listeners when the module is executed
-  addEventListeners();
 };

--- a/lib/ui/layers/panels/style.mjs
+++ b/lib/ui/layers/panels/style.mjs
@@ -263,8 +263,6 @@ export default layer => {
           layer.style.hover = layer.style.hovers[layer.style.theme.setHover]
         }
 
-        layer.style.legend.closest('.modal').remove();
-
         // Replace the children of the style panel.
         layer.view.querySelector('[data-id=style-drawer]')
           .replaceChildren(...mapp.ui.layers.panels.style(layer).children)
@@ -280,35 +278,7 @@ export default layer => {
 
   }
 
-  function modalButton() {
-    return mapp.utils.html`
-      <button
-        style="height: 1.5em; width: 1.5em; float: right; margin-top: 5px;"
-        class="mask-icon open-in-new"
-        title="Open in Modal"
-        onclick=${e => {
-        let btn = e.target
-
-        btn.style.display = 'none'
-
-        mapp.ui.elements.modal({
-          target: layer.mapview.Map.getTargetElement(),
-          content: layer.style.legend.parentElement,
-          top: 20,
-          right: 50,
-          css_style: 'padding: 10px; width: 200px; right: 0;',
-          contained: true,
-          close: () => {
-            layer.style.drawer.append(layer.style.legend.parentElement)
-            btn.style.display = 'block'
-          }
-        })
-
-      }}>`
-  }
-
   mapp.ui.layers.legends[layer.style.theme?.type] && content.push(mapp.utils.html`
-    ${layer.style.allowModal && modalButton() || undefined}
     <div class="legend">
       ${layer.style.theme?.meta && mapp.utils.html`<p>${layer.style.theme.meta}`}
       ${mapp.ui.layers.legends[layer.style.theme.type](layer)}`)

--- a/lib/ui/layers/panels/style.mjs
+++ b/lib/ui/layers/panels/style.mjs
@@ -263,6 +263,8 @@ export default layer => {
           layer.style.hover = layer.style.hovers[layer.style.theme.setHover]
         }
 
+        layer.style.legend.closest('.modal').remove();
+
         // Replace the children of the style panel.
         layer.view.querySelector('[data-id=style-drawer]')
           .replaceChildren(...mapp.ui.layers.panels.style(layer).children)

--- a/lib/ui/layers/panels/style.mjs
+++ b/lib/ui/layers/panels/style.mjs
@@ -292,6 +292,10 @@ export default layer => {
         mapp.ui.elements.modal({
           target: layer.mapview.Map.getTargetElement(),
           content: layer.style.legend.parentElement,
+          top: 20,
+          right: 50,
+          css_style: 'padding: 10px; width: 200px; right: 0;',
+          contained: true,
           close: () => {
             layer.style.drawer.append(layer.style.legend.parentElement)
             btn.style.display = 'block'

--- a/public/css/_ui.css
+++ b/public/css/_ui.css
@@ -92,34 +92,12 @@
   cursor: grab;
   user-select: none;
 
-  & > .header {
-    display: flex;
-    align-items: center;
-
-    & > :not(button):not(label):not(input) {
-      pointer-events: none;
-    }
-
-    & > div,
-    & > button {
-      margin-left: 5px;
-      width: 1.5em;
-      height: 1.5em;
-    }
-
-    & > :nth-child(1) {
-      overflow: hidden;
-      white-space: nowrap;
-      text-overflow: ellipsis;
-    }
-
-    & > :nth-child(2) {
-      margin-left: auto;
-    }
-
-    & > input{
-      user-select: text;
-    }
+  & > button.close {
+    position: absolute;
+    top: 1em;
+    right: 1em;
+    height: 1em;
+    width: 1em;
   }
 }
 

--- a/public/css/_ui.css
+++ b/public/css/_ui.css
@@ -86,9 +86,7 @@
 }
 
 .modal {
-  position: fixed;
-  padding: 10px;
-  z-index: 10001;
+  position: absolute;
   background-color: #fff;
   box-shadow: 1px 1px 3px var(--color-primary-light);
   cursor: grab;

--- a/public/css/ui.css
+++ b/public/css/ui.css
@@ -1492,9 +1492,7 @@ label.checkbox {
   gap: 5px;
 }
 .modal {
-  position: fixed;
-  padding: 10px;
-  z-index: 10001;
+  position: absolute;
   background-color: #fff;
   box-shadow: 1px 1px 3px var(--color-primary-light);
   cursor: grab;

--- a/public/css/ui.css
+++ b/public/css/ui.css
@@ -1497,29 +1497,12 @@ label.checkbox {
   box-shadow: 1px 1px 3px var(--color-primary-light);
   cursor: grab;
   user-select: none;
-  & > .header {
-    display: flex;
-    align-items: center;
-    & > :not(button):not(label):not(input) {
-      pointer-events: none;
-    }
-    & > div,
-    & > button {
-      margin-left: 5px;
-      width: 1.5em;
-      height: 1.5em;
-    }
-    & > :nth-child(1) {
-      overflow: hidden;
-      white-space: nowrap;
-      text-overflow: ellipsis;
-    }
-    & > :nth-child(2) {
-      margin-left: auto;
-    }
-    & > input {
-      user-select: text;
-    }
+  & > button.close {
+    position: absolute;
+    top: 1em;
+    right: 1em;
+    height: 1em;
+    width: 1em;
   }
 }
 .mask-icon {


### PR DESCRIPTION
Modal must not have close button if not defined in constructor.

Modal must not have header if not defined in constructor.

Modal must not have inline styles if not defined in constructor.

Modal should take size from content.

Modal should be movable within the context of the parent.

A target in which the modal will be positioned absolute must be defined.

A header is optional. Can be provided as string or html element.

Close is optional. A close button will be displayed in the top right corner.

Default position is top: 0, left: 0.

Content must be provided to calculate the offset width and height.

```js
mapp.ui.elements.modal({
  target: retailplaceMapview.target,
  header: 'Foo',
  close: true,
  top: 20 // pixel, default 0
  right: 20 // pixel, default left: 0
  content: layerSwitch,
  css_style: 'padding: 10px;',
  contained: true,
  //containedCentre: true
})
```

With the `contained:true` flag the modal bounds can not be shifted outside the target bounds.

With the `containedCentre:true` flag the centre of the modal can not be shifted outside the target bounds.
