### PR TITLE
Assign params as URL paramstring to tile layer URI

### DIFF
--- a/lib/layer/format/tiles.mjs
+++ b/lib/layer/format/tiles.mjs
@@ -10,10 +10,12 @@ export default layer => {
 
   layer.projection ??= 'EPSG:3857'
 
+  layer.paramString ??= mapp.utils.paramString(layer.params)
+
   layer.L = new ol.layer.Tile({
     source: new ol.source[layer.source]({
       projection: layer.projection,
-      url: decodeURIComponent(layer.URI),
+      url: layer.URI+layer.paramString,
       transition: 0
     }),
     layer: layer,

--- a/lib/layer/format/tiles.mjs
+++ b/lib/layer/format/tiles.mjs
@@ -1,9 +1,30 @@
 /**
 ### mapp.layer.formats.tiles()
+This module defines the tiles format for map layers.
 
 @module /layer/formats/tiles
 */
 
+/**
+The function takes a layer object as input and performs the following steps:
+
+1. It sets default values for `layer.source` and `layer.projection` if they are not already defined.
+2. It creates a parameter string (`layer.paramString`) using the `mapp.utils.paramString` function, passing `layer.params` as an argument.
+3. It creates a new `ol.layer.Tile` object and assigns it to `layer.L`. The tile layer is configured with the following properties:
+   - `source`: A new instance of the tile source based on layer.source. The source is created using `ol.source[layer.source]` and is configured with the projection, url, and transition properties.
+   - `layer`: The layer object itself, allowing access to layer properties within the tile layer.
+   - `zIndex`: The z-index of the layer, obtained from `layer.style.zIndex` or defaulting to 0.
+@function tiles
+@param {Object} layer - The layer object.
+@param {string} [layer.source='OSM'] - The source of the tile layer (e.g., 'OSM', 'XYZ').
+@param {string} [layer.projection='EPSG:3857'] - The projection of the tile layer.
+@param {string} [layer.paramString] - The parameter string for the tile layer URL.
+@param {Object} [layer.params] - Additional parameters for the tile layer.
+@param {string} layer.URI - The base URI for the tile layer.
+@param {Object} [layer.style] - The style configuration for the layer.
+@param {number} [layer.style.zIndex=0] - The z-index of the layer.
+@param {ol.layer.Tile} layer.L - The OpenLayers tile layer object.
+*/
 export default layer => {
 
   layer.source ??= 'OSM'

--- a/lib/utils/paramString.mjs
+++ b/lib/utils/paramString.mjs
@@ -5,27 +5,34 @@
 */
 
 // Create param string for XHR request.
-export default params => Object.entries(params)
+export default params => {
 
-  // Value should be 0 or truthy
-  .filter(entry => entry[1] === 0 || !!entry[1])
+  if (!params) return ''
 
-  // Value must not be empty functional brackets.
-  .filter(entry => entry[1] !== '{}')
+  const paramsString = Object.entries(params)
 
-  // Filter out zero length array and objects with empty object values.
-  .filter(entry => typeof entry[1] !== 'object'
-    || entry[1].length
-    || Object.values(entry[1]).some(val => typeof val === 'object' && Object.keys(val).length))
+    // Value should be 0 or truthy
+    .filter(entry => entry[1] === 0 || !!entry[1])
 
-  .map(entry => {
+    // Value must not be empty functional brackets.
+    .filter(entry => entry[1] !== '{}')
 
-    // Stringify non array objects.
-    if (typeof entry[1] === 'object' && !Array.isArray(entry[1])) {
+    // Filter out zero length array and objects with empty object values.
+    .filter(entry => typeof entry[1] !== 'object'
+      || entry[1].length
+      || Object.values(entry[1]).some(val => typeof val === 'object' && Object.keys(val).length))
 
-      return `${entry[0]}=${encodeURIComponent(JSON.stringify(entry[1]))}`
-    }
+    .map(entry => {
 
-    return encodeURI(`${entry[0]}=${entry[1]}`)
+      // Stringify non array objects.
+      if (typeof entry[1] === 'object' && !Array.isArray(entry[1])) {
 
-  }).join('&')
+        return `${entry[0]}=${encodeURIComponent(JSON.stringify(entry[1]))}`
+      }
+
+      return encodeURI(`${entry[0]}=${entry[1]}`)
+
+    }).join('&')
+
+  return paramsString
+}

--- a/lib/utils/paramString.mjs
+++ b/lib/utils/paramString.mjs
@@ -1,9 +1,28 @@
 /**
 ## mapp.utils.paramString()
+This module creates a parameter string for an XHR request.
 
 @module /utils/paramString
 */
 
+/**
+Creates a parameter string for an XHR request based on the provided parameters object.
+
+The function takes an object params as input and performs the following steps:
+1. It returns an empty string if params is falsy.
+2. It applies a series of filters to the entries of params:
+    - It filters out entries where the value is not 0 or truthy.
+    - It filters out entries where the value is an empty functional bracket string ('{}').
+    - It filters out entries where the value is an object with zero length or an object with empty object values.
+3. It maps the remaining entries to a string representation:
+    - If the value is a non-array object, it stringifies the value and encodes it as a URI component.
+    - Otherwise, it encodes the key-value pair as a URI string.
+4. It joins the mapped entries with '&' to create the parameter string.
+5. It returns the resulting parameter string.
+@function paramString
+@param {Object} params - The object containing the parameters.
+@returns {string} The parameter string.
+ */
 // Create param string for XHR request.
 export default params => {
 


### PR DESCRIPTION
The paramString util must return an empty string if provided with a falsy params argument.

The tile layer format should create a paramString to be appended to the layer.URI.

Params such as the api keys should be provided as params in the layer json. eg.

```js
      "here_hybrid": {
        "name": "HERE Hybrid",
        "format": "tiles",
        "URI": "https://{1-4}.aerial.maps.ls.hereapi.com/maptile/2.1/maptile/newest/hybrid.day/{z}/{x}/{y}/256/png8?",
        "params": {
          "apiKey": "here"
        },
        "attribution": {
          "© Here": "https://www.here.com/",
          "© OpenStreetMap": "http://www.openstreetmap.org/copyright"
        }
      },
```