### PR TITLE
Clear all filters fix - needs the second check

### DIFF
--- a/lib/ui/layers/panels/filter.mjs
+++ b/lib/ui/layers/panels/filter.mjs
@@ -144,17 +144,15 @@ export default layer => {
 
       filter.remove = () => {
 
-        if (layer.filter.current[filter.field]) {
-
-          if (!layer.filter.current[filter.field][filter.type]) {
+        // Delete filter for empty input.
+        if(layer.filter.current[filter.field]){
+          if(!layer.filter.current[filter.field][filter.type]){
             delete layer.filter.current[filter.field]
           }
-          else {
+          else{
             delete layer.filter.current[filter.field][filter.type]
           }
-
-          // Delete empty filter.field object.
-          if (!Object.keys(layer.filter.current[filter.field]).length) {
+          if (layer.filter.current[filter.field] && !Object.keys(layer.filter.current[filter.field]).length) {
             delete layer.filter.current[filter.field]
           }
         }


### PR DESCRIPTION
If the first check does the delete then Object.keys() cannot be performed on layer.filter.current[filter.field] as it will be undefined.

The second check ensures there is something run Object.keys on.