### PR TITLE
Load sync plugins in sync before async plugins

### DIFF
--- a/lib/mapview/_mapview.mjs
+++ b/lib/mapview/_mapview.mjs
@@ -134,14 +134,13 @@ export default (mapview) => {
   }).observe(mapview.Map.getTargetElement())
 
   // WARN!
-  mapview.locale.maskBounds && console
-    .warn('locale.maskBounds is set as mask:true in locale.extent')
+  mapview.locale.maskBounds
+    && console.warn('locale.maskBounds is set as mask:true in locale.extent')
 
   // Extent mask
   if (mapview.locale.extent?.mask) {
 
-    // Set world exte
-
+    // Set world extent
     const world = [
       [180, 90],
       [180, -90],
@@ -264,13 +263,26 @@ export default (mapview) => {
 
       await mapp.utils.loadPlugins(mapview.locale.plugins);
 
-      mapview.plugins = Object.keys(mapview.locale)
-      .filter((key) => typeof mapp.plugins[key] === 'function')
-      .map((key) => mapp.plugins[key](mapview.locale[key], mapview));
+      mapview.locale.syncPlugins ??= []
 
-      await Promise.all(mapview.plugins)
+      const syncPlugins = new Set(mapview.locale.syncPlugins)
+
+      for (const key of mapview.locale.syncPlugins) {
+
+        if (typeof mapp.plugins[key] !== 'function') continue;
+
+        await mapp.plugins[key](mapview.locale[key], mapview)
+      }
+
+      const asyncPlugins = Object.keys(mapview.locale)
+        .filter(key => !syncPlugins.has(key))
+        .filter((key) => typeof mapp.plugins[key] === 'function')
+        .map((key) => mapp.plugins[key](mapview.locale[key], mapview));
+
+      await Promise.all(asyncPlugins)
 
       return mapview
+
     })(mapview)
   }
 

--- a/lib/plugins.mjs
+++ b/lib/plugins.mjs
@@ -109,3 +109,75 @@ export function zoomToArea(plugin, mapview) {
 
   btnColumn.append(btn)  
 }
+
+export function zoomBtn(plugin, mapview) {
+
+  const btnColumn = document.getElementById('mapButton');
+
+  // the btnColumn element only exist in the default mapp view.
+  if (!btnColumn) return;
+
+  // Add zoomIn button.
+  const btnZoomIn = btnColumn.appendChild(mapp.utils.html.node`
+    <button
+      id="btnZoomIn"
+      .disabled=${mapview.Map.getView().getZoom() >= mapview.locale.maxZoom}
+      title=${mapp.dictionary.toolbar_zoom_in}
+      onclick=${(e) => {
+        const z = parseInt(mapview.Map.getView().getZoom() + 1);
+        mapview.Map.getView().setZoom(z);
+        e.target.disabled = z >= mapview.locale.maxZoom;
+      }}><div class="mask-icon add">`)
+
+  // Add zoomOut button.
+  const btnZoomOut = btnColumn.appendChild(mapp.utils.html.node`
+    <button
+      id="btnZoomOut"
+      .disabled=${mapview.Map.getView().getZoom() <= mapview.locale.minZoom}
+      title=${mapp.dictionary.toolbar_zoom_out}
+      onclick=${(e) => {
+        const z = parseInt(mapview.Map.getView().getZoom() - 1);
+        mapview.Map.getView().setZoom(z);
+        e.target.disabled = z <= mapview.locale.minZoom;
+      }}><div class="mask-icon remove">`)
+
+  // changeEnd event listener for zoom button
+  mapview.Map.getTargetElement()
+    .addEventListener('changeEnd', () => {
+      const z = mapview.Map.getView().getZoom();
+      btnZoomIn.disabled = z >= mapview.locale.maxZoom;
+      btnZoomOut.disabled = z <= mapview.locale.minZoom;
+    });
+}
+
+export function admin(plugin, mapview) {
+
+  const btnColumn = document.getElementById('mapButton');
+
+  // the btnColumn element only exist in the default mapp view.
+  if (!btnColumn) return;
+
+  // Append user admin link.
+  mapp.user?.admin
+    && btnColumn.appendChild(mapp.utils.html.node`
+      <a
+        title=${mapp.dictionary.toolbar_admin}
+        href="${mapp.host + '/api/user/admin'}">
+        <div class="mask-icon supervisor-account">`);
+}
+
+export function login(plugin, mapview) {
+
+  const btnColumn = document.getElementById('mapButton');
+
+  // the btnColumn element only exist in the default mapp view.
+  if (!btnColumn) return;
+  
+  // Append login/logout link.
+  document.head.dataset.login
+    && btnColumn.appendChild(mapp.utils.html.node`
+      <a
+        title="${mapp.user && mapp.dictionary.toolbar_logout || mapp.dictionary.toolbar_login}"
+        href="${(mapp.user && '?logout=true') || '?login=true'}">
+        <div class="${`mask-icon ${(mapp.user && 'logout') || 'lock-open'}`}">`);
+}

--- a/lib/plugins.mjs
+++ b/lib/plugins.mjs
@@ -174,10 +174,13 @@ export function login(plugin, mapview) {
   if (!btnColumn) return;
   
   // Append login/logout link.
-  document.head.dataset.login
-    && btnColumn.appendChild(mapp.utils.html.node`
-      <a
-        title="${mapp.user && mapp.dictionary.toolbar_logout || mapp.dictionary.toolbar_login}"
-        href="${(mapp.user && '?logout=true') || '?login=true'}">
-        <div class="${`mask-icon ${(mapp.user && 'logout') || 'lock-open'}`}">`);
+  if (!document.head.dataset.login) return;
+
+  const iconClass = `mask-icon ${mapp.user? 'logout': 'lock-open'}`
+
+  btnColumn.appendChild(mapp.utils.html.node`
+    <a
+      title=${mapp.user? mapp.dictionary.toolbar_logout: mapp.dictionary.toolbar_login}"
+      href=${mapp.user? "?logout=true": "?login=true"}>
+      <div class=${iconClass}>`);
 }

--- a/lib/plugins.mjs
+++ b/lib/plugins.mjs
@@ -180,7 +180,7 @@ export function login(plugin, mapview) {
 
   btnColumn.appendChild(mapp.utils.html.node`
     <a
-      title=${mapp.user? mapp.dictionary.toolbar_logout: mapp.dictionary.toolbar_login}"
+      title=${mapp.user? mapp.dictionary.toolbar_logout: mapp.dictionary.toolbar_login}
       href=${mapp.user? "?logout=true": "?login=true"}>
       <div class=${iconClass}>`);
 }

--- a/lib/plugins.mjs
+++ b/lib/plugins.mjs
@@ -1,4 +1,4 @@
-export async function svg_templates(plugin) {
+export async function svg_templates(plugin, mapview) {
 
   if (typeof mapp.utils.svgSymbols.templates !== 'object') {
     mapp.utils.svgSymbols.templates = {}

--- a/public/views/_default.js
+++ b/public/views/_default.js
@@ -284,6 +284,8 @@ window.onload = async () => {
 
   if (!window.ol) await mapp.utils.olScript()
 
+  locale.syncPlugins ??= ['zoomBtn', 'admin', 'login']
+
   // Create mapview
   const mapview = await mapp.Mapview({
     host: mapp.host,
@@ -309,39 +311,6 @@ window.onload = async () => {
 
   // Add layers to mapview.
   await mapview.addLayer(locale.layers);
-
-  // Add zoomIn button.
-  const btnZoomIn = btnColumn.appendChild(mapp.utils.html.node`
-    <button
-      id="btnZoomIn"
-      .disabled=${mapview.Map.getView().getZoom() >= mapview.locale.maxZoom}
-      title=${mapp.dictionary.toolbar_zoom_in}
-      onclick=${(e) => {
-      const z = parseInt(mapview.Map.getView().getZoom() + 1);
-      mapview.Map.getView().setZoom(z);
-      e.target.disabled = z >= mapview.locale.maxZoom;
-    }}>
-      <div class="mask-icon add">`)
-
-  // Add zoomOut button.
-  const btnZoomOut = btnColumn.appendChild(mapp.utils.html.node`
-    <button
-      id="btnZoomOut"
-      .disabled=${mapview.Map.getView().getZoom() <= mapview.locale.minZoom}
-      title=${mapp.dictionary.toolbar_zoom_out}
-      onclick=${(e) => {
-      const z = parseInt(mapview.Map.getView().getZoom() - 1);
-      mapview.Map.getView().setZoom(z);
-      e.target.disabled = z <= mapview.locale.minZoom;
-    }}>
-      <div class="mask-icon remove">`)
-
-  // changeEnd event listener for zoom button.
-  OL.addEventListener('changeEnd', () => {
-    const z = mapview.Map.getView().getZoom();
-    btnZoomIn.disabled = z >= mapview.locale.maxZoom;
-    btnZoomOut.disabled = z <= mapview.locale.minZoom;
-  });
 
   if (mapview.locale.gazetteer) {
 
@@ -384,7 +353,6 @@ window.onload = async () => {
     });
   });
 
-
   // Configure idle mask if set in locale.
   mapp.user &&
     mapview.locale.idle &&
@@ -392,22 +360,6 @@ window.onload = async () => {
       host: mapp.host,
       idle: mapview.locale.idle,
     });
-
-  // Append user admin link.
-  mapp.user?.admin &&
-    btnColumn.appendChild(mapp.utils.html.node`
-      <a
-        title=${mapp.dictionary.toolbar_admin}
-        href="${mapp.host + '/api/user/admin'}">
-        <div class="mask-icon supervisor-account">`);
-
-  // Append login/logout link.
-  document.head.dataset.login &&
-    btnColumn.appendChild(mapp.utils.html.node`
-      <a
-        title="${mapp.user && mapp.dictionary.toolbar_logout || mapp.dictionary.toolbar_login}"
-        href="${(mapp.user && '?logout=true') || '?login=true'}">
-        <div class="${`mask-icon ${(mapp.user && 'logout') || 'lock-open'}`}">`);
 
   // Append spacer for tableview
   btnColumn.appendChild(mapp.utils.html.node`


### PR DESCRIPTION
An array of plugin keys can be defined on the locale as `syncPlugins[]`

The default for this array if undefined is `['zoomBtn', 'admin', 'login']`

```js
locale.syncPlugins ??= ['zoomBtn', 'admin', 'login']
```

The plugins defined in this array will be executed in this order allowing us to configure the order in which buttons are added to the btnColumn element.

The zoomBtn, admin view link, and login/logout link have been converted into core plugins taking the elements out of the _default script and allowing us to control the order of all buttons.