### PR TITLE
Fix cloudinary missing URL error

### DIFF
--- a/mod/sign/cloudinary.js
+++ b/mod/sign/cloudinary.js
@@ -1,12 +1,11 @@
 const { createHash } = require('crypto');
 
-// 1: api_key
-// 2: api_secret
-// 3: cloud_name
-const cloudinary = process.env.CLOUDINARY_URL?.replaceAll('://', ' ').replaceAll(':', ' ').replaceAll('@', ' ').split(' ');
-const baseUrl = `https://api.cloudinary.com/v1_1/${cloudinary[3]}/`
-
 module.exports = async req => {
+    // 1: api_key
+    // 2: api_secret
+    // 3: cloud_name
+    const cloudinary = process.env.CLOUDINARY_URL?.replaceAll('://', ' ').replaceAll(':', ' ').replaceAll('@', ' ').split(' ');
+    const baseUrl = `https://api.cloudinary.com/v1_1/${cloudinary[3]}/`
 
     const folder = (!req.params.folder) ? '' : `${req.params.folder}/`
 


### PR DESCRIPTION
### What
This PR addresses [#Issue 1113](https://github.com/GEOLYTIX/xyz/issues/1113).

### Why
If the cloudinary URL was missing the build would fail

### How 
Build the url when the endpoint is actually called