### PR TITLE
delete geometry entry geometry

### DIFF
--- a/lib/ui/locations/entries/geometry.mjs
+++ b/lib/ui/locations/entries/geometry.mjs
@@ -195,6 +195,8 @@ function show() {
     // Remove existing layer to prevent assertion error.
     this.location.layer.mapview.Map.removeLayer(this.L)
     delete this.L
+
+    delete this.geometry
   }
 
   this.zIndex ??= 99


### PR DESCRIPTION
Otherwise the mapview geojson method would use the geometry json even if the entry.value has been updated.