### PR TITLE
Store user session token in process

### DIFF
--- a/mod/user/auth.js
+++ b/mod/user/auth.js
@@ -29,7 +29,7 @@ module.exports = async (req, res) => {
     if (err) return err
 
     // user [nano] sessions are enabled in the env.
-    if (process.env.NANO_SESSION) {
+    if (process.env.NANO_SESSION && user.session) {
 
       // The session token is stored in the user_session object.
       if (Object.hasOwn(user_sessions, user.email)) {

--- a/mod/user/fromACL.js
+++ b/mod/user/fromACL.js
@@ -127,10 +127,11 @@ async function getUser(request) {
         WHERE lower(email) = lower($1)`,
         [request.email])
 
-      if (rows instanceof Error) return new Error(await languageTemplates({
-        template: 'failed_query',
-        language: request.language
-      }))
+      // The ACL table may not have a session column.
+      if (rows instanceof Error) {
+
+        delete user.session
+      }
 
     }
 


### PR DESCRIPTION
The auth module should store user sessions in the process to reduce the number of requests for the [nano] session token to the ACL.