### PR TITLE
Querying a layer with role restrictions crashes the process.

### DIFF
--- a/mod/query.js
+++ b/mod/query.js
@@ -68,6 +68,8 @@ module.exports = async (req, res) => {
     // Assign role filter and viewport params from layer object.
     await layerQuery(req, res)
 
+    if (res.finished) return;
+    
   } else {
 
     // Reserved params will be deleted to prevent DDL injection.


### PR DESCRIPTION
The layerQuery method which was introduced to reduce the cognitive load on the query module would resolve the request / response object if a layer were restricted by roles.

The subquent query would then fail either because there is no DBS parameter or because the response object has already been resolved.

After awaiting the layerQuery method a check must be made whether the res object has finished.