### PR TITLE
remove nanoid

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,8 +43,6 @@ Node.js v18+
 
 [jsonwebtoken](https://www.npmjs.com/package/jsonwebtoken) - A Node implementation of JSON Web Token.
 
-[nanoid](https://www.npmjs.com/package/nanoid) - A tiny, secure, URL-friendly, unique string ID generator for JavaScript.
-
 [Node-Postgres](https://github.com/brianc/node-postgres) - PostgreSQL client for Node.
 
 [nodemailer](https://github.com/nodemailer/nodemailer) - Send e-mails with Node – easy as cake!

--- a/mod/user/fromACL.js
+++ b/mod/user/fromACL.js
@@ -18,8 +18,6 @@ const languageTemplates = require('../utils/languageTemplates')
 
 const acl = require('./acl')
 
-const { nanoid } = require('nanoid')
-
 /**
  * Exported function fromACL that will authenticate user. 
  * @function fromACL
@@ -139,15 +137,13 @@ async function getUser(request) {
     // password must be removed after check
     delete user.password
 
-    if (process.env.NANO_SESSION) {
+    if (process.env.USER_SESSION) {
 
-      const nano_session = nanoid()
-
-      user.session = nano_session
+      user.session = crypto.randomBytes(10).toString('hex')
 
       rows = await acl(`
         UPDATE acl_schema.acl_table
-        SET session = '${nano_session}'
+        SET session = '${user.session}'
         WHERE lower(email) = lower($1)`,
         [request.email])
 

--- a/mod/utils/logger.js
+++ b/mod/utils/logger.js
@@ -2,14 +2,14 @@
 @module /utils/logger
 */
 
+const crypto = require('crypto')
+
 const logs = new Set(process.env.LOGS?.split(',') || [])
 
 // Errors should always be logged.
 logs.add('err')
 
-const { nanoid } = require('nanoid')
-
-const process_nanoid = nanoid(6)
+const process_id = crypto.randomBytes(3).toString('hex')
 
 const logout = {
   logflare,
@@ -57,7 +57,7 @@ function logflare() {
           'X-API-KEY': params.apikey,
         },
         body: JSON.stringify({
-          [process_nanoid]: log,
+          [process_id]: log,
           key
         })
       }).catch(err => {
@@ -100,7 +100,7 @@ function postgresql() {
       await client.query(
         `INSERT INTO ${table} (process, datetime, key, log, message) 
         VALUES ($1, $2, $3, $4, $5)`, 
-        [process_nanoid, parseInt(Date.now() / 1000), key, logstring, errorMessage]);
+        [process_id, parseInt(Date.now() / 1000), key, logstring, errorMessage]);
     } catch (error) {
       console.error('Error while logging to database:', error);
     } finally {

--- a/package.json
+++ b/package.json
@@ -22,7 +22,6 @@
     "@aws-sdk/s3-request-presigner": "^3.398.0",
     "bcryptjs": "^2.4.3",
     "jsonwebtoken": "^9.0.0",
-    "nanoid": "^3.2.0",
     "nodemailer": "^6.9.7",
     "pg": "^8.7.3",
     "simple-statistics": "^7.8.3"


### PR DESCRIPTION
NanoID was only used on the host to generate a unique[ish] id for the session and and process ID.

The random hex sequence generated by the builtin node crypto module can be used to the same effect.

One dependency less to worry about.