### PR TITLE
maplibre v4.0.2 bump and esm load

### DIFF
--- a/lib/layer/format/maplibre.mjs
+++ b/lib/layer/format/maplibre.mjs
@@ -1,48 +1,39 @@
-let promise, maplibregl = null
+// Assign maplibre from window if already loaded.
+let promise, maplibregl = window.maplibregl
 
 async function MaplibreGL() {
 
   if (maplibregl) return new maplibregl.Map(...arguments);
 
+  // Create promise to load maplibre from esm.sh
   if (!promise) promise = new Promise(async resolve => {
 
-    if (window.maplibregl) {
+    try{
 
-      maplibregl = window.maplibregl
+      const mod = await import('https://esm.sh/maplibre-gl@4.0.2')
 
+      maplibregl = mod.default
+  
+      // Avoid loading RTL Text Plugin twice, else it will error
+      if (!["deferred", "loaded"].includes(maplibregl.getRTLTextPluginStatus())) {
+        maplibregl.setRTLTextPlugin(
+          'https://unpkg.com/@mapbox/mapbox-gl-rtl-text@0.2.3/mapbox-gl-rtl-text.min.js',
+          true // Lazy load the plugin
+        );
+      }
+  
       resolve()
-  
-      return
+
+    } catch {
+
+      console.error('Failed to load maplibre-gl library.')
+      resolve()
     }
-
-    Promise
-      .all([
-        import('https://cdn.skypack.dev/pin/maplibre-gl@v3.3.1-tpQnCWSKVKnsrj9mKNGz/mode=imports,min/optimized/maplibre-gl.js')
-      ])
-      .then(imports => {
- 
-        maplibregl = imports[0]
-
-        // Avoid loading RTL Text Plugin twice, else it will error
-        if (!["deferred", "loaded"].includes(maplibregl.getRTLTextPluginStatus())) {
-          maplibregl.setRTLTextPlugin(
-            'https://unpkg.com/@mapbox/mapbox-gl-rtl-text@0.2.3/mapbox-gl-rtl-text.min.js',
-            null,
-            true // Lazy load the plugin
-          );
-        }
-
-        resolve()
-      })
-      .catch(error => {
-        console.error(error.message)
-        alert('Failed to load MaplibreGL library. Please reload the browser.')
-      })
-  
   })
 
   await promise
 
+  if (!maplibregl) return;
 
   return new maplibregl.Map(...arguments);
 }
@@ -80,6 +71,8 @@ export default async layer => {
       return {url}
     }
   });
+
+  if (!layer.Map) return;
 
   // The Maplibre Map control must resize with mapview Map targetElement.
   layer.mapview.Map.getTargetElement().addEventListener('resize', ()=>layer.Map.resize())


### PR DESCRIPTION
Update maplibre to 4.0.2 to be loaded from ESM instead of skypack.