### PR TITLE
layer.zoomDisplay flag

### DIFF
--- a/lib/layer/decorate.mjs
+++ b/lib/layer/decorate.mjs
@@ -12,8 +12,6 @@ export default async layer => {
     hideCallbacks: [],
     tableCurrent,
     geomCurrent,
-    tableMax,
-    tableMin,
     zoomToExtent,
   });
 
@@ -261,6 +259,19 @@ export default async layer => {
 
 function show() {
 
+  // Layer should be shown if possible.
+  this.zoomDisplay = true;
+
+  // Push the layer into the layers hook array.
+  this.mapview.hooks && mapp.hooks.push('layers', this.key);
+
+  if (this.tables && !this.tableCurrent()) {
+
+    // Layer is outside of zoomDisplay range.
+    delete this.display;
+    return;
+  }
+
   // Show the layer
   this.display = true;
 
@@ -277,14 +288,17 @@ function show() {
   // Add layer attribution to mapview attribution.
   this.mapview.attribution?.check();
 
-  // Push the layer into the layers hook array.
-  this.mapview.hooks && mapp.hooks.push('layers', this.key);
-
   // Execute showCallbacks
   this.showCallbacks?.forEach(fn => fn instanceof Function && fn(this));
 }
 
 function hide() {
+
+  if (this.tables && this.tableCurrent()) {
+
+    // Layer should never be displayed.
+    delete this.zoomDisplay;
+  }
 
   // Hide the layer.
   this.display = false;
@@ -296,7 +310,9 @@ function hide() {
   this.mapview.attribution?.check();
 
   // Filter the layer from the layers hook array.
-  this.mapview.hooks && mapp.hooks.filter('layers', this.key);
+  if (this.mapview.hooks && !this.zoomDisplay) {
+    mapp.hooks.filter('layers', this.key);
+  }
 
   // Execute hideCallbacks
   this.hideCallbacks?.forEach(fn => fn instanceof Function && fn(this));
@@ -362,28 +378,6 @@ function geomCurrent() {
   geom = zoom > maxZoomKey ? this.geoms[maxZoomKey] : geom;
 
   return geom;
-}
-
-function tableMax() {
-
-  // Returns the max table
-
-  // A layer must have either a table or tables configuration.
-  if (!this.tables) return this.table;
-
-  // Return first value from (reversed) tables object which is not null.
-  return Object.values(this.tables).reverse().find(val => !!val);
-}
-
-function tableMin() {
-
-  // Returns the min table.
-
-  // A layer must have either a table or tables configuration.
-  if (!this.tables) return this.table;
-
-  // Return first value from tables object which is not null.
-  return Object.values(this.tables).find(val => !!val);
 }
 
 async function zoomToExtent(params) {

--- a/lib/ui/layers/view.mjs
+++ b/lib/ui/layers/view.mjs
@@ -98,8 +98,30 @@ export default (layer) => {
         e.target.disabled = !response
       }}>` || ``
 
-    // Create toggleDisplay button for header.
-    const toggleDisplay = mapp.utils.html.node`
+    // Create a div for the magnifying glass icon
+    layer.zoomButton = layer.tables && mapp.utils.html.node`
+      <button class="mask-icon search" title="${mapp.dictionary.zoom_to}" data-id="zoom-to">`
+
+    // Add an event listener to the magnifying glass icon to show the zoom level button when clicked
+    layer.zoomButton?.addEventListener('click', () => {
+
+      // Zoom to the extent of the layer if table provided. 
+      if (layer.tableCurrent() !== null) {
+        layer.zoomToExtent();
+        layer.show();
+      };
+
+      // Zoom to the zoom level if tables object. 
+      for (const key in layer.tables) {
+        if (layer.tables[key] !== null) {
+          layer.mapview.Map.getView().setZoom(key);
+          layer.show();
+        }
+      }
+    });
+
+    // Create layer.displayToggle button for header.
+    layer.displayToggle = mapp.utils.html.node`
       <button
         data-id=display-toggle
         title=${mapp.dictionary.layer_visibility}
@@ -108,18 +130,19 @@ export default (layer) => {
 
     // Add on callback for toggle button.
     layer.showCallbacks.push(() => {
-      toggleDisplay.classList.add('on')
+      layer.displayToggle.classList.add('on')
     })
 
     // Remove on callback for toggle button.
     layer.hideCallbacks.push(() => {
-      toggleDisplay.classList.remove('on')
+      layer.displayToggle.classList.remove('on')
     })
 
     const header = mapp.utils.html`
       <h2>${layer.name || layer.key}</h2>
       ${zoomToExtent}
-      ${toggleDisplay}
+      ${layer.zoomButton}
+      ${layer.displayToggle}
       <div class="mask-icon expander"></div>`
 
     // Create layer drawer node.
@@ -139,50 +162,37 @@ export default (layer) => {
     content.forEach(el => layer.view.append(el))
   }
 
-  // Create a div for the magnifying glass icon
-  const zoomButton = mapp.utils.html.node`<button class="mask-icon search" title="${mapp.dictionary.zoom_to}" data-id="zoom-to">`
-  
-  // Add an event listener to the magnifying glass icon to show the zoom level button when clicked
-  zoomButton.addEventListener('click', () => {
-
-    // Zoom to the extent of the layer if table provided. 
-    if (layer.tableCurrent() !== null) {
-      layer.zoomToExtent();
-      layer.show();
-    };
-
-    // Zoom to the zoom level if tables object. 
-    for (const key in layer.tables) {
-      if (layer.tables[key] !== null) {
-        layer.mapview.Map.getView().setZoom(key);
-        layer.show();
-      }
-    }
-  });
-
-  // Add the zoom Button before the layer toggle.
-  layer.view.querySelector('[data-id=display-toggle]').before(zoomButton)
-
   // The layer view drawer should be disabled if layer.tables are not available for the current zoom level.
   layer.mapview.Map.getTargetElement().addEventListener('changeEnd', () => {
 
     if (!layer.tables) return;
 
-    if (layer.tableCurrent() === null) {
+    if (!layer.tableCurrent()) {
 
-      // The layer should be set to display false, as it is not available at the current zoom level.
-      layer.display = false;
+      // Layer should be shown if possible.
+      layer.zoomDisplay ??= !!layer.display
+
+      layer.hide()
+
       // Collapse drawer and disable layer.view.
       layer.view.querySelector('[data-id=layer-drawer]').classList.remove('expanded')
 
       // Remove the active state from the layer view toggle button.
-      layer.view.querySelector('[data-id=display-toggle]').classList.remove('on')
+      layer.displayToggle.classList.remove('on')
+
       // Set the layer toggle button to disabled.
-      layer.view.querySelector('[data-id=display-toggle]').classList.add('disabled')
+      layer.displayToggle.classList.add('disabled')
 
     } else {
+
       // Set the layer toggle button to enabled.
-      layer.view.querySelector('[data-id=display-toggle]').classList.remove('disabled')
+      layer.displayToggle.classList.remove('disabled')
+
+      if (layer.zoomDisplay) {
+
+        // Show layer if within zoomDisplay range.
+        layer.show()
+      }
     }
 
   })


### PR DESCRIPTION
The layer.zoomDisplay flag is introduced in this PR to control whether a layer should be displayed when in range.

The layer.show method will set the zoomDisplay true.

The layer.view changeEnd method will hide a layer without a layer.tableCurrent() but set the zoomDisplay true if the display is true. The layer.show() method will be called by the changeEnd method if layer.tableCurrent() and zoomDisplay is true.

layer.tableMax and layer.tableMin are removed since they are unused.