### PR TITLE
Provide label and names for input elements

### DIFF
--- a/lib/ui/Gazetteer.mjs
+++ b/lib/ui/Gazetteer.mjs
@@ -11,7 +11,8 @@ export default gazetteer => {
     }
   })
 
-  gazetteer.input = mapp.utils.html.node`<input 
+  gazetteer.input = mapp.utils.html.node`<input
+    name="gazetteer-search-input" 
     type="search" 
     placeholder=${gazetteer.placeholder}>`
 

--- a/lib/ui/elements/chkbox.mjs
+++ b/lib/ui/elements/chkbox.mjs
@@ -3,6 +3,7 @@ export default (params) => mapp.utils.html.node`
     data-id=${params.data_id || 'chkbox'}
     class="checkbox">
     <input
+      name="mapp-ui-chkbox-element"
       type="checkbox"
       .disabled=${!!params.disabled}
       .checked=${!!params.checked}

--- a/lib/ui/elements/slider.mjs
+++ b/lib/ui/elements/slider.mjs
@@ -8,17 +8,20 @@ export default params => {
       class="input-range single"
       style=${`--min: ${params.min}; --max: ${params.max}; --a: ${params.val}; ${params.style || ''}`}>
       <div class="label-row">
-        <label>${params.label}</label>
+        <label>${params.label}
         <input data-id="a"
+          name="slider-number-input"
           type="number"
           min=${params.min}
           max=${params.max}
           step=${params.step || 1}
           value=${params.val}
           oninput=${onInput}></input>
+        </label>
       </div>
       <div class="track-bg"></div>
       <input data-id="a"
+        name="slider-range-input"
         type="range"
         min=${params.min}
         max=${params.max}


### PR DESCRIPTION
Labels associated with an input should contain the input.

Input elements should have a name.

This is to prevent issues in the google chrome dev tools.

![image](https://github.com/GEOLYTIX/xyz/assets/22201617/b7db08ef-da3f-4a90-a381-6ba89034f1d2)
