### PR TITLE
Add check for Style labelCheckbox

### DIFF
--- a/lib/ui/layers/panels/style.mjs
+++ b/lib/ui/layers/panels/style.mjs
@@ -231,9 +231,9 @@ export default layer => {
     const z = layer.mapview.Map.getView().getZoom();
 
     if (z <= layer.style.label.minZoom || z >= layer.style.label.maxZoom) {
-      layer.style.labelCheckbox.classList.add('disabled');
+      layer.style.labelCheckbox?.classList.add('disabled');
     } else {
-      layer.style.labelCheckbox.classList.remove('disabled');
+      layer.style.labelCheckbox?.classList.remove('disabled');
     }
   });
 


### PR DESCRIPTION
## `labelCheckbox`

- Due to this PR [#1149](https://github.com/GEOLYTIX/xyz/pull/1149) it is possible for a layer style panel to not have a labelCheckbox.

- So I have added in a check on the `layer.style` object if its present before adding the `classList`

```js
 layer.style.labelCheckbox?.classList.add('disabled');
```