### PR TITLE
update user in cookie

### DIFF
--- a/mod/user/cookie.js
+++ b/mod/user/cookie.js
@@ -2,34 +2,54 @@ const login = require('./login')
 
 const jwt = require('jsonwebtoken')
 
-const languageTemplates = require('../utils/languageTemplates')
+const acl = require('./acl')
 
 module.exports = async (req, res) => {
 
   const cookie = req.cookies && req.cookies[process.env.TITLE]
 
+  if (!cookie) {
+    req.params.msg = 'no_cookie_found'
+    return login(req, res)
+  }
+
   if (req.params.destroy) {
+
+    // Remove cookie.
     res.setHeader('Set-Cookie', `${process.env.TITLE}=null;HttpOnly;Max-Age=0;Path=${process.env.DIR || '/'}`)
     return res.send('This too shall pass')
   }
 
-  if (!cookie && req.params.renew) return res.status(401).send('Failed to renew cookie')
-
-  if (!cookie) {
-    req.params.msg = 'no_cookie_found'
-    
-    return login(req, res)
-  }
-
+  // Verify current cookie
   jwt.verify(
     cookie,
     process.env.SECRET,
-    async (err, user) => {
+    async (err, payload) => {
 
       if (err) return err
 
-      delete user.iat
-      delete user.exp
+      // Get updated user credentials from ACL
+      let rows = await acl(`
+        SELECT email, admin, language, roles, blocked
+        FROM acl_schema.acl_table
+        WHERE lower(email) = lower($1);`, [payload.email])
+    
+      if (rows instanceof Error) {
+        res.setHeader('Set-Cookie', `${process.env.TITLE}=null;HttpOnly;Max-Age=0;Path=${process.env.DIR || '/'}`)
+        return res.status(500).send('Failed to retrieve user from ACL');
+      }
+
+      const user = rows[0]
+    
+      if (user.blocked) {
+        res.setHeader('Set-Cookie', `${process.env.TITLE}=null;HttpOnly;Max-Age=0;Path=${process.env.DIR || '/'}`)
+        return res.status(403).send('Account is blocked');
+      }
+
+      if (payload.session) {
+
+        user.session = payload.session
+      }
 
       const token = jwt.sign(user, process.env.SECRET, {
         expiresIn: parseInt(process.env.COOKIE_TTL)
@@ -40,7 +60,6 @@ module.exports = async (req, res) => {
       res.setHeader('Set-Cookie', cookie)
 
       res.send(user)
-
     })
 
 }

--- a/public/views/_default.html
+++ b/public/views/_default.html
@@ -3,7 +3,6 @@
 
 <head
   data-dir="{{dir}}" 
-  data-user="{{user}}" 
   data-login="{{login}}">
 
   <title>{{title}}</title>

--- a/public/views/_default.js
+++ b/public/views/_default.js
@@ -136,10 +136,8 @@ window.onload = async () => {
     },
   })
 
-  // Parse user object from dataset attribute on document head.
-  mapp.user = document.head.dataset.user &&
-    JSON.parse(decodeURI(document.head.dataset.user))
-    || undefined
+  // Refresh cookie and get user with updated credentials.
+  mapp.user = await mapp.utils.xhr(`${mapp.host}/api/user/cookie`);
 
   // Language as URL parameter will override user language.
   mapp.language = mapp.hooks.current.language


### PR DESCRIPTION
The `/api/user/cookie` endpoint returns the user object.

The endpoint will now query the user from the ACL and update language, roles, and admin flag.

![image](https://github.com/GEOLYTIX/xyz/assets/22201617/2013b79e-b1c3-419d-8663-131450269dda)

The default view ands script will no longer store the user in the head but request the user from the cookie endpoint refreshing the cookie and updating the user object in the process.