### PR TITLE
Allow to define the attribution target

### DIFF
--- a/lib/mapview/attribution.mjs
+++ b/lib/mapview/attribution.mjs
@@ -2,15 +2,16 @@ export default function attribution(mapview) {
 
   if (typeof mapview.attribution !== 'object') return;
 
-  if (!mapview.attribution.target) {
+  mapview.attribution.target ??= mapview.target
 
-    mapview.attribution.node = mapview.target.appendChild(
-      mapp.utils.html.node`<div class="map-attribution">
-        ${mapview.attribution.logo}`)
+  mapview.attribution.node = mapp.utils.html.node`
+    <div class="map-attribution">${mapview.attribution.logo}`
 
-    mapview.attribution.target = mapview.attribution.node
-      .appendChild(mapp.utils.html.node`<div class="attribution-links">`)
-  }
+  mapview.attribution.target.append(mapview.attribution.node)
+
+  mapview.attribution.linksTarget = mapp.utils.html.node`<div class="attribution-links">`
+    
+  mapview.attribution.node.append(mapview.attribution.linksTarget)
 
   mapview.attribution.links ??= {}
 
@@ -31,7 +32,7 @@ export default function attribution(mapview) {
 
     // Render all links into mapview.attribution.target.
     mapp.utils.render(
-      mapview.attribution.target,
+      mapview.attribution.linksTarget,
       mapp.utils.html.node`${elements}`)
 
   }

--- a/public/views/_default.js
+++ b/public/views/_default.js
@@ -296,6 +296,7 @@ window.onload = async () => {
     hooks: true,
     scrollWheelZoom: true,
     attribution: {
+      target: document.getElementById('Map'),
       logo: mapp.utils.html.node`
         <a class="logo" target="_blank" href="https://geolytix.co.uk">
           <img src="https://geolytix.github.io/public/geolytix_mapp.svg">`,


### PR DESCRIPTION
It must be possible to define the target of the attribution.

In the case of the default mapview the attribution must be assigned to the `#Map` parent element of the `#OL` mapview.target.

This is to allow for the attribution to float with the tabview and not over it.