### PR TITLE
Remove defaults from fitView

### DIFF
--- a/lib/mapview/fitView.mjs
+++ b/lib/mapview/fitView.mjs
@@ -16,8 +16,8 @@ export default function (extent, options = {}){
   }
 
   this.Map.getView().fit(extent, {
-    padding: [50, 50, 50, 50],
-    duration: 1000,
+    //padding: [50,50,50,50],
+    //duration: 1000,
     ...options
   })
 }


### PR DESCRIPTION
There should be no defaults provided to the fitView options.

There seems to be an issue with the padding when used in some custom views.

In one custom mapview I was required to provide -200 padding where the default padding would just zoom out to the extent of the mapview.

```js
  customMapview.fitView(isoline_10min.L.getSource().getExtent(),{
    padding: [-200, -200, -200, -200]
  })
```

The issue doesn't seem to be with openlayers but the way the map element is placed in a document.

https://codepen.io/dbauszus-glx/pen/VwNzMYq