### PR TITLE
Check whether format exists in layer decorator

### DIFF
--- a/lib/layer/decorate.mjs
+++ b/lib/layer/decorate.mjs
@@ -25,7 +25,7 @@ The layer object to be decorated.
 export default async function decorate(layer) {
 
   // Decorate layer format methods.
-  await mapp.layer.formats[layer.format](layer);
+  await mapp.layer.formats[layer.format]?.(layer);
 
   // If layer does not exist, return.
   if (!layer.L) return;


### PR DESCRIPTION
The decorator should check whether a layer format exists.

An error will be thrown trying to decorate a layer with a custom format from plugin if the format is not known.