### PR TITLE
Formatting fix

### DIFF
--- a/lib/ui/elements/numericFormatter.mjs
+++ b/lib/ui/elements/numericFormatter.mjs
@@ -9,6 +9,8 @@ formatterParams supplied on the entries.
 @module /ui/elements/numericFormatter
 */
 
+import { raw } from "express";
+
 /**
 Returns the decimal and thousand separators produced by toLocaleString or formatterParams 
 @param {Object} entry - An infoj entry object.
@@ -35,7 +37,12 @@ function getFormatterParams(entry, inValue) {
     prefix = ''
     suffix = ''
     round = null
+    rawValueTabulatorFormatting = rawValue.toLocaleString('en-GB').split('.')
+    rawValueInfojFormatting = parseFloat(value).toLocaleString(entry.formatterParams.locale)
   }
+
+  rawValueTabulatorFormatting ??= rawValue.toLocaleString('en-GB', entry.formatterParams.options).split('.')
+  rawValueInfojFormatting ??= parseFloat(value).toLocaleString(entry.formatterParams.locale, entry.formatterParams.options)
 
   if (!value) {
     return { value: null }
@@ -75,12 +82,12 @@ function getFormatterParams(entry, inValue) {
   if (entry.formatterParams?.decimal || entry.formatterParams?.thousand) {
     entry.formatterParams.decimal ??= '.'
     rawValue = parseFloat(value)
-    let rawList = entry.filterInput ? rawValue.toLocaleString('en-GB').split('.') : rawValue.toLocaleString('en-GB', entry.formatterParams.options).split('.')
+    let rawList = rawValueFormating
     rawList[0] = rawList[0].replaceAll(',', entry.formatterParams.thousand)
     rawValue = rawList.join(entry.formatterParams.decimal)
   } else {
     //Infoj formatter options
-    rawValue = entry.filterInput ? parseFloat(value).toLocaleString(entry.formatterParams.locale) : parseFloat(value).toLocaleString(entry.formatterParams.locale, entry.formatterParams.options)
+    rawValue = rawValueInfojFormatting
   }
 
   //Add The affixes

--- a/lib/ui/elements/numericFormatter.mjs
+++ b/lib/ui/elements/numericFormatter.mjs
@@ -33,6 +33,8 @@ function getFormatterParams(entry, inValue) {
   let suffix = entry.suffix ??= ''
   let round = entry.round
 
+  let rawValueTabulatorFormatting = rawValue.toLocaleString('en-GB', entry.formatterParams.options).split('.')
+  let rawValueInfojFormatting = parseFloat(value).toLocaleString(entry.formatterParams.locale, entry.formatterParams.options)
   if (entry.filterInput) {
     prefix = ''
     suffix = ''
@@ -40,9 +42,6 @@ function getFormatterParams(entry, inValue) {
     rawValueTabulatorFormatting = rawValue.toLocaleString('en-GB').split('.')
     rawValueInfojFormatting = parseFloat(value).toLocaleString(entry.formatterParams.locale)
   }
-
-  rawValueTabulatorFormatting ??= rawValue.toLocaleString('en-GB', entry.formatterParams.options).split('.')
-  rawValueInfojFormatting ??= parseFloat(value).toLocaleString(entry.formatterParams.locale, entry.formatterParams.options)
 
   if (!value) {
     return { value: null }

--- a/lib/ui/elements/numericFormatter.mjs
+++ b/lib/ui/elements/numericFormatter.mjs
@@ -70,12 +70,13 @@ function getFormatterParams(entry, inValue) {
   if (entry.formatterParams?.decimal || entry.formatterParams?.thousand) {
     entry.formatterParams.decimal ??= '.'
     rawValue = parseFloat(value)
-    let rawList = entry.filterInput ? rawValue.toLocaleString('en-GB').split('.') : rawValue.toLocaleString('en-GB', entry.formatterParams.options).split('.')
+
+    let rawList = rawValue.toLocaleString('en-GB', entry.formatterParams.options).split('.')
     rawList[0] = rawList[0].replaceAll(',', entry.formatterParams.thousand)
     rawValue = rawList.join(entry.formatterParams.decimal)
   } else {
     //Infoj formatter options
-    rawValue = entry.filterInput ? parseFloat(value).toLocaleString(entry.formatterParams.locale) : parseFloat(value).toLocaleString(entry.formatterParams.locale, entry.formatterParams.options)
+    rawValue = parseFloat(value).toLocaleString(entry.formatterParams.locale, entry.formatterParams.options)
   }
 
   //Add The affixes

--- a/lib/ui/elements/numericFormatter.mjs
+++ b/lib/ui/elements/numericFormatter.mjs
@@ -143,6 +143,8 @@ export function numericFormatter(entry, inValue, reverse) {
 
   entry.value = inValue || entry.value
 
+  if(!entry.formatterParams?.locale) return entry.value;
+  
   //Do the opposite of formatting
   if (reverse) {
     return undoFormatting(entry)

--- a/lib/ui/elements/numericFormatter.mjs
+++ b/lib/ui/elements/numericFormatter.mjs
@@ -19,7 +19,7 @@ export function getSeparators(entry) {
   //Do nothing if entry is null or no formatter is present
   if (!entry) return;
   if (!entry.formatter && entry.type !== 'integer') return { decimals: '.' };
-  //Use a number to determin what the fields 
+  //Use a number to determine what the fields 
   //formatted input would look like
   entry.value = 1000000.99
   return getFormatterParams(entry).separators
@@ -31,7 +31,7 @@ function getFormatterParams(entry, inValue) {
   let suffix = entry.suffix ??= ''
   let round = entry.round
 
-  if(entry.filterInput){
+  if (entry.filterInput) {
     prefix = ''
     suffix = ''
     round = null
@@ -54,8 +54,18 @@ function getFormatterParams(entry, inValue) {
     return { value: `${prefix}   ${suffix}`, separators: { thousands: '', decimals: '' } }
   }
 
-  //Framework formatter type
-  entry.formatterParams ??= { locale: 'en-GB' }
+  // Assign if nullish.
+  entry.formatterParams ??= {};
+
+  // Assign user language as locale if nullish but not null.
+  if (entry.formatterParams.locale !== null || entry.formatter === 'toLocaleString') {
+    entry.formatterParams.locale ??= mapp?.user?.language || mapp?.language;
+  }
+
+  // If formatter is money - use en-GB locale
+  if (entry.formatter === 'money') {
+    entry.formatterParams.locale = 'en-GB'
+  };
 
   //Setup formatter options for rounding
   entry.formatterParams.options ??= {}
@@ -125,6 +135,10 @@ export function numericFormatter(entry, inValue, reverse) {
   //Do nothing if entry is null or no formatter is present
   if (!entry) return entry.value || inValue;
   if (!entry.formatter && entry.type !== 'integer') return entry.value || inValue;
+
+  // If value is 0, return 0
+  if (inValue === 0) return 0;
+
   entry.value = inValue || entry.value
 
   //Do the opposite of formatting

--- a/lib/ui/elements/numericFormatter.mjs
+++ b/lib/ui/elements/numericFormatter.mjs
@@ -9,8 +9,6 @@ formatterParams supplied on the entries.
 @module /ui/elements/numericFormatter
 */
 
-import { raw } from "express";
-
 /**
 Returns the decimal and thousand separators produced by toLocaleString or formatterParams 
 @param {Object} entry - An infoj entry object.
@@ -33,14 +31,10 @@ function getFormatterParams(entry, inValue) {
   let suffix = entry.suffix ??= ''
   let round = entry.round
 
-  let rawValueTabulatorFormatting = rawValue.toLocaleString('en-GB', entry.formatterParams.options).split('.')
-  let rawValueInfojFormatting = parseFloat(value).toLocaleString(entry.formatterParams.locale, entry.formatterParams.options)
   if (entry.filterInput) {
     prefix = ''
     suffix = ''
     round = null
-    rawValueTabulatorFormatting = rawValue.toLocaleString('en-GB').split('.')
-    rawValueInfojFormatting = parseFloat(value).toLocaleString(entry.formatterParams.locale)
   }
 
   if (!value) {
@@ -68,11 +62,6 @@ function getFormatterParams(entry, inValue) {
     entry.formatterParams.locale ??= mapp.user?.language;
   }
 
-  // If formatter is money - use en-GB locale
-  if (entry.formatter === 'money') {
-    entry.formatterParams.locale = 'en-GB'
-  };
-
   //Setup formatter options for rounding
   entry.formatterParams.options ??= {}
   entry.formatterParams.options.maximumFractionDigits ??= entry.formatterParams.precision ??= round
@@ -81,12 +70,12 @@ function getFormatterParams(entry, inValue) {
   if (entry.formatterParams?.decimal || entry.formatterParams?.thousand) {
     entry.formatterParams.decimal ??= '.'
     rawValue = parseFloat(value)
-    let rawList = rawValueFormating
+    let rawList = entry.filterInput ? rawValue.toLocaleString('en-GB').split('.') : rawValue.toLocaleString('en-GB', entry.formatterParams.options).split('.')
     rawList[0] = rawList[0].replaceAll(',', entry.formatterParams.thousand)
     rawValue = rawList.join(entry.formatterParams.decimal)
   } else {
     //Infoj formatter options
-    rawValue = rawValueInfojFormatting
+    rawValue = entry.filterInput ? parseFloat(value).toLocaleString(entry.formatterParams.locale) : parseFloat(value).toLocaleString(entry.formatterParams.locale, entry.formatterParams.options)
   }
 
   //Add The affixes
@@ -144,6 +133,12 @@ export function numericFormatter(entry, inValue, reverse) {
 
   // If value is 0, return 0
   if (inValue === 0) return 0;
+
+  // If formatter is money - use en-GB locale
+  if (entry.formatter === 'money') {
+    entry.formatterParams ??= {}
+    entry.formatterParams.locale = 'en-GB'
+  };
 
   entry.value = inValue || entry.value
 

--- a/lib/ui/elements/numericFormatter.mjs
+++ b/lib/ui/elements/numericFormatter.mjs
@@ -59,7 +59,7 @@ function getFormatterParams(entry, inValue) {
 
   // Assign user language as locale if nullish but not null.
   if (entry.formatterParams.locale !== null || entry.formatter === 'toLocaleString') {
-    entry.formatterParams.locale ??= mapp?.user?.language || mapp?.language;
+    entry.formatterParams.locale ??= mapp.user?.language;
   }
 
   // If formatter is money - use en-GB locale

--- a/lib/ui/locations/entries/numeric.mjs
+++ b/lib/ui/locations/entries/numeric.mjs
@@ -25,13 +25,16 @@ export default entry => {
 
   if (entry.value === undefined || entry.value === null || isNaN(entry.value)) return;
 
-  if (entry.type === 'integer') {
+ // Set rounding to entry.round or 2 if not defined
+  let round = entry.round || 2;
 
+  // If integer, set maximumFractionDigits to 0
+  if (entry.type === 'integer') {
     entry.formatterParams.options.maximumFractionDigits = 0
   } else {
 
-    // Set rounding to entry.round or 2 if not defined
-    entry.formatterParams.options.maximumFractionDigits ??= entry.round || 2
+    // Set rounding to round
+    entry.formatterParams.options.maximumFractionDigits ??= round;
 
     // If maximumFractionDigits is greater than 2, add minimumFractionDigits
     if (entry.formatterParams.options.maximumFractionDigits > 2) {

--- a/lib/ui/locations/entries/numeric.mjs
+++ b/lib/ui/locations/entries/numeric.mjs
@@ -5,8 +5,9 @@ export default entry => {
   entry.formatterParams.options ??= {}
 
   // Assign user language as locale if nullish but not null.
+  let language = mapp.user?.language || mapp.language;
   if (entry.formatterParams.locale !== null) {
-    entry.formatterParams.locale ??= mapp.user?.language || mapp.language;
+    entry.formatterParams.locale ??= language;
   }
  
   if (entry.edit) {

--- a/lib/ui/locations/entries/numeric.mjs
+++ b/lib/ui/locations/entries/numeric.mjs
@@ -6,7 +6,7 @@ export default entry => {
 
   // Assign user language as locale if nullish but not null.
   if (entry.formatterParams.locale !== null) {
-    entry.formatterParams.locale ??= mapp.user.language;
+    entry.formatterParams.locale ??= mapp.user?.language || mapp.language;
   }
  
   if (entry.edit) {


### PR DESCRIPTION
A few fixes from #1176 

1. In custom views `mapp.user.language` does not exist - so added `mapp.language` too. 
2. numericFormatter - if min or max is 0 it wasn't being displayed in the input box. 
3. numericFormatter - if formatter is money, use `en-GB` locale.
4. numericFormatter - nullish coalescing assignment of locale. 

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1206763330154198