### PR TITLE
Null Geometries not being displayed when dependents used

### DIFF
--- a/lib/ui/locations/entries/geometry.mjs
+++ b/lib/ui/locations/entries/geometry.mjs
@@ -46,9 +46,6 @@ export default entry => {
 
   entry.srid ??= entry.location?.layer?.srid
 
-  // Turn off display with no geometry to display.
-  entry.display = (entry.display && entry.value)
-
   // Drawing is only available within an edit context.
   if (entry.edit?.draw) {
 


### PR DESCRIPTION
With this config below where - 
1. geometry_4326 is null 
2. geometry_not_null_4326 is populated by a trigger when a new point is added. 
``` json 
 {
      "display": true,
      "field": "geometry_4326",
      "fieldfx": "ST_AsGeoJSON(ST_TRANSFORM(geometry_4326,4326))",
      "type": "geometry"
}, 
{
      "display": true,
      "field": "geometry_not_null_4326",
      "type": "geometry",
      "dependents": ["geometry_4326"]
}
```

The geometry_4326 field will never display without the checkbox being toggled, due to an incorrect line in `geometry.mjs` that sets display to false without a value. 

This PR addresses that by removing the line of code.


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1206750193763473