### PR TITLE
vector / mvt layer with tables zoom restriction

### DIFF
--- a/lib/layer/decorate.mjs
+++ b/lib/layer/decorate.mjs
@@ -259,18 +259,8 @@ export default async layer => {
 
 function show() {
 
-  // Layer should be shown if possible.
-  this.zoomDisplay = true;
-
   // Push the layer into the layers hook array.
   this.mapview.hooks && mapp.hooks.push('layers', this.key);
-
-  if (this.tables && !this.tableCurrent()) {
-
-    // Layer is outside of zoomDisplay range.
-    delete this.display;
-    return;
-  }
 
   // Show the layer
   this.display = true;
@@ -294,12 +284,6 @@ function show() {
 
 function hide() {
 
-  if (this.tables && this.tableCurrent()) {
-
-    // Layer should never be displayed.
-    delete this.zoomDisplay;
-  }
-
   // Hide the layer.
   this.display = false;
 
@@ -318,9 +302,8 @@ function hide() {
   this.hideCallbacks?.forEach(fn => fn instanceof Function && fn(this));
 }
 
+// Return the current table if it exists.
 function tableCurrent() {
-
-  // Return the current table if it exists.
 
   // A layer must have either a table or tables configuration.
   if (!this.tables) return this.table;
@@ -349,9 +332,8 @@ function tableCurrent() {
   return table;
 }
 
+// Return the current table if it exists.
 function geomCurrent() {
-
-  // Return the current table if it exists.
 
   // A layer must have either a table or tables configuration.
   if (!this.geoms) return this.geom;
@@ -380,9 +362,8 @@ function geomCurrent() {
   return geom;
 }
 
+// Zooms to a specific extent
 async function zoomToExtent(params) {
-
-  // Zooms to a specific extent
 
   // XMLHttpRequest to layer extent endpoint
   let response = await mapp.utils.xhr(`${this.mapview.host}/api/query/layer_extent?` +

--- a/lib/layer/format/mvt.mjs
+++ b/lib/layer/format/mvt.mjs
@@ -23,6 +23,26 @@ export default layer => {
   // MVT query must not have a viewport, this is defined by the tile extent.
   delete layer.params.viewport
 
+  // The layer may be zoom level restricted.
+  layer.tables && layer.mapview.Map.getTargetElement().addEventListener('changeEnd', () => {
+
+    if (!layer.tableCurrent() && layer.display) {
+
+      // Layer should be shown if possible.
+      layer.zoomDisplay = true
+
+      layer.hide()
+      
+    } else if (layer.zoomDisplay && !layer.display) {
+
+      // Prevents layer.show() being fired on zoom change within range.
+      delete layer.zoomDisplay
+
+      // Show layer if within zoomDisplay range.
+      layer.show()
+    }
+  })
+
   layer.reload = () => {
 
     if (layer.wkt_properties) {

--- a/lib/layer/format/vector.mjs
+++ b/lib/layer/format/vector.mjs
@@ -54,6 +54,26 @@ export default layer => {
     layer.L.setSource(layer.source)
   }
 
+  // The layer may be zoom level restricted.
+  layer.tables && layer.mapview.Map.getTargetElement().addEventListener('changeEnd', () => {
+
+    if (!layer.tableCurrent() && layer.display) {
+
+      // Layer should be shown if possible.
+      layer.zoomDisplay = true
+
+      layer.hide()
+      
+    } else if (layer.zoomDisplay && !layer.display) {
+
+      // Prevents layer.show() being fired on zoom change within range.
+      delete layer.zoomDisplay
+
+      // Show layer if within zoomDisplay range.
+      layer.show()
+    }
+  })
+
   layer.reload = () => {
 
     // Do not reload the layer if features have been assigned.

--- a/lib/mapview/_mapview.mjs
+++ b/lib/mapview/_mapview.mjs
@@ -58,19 +58,21 @@ export default (mapview) => {
     }
   })
 
+  mapview.view ??= mapview.locale.view
+
   // Get the initialZoom for the mapview.
   const initialZoom = mapp.hooks?.current?.z
-    || mapview.locale.view?.z
+    || mapview.view?.z
     || mapview.locale.minZoom
     || 0
 
   // Get the initialCenter for the mapview.
   const initialCenter = ol.proj.fromLonLat([
     parseFloat(mapp.hooks?.current?.lng
-      || mapview.locale.view?.lng
+      || mapview.view?.lng
       || 0),
     parseFloat(mapp.hooks?.current?.lat
-      || mapview.locale.view?.lat
+      || mapview.view?.lat
       || 0),
   ])
 

--- a/lib/ui/layers/view.mjs
+++ b/lib/ui/layers/view.mjs
@@ -163,41 +163,27 @@ export default (layer) => {
     content.forEach(el => layer.view.append(el))
   }
 
-  // The layer view drawer should be disabled if layer.tables are not available for the current zoom level.
-  layer.mapview.Map.getTargetElement().addEventListener('changeEnd', () => {
-
-    if (!layer.tables) return;
+  // The layer may be zoom level restricted.
+  layer.tables && layer.mapview.Map.getTargetElement().addEventListener('changeEnd', () => {
 
     if (!layer.tableCurrent()) {
-
-      // Layer should be shown if possible.
-      layer.zoomDisplay ??= !!layer.display
-
-      layer.hide()
 
       // Collapse drawer and disable layer.view.
       layer.view.querySelector('[data-id=layer-drawer]').classList.remove('expanded')
       
-      // Set the layer toggle button to disabled.
+      // Disable layer display toggle.
       layer.displayToggle.classList.add('disabled')
 
-      content.forEach(el => {
-        el.classList.add('disabled')
-        el.classList.remove('expanded')
-      })
+      // Disable layer.view content.
+      content.forEach(el => el.classList.add('disabled'))
       
     } else {
 
-      // Set the layer toggle button to enabled.
+      // Enable layer display toggle.
       layer.displayToggle.classList.remove('disabled')
 
+      // Enable layer.view content.
       content.forEach(el => el.classList.remove('disabled'))
-
-      if (layer.zoomDisplay) {
-
-        // Show layer if within zoomDisplay range.
-        layer.show()
-      }
     }
 
   })

--- a/lib/ui/layers/view.mjs
+++ b/lib/ui/layers/view.mjs
@@ -97,6 +97,17 @@ export default (layer) => {
           layer.show()
         }}>`
 
+    // Create layer.displayToggle button for header.
+    layer.displayToggle = mapp.utils.html.node`
+      <button
+        data-id=display-toggle
+        title=${mapp.dictionary.layer_visibility}
+        class="${`mask-icon toggle ${(layer.zoomDisplay || layer.display)? 'on': ''}`}"
+        onclick=${e => {
+          const toggle = e.target.classList.toggle('on')
+          toggle? layer.show(): layer.hide()
+        }}>`
+
     // Create a div for the magnifying glass icon
     layer.zoomBtn = layer.tables && mapp.utils.html.node`
       <button 
@@ -116,18 +127,7 @@ export default (layer) => {
             view.setZoom(maxZoom)
 
           layer.show()
-        }}>`
-
-    // Create layer.displayToggle button for header.
-    layer.displayToggle = mapp.utils.html.node`
-      <button
-        data-id=display-toggle
-        title=${mapp.dictionary.layer_visibility}
-        class="${`mask-icon toggle ${(layer.zoomDisplay || layer.display)? 'on': ''}`}"
-        onclick=${e => {
-          const toggle = e.target.classList.toggle('on')
-          toggle? layer.show(): layer.hide()
-        }}>`
+        }}>`        
 
     // Add on callback for toggle button.
     layer.showCallbacks.push(() => {
@@ -142,8 +142,8 @@ export default (layer) => {
     const header = mapp.utils.html`
       <h2>${layer.name || layer.key}</h2>
       ${layer.zoomToExtentBtn}
-      ${layer.zoomBtn}
       ${layer.displayToggle}
+      ${layer.zoomBtn}
       <div class="mask-icon expander"></div>`
 
     // Create layer drawer node.
@@ -167,6 +167,8 @@ export default (layer) => {
   layer.tables && layer.mapview.Map.getTargetElement().addEventListener('changeEnd', () => {
 
     if (!layer.tableCurrent()) {
+      
+      layer.zoomBtn.style.display = 'block'
 
       // Collapse drawer and disable layer.view.
       layer.view.querySelector('[data-id=layer-drawer]').classList.remove('expanded')
@@ -178,6 +180,8 @@ export default (layer) => {
       content.forEach(el => el.classList.add('disabled'))
       
     } else {
+
+      layer.zoomBtn.style.display = 'none'
 
       // Enable layer display toggle.
       layer.displayToggle.classList.remove('disabled')


### PR DESCRIPTION
The layer.view should not toggle the layer show / or hide method. This must be controlled from the layer itself to work in custom views where a layer may not have a view element, or a custom view element, or the mapp.ui is not even loaded.

The changeEnd event should only be added for layer with tables and not to every layer and then short circuit if the layer has no tables key.

The layer.view changeEnd event should only control the status / classList of layer.view elements.

The vector / mvt format changeEnd event should control whether the layer is displayed or not.

The layer show / hide event should only be fired when the zoom level changes in or out of range and not within or outside the range.

### mapview.view

It must be possible to override the locale.view when creating a mapview by providing the view object in the mapview constructor.

```js
mapp.Mapview({
      host: mapp.host,
      target: secondTop.querySelector('.map'),
      locale: locale,
      view: {
        lng: locationPin.lnglat[0],
        lat: locationPin.lnglat[1],
        z: 9
      },
      scrollWheelZoom: true,
    });
```