### PR TITLE
Role Check Fix

### DIFF
--- a/mod/workspace/_workspace.js
+++ b/mod/workspace/_workspace.js
@@ -113,6 +113,7 @@ async function locale(req, res) {
       })
 
       if (layer instanceof Error) continue;
+      if(!Roles.check(layer, req.params.user?.roles)) continue;
 
       layers.push(layer)
     }


### PR DESCRIPTION
## Fix Bug for Role Check in [mod/workspace/_workspace.js]

**Description:**

The bug allows users without the necessary roles to view restricted layers. The fix involves incorporating a role check condition to ensure that only users with appropriate roles can access specific layers.

**Changes:**

- Added a role check condition to rectify the access control bug.
- Utilized the `Roles.check` method to verify the user's roles against the required roles for the given layer.
- Implemented a conditional statement to continue processing only if the user possesses the necessary roles.