### PR TITLE
Allow for mapview to be assigned on entry

### DIFF
--- a/lib/ui/locations/entries/mvt_clone.mjs
+++ b/lib/ui/locations/entries/mvt_clone.mjs
@@ -5,7 +5,13 @@ export default entry => {
   if (entry.panel) return entry.panel;
 
   // Assign mapview to entry to provide shortened lookup.
-  entry.mapview = entry.location.layer.mapview
+  entry.mapview ??= entry.location.layer.mapview
+
+  if (!entry.mapview) {
+
+    console.warn(`mvt_clone entry requires a mapview.`)
+    return;
+  }
 
   // Assign the mvt layer to be cloned from mapview layers.
   entry.Layer = entry.mapview.layers[entry.layer]

--- a/lib/ui/locations/entries/vector_layer.mjs
+++ b/lib/ui/locations/entries/vector_layer.mjs
@@ -5,7 +5,13 @@ export default entry => {
   if (entry.panel) return entry.panel;
 
   // Assign mapview to entry to provide shortened lookup.
-  entry.mapview = entry.location.layer.mapview
+  entry.mapview ??= entry.location.layer.mapview
+
+  if (!entry.mapview) {
+
+    console.warn(`vector_layer entry requires a mapview.`)
+    return;
+  }
 
   entry.style ??= {}
 


### PR DESCRIPTION
Do not attempt to assign mapview from entry.location.layer if implicit.

Warn if missing.
