### PR TITLE
Assign ID for wkt_properties features

### DIFF
--- a/lib/layer/featureFormats.mjs
+++ b/lib/layer/featureFormats.mjs
@@ -69,7 +69,9 @@ export function wkt_properties(layer, features) {
 
   for (const feature of features) {
 
-    const properties = {}
+    const properties = {
+      id: feature[0]
+    }
 
     // Assign field key and value to properties object
     layer.params.fields?.forEach((field, i) => {


### PR DESCRIPTION
The property assignment in the wkt_properties feature format was missing the id assignment.

This caused the hover query to fail because of missing id assignment in the query.

This must tested with an overlay where the qID is not id.

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1206703776218335