### PR TITLE
The request params object may be optional

### DIFF
--- a/mod/provider/cloudfront.js
+++ b/mod/provider/cloudfront.js
@@ -44,7 +44,7 @@ module.exports = async ref => {
 
     if (url.match(/\.json$/i)) return await response.json()
 
-    if (ref.params.buffer) return await response.buffer()
+    if (ref.params?.buffer) return await response.buffer()
 
     return await response.text()
 


### PR DESCRIPTION
Check for the params to exist in cloudfront provider mod.