### PR TITLE
Remove empty cat filter from theme legend

### DIFF
--- a/lib/ui/layers/legends/categorized.mjs
+++ b/lib/ui/layers/legends/categorized.mjs
@@ -140,7 +140,7 @@ export default (layer) => {
             // Delete current field filter if NI array is empty.
             if (!layer.filter.current[theme.field].ni.length) {
               delete layer.filter.current[theme.field].ni
-              if (!Object.keys(layer.filter.current[theme.field])) {
+              if (!Object.keys(layer.filter.current[theme.field]).length) {
                 delete layer.filter.current[theme.field]
               }
             }


### PR DESCRIPTION
Having a current filter, then toggling a category filter on and off will crash the wkt query because the check on the empty filter passes without checking for the key length.

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1206900457248763