### PR TITLE
mapp.layer.themeStyle() method

### DIFF
--- a/lib/layer/Style.mjs
+++ b/lib/layer/Style.mjs
@@ -52,7 +52,8 @@ export default layer => {
     }
 
     // Assign default style as feature.style.
-    feature.style = { ...structuredClone(layer.style.default), ...layer.style.theme?.style }
+    //feature.style = { ...structuredClone(layer.style.default), ...layer.style.theme?.style }
+    feature.style = layer.style.default
 
     // Check whether feature is in lookup.
     if (Array.isArray(layer.featureLookup)) {

--- a/lib/layer/Style.mjs
+++ b/lib/layer/Style.mjs
@@ -52,7 +52,6 @@ export default layer => {
     }
 
     // Assign default style as feature.style.
-    //feature.style = { ...structuredClone(layer.style.default), ...layer.style.theme?.style }
     feature.style = layer.style.default
 
     // Check whether feature is in lookup.

--- a/lib/layer/_layer.mjs
+++ b/lib/layer/_layer.mjs
@@ -14,6 +14,8 @@ import * as featureFields from './featureFields.mjs'
 
 import Style from './Style.mjs'
 
+import themeStyle from './themes/themeStyle.mjs'
+
 import categorized from './themes/categorized.mjs'
 
 import distributed from './themes/distributed.mjs'
@@ -29,6 +31,7 @@ export default {
   featureFilter,
   fade,
   Style,
+  themeStyle,
   themes: {
     categorized,
     distributed,

--- a/lib/layer/format/mvt.mjs
+++ b/lib/layer/format/mvt.mjs
@@ -25,6 +25,8 @@ export default layer => {
 
   layer.reload = () => {
 
+    mapp.layer.themeStyle(layer)
+
     if (layer.wkt_properties) {
       changeEndLoad(layer)
       return;

--- a/lib/layer/format/vector.mjs
+++ b/lib/layer/format/vector.mjs
@@ -56,6 +56,8 @@ export default layer => {
 
   layer.reload = () => {
 
+    mapp.layer.themeStyle(layer)
+
     // Do not reload the layer if features have been assigned.
     if (layer.features) return;
 

--- a/lib/layer/themes/categorized.mjs
+++ b/lib/layer/themes/categorized.mjs
@@ -10,18 +10,15 @@ export default function (theme, feature) {
 
   if (!cat) return;
 
-  const catStyle = cat.style || cat
-
-  if (typeof catStyle === 'undefined') return;
+  if (typeof cat.style === 'undefined') return;
 
   if (feature.geometryType === 'Point') {
 
     // Merge catStyle if icon style is not implicit.
-    feature.style.icon = catStyle.icon || Object.assign(feature.style.icon, catStyle)
+    feature.style.icon = cat.style.icon || cat.style
     delete feature.style.icon.url;
     return;
   }
 
-  // Merge catStyle for vector features.
-  mapp.utils.merge(feature.style, catStyle)
+  feature.style = cat.style
 }

--- a/lib/layer/themes/graduated.mjs
+++ b/lib/layer/themes/graduated.mjs
@@ -19,22 +19,19 @@ export default function(theme, feature) {
       if (catValue <= parseFloat(theme.cat_arr[i].value)) break;
 
       // Set cat_style to current cat style after value check.
-      var catStyle = structuredClone(theme.cat_arr[i].style || theme.cat_arr[i])
-
-      delete catStyle.label
+      var cat = theme.cat_arr[i]
     }
 
-    if (typeof catStyle === 'undefined') return;
+    if (typeof cat.style === 'undefined') return;
 
     if (feature.geometryType === 'Point') {
   
       // Merge catStyle if icon style is not implicit.
-      feature.style.icon = catStyle.icon || Object.assign(feature.style.icon, catStyle)
+      feature.style.icon = cat.style.icon || cat.style
       delete feature.style.icon.url;
       return;
     }
-  
-    // Merge catStyle for vector features.
-    mapp.utils.merge(feature.style, catStyle)
+
+    feature.style = cat.style
   }
 }

--- a/lib/layer/themes/themeStyle.mjs
+++ b/lib/layer/themes/themeStyle.mjs
@@ -1,0 +1,32 @@
+export default layer => {
+
+  if (layer.style.theme?.cat) {
+
+    Object.keys(layer.style.theme?.cat).forEach(key => {
+
+      const cat = layer.style.theme?.cat[key]
+
+      cat.style ??= structuredClone(cat)
+
+      cat.style = {
+        ...structuredClone(layer.style.default),
+        ...cat.style
+      }
+    })
+  }
+
+  if (layer.style.theme?.cat_arr) {
+
+    for (const cat of layer.style.theme?.cat_arr) {
+
+      cat.style ??= structuredClone(cat)
+
+      cat.style = {
+        ...structuredClone(layer.style.default),
+        ...cat.style
+      }
+
+      delete cat.style.label
+    }
+  }
+}


### PR DESCRIPTION
Theme methods require an excessive amount of object merging.

This can be significantly reduced by processing the theme once in the layer.reload().

mapp.layer.themeStyle() method which processes the theme categories can merge the default style into the category.

Other issues such as missing style / icon definitions can be fixed within this process method.

This will also allow us to update the style object definition without breaking backwards compatibility.