### PR TITLE
The hover method must be assigned if not member of the hover object.

### DIFF
--- a/lib/ui/layers/panels/style.mjs
+++ b/lib/ui/layers/panels/style.mjs
@@ -266,6 +266,9 @@ export default layer => {
         if (layer.style.theme.setHover && layer.style.hovers) {
 
           layer.style.hover = layer.style.hovers[layer.style.theme.setHover]
+
+          // Assign default featureHover method if non is provided.
+          layer.style.hover.method ??= mapp.layer.featureHover;
         }
 
         // Replace the children of the style panel.


### PR DESCRIPTION
Fixes a bug where changing the hover through theme would assign a hover object without a method.