### PR TITLE
Do not reset candidateKeys in highlight interaction clear event.

### DIFF
--- a/lib/mapview/interactions/highlight.mjs
+++ b/lib/mapview/interactions/highlight.mjs
@@ -148,10 +148,9 @@ export default function (params) {
     }
 
     // Find candidate from key which is not in candidates set.
-    let candidate = candidates[Object.keys(candidates).find(key => !mapview.interaction.candidateKeys.has(key))]
+    const candidate = candidates[Object.keys(candidates).find(key => !mapview.interaction.candidateKeys.has(key))]
 
-    // Assign candidate from first key if candidate is falsy.
-    candidate = candidate
+      // Or assign candidate from first key
       || mapview.interaction.current?.key && candidates[mapview.interaction.current?.key]
       || candidates[Object.keys(candidates)[0]]
 
@@ -285,9 +284,6 @@ export default function (params) {
 
     // Delete the highlight id from current layer.
     delete mapview.interaction.current.layer.highlight
-
-    // Reset candidateKeys
-    mapview.interaction.candidateKeys = new Set();
 
     // Style the feature itself if possible.
     if (mapview.interaction.current.layer.format !== 'mvt'


### PR DESCRIPTION
This should reduce the number of hover requests send. The highlight event method of the highlight interaction should only be triggered is the candidateKeys set is different from the set of feature keys at pixel.
