### PR TITLE
Err on null password login

### DIFF
--- a/mod/user/fromACL.js
+++ b/mod/user/fromACL.js
@@ -52,6 +52,12 @@ module.exports = async (req) => {
 
   const user = await getUser(request)
 
+  if (user === undefined) {
+
+    // This will happen when a user has a null password.
+    return new Error('auth_failed')
+  }
+
   if (user instanceof Error) {
 
     return await failedLogin(request)
@@ -80,7 +86,7 @@ async function getUser(request) {
 
   if (!user) return new Error('auth_failed')
 
-  if (!user.password) return new Error('no_user_password')
+  if (!user.password) return;
 
   // Blocked user cannot login.
   if (user.blocked) {

--- a/mod/user/fromACL.js
+++ b/mod/user/fromACL.js
@@ -80,6 +80,8 @@ async function getUser(request) {
 
   if (!user) return new Error('auth_failed')
 
+  if (!user.password) return new Error('no_user_password')
+
   // Blocked user cannot login.
   if (user.blocked) {
     return new Error(await languageTemplates({


### PR DESCRIPTION
User can be added with the api/user/add endpoint. These user have null as password. User with a null password cannot reset their password. The primary use case for these user is to provide a user object for SAML and other third party login.

The account should not get locked trying to login with a random password.

The fromACL method should return an appropriate error when a user with null password attempts to login with password.

The bcrypt method will crash the process attempting to compare string with null/object. This must not happen.

The user must returned as undefined fromACL to prevent the failed login counter to lock the account.