### PR TITLE
preserveDrawingBuffer defaults true for maplibre layer

### DIFF
--- a/lib/layer/format/maplibre.mjs
+++ b/lib/layer/format/maplibre.mjs
@@ -69,7 +69,7 @@ export default async layer => {
     pitchWithRotate: false,
     scrollZoom: false,
     touchZoomRotate: false,
-    preserveDrawingBuffer: layer.preserveDrawingBuffer,
+    preserveDrawingBuffer: true,
     transformRequest: (url, resourceType) => {
 
       if (url.indexOf('mapbox:') === 0) {


### PR DESCRIPTION
This allows to export the canvas as blob/png in a screenshot.