### PR TITLE
Set language in user verification

### DIFF
--- a/mod/user/verify.js
+++ b/mod/user/verify.js
@@ -44,12 +44,11 @@ module.exports = async (req, res) => {
   rows = await acl(`
     UPDATE acl_schema.acl_table SET
       failedattempts = 0,
-      ${user.password_reset ?
-      `password = '${user.password_reset}',
-        password_reset = null,` : ''}
+      password = $3,
       verified = true,
-      verificationtoken = null
-    WHERE lower(email) = lower($1);`, [user.email])
+      verificationtoken = null,
+      language = $2
+    WHERE lower(email) = lower($1);`, [user.email, req.params.language || user.language, user.password_reset])
 
   if (rows instanceof Error) {
 


### PR DESCRIPTION
A user should be able to change the registered language. However it should not be possible for others to change someone else's language.

The password reset token sent in the verification email has been extended with a language param. The language from the param will be set as the user language when the verification token is resolved.