### PR TITLE
Review Location view module; edit toggle & confirmation dialogs.

### DIFF
--- a/lib/location/decorate.mjs
+++ b/lib/location/decorate.mjs
@@ -5,6 +5,8 @@ export default location => {
     Layers: [],
     remove,
     removeCallbacks: [],
+    removeEdits,
+    restoreEdits,
     trash,
     update,
     syncFields,
@@ -135,4 +137,33 @@ async function trash() {
     }))
 
   this.remove()
+}
+
+function removeEdits() {
+
+  // Iterate through the location.infoj entries.
+  this.infoj.forEach(entry => {
+
+    if (!entry.edit) return;
+
+    // Remove newValue
+    // Unsaved edits will be lost.
+    delete entry.newValue
+
+    // Change edit key to _edit
+    entry._edit = entry.edit
+    delete entry.edit
+  })
+}
+
+function restoreEdits() {
+  
+  // Restore edit in infoj entries
+  this.infoj.forEach(entry => {
+
+    if (!entry._edit) return;
+
+    entry.edit = entry._edit
+    delete entry._edit
+  })
 }

--- a/lib/ui/locations/view.mjs
+++ b/lib/ui/locations/view.mjs
@@ -231,11 +231,15 @@ export default location => {
 
 async function toggleViewEdits(e, location) {
 
-  // Turn edit mode off.
-  if (e.target.classList.contains('on')) {
+  const toggleOff = e.target.classList.toggle('on')
 
-    // Remove on class from button.
-    e.target.classList.remove('on')
+  // Turn edit mode off.
+  if (toggleOff) {
+
+    location.restoreEdits()
+
+    // Turn edit mode on.
+  } else {
 
     // If there are unsaved edits.
     if (location.infoj.some(entry => typeof entry.newValue !== 'undefined')) {
@@ -253,19 +257,12 @@ async function toggleViewEdits(e, location) {
         location.removeEdits()
         location.view.querySelector('.btn-save').style.display = 'none'
       }
+
     } else {
 
       // No changes to save.
       location.removeEdits()
     }
-
-    // Turn edit mode on.
-  } else {
-
-    // Add on class to button.
-    e.target.classList.add('on')
-
-    location.restoreEdits()
   }
 
   // Remove location.viewEntries

--- a/lib/ui/locations/view.mjs
+++ b/lib/ui/locations/view.mjs
@@ -114,7 +114,36 @@ export default location => {
     location.editToggle = mapp.utils.html.node`<button
       title = "Enable edits"
       class = ${`mask-icon edit ${location.new && 'on' || ''}`}
-      onclick = ${e => toggleViewEdits(e, location)}>`
+      onclick = ${toggleViewEdits}>`
+
+    async function toggleViewEdits(e) {
+
+      // Turn edit mode on.
+      if (e.target.classList.toggle('on')) {
+
+        location.restoreEdits()
+
+        // Turn edit mode off.
+      } else if (location.infoj.some(entry => typeof entry.newValue !== 'undefined')
+
+        // Ask user whether to save edits.
+        && confirm(mapp.dictionary.location_save_changes)) {
+
+        await location.update()
+
+      } else {
+
+        // No changes to save.
+        location.removeEdits()
+        location.view.querySelector('.btn-save').style.display = 'none'
+      }
+
+      // Remove location.viewEntries
+      location.viewEntries.remove()
+
+      // Recreate location.viewEntries
+      location.viewEntries = location.view.appendChild(mapp.ui.locations.infoj(location))
+    }      
 
     header.push(location.editToggle)
   }
@@ -227,47 +256,4 @@ export default location => {
     // Recreate location.viewEntries.
     location.viewEntries = location.view.appendChild(mapp.ui.locations.infoj(location))
   })
-}
-
-async function toggleViewEdits(e, location) {
-
-  const toggleOff = e.target.classList.toggle('on')
-
-  // Turn edit mode off.
-  if (toggleOff) {
-
-    location.restoreEdits()
-
-    // Turn edit mode on.
-  } else {
-
-    // If there are unsaved edits.
-    if (location.infoj.some(entry => typeof entry.newValue !== 'undefined')) {
-
-      // Ask user whether to save edits.
-      if (confirm(mapp.dictionary.location_save_changes)) {
-
-        // Save edits.
-        await location.update()
-
-        // If user does not want to save edits.
-      } else {
-
-        // Remove edits from infoj entries.
-        location.removeEdits()
-        location.view.querySelector('.btn-save').style.display = 'none'
-      }
-
-    } else {
-
-      // No changes to save.
-      location.removeEdits()
-    }
-  }
-
-  // Remove location.viewEntries
-  location.viewEntries.remove()
-
-  // Recreate location.viewEntries
-  location.viewEntries = location.view.appendChild(mapp.ui.locations.infoj(location))
 }

--- a/lib/ui/locations/view.mjs
+++ b/lib/ui/locations/view.mjs
@@ -126,14 +126,14 @@ export default location => {
         // Turn edit mode off.
       } else if (location.infoj.some(entry => typeof entry.newValue !== 'undefined')
 
-        // Ask user whether to save edits.
+        // and confirm whether to save edits.
         && confirm(mapp.dictionary.location_save_changes)) {
 
         await location.update()
 
       } else {
 
-        // No changes to save.
+        // Remove edits and hide save btn.
         location.removeEdits()
         location.view.querySelector('.btn-save').style.display = 'none'
       }

--- a/lib/ui/locations/view.mjs
+++ b/lib/ui/locations/view.mjs
@@ -5,6 +5,7 @@ mapp.utils.merge(mapp.dictionaries, {
     location_remove: 'Remove feature from selection',
     location_delete: 'Delete location',
     location_save_changes: 'Save your changes to this location?',
+    location_close_without_save: 'Close location without saving changes?'
   },
   de: {
     location_zoom: 'Ansicht den Lagen Geometrien anpassen',
@@ -91,114 +92,39 @@ export default location => {
   ]
 
   // Zoom to location bounds.
-  location.infoj.some(
-    entry => (entry.type === 'pin' || entry.type === 'geometry')
-      && entry.value) && header.push(mapp.utils.html`
-    <button
+  if (location.infoj
+    .filter(entry => new Set(['pin', 'geometry']).has(entry.type))
+    .some(entry => !!entry.value)) {
+    header.push(mapp.utils.html`<button
       title = ${mapp.dictionary.location_zoom}
       class = "mask-icon search"
-      onclick = ${e => {
-          location.flyTo()
-        }}>`)
+      onclick = ${() => location.flyTo()}>`)
+  }
 
   // Edits must be toggled.
   if (location.layer?.toggleLocationViewEdits
 
     // Check whether there is anything to edit in the first place.
-    && location.infoj.some(entry => typeof entry.edit !== 'undefined')) {
-
-    // Remove edit from infoj entries
-    location.removeEdits = () => {
-
-      // Iterate through the location.infoj entries.
-      location.infoj
-
-        // Filter entries which have an edit key.
-        .filter(entry => typeof entry.edit !== 'undefined')
-        .forEach(entry => {
-
-          // Remove newValue
-          // Unsaved edits will be lost.
-          delete entry.newValue
-
-          // Change edit key to _edit
-          entry._edit = entry.edit
-          delete entry.edit
-        })
-    }
+    && location.infoj.some(entry => !!entry.edit)) {
 
     // New locations should be editable.
     !location.new && location.removeEdits()
 
     // Create edit toggle button.
-    location.editToggle = mapp.utils.html.node`
-      <button
-        title = "Enable edits"
-        class = ${`mask-icon edit ${location.new && 'on' || ''}`}
-        onclick = ${async e => {
-
-        // Edits are on
-        if (e.target.classList.contains('on')) {
-
-          // Remove on class from button.
-          e.target.classList.remove('on')
-
-          // If there are unsaved edits.
-          if (location.infoj.some(entry => typeof entry.newValue !== 'undefined')) {
-
-            // Ask user whether to save edits.
-            if (confirm(`Save your changes to this location?`)) {
-
-              // Save edits.
-              await location.update()
-
-              // If user does not want to save edits.
-            } else {
-
-              // Remove edits from infoj entries.
-              location.removeEdits()
-            }
-          }
-          // If there's nothing to save.
-          else {
-            // Just remove edits from infoj entries.
-            location.removeEdits()
-          }
-
-        } else {
-
-          // Add on class to button.
-          e.target.classList.add('on')
-
-          // Restore edit in infoj entries
-          location.infoj.forEach(entry => {
-
-            if (!entry._edit) return;
-
-            entry.edit = entry._edit
-            delete entry._edit
-          })
-
-        }
-
-        // Remove location.viewEntries
-        location.viewEntries.remove()
-
-        // Recreate location.viewEntries
-        location.viewEntries = location.view.appendChild(mapp.ui.locations.infoj(location))
-
-      }}>`
+    location.editToggle = mapp.utils.html.node`<button
+      title = "Enable edits"
+      class = ${`mask-icon edit ${location.new && 'on' || ''}`}
+      onclick = ${e => toggleViewEdits(e, location)}>`
 
     header.push(location.editToggle)
   }
 
   // Update icon.
-  header.push(mapp.utils.html`
-    <button
-      title = ${mapp.dictionary.location_save}
-      class = "btn-save mask-icon done"
-      style = "display: none;"
-      onclick = ${e => {
+  header.push(mapp.utils.html`<button
+    title = ${mapp.dictionary.location_save}
+    class = "btn-save mask-icon done"
+    style = "display: none;"
+    onclick = ${() => {
       location.view.classList.add('disabled')
       location.update()
     }}>`);
@@ -211,33 +137,21 @@ export default location => {
   // Trash icon.
   if (location.layer?.edit?.delete || location.layer?.deleteLocation) {
 
-    header.push(mapp.utils.html`
-      <button
-        title = ${mapp.dictionary.location_delete}
-        class = "mask-icon trash"
-        onclick = ${e => {
-        location.trash()
-      }}>`)
+    header.push(mapp.utils.html`<button
+      title = ${mapp.dictionary.location_delete}
+      class = "mask-icon trash"
+      onclick = ${()=>location.trash()}>`)
   }
 
   // Clear selection.
-  header.push(mapp.utils.html`
-    <button
-      title = ${mapp.dictionary.location_remove}
-      class = "mask-icon close no"
-      onclick = ${async e => {
+  header.push(mapp.utils.html`<button
+    title = ${mapp.dictionary.location_remove}
+    class = "mask-icon close no"
+    onclick = ${() => {
 
       if (location.infoj.some(entry => typeof entry.newValue !== 'undefined')) {
 
-        if (confirm(`${mapp.dictionary.location_save_changes}`)) {
-
-          await location.update()
-
-        } else {
-
-          // The location will not be closed.
-          return;
-        }
+        if (!confirm(`${mapp.dictionary.location_close_without_save}`)) return;
       }
 
       location.remove()
@@ -250,26 +164,26 @@ export default location => {
 
   location.viewEntries = location.view.appendChild(mapp.ui.locations.infoj(location))
 
+  // Assign location.record.colour as border to the location.view header.
   location.view.querySelector('.header').style.borderBottom = `3px solid ${location.record.colour}`
 
   // Add listener for custom valChange event.
   location.view.addEventListener('valChange', e => {
 
+    // detail entry has a custom valChangeMethod.
     if (e.detail.valChangeMethod instanceof Function) {
 
       e.detail.valChangeMethod(e.detail)
       return;
     }
 
-    // entry object is provided as event detail.
+    // Is newValue different from [current] value.
     if (e.detail.value != e.detail.newValue) {
 
-      // New value is different from current value.
       e.detail.node.classList.add('val-changed')
 
     } else {
 
-      // New value is the same as current value.
       delete e.detail.newValue
       e.detail.node.classList.remove('val-changed')
     }
@@ -279,7 +193,6 @@ export default location => {
       location.infoj.some(entry => typeof entry.newValue !== 'undefined')
         ? 'inline-block'
         : 'none';
-
   })
 
   location.view.addEventListener('updateInfo', () => {
@@ -314,4 +227,50 @@ export default location => {
     // Recreate location.viewEntries.
     location.viewEntries = location.view.appendChild(mapp.ui.locations.infoj(location))
   })
+}
+
+async function toggleViewEdits(e, location) {
+
+  // Turn edit mode off.
+  if (e.target.classList.contains('on')) {
+
+    // Remove on class from button.
+    e.target.classList.remove('on')
+
+    // If there are unsaved edits.
+    if (location.infoj.some(entry => typeof entry.newValue !== 'undefined')) {
+
+      // Ask user whether to save edits.
+      if (confirm(mapp.dictionary.location_save_changes)) {
+
+        // Save edits.
+        await location.update()
+
+        // If user does not want to save edits.
+      } else {
+
+        // Remove edits from infoj entries.
+        location.removeEdits()
+        location.view.querySelector('.btn-save').style.display = 'none'
+      }
+    } else {
+
+      // No changes to save.
+      location.removeEdits()
+    }
+
+    // Turn edit mode on.
+  } else {
+
+    // Add on class to button.
+    e.target.classList.add('on')
+
+    location.restoreEdits()
+  }
+
+  // Remove location.viewEntries
+  location.viewEntries.remove()
+
+  // Recreate location.viewEntries
+  location.viewEntries = location.view.appendChild(mapp.ui.locations.infoj(location))
 }


### PR DESCRIPTION
The remove and restore edit methods are assigned to the location itself in the location decorator instead of the location view.

Closing a location with unsaved edits will ask for confirmation whether to close the location without saving changes.

This message has been added to the dictionary.

Cancelling will not close the location allowing the user to save the changes.

The hideous edit toggle method has been sanitised.

Script comments have been updated.