### PR TITLE
Fix Numeric and Date Inputs

### DIFF
--- a/lib/ui/utils/tabulator.mjs
+++ b/lib/ui/utils/tabulator.mjs
@@ -278,8 +278,8 @@ function like(_this) {
 
     function likeFilter(e) {
 
-      // Set layer filter and reload layer and table data.
-      if (headerFilterParams.layerFilter) {
+    // Set layer filter when layerFilter is true and headerFilterParams.layerFilter is true.
+    if (headerFilterParams.layerFilter && _this.layerFilter) {
 
         if (e.target.value.length) {
 
@@ -381,8 +381,8 @@ function numeric(_this) {
       if (Number(e.target.value)) {
         _this.Tabulator.addFilter(field, `${filterType}`, Number(e.target.value))
 
-        // Set layer filter
-        if (headerFilterParams.layerFilter) {
+        // Set layer filter when layerFilter is true and headerFilterParams.layerFilter is true.
+        if (headerFilterParams.layerFilter && _this.layerFilter) {
 
           // Assign the filter to the layer filter.
           _this.layer.filter.current[field] = Object.assign(_this.layer.filter.current[field] || {}, { [filterCurrent]: Number(e.target.value) })
@@ -443,8 +443,8 @@ function dateFilter(_this) {
       if (val) {
         _this.Tabulator.addFilter(field, filterType, val)
 
-        // Set layer filter
-        if (headerFilterParams.layerFilter) {
+    // Set layer filter when layerFilter is true and headerFilterParams.layerFilter is true.
+    if (headerFilterParams.layerFilter && _this.layerFilter) {
           _this.layer.filter.current[field] = Object.assign(_this.layer.filter.current[field] || {}, { [filterCurrent]: val })
           _this.layer.reload();
           _this.update();
@@ -516,7 +516,8 @@ function set(_this) {
 
     async function callback(e, options) {
 
-      if (headerFilterParams.layerFilter) {
+    // Set layer filter when layerFilter is true and headerFilterParams.layerFilter is true.
+    if (headerFilterParams.layerFilter && _this.layerFilter) {
 
         // Create current filter for the layer.
         options.length
@@ -674,6 +675,9 @@ function layerfilter(_this) {
       e.target.classList.toggle('active')
       _this.queryparams.filter = !_this.queryparams.filter
       _this.update()
+      // If the button is active, set the layer filter to true, else set it to false.
+      _this.layerFilter = e.target.classList.contains('active') ? true : false
+      console.log(_this.layerFilter)
 
     }}>Layer Filter`
 

--- a/lib/ui/utils/tabulator.mjs
+++ b/lib/ui/utils/tabulator.mjs
@@ -676,8 +676,7 @@ function layerfilter(_this) {
       _this.queryparams.filter = !_this.queryparams.filter
       _this.update()
       // If the button is active, set the layer filter to true, else set it to false.
-      _this.layerFilter = e.target.classList.contains('active') ? true : false
-      console.log(_this.layerFilter)
+      _this.layerFilter = e.target.classList.contains('active')
 
     }}>Layer Filter`
 

--- a/lib/ui/utils/tabulator.mjs
+++ b/lib/ui/utils/tabulator.mjs
@@ -258,7 +258,7 @@ function columns(_this) {
     if (Object.hasOwn(mapp.ui.utils.tabulator.headerFilter, col.headerFilter)) {
 
       // Assign custom headerFilter from ui utils.
-      col.headerFilter = mapp.ui.utils.tabulator.headerFilter[col.headerFilter](_this)      
+      col.headerFilter = mapp.ui.utils.tabulator.headerFilter[col.headerFilter](_this)
     }
 
     // Check for custom formatter in the ui utils.
@@ -341,18 +341,33 @@ function numeric(_this) {
     // Select the field
     const field = cell.getColumn().getField()
 
+    // Create the minimum input element.
     const inputMin = mapp.utils.html`
-      <input 
-        type="number" 
-        placeholder=${mapp.dictionary.layer_filter_greater_than}
-        oninput=${minEvent}
-        onchange=${minEvent}
-        onblur=${minEvent}>`
+  <input 
+    type="number" 
+    placeholder=${mapp.dictionary.layer_filter_greater_than}
+    oninput=${(e) => NumericEvent(e, 'min')}
+    onchange=${(e) => NumericEvent(e, 'min')}
+    onblur=${(e) => NumericEvent(e, 'min')}>`;
 
-    function minEvent(e) {
+    // Create the maximum input element.
+    const inputMax = mapp.utils.html`
+  <input 
+    type="number" 
+    placeholder=${mapp.dictionary.layer_filter_less_than}
+    oninput=${(e) => NumericEvent(e, 'max')}
+    onchange=${(e) => NumericEvent(e, 'max')}
+    onblur=${(e) => NumericEvent(e, 'max')}>`;
 
+
+    // Function to filter the data.
+    function NumericEvent(e, type) {
+
+      // If type is min, use >= filter, else use <= filter.
+      const filterType = type === 'min' ? '>=' : '<='
+      const filterCurrent = type === 'min' ? 'gte' : 'lte'
       // Get filter for that field if exists
-      const filter = _this.Tabulator.getFilters().find(f => f.field === field && f.type == '>=')
+      const filter = _this.Tabulator.getFilters().find(f => f.field === field && f.type == `${filterType}`)
 
       // Remove existing filter
       if (filter) {
@@ -364,55 +379,24 @@ function numeric(_this) {
 
       // Add filter for valid target value.
       if (Number(e.target.value)) {
-        _this.Tabulator.addFilter(field, '>=', Number(e.target.value))
+        _this.Tabulator.addFilter(field, `${filterType}`, Number(e.target.value))
 
         // Set layer filter
         if (headerFilterParams.layerFilter) {
-          _this.layer.filter.current[field] = Object.assign(_this.layer.filter.current[field] || {}, { gte: Number(e.target.value) })
+
+          // Assign the filter to the layer filter.
+          _this.layer.filter.current[field] = Object.assign(_this.layer.filter.current[field] || {}, { [filterCurrent]: Number(e.target.value) })
+          // Reload the layer and update the table.
           _this.layer.reload();
           _this.update();
         }
       }
     }
 
-    const inputMax = mapp.utils.html`
-      <input 
-        type="number" 
-        placeholder=${mapp.dictionary.layer_filter_less_than}
-        oninput=${e => maxEvent(e, headerFilterParams, _this)}
-        onchange=${e => maxEvent(e, headerFilterParams, _this)}
-        onblur=${e => maxEvent(e, headerFilterParams, _this)}>`
-
     // flex container must be encapsulated since tabulator will strip attribute from most senior item returned.
     return mapp.utils.html.node`
       <div><div style="display: flex;">${inputMin}${inputMax}`
 
-  }
-}
-
-function maxEvent(e, headerFilterParams, _this) {
-
-  // Get filter for that field if exists
-  const filter = _this.Tabulator.getFilters().find(f => f.field === field && f.type == '<=')
-
-  // Remove existing filter
-  if (filter) {
-    _this.Tabulator.removeFilter(...Object.values(filter))
-
-    // Remove layer filter
-    headerFilterParams.layerFilter && delete _this.layer.filter.current[field]
-  }
-
-  // Add filter for valid target value.
-  if (Number(e.target.value)) {
-    _this.Tabulator.addFilter(field, '<=', Number(e.target.value))
-
-    // Set layer filter
-    if (headerFilterParams.layerFilter) {
-      _this.layer.filter.current[field] = Object.assign(_this.layer.filter.current[field] || {}, { lte: Number(e.target.value) })
-      _this.layer.reload();
-      _this.update();
-    }
   }
 }
 
@@ -423,17 +407,29 @@ function dateFilter(_this) {
     // Select the field
     const field = cell.getColumn().getField()
 
+    // Create the minimum input element.
+
     const inputMin = mapp.utils.html`
     <input
       type="date"
-      onchange=${minEvent}>`;
+      onchange=${(e) => DateEvent(e, 'min')}>`;
 
-    function minEvent(e) {
+    // Create the maximum input element.
+    const inputMax = mapp.utils.html`
+<input
+  type="date"
+  onchange=${(e) => DateEvent(e, 'max')}>`;
+
+    function DateEvent(e, type) {
 
       const val = new Date(e.target.value).getTime() / 1000
 
+      // If type is min, use >= filter, else use <= filter.
+      const filterType = type === 'min' ? '>=' : '<='
+      const filterCurrent = type === 'min' ? 'gte' : 'lte'
+
       // Get filter for that field if exists
-      const filter = _this.Tabulator.getFilters().find(f => f.field === field && f.type == '>=')
+      const filter = _this.Tabulator.getFilters().find(f => f.field === field && f.type == filterType)
 
       // Remove existing filter
       if (filter) {
@@ -445,54 +441,21 @@ function dateFilter(_this) {
 
       // Add filter for valid target value.
       if (val) {
-        _this.Tabulator.addFilter(field, '>=', val)
+        _this.Tabulator.addFilter(field, filterType, val)
 
         // Set layer filter
         if (headerFilterParams.layerFilter) {
-          _this.layer.filter.current[field] = Object.assign(_this.layer.filter.current[field] || {}, { gte: val })
+          _this.layer.filter.current[field] = Object.assign(_this.layer.filter.current[field] || {}, { [filterCurrent]: val })
           _this.layer.reload();
           _this.update();
         }
       }
     }
 
-    const inputMax = mapp.utils.html`
-    <input
-      type="date"
-      onchange=${e => maxEventDate(e, headerFilterParams, _this)}>`;
-
     // flex container must be encapsulated since tabulator will strip attribute from most senior item returned.
     return mapp.utils.html.node`
       <div><div style="display: flex;">${inputMin}${inputMax}`
 
-  }
-}
-
-function maxEventDate(e, headerFilterParams, _this) {
-
-  const val = new Date(e.target.value).getTime() / 1000
-
-  // Get filter for that field if exists
-  const filter = _this.Tabulator.getFilters().find(f => f.field === field && f.type == '<=')
-
-  // Remove existing filter
-  if (filter) {
-    _this.Tabulator.removeFilter(...Object.values(filter))
-
-    // Remove layer filter
-    headerFilterParams.layerFilter && delete _this.layer.filter.current[field]
-  }
-
-  // Add filter for valid target value.
-  if (val) {
-    _this.Tabulator.addFilter(field, '<=', val)
-
-    // Set layer filter
-    if (headerFilterParams.layerFilter) {
-      _this.layer.filter.current[field] = Object.assign(_this.layer.filter.current[field] || {}, { lte: val })
-      _this.layer.reload();
-      _this.update();
-    }
   }
 }
 
@@ -521,7 +484,7 @@ function set(_this) {
 
           // If response is not an array, make it an array.
           if (!Array.isArray(response)) response = [response];
-          
+
           // Render dropdown with distinct values from response.
           mapp.utils.render(dropdown, mapp.ui.elements.dropdown({
             multi: true,
@@ -711,6 +674,7 @@ function layerfilter(_this) {
       e.target.classList.toggle('active')
       _this.queryparams.filter = !_this.queryparams.filter
       _this.update()
+
     }}>Layer Filter`
 
 }


### PR DESCRIPTION
The Tabulator Numeric and Date HeaderFilter Inputs were broken. 
This PR fixes the min and max inputs, using the same function for Numeric and Date by passing in a `min` or `max` flag - reducing the code maintenance required. 

The layerFilter Button was also broken, this now been fixed. 

This PR wants to be tested with: 

- Like, Set, Date, Numeric Filtering
- Like, Set, Date, Numeric Filtering with layerFiltering enabled
- layerFiltering and viewport Buttons also need to be tested.