### PR TITLE
Fixes for infoj entry and filter issues

### DIFF
--- a/lib/ui/elements/numericFormatter.mjs
+++ b/lib/ui/elements/numericFormatter.mjs
@@ -80,10 +80,10 @@ function getFormatterParams(entry, inValue) {
   let separators = [entry.formatterParams?.thousand, entry.formatterParams?.decimal]
   let localeSeparators = Array.from(new Set(formattedValue.match(/\D/g)))
   localeSeparators[1] ??= '.'
-  
+
   //If not supplied look in the formatted string
   separators[0] = separators[0] ? separators[0] : localeSeparators[0]
-  separators[1] = separators[1] ? separators[1] : 
+  separators[1] = separators[1] ? separators[1] : localeSeparators[1]
 
   formattedValue = `${negative ? '-' : ''}${formattedValue}`
   return { value: formattedValue, separators: { thousands: separators[0], decimals: separators[1] } }

--- a/lib/ui/elements/numericFormatter.mjs
+++ b/lib/ui/elements/numericFormatter.mjs
@@ -19,8 +19,6 @@ export function getSeparators(entry) {
   //Do nothing if entry is null or no formatter is present
   if (!entry) return;
   if (!entry.formatter && entry.type !== 'integer') return { decimals: '.' };
-  entry.prefix = ''
-  entry.suffix = ''
   //Use a number to determin what the fields 
   //formatted input would look like
   entry.value = 1000000.99
@@ -29,8 +27,15 @@ export function getSeparators(entry) {
 
 function getFormatterParams(entry, inValue) {
   let value = entry.value || inValue;
-  entry.prefix ??= ''
-  entry.suffix ??= ''
+  let prefix = entry.prefix ??= ''
+  let suffix = entry.suffix ??= ''
+  let round = entry.round
+
+  if(entry.filterInput){
+    prefix = ''
+    suffix = ''
+    round = null
+  }
 
   if (!value) {
     return { value: null }
@@ -46,7 +51,7 @@ function getFormatterParams(entry, inValue) {
 
   //Check if supplied value is a valid number
   if (isNaN(parseFloat(value))) {
-    return { value: `${entry.prefix}   ${entry.suffix}`, separators: { thousands: '', decimals: '' } }
+    return { value: `${prefix}   ${suffix}`, separators: { thousands: '', decimals: '' } }
   }
 
   //Framework formatter type
@@ -54,22 +59,22 @@ function getFormatterParams(entry, inValue) {
 
   //Setup formatter options for rounding
   entry.formatterParams.options ??= {}
-  entry.formatterParams.options.maximumFractionDigits ??= entry.formatterParams.precision || entry.round
-  entry.formatterParams.options.minimumFractionDigits ??= entry.formatterParams.precision || entry.round
+  entry.formatterParams.options.maximumFractionDigits ??= entry.formatterParams.precision || round
+  entry.formatterParams.options.minimumFractionDigits ??= entry.formatterParams.precision || round
   //Tabulator formatterOptions
   if (entry.formatterParams?.decimal || entry.formatterParams?.thousand) {
     rawValue = parseFloat(value)
-    let rawList = rawValue.toLocaleString('en-GB', entry.formatterParams.options).split('.')
+    let rawList = entry.filterInput ? rawValue.toLocaleString('en-GB').split('.') : rawValue.toLocaleString('en-GB', entry.formatterParams.options).split('.')
     rawList[0] = rawList[0].replaceAll(',', entry.formatterParams.thousand)
     rawValue = rawList.join(entry.formatterParams.decimal || '.')
   } else {
 
     //Infoj formatter options
-    rawValue = parseFloat(value).toLocaleString(entry.formatterParams.locale, entry.formatterParams.options)
+    rawValue = entry.filterInput ? parseFloat(value).toLocaleString(entry.formatterParams.locale) : parseFloat(value).toLocaleString(entry.formatterParams.locale, entry.formatterParams.options)
   }
 
   //Add The affixes
-  let formattedValue = `${entry.prefix}${rawValue}${entry.suffix}`
+  let formattedValue = `${prefix}${rawValue}${suffix}`
 
   //Look for separators in formatterOptions.
   let separators = [entry.formatterParams?.thousand, entry.formatterParams?.decimal]
@@ -120,15 +125,6 @@ export function numericFormatter(entry, inValue, reverse) {
   if (!entry) return entry.value || inValue;
   if (!entry.formatter && entry.type !== 'integer') return entry.value || inValue;
   entry.value = inValue || entry.value
-  if(entry.filterInput){
-     delete entry.prefix
-     delete entry.suffix
-     delete entry.round
-     if(entry.formatterParams){
-        delete entry.formatterParams.options
-        delete entry.formatterParams.precision
-     }
-  }
 
   //Do the opposite of formatting
   if (reverse) {

--- a/lib/ui/elements/numericFormatter.mjs
+++ b/lib/ui/elements/numericFormatter.mjs
@@ -59,16 +59,16 @@ function getFormatterParams(entry, inValue) {
 
   //Setup formatter options for rounding
   entry.formatterParams.options ??= {}
-  entry.formatterParams.options.maximumFractionDigits ??= entry.formatterParams.precision || round
-  entry.formatterParams.options.minimumFractionDigits ??= entry.formatterParams.precision || round
+  entry.formatterParams.options.maximumFractionDigits ??= entry.formatterParams.precision ??= round
+  entry.formatterParams.options.minimumFractionDigits ??= entry.formatterParams.precision ??= round
   //Tabulator formatterOptions
   if (entry.formatterParams?.decimal || entry.formatterParams?.thousand) {
+    entry.formatterParams.decimal ??= '.'
     rawValue = parseFloat(value)
     let rawList = entry.filterInput ? rawValue.toLocaleString('en-GB').split('.') : rawValue.toLocaleString('en-GB', entry.formatterParams.options).split('.')
     rawList[0] = rawList[0].replaceAll(',', entry.formatterParams.thousand)
-    rawValue = rawList.join(entry.formatterParams.decimal || '.')
+    rawValue = rawList.join(entry.formatterParams.decimal)
   } else {
-
     //Infoj formatter options
     rawValue = entry.filterInput ? parseFloat(value).toLocaleString(entry.formatterParams.locale) : parseFloat(value).toLocaleString(entry.formatterParams.locale, entry.formatterParams.options)
   }
@@ -82,7 +82,7 @@ function getFormatterParams(entry, inValue) {
 
   //If not supplied look in the formatted string
   separators[0] = separators[0] ? separators[0] : localeSeparators[0]
-  separators[1] = separators[1] ? separators[1] : localeSeparators[1] || '.'
+  separators[1] = separators[1] ? separators[1] : localeSeparators[1] ??= '.'
 
   formattedValue = `${negative ? '-' : ''}${formattedValue}`
   return { value: formattedValue, separators: { thousands: separators[0], decimals: separators[1] } }

--- a/lib/ui/elements/numericFormatter.mjs
+++ b/lib/ui/elements/numericFormatter.mjs
@@ -18,7 +18,7 @@ Returns the decimal and thousand separators produced by toLocaleString or format
 export function getSeparators(entry) {
   //Do nothing if entry is null or no formatter is present
   if (!entry) return;
-  if (!entry.formatter) return { decimals: '.' };
+  if (!entry.formatter && entry.type !== 'integer') return { decimals: '.' };
   entry.prefix = ''
   entry.suffix = ''
   //Use a number to determin what the fields 
@@ -50,10 +50,12 @@ function getFormatterParams(entry, inValue) {
   }
 
   //Framework formatter type
-  if (entry.formatter === 'toLocaleString' || entry.type === 'integer') {
-    entry.formatterParams ??= { locale: 'en-GB'}
-  }
+  entry.formatterParams ??= { locale: 'en-GB' }
 
+  //Setup formatter options for rounding
+  entry.formatterParams.options ??= {}
+  entry.formatterParams.options.maximumFractionDigits ??= entry.formatterParams.precision || entry.round
+  entry.formatterParams.options.minimumFractionDigits ??= entry.formatterParams.precision || entry.round
   //Tabulator formatterOptions
   if (entry.formatterParams?.decimal || entry.formatterParams?.thousand) {
     rawValue = parseFloat(value)
@@ -63,7 +65,6 @@ function getFormatterParams(entry, inValue) {
   } else {
 
     //Infoj formatter options
-    entry.formatterParams ??= { locale: 'en-GB' }
     rawValue = parseFloat(value).toLocaleString(entry.formatterParams.locale, entry.formatterParams.options)
   }
 
@@ -118,9 +119,16 @@ export function numericFormatter(entry, inValue, reverse) {
   //Do nothing if entry is null or no formatter is present
   if (!entry) return entry.value || inValue;
   if (!entry.formatter && entry.type !== 'integer') return entry.value || inValue;
-  entry.prefix = ''
-  entry.suffix = ''
   entry.value = inValue || entry.value
+  if(entry.filterInput){
+     delete entry.prefix
+     delete entry.suffix
+     delete entry.round
+     if(entry.formatterParams){
+        delete entry.formatterParams.options
+        delete entry.formatterParams.precision
+     }
+  }
 
   //Do the opposite of formatting
   if (reverse) {

--- a/lib/ui/elements/numericFormatter.mjs
+++ b/lib/ui/elements/numericFormatter.mjs
@@ -117,7 +117,7 @@ export function numericFormatter(entry, inValue, reverse) {
 
   //Do nothing if entry is null or no formatter is present
   if (!entry) return entry.value || inValue;
-  if (!entry.formatter && !entry.type === 'integer') return entry.value || inValue;
+  if (!entry.formatter && entry.type !== 'integer') return entry.value || inValue;
   entry.prefix = ''
   entry.suffix = ''
   entry.value = inValue || entry.value

--- a/lib/ui/elements/numericFormatter.mjs
+++ b/lib/ui/elements/numericFormatter.mjs
@@ -50,8 +50,8 @@ function getFormatterParams(entry, inValue) {
   }
 
   //Framework formatter type
-  if (entry.formatter === 'toLocaleString') {
-    entry.formatterParams ??= { locale: navigator.language }
+  if (entry.formatter === 'toLocaleString' || entry.type === 'integer') {
+    entry.formatterParams ??= { locale: 'en-GB'}
   }
 
   //Tabulator formatterOptions
@@ -117,7 +117,7 @@ export function numericFormatter(entry, inValue, reverse) {
 
   //Do nothing if entry is null or no formatter is present
   if (!entry) return entry.value || inValue;
-  if (!entry.formatter) return entry.value || inValue;
+  if (!entry.formatter && !entry.type === 'integer') return entry.value || inValue;
   entry.prefix = ''
   entry.suffix = ''
   entry.value = inValue || entry.value

--- a/lib/ui/elements/numericFormatter.mjs
+++ b/lib/ui/elements/numericFormatter.mjs
@@ -79,10 +79,11 @@ function getFormatterParams(entry, inValue) {
   //Look for separators in formatterOptions.
   let separators = [entry.formatterParams?.thousand, entry.formatterParams?.decimal]
   let localeSeparators = Array.from(new Set(formattedValue.match(/\D/g)))
-
+  localeSeparators[1] ??= '.'
+  
   //If not supplied look in the formatted string
   separators[0] = separators[0] ? separators[0] : localeSeparators[0]
-  separators[1] = separators[1] ? separators[1] : localeSeparators[1] ??= '.'
+  separators[1] = separators[1] ? separators[1] : 
 
   formattedValue = `${negative ? '-' : ''}${formattedValue}`
   return { value: formattedValue, separators: { thousands: separators[0], decimals: separators[1] } }

--- a/lib/ui/layers/filters.mjs
+++ b/lib/ui/layers/filters.mjs
@@ -128,6 +128,7 @@ async function filter_numeric(layer, filter){
   entry.formatter ??= entry.formatterParams
   let affix = entry.prefix || entry.suffix
   affix = affix ? `(${affix.trim()})` : ''
+  entry.filterInput = true
   applyFilter(layer);
   return mapp.ui.elements.slider_ab({
     min: Number(filter.min),

--- a/lib/ui/locations/entries/numeric.mjs
+++ b/lib/ui/locations/entries/numeric.mjs
@@ -4,6 +4,11 @@ export default entry => {
 
   entry.formatterParams.options ??= {}
 
+  // If the user has a language, set the locale
+  if (mapp.user.language) {
+    entry.formatterParams.locale = mapp.user.language;
+  }
+  
   if (entry.edit) {
 
     if (entry.edit.range) {
@@ -34,10 +39,16 @@ export default entry => {
     }
   }
 
-  // If no locale is set, use the default locale
-  entry.formatterParams.locale ??= 'en-GB';
+  // If locale is defined, use toLocaleString
+  let localeValue;
+  if (entry.formatterParams.locale) {
+    localeValue = parseFloat(entry.value).toLocaleString(entry.formatterParams.locale, entry.formatterParams.options)
+  }
+  // If no locale, parseFloat and use maximumFractionDigits to round
+  else {
+    localeValue = parseFloat(entry.value).toFixed(entry.formatterParams.options.maximumFractionDigits)
+  }
 
-  const localeValue = parseFloat(entry.value).toLocaleString(entry.formatterParams.locale, entry.formatterParams.options)
   return mapp.utils.html.node`
   <div class="val" style=${entry.css_val}>
     ${entry.prefix}${localeValue}${entry.suffix}`;

--- a/lib/ui/locations/entries/numeric.mjs
+++ b/lib/ui/locations/entries/numeric.mjs
@@ -4,11 +4,11 @@ export default entry => {
 
   entry.formatterParams.options ??= {}
 
-  // If the user has a language, set the locale
-  if (mapp.user.language) {
-    entry.formatterParams.locale = mapp.user.language;
+  // Assign user language as locale if nullish but not null.
+  if (entry.formatterParams.locale !== null) {
+    entry.formatterParams.locale ??= mapp.user.language;
   }
-  
+ 
   if (entry.edit) {
 
     if (entry.edit.range) {

--- a/lib/ui/locations/entries/numeric.mjs
+++ b/lib/ui/locations/entries/numeric.mjs
@@ -24,10 +24,20 @@ export default entry => {
     entry.formatterParams.options.maximumFractionDigits = 0
   } else {
 
+    // Set rounding to entry.round or 2 if not defined
     entry.formatterParams.options.maximumFractionDigits ??= entry.round || 2
+
+    // If maximumFractionDigits is greater than 2, add minimumFractionDigits
+    if (entry.formatterParams.options.maximumFractionDigits > 2) {
+      // Add minimumFractionDigits if maximumFractionDigits is greater than 2
+      entry.formatterParams.options.minimumFractionDigits ??= entry.formatterParams.options.maximumFractionDigits
+    }
   }
 
-  const localeValue = entry.formatterParams.locale ? parseFloat(entry.value).toLocaleString(entry.formatterParams.locale, entry.formatterParams.options) : parseFloat(entry.value)
+  // If no locale is set, use the default locale
+  entry.formatterParams.locale ??= 'en-GB';
+
+  const localeValue = parseFloat(entry.value).toLocaleString(entry.formatterParams.locale, entry.formatterParams.options)
   return mapp.utils.html.node`
   <div class="val" style=${entry.css_val}>
     ${entry.prefix}${localeValue}${entry.suffix}`;

--- a/lib/ui/utils/tabulator.mjs
+++ b/lib/ui/utils/tabulator.mjs
@@ -372,6 +372,7 @@ function numeric(_this) {
       if(tableField.formatter){
         entry.formatter = tableField.formatter
         entry.formatterParams = tableField.formatterParams
+        entry.filterInput = true
         const values = getValues(entry)
         formattedValue = values.formatted
         e.target.value = values.numericValue


### PR DESCRIPTION
**Issue**
* A `infoj` entry of `type:integer` will not be formatted correctly, neither formatting nor rounding is applied. 
* This was due to a check in line 30 of `numeric.mjs` that was conditional on `entry.formatterParams.locale`. However, there was no default applied. 
* I also noticed that providing a `maximumFractionDigit` of >2 when using certain locales (e.g. `en-GB`) was not applied.
* The `numericFormatter.mjs` was not checking if the type was integer so it was not formatting the value in the filter in this case. 

**Fixes** 
* The default locale is set to `en-GB`, but can be overriden in the configuration of an `infoj` entry. 
* If a `maximumFractionDigit` of >2 is applied, then the `minimumFractionDigit` (if not provided in the configuration), is set to the same value, so that this is applied. 
* `numericFormatter.mjs` now checks if the type if integer and sets the default locale to `en-GB`.  

**How to Test** 
Please test the various configuration options - examples below but this may not be exhaustive.
* `type: integer` + `formatterParams.locale` + `filter: integer`
* `type: numeric` + `round: 3` + `filter: numeric`
* `type: integer` + `filter: integer` 
* `type: numeric` + `filter: numeric`
``` json 
 {
      "field": "X",
      "type": "integer",
      "prefix": "£",
      "inline": true,
      "formatterParams": {
        "locale": "ar-EG"
      },
      "filter": {
        "type": "integer"
      }
    },
    {
      "field": "Y",
      "type": "numeric",
      "round": 3,
      "prefix": "£",
      "inline": true,
      "skipNullValue": true,
      "filter": {
        "type": "numeric"
      }
    },
    {
      "field": "Z",
      "type": "numeric",
      "prefix": "£",
      "inline": true,
      "skipNullValue": true,
      "filter": {
        "type": "numeric"
      }
    },
    {
      "field": "A",
      "type": "integer",
      "prefix": "£",
      "inline": true,
      "skipNullValue": true,
      "filter": {
        "type": "integer"
      }
    },

```