### PR TITLE
Create layer changend module.

### DIFF
--- a/lib/layer/_layer.mjs
+++ b/lib/layer/_layer.mjs
@@ -8,6 +8,7 @@ The module export methods to decorate layer objects.
 import decorate from './decorate.mjs'
 import formats from './format/_format.mjs';
 import fade from './fade.mjs'
+import changeEnd from './changeEnd.mjs'
 import featureHover from './featureHover.mjs'
 import featureFilter from './featureFilter.mjs'
 import * as featureFormats from './featureFormats.mjs'
@@ -19,6 +20,7 @@ import graduated from './themes/graduated.mjs'
 
 export default {
   decorate,
+  changeEnd,
   formats,
   featureFormats,
   featureFields,

--- a/lib/layer/changeEnd.mjs
+++ b/lib/layer/changeEnd.mjs
@@ -1,0 +1,36 @@
+/**
+### mapp.layer.changeEnd(layer)
+
+@module /layer/featureFilter
+*/
+
+export default function(layer) {
+
+  // The layer may be zoom level restricted.
+  layer.tables && layer.mapview.Map.getTargetElement().addEventListener('changeEnd', changeEnd)
+
+  function changeEnd() {
+
+    // Layer is out of zoom range.
+    if (!layer.tableCurrent()) {
+
+      if (layer.display) {
+
+        // Layer should be shown if possible.
+        layer.zoomDisplay = true
+        layer.hide()
+      }
+
+      return;
+    }
+
+    if (layer.zoomDisplay) {
+
+      // Prevents layer.show() being fired on zoom change within range.
+      delete layer.zoomDisplay
+
+      // Show layer if within zoomDisplay range.
+      layer.show()
+    }
+  }
+}

--- a/lib/layer/decorate.mjs
+++ b/lib/layer/decorate.mjs
@@ -224,10 +224,10 @@ function show() {
   // Push the layer into the layers hook array.
   this.mapview.hooks && mapp.hooks.push('layers', this.key);
 
-  // Show the layer
   this.display = true;
 
   try {
+
     // Add layer to map
     this.mapview.Map.addLayer(this.L);
   } catch {
@@ -250,7 +250,7 @@ function show() {
  * @function hide
  */
 function hide() {
-  // Hide the layer.
+
   this.display = false;
 
   // Remove OL layer from mapview.
@@ -275,6 +275,7 @@ function hide() {
  * @returns {string} - The current table associated with the layer.
  */
 function tableCurrent() {
+
   // Return the current table if it exists.
   if (!this.tables) return this.table;
 
@@ -334,30 +335,6 @@ function geomCurrent() {
   geom = zoom > maxZoomKey ? this.geoms[maxZoomKey] : geom;
 
   return geom;
-}
-
-/**
- * Returns the maximum table associated with the layer.
- * @memberof module:layer/decorate
- * @function tableMax
- * @returns {string} - The maximum table associated with the layer.
- */
-function tableMax() {
-  // Returns the max table.
-  if (!this.tables) return this.table;
-  return Object.values(this.tables).reverse().find(val => !!val);
-}
-
-/**
- * Returns the minimum table associated with the layer.
- * @memberof module:layer/decorate
- * @function tableMin
- * @returns {string} - The minimum table associated with the layer.
- */
-function tableMin() {
-  // Returns the min table.
-  if (!this.tables) return this.table;
-  return Object.values(this.tables).find(val => !!val);
 }
 
 /**

--- a/lib/layer/format/mvt.mjs
+++ b/lib/layer/format/mvt.mjs
@@ -9,21 +9,14 @@ This module defines the MVT (MapBox Vector Tile) format for map layers.
   @function mvt
   @param {Object} layer - The layer object.
   @param {string} [layer.srid='3857'] - The spatial reference system identifier (SRID) for the layer.
-  @param {Object} [layer.style={}] - The style object for the layer.
-  @param {Object} [layer.params={}] - Additional parameters for the layer.
-  @param {boolean} [layer.mvt_cache] - Flag indicating whether to use MVT caching (deprecated).
-  @param {string[]} [layer.tables] - An array of table names for the layer.
+  @param {Object} [layer.style{}] - The style object for the layer.
+  @param {Object} [layer.params{}] - Additional parameters for the layer.
+  @param {Object} [layer.tables{}] - An object of zoom [key] and table [value] for the layer.
   @param {string[]} [layer.wkt_properties] - An array of properties to be retrieved as WKT (Well-Known Text) format.
   @param {number} [layer.transition] - The transition duration for the layer.
   @param {number} [layer.cacheSize] - The cache size for the layer.
   @param {Object} layer.mapview - The mapview object.
-  @param {string} layer.mapview.host - The host URL for the API.
-  @param {Object} layer.mapview.locale - The locale object.
-  @param {string} layer.mapview.locale.key - The key for the locale.
-  @param {string} layer.mapview.srid - The SRID for the mapview.
-  @param {ol.Map} layer.mapview.Map - The OpenLayers map object.
-  @param {Object} layer.filter - The filter object for the layer.
-  @param {function} layer.filter.current - The current filter function for the layer.
+  @param {Object} layer.filter - The layer filter object.
   @param {function} layer.tableCurrent - A function that returns the current table for the layer.
   @param {function} layer.geomCurrent - A function that returns the current geometry for the layer.
   @param {ol.layer.VectorTile} layer.L - The OpenLayers vector tile layer.
@@ -54,25 +47,8 @@ export default layer => {
   // MVT query must not have a viewport, this is defined by the tile extent.
   delete layer.params.viewport
 
-  // The layer may be zoom level restricted.
-  layer.tables && layer.mapview.Map.getTargetElement().addEventListener('changeEnd', () => {
-
-    if (!layer.tableCurrent() && layer.display) {
-
-      // Layer should be shown if possible.
-      layer.zoomDisplay = true
-
-      layer.hide()
-      
-    } else if (layer.zoomDisplay && !layer.display) {
-
-      // Prevents layer.show() being fired on zoom change within range.
-      delete layer.zoomDisplay
-
-      // Show layer if within zoomDisplay range.
-      layer.show()
-    }
-  })
+  // Assigns changeEnd event/method for zoom restricted layers.
+  mapp.layer.changeEnd(layer)
 
   layer.reload = () => {
 

--- a/lib/layer/format/vector.mjs
+++ b/lib/layer/format/vector.mjs
@@ -60,25 +60,8 @@ export default layer => {
     layer.L.setSource(layer.source)
   }
 
-  // The layer may be zoom level restricted.
-  layer.tables && layer.mapview.Map.getTargetElement().addEventListener('changeEnd', () => {
-
-    if (!layer.tableCurrent() && layer.display) {
-
-      // Layer should be shown if possible.
-      layer.zoomDisplay = true
-
-      layer.hide()
-      
-    } else if (layer.zoomDisplay && !layer.display) {
-
-      // Prevents layer.show() being fired on zoom change within range.
-      delete layer.zoomDisplay
-
-      // Show layer if within zoomDisplay range.
-      layer.show()
-    }
-  })
+  // Assigns changeEnd event/method for zoom restricted layers.
+  mapp.layer.changeEnd(layer)
 
   layer.reload = () => {
 


### PR DESCRIPTION
The changeend should not be duplicated for mvt and vector layer but called from a mapp.layer module.

The changeend method should not sent multiple show / hide calls on changes within or outside the zoom range.