### PR TITLE
Filter toolbar elements to remove undefined

### DIFF
--- a/lib/ui/Dataview.mjs
+++ b/lib/ui/Dataview.mjs
@@ -92,7 +92,9 @@ export default async (_this) => {
 
     let toolbar =
       (typeof _this.toolbar === 'function' && _this.toolbar()) ||
-      Object.keys(_this.toolbar).map((key) => mapp.ui.utils[_this.dataview]?.toolbar[key]?.(_this));
+      Object.keys(_this.toolbar)
+      .map((key) => mapp.ui.utils[_this.dataview]?.toolbar[key]?.(_this))
+      .filter((item) => !!item);
 
     // Append flex container target element and assign as panel to dataview entry.
     // The panel will be assigned in a tabview.


### PR DESCRIPTION
This PR fixes an issue whereby undefined toolbar elements errored. Instead, this will just filter them out. 