### PR TITLE
Remove user param from view endpoint

### DIFF
--- a/mod/view.js
+++ b/mod/view.js
@@ -31,18 +31,7 @@ module.exports = async (req, res) => {
     language: req.params.language
   })
 
-  if (req.params.user && typeof req.params.user === 'object') {
-
-    params.language ??= req.params.user.language
-
-    // Encode stringified user for template.
-    params.user ??= encodeURI(JSON.stringify({
-      email: req.params.user.email,
-      admin: req.params.user.admin,
-      roles: req.params.user.roles,
-      language: req.params.user.language
-    }));
-  }
+  params.language ??= req.params.user?.language || 'en'
 
   const template = await languageTemplates(params)
 


### PR DESCRIPTION
The view endpoint should not assign a stringified user object to view templates.

The user object should be fetched from the user/cookie endpoint and assigned to the mapp object like shown in the _default view script.

```js
  // Refresh cookie and get user with updated credentials.
  mapp.user = await mapp.utils.xhr(`${mapp.host}/api/user/cookie`);
```

'en' should be assigned as default language param.