### PR TITLE
Add console.log for chart and tabulator imports

### DIFF
--- a/lib/ui/utils/Chart.mjs
+++ b/lib/ui/utils/Chart.mjs
@@ -61,6 +61,8 @@ async function chart(canvas, options) {
       ])
       .then(imports => {
 
+        console.log(`imports from https://cdn.jsdelivr.net/npm/chart.js/+esm`)
+
         // Register imports
         imports[0].Chart.register(...imports[0].registerables);
 

--- a/lib/ui/utils/tabulator.mjs
+++ b/lib/ui/utils/tabulator.mjs
@@ -89,6 +89,8 @@ async function tabulator() {
       ])
       .then(imports => {
 
+        console.log(`imports from https://unpkg.com/tabulator-tables@5.5.2/dist/js/tabulator_esm.min.js`)
+
         Tabulator = imports[0].TabulatorFull
 
         resolve()


### PR DESCRIPTION
Log when the chartjs or tabulator module are imported.