### PR TITLE
Throw error for invalid query parameter substitution

### DIFF
--- a/mod/query.js
+++ b/mod/query.js
@@ -168,9 +168,7 @@ module.exports = async (req, res) => {
         // Change value may only contain a limited set of whitelisted characters.
         if (!reserved.has(param) && !/^[A-Za-z0-9,"'._-\s]*$/.test(change)) {
 
-          // Err and return empty string if the change value is invalid.
-          console.error('Change param no bueno')
-          return ''
+          throw new Error(`Substitute \${${param}} value rejected: ${change}`);
         }
 
         return change


### PR DESCRIPTION
The query module should throw an error when an invalid substitute param is checked.

![image](https://github.com/GEOLYTIX/xyz/assets/22201617/7a5e8a07-5a33-426b-a4fb-34302d3ec51e)
