### PR TITLE
Replace zoom draw style function with expression.

### DIFF
--- a/lib/mapview/interactions/zoom.mjs
+++ b/lib/mapview/interactions/zoom.mjs
@@ -36,15 +36,10 @@ export default function(params){
     source: mapview.interaction.Layer.getSource(),
     type: 'Circle',
     geometryFunction: ol.interaction.Draw.createBox(),
-    style: new ol.style.Style({
-      stroke: new ol.style.Stroke({
-        color: '#ddd',
-        width: 1
-      }),
-      fill: new ol.style.Stroke({
-        color: '#fff9'
-      })
-    })
+    style: {
+      'stroke-color': '#ddd',
+      'fill-color': '#fff9'
+    }
   })
 
   mapview.interaction.interaction.on('drawend', e => {


### PR DESCRIPTION
This was borked due to the assignment of a stroke to the style to the fill.