### PR TITLE
Allow hiding of Hovers and Labels

### DIFF
--- a/lib/ui/layers/panels/style.mjs
+++ b/lib/ui/layers/panels/style.mjs
@@ -146,7 +146,7 @@ export default layer => {
     }))
   }
 
-  if (layer.style.hover) {
+  if (layer.style.hover && !layer.style.hover.hidden) {
 
     // Add checkbox to toggle label display.
     layer.style.hoverCheckbox = mapp.ui.elements.chkbox({
@@ -166,7 +166,10 @@ export default layer => {
       // Add dropdown to switch label.
       content.push(mapp.ui.elements.dropdown({
         placeholder: layer.style.hover.title,
-        entries: Object.keys(layer.style.hovers).map(key => ({
+        entries: Object.keys(layer.style.hovers)
+           // Check if that label is set to be hidden. 
+           .filter(key => !layer.style.hovers[key].hidden)
+           .map(key => ({
           title: layer.style.hovers[key].title || key,
           option: key
         })),
@@ -186,7 +189,7 @@ export default layer => {
     }
   }
 
-  if (layer.style.label) {
+  if (layer.style.label && !layer.style.label.hidden) {
 
     // Add checkbox to toggle label display.
     layer.style.labelCheckbox = mapp.ui.elements.chkbox({
@@ -204,13 +207,15 @@ export default layer => {
 
     if (Object.keys(layer.style.labels || 0).length > 1) {
 
-      // Add dropdown to switch label.
       content.push(mapp.ui.elements.dropdown({
         placeholder: layer.style.label.title,
-        entries: Object.keys(layer.style.labels).map(key => ({
-          title: layer.style.labels[key].title || key,
-          option: key
-        })),
+        entries: Object.keys(layer.style.labels)
+          // Check if that label is set to be hidden. 
+          .filter(key => !layer.style.labels[key].hidden)
+          .map(key => ({
+            title: layer.style.labels[key].title || key,
+            option: key
+          })),
         callback: (e, entry) => {
 
           const display = layer.style.label.display


### PR DESCRIPTION
We use checkboxes to control the visibility of hovers and labels via the Style Panel.

However, it is perfectly valid to want to hide these from view, being able to hide them has multiple uses: 
1. If a layer has just a default styling, then a style panel is rendered just for hover and label checkboxes. 
2. If a layer has lots of themes and uses setLabel and setHover, there is no need for 3 dropdowns that clutter the UI, and so hiding them would be much neater.

This PR introduces an optional flag `hidden` that can be applied to `layer.style.hover`, `layer.style.hovers`, `layer.style.label` and `layer.style.labels` to control whether the user sees this dropdown. 

This wants to be tested using: 
 - `layer.style.hover` 
 - `layer.style.hovers` 
 - `layer.style.label`
 - `layer.style.labels`
 - `setLabel`
 - `setHover`