### PR TITLE
Remove the API /location path from express routes.

### DIFF
--- a/express.js
+++ b/express.js
@@ -41,11 +41,6 @@ app.post(`${process.env.DIR||''}/api/fetch/:template?`, express.json({limit: '5m
 app.get(`${process.env.DIR||''}/api/workspace/:key?`, api)
 
 
-app.get(`${process.env.DIR||''}/api/location/:method?`, api)
-
-app.post(`${process.env.DIR||''}/api/location/:method?`, express.json({limit: '5mb'}), api)
-
-
 app.get(`${process.env.DIR||''}/api/user/:method?/:key?`, api)
 
 app.post(`${process.env.DIR||''}/api/user/:method?/:key?`, express.urlencoded({extended: true}), api)


### PR DESCRIPTION
This isn't required since all the location methods are queries.