### PR TITLE
clear highlight [candidates] on mouseleave and mousemove.

### DIFF
--- a/lib/mapview/interactions/highlight.mjs
+++ b/lib/mapview/interactions/highlight.mjs
@@ -167,6 +167,9 @@ export default function (params) {
 
   function highlight(feature, e) {
 
+    // Clear curent highlight before assigning new.
+    clear()
+
     // Assign the layer and ID to the candidate object.
     mapview.interaction.current = Object.assign(feature, {
       layer: mapview.layers[feature.L.get('key')],

--- a/lib/mapview/interactions/highlight.mjs
+++ b/lib/mapview/interactions/highlight.mjs
@@ -57,8 +57,6 @@ export default function (params) {
 
     // Reset candidateKeys Set
     mapview.interaction.candidateKeys = new Set();
-    shortCircuit = false;
-
     clear()
   }
 
@@ -95,21 +93,10 @@ export default function (params) {
     mapview.Map.getTargetElement().style.cursor = 'auto'
   }
 
-  let shortCircuit
-
   function pointerMove(e) {
-
-    // A popup is open.
-    if (mapview.popup()) return;
 
     // Clear longClick timeout.
     mapview.interaction.longClickTimeout && clearTimeout(mapview.interaction.longClickTimeout)
-
-    // Method should short circuit if still processing.
-    if (shortCircuit) return;
-
-    // Set shortCircuit flag.
-    shortCircuit = true;
 
     let candidates = {};
 
@@ -133,8 +120,6 @@ export default function (params) {
     // Check whether set of candidate keys is equal to mapview.interaction.candidateKeys
     if (mapp.utils.areSetsEqual(mapview.interaction.candidateKeys, new Set(Object.keys(candidates)))) {
 
-      shortCircuit = false;
-
       // The highlight hasn't changed.
       return;
 
@@ -142,10 +127,9 @@ export default function (params) {
 
       // Reset candidateKeys Set
       mapview.interaction.candidateKeys = new Set();
-      shortCircuit = false;
-
       clear()
       return;
+
     }
 
     // Find candidate from key which is not in candidates set.
@@ -158,8 +142,8 @@ export default function (params) {
     // Assign new Set of candidate keys to mapview.interaction.
     mapview.interaction.candidateKeys = new Set(Object.keys(candidates))
 
-    // Remove shortCircuit flag.
-    shortCircuit = false;
+    // Don't highlight the highlighted candidate.
+    if (mapview.interaction.current?.key === candidate.key) return;
 
     // Call highlight method.
     mapview.interaction.highlight(candidate, e)
@@ -188,7 +172,6 @@ export default function (params) {
 
       // Clear touch highlight.
       clear()
-
       return;
     }
 
@@ -272,7 +255,7 @@ export default function (params) {
     }
   }
 
-  function clear() {
+  function clear(foo) {
 
     // Highlight has already been cleared.
     if (!mapview.interaction.current) return;

--- a/lib/mapview/interactions/highlight.mjs
+++ b/lib/mapview/interactions/highlight.mjs
@@ -255,7 +255,7 @@ export default function (params) {
     }
   }
 
-  function clear(foo) {
+  function clear() {
 
     // Highlight has already been cleared.
     if (!mapview.interaction.current) return;

--- a/lib/mapview/interactions/highlight.mjs
+++ b/lib/mapview/interactions/highlight.mjs
@@ -51,7 +51,16 @@ export default function (params) {
 
   mapview.Map.getTargetElement().addEventListener('mouseup', mouseUp)
 
-  mapview.Map.getTargetElement().addEventListener('mouseout', clear)
+  mapview.Map.getTargetElement().addEventListener('mouseleave', mouseleave)
+
+  function mouseleave() {
+
+    // Reset candidateKeys Set
+    mapview.interaction.candidateKeys = new Set();
+    shortCircuit = false;
+
+    clear('mouseleave')
+  }
 
   // Prevent mouseDown event on touch input.
   function touchStart(e) {
@@ -121,29 +130,21 @@ export default function (params) {
         hitTolerance: mapview.interaction.hitTolerance,
       })
 
-    // No features at pixel.
-    if (!Object.keys(candidates).length) {
-
-      // Reset candidateKeys
-      mapview.interaction.candidateKeys = new Set();
-
-      // Remove shortCircuit flag.
-      shortCircuit = false;
-
-      // Clear highlight.
-      clear();
-
-      // There is nothing to highlight.
-      return;
-    }
-
     // Check whether set of candidate keys is equal to mapview.interaction.candidateKeys
     if (mapp.utils.areSetsEqual(mapview.interaction.candidateKeys, new Set(Object.keys(candidates)))) {
 
-      // Remove shortCircuit flag
       shortCircuit = false;
 
       // The highlight hasn't changed.
+      return;
+
+    } else if (!Object.keys(candidates).length) {
+
+      // Reset candidateKeys Set
+      mapview.interaction.candidateKeys = new Set();
+      shortCircuit = false;
+
+      clear('pointerMove')
       return;
     }
 
@@ -167,7 +168,7 @@ export default function (params) {
   function highlight(feature, e) {
 
     // Highlight method should only be called if the highlight has changed.
-    clear()
+    // clear('hightlight')
 
     // Assign the layer and ID to the candidate object.
     mapview.interaction.current = Object.assign(feature, {
@@ -186,7 +187,7 @@ export default function (params) {
       e.type !== 'pointermove' && mapview.interaction.getFeature(mapview.interaction.current)
 
       // Clear touch highlight.
-      clear()
+      clear('mouse')
 
       return;
     }
@@ -375,7 +376,7 @@ export default function (params) {
   function finish() {
 
     // Clear must be called before interaction is nulled.
-    clear()
+    clear('finish')
 
     // Remove popup from mapview.
     mapview.popup(null)
@@ -386,7 +387,7 @@ export default function (params) {
     mapview.Map.getTargetElement().removeEventListener('mousedown', mouseDown)
     mapview.Map.getTargetElement().removeEventListener('touchstart', touchStart)
     mapview.Map.getTargetElement().removeEventListener('mouseup', mouseUp)
-    mapview.Map.getTargetElement().removeEventListener('mouseout', clear)
+    mapview.Map.getTargetElement().removeEventListener('mouseleave', mouseleave)
 
     mapview.interaction.callback?.()
   }

--- a/lib/mapview/interactions/highlight.mjs
+++ b/lib/mapview/interactions/highlight.mjs
@@ -59,7 +59,7 @@ export default function (params) {
     mapview.interaction.candidateKeys = new Set();
     shortCircuit = false;
 
-    clear('mouseleave')
+    clear()
   }
 
   // Prevent mouseDown event on touch input.
@@ -144,7 +144,7 @@ export default function (params) {
       mapview.interaction.candidateKeys = new Set();
       shortCircuit = false;
 
-      clear('pointerMove')
+      clear()
       return;
     }
 
@@ -167,9 +167,6 @@ export default function (params) {
 
   function highlight(feature, e) {
 
-    // Highlight method should only be called if the highlight has changed.
-    // clear('hightlight')
-
     // Assign the layer and ID to the candidate object.
     mapview.interaction.current = Object.assign(feature, {
       layer: mapview.layers[feature.L.get('key')],
@@ -187,7 +184,7 @@ export default function (params) {
       e.type !== 'pointermove' && mapview.interaction.getFeature(mapview.interaction.current)
 
       // Clear touch highlight.
-      clear('mouse')
+      clear()
 
       return;
     }
@@ -376,7 +373,7 @@ export default function (params) {
   function finish() {
 
     // Clear must be called before interaction is nulled.
-    clear('finish')
+    clear()
 
     // Remove popup from mapview.
     mapview.popup(null)


### PR DESCRIPTION
The mouseleave event must reset the highlights candidates set.

The mousemove event should only clear and reset the candidates if the sets are different.