### PR TITLE
🐶 Add Layer Test Suite 🧪

### DIFF
--- a/mod/workspace/templates/get_last_location.js
+++ b/mod/workspace/templates/get_last_location.js
@@ -8,7 +8,7 @@ module.exports = _ => {
           SELECT
           ${_.layer.qID} as id
           FROM ${table}
-          WHERE ${geom} IS NOT NULL AND ${_.layer.qID} IS NOT NULL
+          WHERE ${geom} IS NOT NULL AND ${_.layer.qID} IS NOT NULL \${filter}
           ORDER BY ${_.layer.qID} DESC
           LIMIT 1`
 }

--- a/public/tests/Sure! Here's an updated write-up with em.md
+++ b/public/tests/Sure! Here's an updated write-up with em.md
@@ -1,0 +1,25 @@
+# 🐶 Add Layer Test Suite 🧪
+
+## 📝 Description
+This pull request introduces a new test suite for the layers in a mapview. The purpose of this test suite is to ensure the integrity and functionality of each layer within the mapview. This will hit queries and templates belong to a layer.
+
+## 🛠️ Changes
+- Added a new function `layerTest` that takes a `mapview` object as a parameter.
+- Inside the `layerTest` function, a test suite is created using the `describe` function from the `codi` test library.
+- The test suite iterates over each layer in the `mapview.layers` object using a `for...in` loop.
+- For each layer, an individual test case is created using the `it` function.
+- The test case checks if the layer's format is either 'maplibre' or 'tiles', or if the layer has an `infoj` property.
+- If the condition is met, the test case proceeds to retrieve the last location associated with the layer by making an API call to `${mapp.host}/api/query` with the appropriate query parameters.
+- The test case asserts that the retrieved last location has a defined `id` property using the `assertTrue` function.
+- If the last location has an `id`, the test case retrieves the corresponding location using `mapp.location.get` with the layer and location ID.
+- Finally, the retrieved location is removed using the `remove` method.
+
+## ✨ Benefits
+- Ensures the correctness and functionality of each layer in the mapview. ✅
+- Helps identify any issues or inconsistencies related to layer formats, last locations, and location retrieval. 🐛
+- Provides a structured way to test and maintain the layers in the mapview. 📊
+
+## 🚀 Testing
+- To run the test suite, you can simply hit the test view on localhost or any deployed instance.
+
+Please let me know if you have any questions or if there are any additional changes required for this pull request. 😊

--- a/public/tests/_default.test.mjs
+++ b/public/tests/_default.test.mjs
@@ -380,7 +380,7 @@ describe('Mapview test', async () => {
                 key: locale.key,
             })),
             callback: (e, entry) => {
-                window.location.assign(`${mapp.host}?locale=${entry.key}`);
+                window.location.assign(`${mapp.host}?template=test_view&locale=${entry.key}`);
             },
         });
 

--- a/public/tests/_default.test.mjs
+++ b/public/tests/_default.test.mjs
@@ -1,5 +1,5 @@
 import { describe, it, assertEqual, assertNotEqual, assertTrue, assertFalse, assertThrows } from 'https://esm.sh/codi-test-framework@0.0.12';
-
+import { layerTest } from './layer.test.mjs';
 
 describe('Mapview test', async () => {
 
@@ -603,5 +603,7 @@ describe('Mapview test', async () => {
         // Assert that the margin top of the map target element is set to 0
         assertEqual(mapview.Map.getTargetElement().style.marginTop, '0px', 'Margin top of the map target element should be set to 0 after removeLastTab is called');
     });
+
+    layerTest(mapview);
 
 });

--- a/public/tests/layer.test.mjs
+++ b/public/tests/layer.test.mjs
@@ -1,0 +1,31 @@
+import { describe, it, assertEqual, assertNotEqual, assertTrue, assertFalse, assertThrows } from 'https://esm.sh/codi-test-framework@0.0.12';
+
+export async function layerTest(mapview) {
+
+     describe(`${mapview.host} : Layer Test`, () => {
+        for (const key in mapview.layers) {
+            if (mapview.layers.hasOwnProperty(key)) {
+                it(`Layer test : ${key}`, async () => {
+                    const layer = mapview.layers[key];
+
+                    if (!['maplibre', 'tiles'].includes(layer.format) || layer.infoj) {
+
+                        const lastLocation = await mapp.utils.xhr(`${mapp.host}/api/query?template=get_last_location&locale=${encodeURIComponent(mapview.locale.key)}&layer=${key}`);
+
+                        assertTrue(lastLocation.id !== undefined, 'Last Location is undefined');
+
+                        if (lastLocation.id) {
+                            const location = await mapp.location.get({
+                                layer: layer,
+                                id: lastLocation.id,
+                            });
+
+                            location.remove();
+                        }
+                    }
+                });
+
+            }
+        }
+    });
+}

--- a/public/tests/layer.test.mjs
+++ b/public/tests/layer.test.mjs
@@ -8,6 +8,8 @@ export async function layerTest(mapview) {
                 it(`Layer test : ${key}`, async () => {
                     const layer = mapview.layers[key];
 
+                    layer.show();
+
                     if (!['maplibre', 'tiles'].includes(layer.format) || layer.infoj) {
 
                         const lastLocation = await mapp.utils.xhr(`${mapp.host}/api/query?template=get_last_location&locale=${encodeURIComponent(mapview.locale.key)}&layer=${key}`);

--- a/public/tests/layer.test.mjs
+++ b/public/tests/layer.test.mjs
@@ -2,11 +2,23 @@ import { describe, it, assertEqual, assertNotEqual, assertTrue, assertFalse, ass
 
 export async function layerTest(mapview) {
 
-     describe(`${mapview.host} : Layer Test`, () => {
+    const default_zoom = mapview.view.z;
+
+    describe(`${mapview.host} : Layer Test`, async () => {
         for (const key in mapview.layers) {
             if (mapview.layers.hasOwnProperty(key)) {
-                it(`Layer test : ${key}`, async () => {
+                await it(`Layer test : ${key}`, async () => {
                     const layer = mapview.layers[key];
+
+                    if (layer.tables) {
+                        const layerZoom = parseInt(Object.entries(layer.tables).find(([key, value]) => value !== null)[0]);
+                        mapview.Map.getView().setZoom(layerZoom);
+                        //console.log(mapview.Map.getView().getZoom());
+                    }
+                    else {
+                        mapview.Map.getView().setZoom(default_zoom);
+                        //console.log(mapview.Map.getView().getZoom());
+                    }
 
                     layer.show();
 
@@ -26,7 +38,9 @@ export async function layerTest(mapview) {
                         }
                     }
 
-                    layer.hide();
+                    if (!['maplibre', 'tiles'].includes(layer.format)) {
+                        layer.hide();
+                    }
                 });
             }
         }

--- a/public/tests/layer.test.mjs
+++ b/public/tests/layer.test.mjs
@@ -10,7 +10,7 @@ export async function layerTest(mapview) {
 
                     layer.show();
 
-                    if (!['maplibre', 'tiles'].includes(layer.format) || layer.infoj) {
+                    if (!['maplibre', 'tiles'].includes(layer.format) && layer.infoj) {
 
                         const lastLocation = await mapp.utils.xhr(`${mapp.host}/api/query?template=get_last_location&locale=${encodeURIComponent(mapview.locale.key)}&layer=${key}`);
 
@@ -25,8 +25,9 @@ export async function layerTest(mapview) {
                             location.remove();
                         }
                     }
-                });
 
+                    layer.hide();
+                });
             }
         }
     });

--- a/public/tests/layer.test.mjs
+++ b/public/tests/layer.test.mjs
@@ -2,6 +2,12 @@ import { describe, it, assertEqual, assertNotEqual, assertTrue, assertFalse, ass
 
 export async function layerTest(mapview) {
 
+    function delayFunction(delay) {
+        return new Promise(resolve => {
+          setTimeout(resolve, delay);
+        });
+      }
+
     const default_zoom = mapview.view.z;
 
     describe(`${mapview.host} : Layer Test`, async () => {
@@ -29,11 +35,20 @@ export async function layerTest(mapview) {
                         assertTrue(lastLocation.id !== undefined, 'Last Location is undefined');
 
                         if (lastLocation.id) {
+
+                            layer.infoj = layer.infoj.map(entry => {
+                                if(entry.type === 'dataview'){
+                                    return { ...entry, display: true}
+                                }
+                                return entry;
+                            });
+
                             const location = await mapp.location.get({
                                 layer: layer,
                                 id: lastLocation.id,
                             });
 
+                            //await delayFunction(3000);
                             location.remove();
                         }
                     }

--- a/public/tests/layer.test.mjs
+++ b/public/tests/layer.test.mjs
@@ -26,6 +26,12 @@ export async function layerTest(mapview) {
                         //console.log(mapview.Map.getView().getZoom());
                     }
 
+                    if(layer.dataviews){
+                        for(const dataview in layer.dataview){
+                            dataview = { ...dataview, display: true}
+                        }
+                    }
+
                     layer.show();
 
                     if (!['maplibre', 'tiles'].includes(layer.format) && layer.infoj) {


### PR DESCRIPTION
# 🐶 Add Layer Test Suite 🧪

## 📝 Description
This pull request introduces a new test suite for the layers in a mapview. The purpose of this test suite is to ensure the integrity and functionality of each layer within the mapview. This will hit queries and templates belong to a layer.

## 🛠️ Changes
- Added a new function `layerTest` that takes a `mapview` object as a parameter.
- Inside the `layerTest` function, a test suite is created using the `describe` function from the `codi` test library.
- The test suite iterates over each layer in the `mapview.layers` object using a `for...in` loop.
- For each layer, an individual test case is created using the `it` function.
- The test case checks if the layer's format is either 'maplibre' or 'tiles', or if the layer has an `infoj` property.
- If the condition is met, the test case proceeds to retrieve the last location associated with the layer by making an API call to `${mapp.host}/api/query` with the appropriate query parameters.
- The test case asserts that the retrieved last location has a defined `id` property using the `assertTrue` function.
- If the last location has an `id`, the test case retrieves the corresponding location using `mapp.location.get` with the layer and location ID.
- Finally, the retrieved location is removed using the `remove` method.

## ✨ Benefits
- Ensures the correctness and functionality of each layer in the mapview. ✅
- Helps identify any issues or inconsistencies related to layer formats, last locations, and location retrieval. 🐛
- Provides a structured way to test and maintain the layers in the mapview. 📊

## 🚀 Testing
- To run the test suite, you can simply hit the test view on localhost or any deployed instance.

Please let me know if you have any questions or if there are any additional changes required for this pull request. 😊