### PR TITLE
Use password_reset for registration

### DIFF
--- a/mod/user/_user.js
+++ b/mod/user/_user.js
@@ -2,6 +2,8 @@
 @module /user
 */
 
+const reqHost = require('../utils/reqHost')
+
 const view = require('../view')
 
 const methods = {
@@ -64,9 +66,7 @@ module.exports = async (req, res) => {
     return res.send(`Failed to evaluate 'method' param.`)
   }
 
-  req.params.host = `${req.headers.origin 
-    || req.headers.host && 'https://' + (process.env.ALIAS || req.headers.host)}${process.env.DIR}`
-    || req.headers.referer && new URL(req.headers.referer).origin 
+  req.params.host = reqHost(req)
 
   if (!req.params.user && (method.login || method.admin)) {
 

--- a/mod/user/_user.js
+++ b/mod/user/_user.js
@@ -6,7 +6,7 @@ const view = require('../view')
 
 const methods = {
   admin: {
-    handler: (req,res) => {
+    handler: (req, res) => {
       req.params.template = 'user_admin_view'
       req.params.language = req.params.user.language
       req.params.user = req.params.user.email
@@ -64,16 +64,20 @@ module.exports = async (req, res) => {
     return res.send(`Failed to evaluate 'method' param.`)
   }
 
+  req.params.host = `${req.headers.origin 
+    || req.headers.host && 'https://' + (process.env.ALIAS || req.headers.host)}${process.env.DIR}`
+    || req.headers.referer && new URL(req.headers.referer).origin 
+
   if (!req.params.user && (method.login || method.admin)) {
 
     req.params.msg = 'login_required'
-    return methods.login.handler(req,res)
+    return methods.login.handler(req, res)
   }
 
   if (req.params.user && (!req.params.user.admin && method.admin)) {
 
     req.params.msg = 'admin_required'
-    return methods.login.handler(req,res)
+    return methods.login.handler(req, res)
   }
 
   method.handler(req, res)

--- a/mod/user/delete.js
+++ b/mod/user/delete.js
@@ -20,14 +20,16 @@ module.exports = async (req, res) => {
 
   const user = rows[0]
 
+  const host = `${req.headers.origin 
+    || req.headers.host && 'https://' + (process.env.ALIAS || req.headers.host)}${process.env.DIR}`
+    || req.headers.referer && new URL(req.headers.referer).origin 
+
   // Sent email to inform user that their account has been deleted.
   await mailer({
     template: 'deleted_account',
     language: user.language,
     to: user.email,
-    host: `${req.headers.origin 
-      || req.headers.referer && new URL(req.headers.referer).origin 
-      || 'https://' + (process.env.ALIAS || req.headers.host)}${process.env.DIR}`
+    host
   })
 
   res.send('User account deleted.')

--- a/mod/user/delete.js
+++ b/mod/user/delete.js
@@ -20,16 +20,12 @@ module.exports = async (req, res) => {
 
   const user = rows[0]
 
-  const host = `${req.headers.origin 
-    || req.headers.host && 'https://' + (process.env.ALIAS || req.headers.host)}${process.env.DIR}`
-    || req.headers.referer && new URL(req.headers.referer).origin 
-
   // Sent email to inform user that their account has been deleted.
   await mailer({
     template: 'deleted_account',
     language: user.language,
     to: user.email,
-    host
+    host: req.params.host
   })
 
   res.send('User account deleted.')

--- a/mod/user/fromACL.js
+++ b/mod/user/fromACL.js
@@ -72,11 +72,6 @@ module.exports = async (req) => {
     return new Error('auth_failed')
   }
 
-  if (user instanceof Error) {
-
-    return await failedLogin(request)
-  }
-
   return user
 }
 
@@ -167,7 +162,7 @@ async function getUser(request) {
     return user
   }
 
-  return new Error('compare_sync_fail')
+  return await failedLogin(request)
 }
 
 /**

--- a/mod/user/fromACL.js
+++ b/mod/user/fromACL.js
@@ -60,9 +60,9 @@ module.exports = async (req) => {
   request.date = new Date()
 
   // Get the host for the account verification email.
-  request.host = `${req.headers.origin
-    || req.headers.referer && new URL(req.headers.referer).origin
-    || 'https://' + (process.env.ALIAS || req.headers.host)}${process.env.DIR}`
+  const host = `${req.headers.origin 
+    || req.headers.host && 'https://' + (process.env.ALIAS || req.headers.host)}${process.env.DIR}`
+    || req.headers.referer && new URL(req.headers.referer).origin 
 
   const user = await getUser(request)
 

--- a/mod/user/fromACL.js
+++ b/mod/user/fromACL.js
@@ -60,9 +60,7 @@ module.exports = async (req) => {
   request.date = new Date()
 
   // Get the host for the account verification email.
-  request.host = `${req.headers.origin 
-    || req.headers.host && 'https://' + (process.env.ALIAS || req.headers.host)}${process.env.DIR}`
-    || req.headers.referer && new URL(req.headers.referer).origin 
+  request.host = req.params.host
 
   const user = await getUser(request)
 

--- a/mod/user/fromACL.js
+++ b/mod/user/fromACL.js
@@ -60,7 +60,9 @@ module.exports = async (req) => {
   request.date = new Date()
 
   // Get the host for the account verification email.
-  request.host = req.params.host
+  request.host = `${req.headers.origin
+    || req.headers.host && 'https://' + (process.env.ALIAS || req.headers.host)}${process.env.DIR}`
+    || req.headers.referer && new URL(req.headers.referer).origin 
 
   const user = await getUser(request)
 

--- a/mod/user/fromACL.js
+++ b/mod/user/fromACL.js
@@ -60,7 +60,7 @@ module.exports = async (req) => {
   request.date = new Date()
 
   // Get the host for the account verification email.
-  const host = `${req.headers.origin 
+  request.host = `${req.headers.origin 
     || req.headers.host && 'https://' + (process.env.ALIAS || req.headers.host)}${process.env.DIR}`
     || req.headers.referer && new URL(req.headers.referer).origin 
 

--- a/mod/user/fromACL.js
+++ b/mod/user/fromACL.js
@@ -12,6 +12,8 @@ const crypto = require('crypto')
 
 const mailer = require('../utils/mailer')
 
+const reqHost = require('../utils/reqHost')
+
 const languageTemplates = require('../utils/languageTemplates')
 
 const acl = require('./acl')
@@ -60,9 +62,7 @@ module.exports = async (req) => {
   request.date = new Date()
 
   // Get the host for the account verification email.
-  request.host = `${req.headers.origin
-    || req.headers.host && 'https://' + (process.env.ALIAS || req.headers.host)}${process.env.DIR}`
-    || req.headers.referer && new URL(req.headers.referer).origin 
+  request.host = reqHost(req)
 
   const user = await getUser(request)
 

--- a/mod/user/list.js
+++ b/mod/user/list.js
@@ -19,7 +19,8 @@ module.exports = async (req, res) => {
     failedattempts,
     approved_by,
     ${process.env.APPROVAL_EXPIRY ? 'expires_on,' : ''}
-    blocked
+    blocked,
+    verificationtoken
   FROM acl_schema.acl_table
   ORDER BY email;`)
 

--- a/mod/user/login.js
+++ b/mod/user/login.js
@@ -10,10 +10,6 @@ const view = require('../view')
 
 module.exports = async (req, res) => {
 
-  req.params.host = `${req.headers.origin 
-    || req.headers.host && 'https://' + (process.env.ALIAS || req.headers.host)}${process.env.DIR}`
-    || req.headers.referer && new URL(req.headers.referer).origin 
-
   if (req.body) {
 
     const user = await fromACL(req)

--- a/mod/user/login.js
+++ b/mod/user/login.js
@@ -10,6 +10,10 @@ const view = require('../view')
 
 module.exports = async (req, res) => {
 
+  req.params.host = `${req.headers.origin 
+    || req.headers.host && 'https://' + (process.env.ALIAS || req.headers.host)}${process.env.DIR}`
+    || req.headers.referer && new URL(req.headers.referer).origin 
+
   if (req.body) {
 
     const user = await fromACL(req)

--- a/mod/user/register.js
+++ b/mod/user/register.js
@@ -162,13 +162,11 @@ async function post(req, res) {
     return res.send(password_reset_verification)
   }
 
-  
-  
   // Create new user account
   rows = await acl(`
     INSERT INTO acl_schema.acl_table (
       email,
-      password,
+      password_reset,
       language,
       ${process.env.APPROVAL_EXPIRY ? 'expires_on,' : ''}
       verificationtoken,
@@ -176,7 +174,7 @@ async function post(req, res) {
 
     SELECT
       '${req.body.email}' AS email,
-      '${password}' AS password,
+      '${password}' AS password_reset,
       '${language}' AS language,
       ${process.env.APPROVAL_EXPIRY ? `${parseInt((new Date().getTime() + process.env.APPROVAL_EXPIRY * 1000 * 60 * 60 * 24)/1000)} AS expires_on,` : ''}
       '${verificationtoken}' AS verificationtoken,

--- a/mod/user/register.js
+++ b/mod/user/register.js
@@ -10,6 +10,8 @@ const acl = require('./acl')
 
 const mailer = require('../utils/mailer')
 
+const reqHost = require('../utils/reqHost')
+
 const languageTemplates = require('../utils/languageTemplates')
 
 const view = require('../view')
@@ -18,9 +20,7 @@ module.exports = async (req, res) => {
 
   if (!acl) return res.status(500).send('ACL unavailable.')
 
-  req.params.host = `${req.headers.origin 
-    || req.headers.host && 'https://' + (process.env.ALIAS || req.headers.host)}${process.env.DIR}`
-    || req.headers.referer && new URL(req.headers.referer).origin 
+  req.params.host = reqHost(req)
 
   // Post request to register new user.
   if (req.body && req.body.register) return post(req, res)
@@ -105,7 +105,7 @@ async function post(req, res) {
 
   // Setting the password to NULL will disable access to the account and prevent resetting the password.
   // Checking for password reset to allow registering again before verification.
-  if (!user.password_reset && user?.password === null) {
+  if (!user?.password_reset && user?.password === null) {
 
     return res.status(401).send('User account has restricted access')
   }

--- a/mod/user/register.js
+++ b/mod/user/register.js
@@ -123,7 +123,7 @@ async function post(req, res) {
   if (user) {
 
     // Blocked user may not reset their password.
-    if (user.blocked) return res.status(500).send(await languageTemplates({
+    if (user.blocked) return res.status(403).send(await languageTemplates({
       template: 'user_blocked',
       language
     }))

--- a/mod/user/register.js
+++ b/mod/user/register.js
@@ -116,8 +116,8 @@ async function post(req, res) {
 
   // Get the host for account verification email.
   const host = `${req.headers.origin 
+    || req.headers.host && 'https://' + (process.env.ALIAS || req.headers.host)}${process.env.DIR}`
     || req.headers.referer && new URL(req.headers.referer).origin 
-    || 'https://' + (process.env.ALIAS || req.headers.host)}${process.env.DIR}`
 
   // The password will be reset for exisiting user accounts.
   if (user) {

--- a/mod/user/register.js
+++ b/mod/user/register.js
@@ -166,6 +166,7 @@ async function post(req, res) {
   rows = await acl(`
     INSERT INTO acl_schema.acl_table (
       email,
+      password,
       password_reset,
       language,
       ${process.env.APPROVAL_EXPIRY ? 'expires_on,' : ''}
@@ -174,6 +175,7 @@ async function post(req, res) {
 
     SELECT
       '${req.body.email}' AS email,
+      '${password}' AS password,
       '${password}' AS password_reset,
       '${language}' AS language,
       ${process.env.APPROVAL_EXPIRY ? `${parseInt((new Date().getTime() + process.env.APPROVAL_EXPIRY * 1000 * 60 * 60 * 24)/1000)} AS expires_on,` : ''}

--- a/mod/user/update.js
+++ b/mod/user/update.js
@@ -38,10 +38,6 @@ module.exports = async (req, res) => {
     return res.status(500).send(error_message)
   }
 
-  const host = `${req.headers.origin 
-    || req.headers.host && 'https://' + (process.env.ALIAS || req.headers.host)}${process.env.DIR}`
-    || req.headers.referer && new URL(req.headers.referer).origin 
-
   // Send email to the user account if an account has been approved.
   if (req.params.field === 'approved' && req.params.value === true) {
    
@@ -49,7 +45,7 @@ module.exports = async (req, res) => {
       template: 'approved_account',
       language: req.params.user.language,
       to: email,
-      host: host
+      host: req.params.host
     })
   }
 

--- a/mod/user/update.js
+++ b/mod/user/update.js
@@ -39,8 +39,8 @@ module.exports = async (req, res) => {
   }
 
   const host = `${req.headers.origin 
+    || req.headers.host && 'https://' + (process.env.ALIAS || req.headers.host)}${process.env.DIR}`
     || req.headers.referer && new URL(req.headers.referer).origin 
-    || 'https://' + (process.env.ALIAS || req.headers.host)}${process.env.DIR}`
 
   // Send email to the user account if an account has been approved.
   if (req.params.field === 'approved' && req.params.value === true) {

--- a/mod/user/verify.js
+++ b/mod/user/verify.js
@@ -55,7 +55,7 @@ module.exports = async (req, res) => {
 
   let substitute_params = [user.email, req.params.language || user.language]
 
-  user.password_reset && params.push(user.password_reset)
+  user.password_reset && substitute_params.push(user.password_reset)
 
   // Update user account in ACL with the approval token and remove verification token.
   await acl(`
@@ -110,6 +110,11 @@ module.exports = async (req, res) => {
   // One or more administrator have been 
   if (rows.length > 0) {
 
+    // Get the host for approval email.
+    const host = `${req.headers.origin 
+      || req.headers.referer && new URL(req.headers.referer).origin 
+      || 'https://' + (process.env.ALIAS || req.headers.host)}${process.env.DIR}`
+
     // Get array of mail promises.
     const mail_promises = rows.map(async row => {
 
@@ -118,9 +123,7 @@ module.exports = async (req, res) => {
         language: row.language,
         to: row.email,
         email: user.email,
-        host: `${req.headers.origin
-          || req.headers.referer && new URL(req.headers.referer).origin
-          || 'https://' + (process.env.ALIAS || req.headers.host)}${process.env.DIR}`
+        host
       })
     })
 

--- a/mod/user/verify.js
+++ b/mod/user/verify.js
@@ -53,19 +53,16 @@ module.exports = async (req, res) => {
     return res.status(302).send(token_not_found)
   }
 
-  let substitute_params = [user.email, req.params.language || user.language]
-
-  user.password_reset && substitute_params.push(user.password_reset)
-
   // Update user account in ACL with the approval token and remove verification token.
   await acl(`
     UPDATE acl_schema.acl_table SET
       failedattempts = 0,
-      ${user.password_reset && `password = $3,` ||''}
+      password = $3,
       verified = true,
       verificationtoken = null,
       language = $2
-    WHERE lower(email) = lower($1);`, substitute_params);
+    WHERE lower(email) = lower($1);`,
+    [user.email, req.params.language || user.language, user.password_reset]);
 
   if (rows instanceof Error) {
 

--- a/mod/user/verify.js
+++ b/mod/user/verify.js
@@ -109,8 +109,8 @@ module.exports = async (req, res) => {
 
     // Get the host for approval email.
     const host = `${req.headers.origin 
+      || req.headers.host && 'https://' + (process.env.ALIAS || req.headers.host)}${process.env.DIR}`
       || req.headers.referer && new URL(req.headers.referer).origin 
-      || 'https://' + (process.env.ALIAS || req.headers.host)}${process.env.DIR}`
 
     // Get array of mail promises.
     const mail_promises = rows.map(async row => {

--- a/mod/user/verify.js
+++ b/mod/user/verify.js
@@ -107,11 +107,6 @@ module.exports = async (req, res) => {
   // One or more administrator have been 
   if (rows.length > 0) {
 
-    // Get the host for approval email.
-    const host = `${req.headers.origin 
-      || req.headers.host && 'https://' + (process.env.ALIAS || req.headers.host)}${process.env.DIR}`
-      || req.headers.referer && new URL(req.headers.referer).origin 
-
     // Get array of mail promises.
     const mail_promises = rows.map(async row => {
 
@@ -120,7 +115,7 @@ module.exports = async (req, res) => {
         language: row.language,
         to: row.email,
         email: user.email,
-        host
+        host: req.params.host
       })
     })
 

--- a/mod/utils/reqHost.js
+++ b/mod/utils/reqHost.js
@@ -9,7 +9,7 @@ module.exports = req => {
     host = `http://${process.env.ALIAS||req.headers.host}${process.env.DIR}`
   } else if (req.headers.host) {
 
-    host = `http://${process.env.ALIAS||req.headers.host}${process.env.DIR}`
+    host = `https://${process.env.ALIAS||req.headers.host}${process.env.DIR}`
   } else if (req.headers.referer) {
 
     host = new URL(req.headers.referer).origin

--- a/mod/utils/reqHost.js
+++ b/mod/utils/reqHost.js
@@ -1,0 +1,21 @@
+const logger = require('./logger')
+
+module.exports = req => {
+
+  let host
+
+  if (req.headers.host.startsWith('localhost')) {
+
+    host = `http://${process.env.ALIAS||req.headers.host}${process.env.DIR}`
+  } else if (req.headers.host) {
+
+    host = `http://${process.env.ALIAS||req.headers.host}${process.env.DIR}`
+  } else if (req.headers.referer) {
+
+    host = new URL(req.headers.referer).origin
+  }
+
+  logger(host, 'reqhost')
+
+  return host
+}

--- a/mod/utils/reqHost.js
+++ b/mod/utils/reqHost.js
@@ -6,7 +6,7 @@ module.exports = req => {
 
   if (req.headers.host.startsWith('localhost')) {
 
-    host = `http://${process.env.ALIAS||req.headers.host}${process.env.DIR}`
+    host = `http://${req.headers.host}${process.env.DIR}`
   } else if (req.headers.host) {
 
     host = `https://${process.env.ALIAS||req.headers.host}${process.env.DIR}`

--- a/public/views/_user.html
+++ b/public/views/_user.html
@@ -86,6 +86,7 @@
 
     .btn-row {
       align-items: center;
+      flex-wrap: wrap;
       display: flex;
       gap: 10px;
       margin: 10px 0;
@@ -121,7 +122,8 @@
     <h1>Account admin</h1>
 
     <div class="btn-row">
-      <label>Filter<input id="filterInput" type="text" placeholder="e.g. geolytix" style="margin-left: 10px;"></label>
+      <label>Filter</label>
+      <input id="filterInput" type="text" placeholder="e.g. geolytix" style="max-width: 100%;">
       <button id="toggleBlocked">Show blocked accounts</button>
       <a class="default-view" href="{{dir}}">{{dir}}</a>
       <a class="logout" href="?logout=true">Logout</a>

--- a/public/views/_user.html
+++ b/public/views/_user.html
@@ -122,7 +122,7 @@
     <h1>Account admin</h1>
 
     <div class="btn-row">
-      <label>Filter</label>
+      <span>Filter</span>
       <input id="filterInput" type="text" placeholder="e.g. geolytix" style="max-width: 100%;">
       <button id="toggleBlocked">Show blocked accounts</button>
       <a class="default-view" href="{{dir}}">{{dir}}</a>


### PR DESCRIPTION
User registration must set the password as password_reset not as password.

Otherwise a user trying to login with an unverified password will create failed logins.

The verification set's the password_reset as password if successful.

Added reqHost util which generates the host value for emails. Takes localhost into account. Logger key `reqhost` logs the host value.