### PR TITLE
headerFilter Map Issue

### DIFF
--- a/lib/ui/utils/tabulator.mjs
+++ b/lib/ui/utils/tabulator.mjs
@@ -519,6 +519,9 @@ function set(_this) {
           field
         })).then(response => {
 
+          // If response is not an array, make it an array.
+          if (!Array.isArray(response)) response = [response];
+          
           // Render dropdown with distinct values from response.
           mapp.utils.render(dropdown, mapp.ui.elements.dropdown({
             multi: true,


### PR DESCRIPTION
When the headerFilter returns a single response value, the `.map` was failing.
This PR simply checks if the response is not an array, and converts to one if not - fixing the error.