### PR TITLE
mapp.utils.polygonIntersectFeatures

### DIFF
--- a/lib/utils/_utils.mjs
+++ b/lib/utils/_utils.mjs
@@ -66,6 +66,8 @@ import merge from './merge.mjs'
 
 import paramString from './paramString.mjs'
 
+import {polygonIntersectFeatures} from './polygonIntersectFeatures.mjs'
+
 import promiseAll from './promiseAll.mjs'
 
 import queryParams from './queryParams.mjs'
@@ -98,6 +100,7 @@ export default {
   merge,
   olScript,
   paramString,
+  polygonIntersectFeatures,
   promiseAll,
   queryParams,
   style,

--- a/lib/utils/polygonIntersectFeatures.mjs
+++ b/lib/utils/polygonIntersectFeatures.mjs
@@ -1,0 +1,51 @@
+/**
+## mapp.utils.polygonIntersectFeatures()
+
+@module /utils/polygonIntersectFeatures
+*/
+
+export function polygonIntersectFeatures(params) {
+
+  if (!params.mapview) return;
+
+  function getArrayDepth(arr) {
+    return Array.isArray(arr) ?
+      1 + Math.max(0, ...arr.map(getArrayDepth)) :
+      0;
+  }
+
+  // Config for mapview draw interaction.
+  let interaction = {
+
+    // Draw polygon.
+    type: 'Polygon',
+
+    drawend: e => {
+
+      const poly = e.feature
+
+      const polyGeom = poly.getGeometry()
+
+      let features = params.mapview.interaction.snap.source.getFeatures()
+
+      features = features
+        .filter(feature => {
+
+          let coordinates = feature.getGeometry().getCoordinates()//.flat(2)
+
+          coordinates = coordinates.flat(getArrayDepth(coordinates) - 2)
+
+          return coordinates.some(coord => polyGeom.intersectsCoordinate(coord))
+        })
+
+      if (params.drawendCallback) {
+
+        params.drawendCallback(features)
+      }
+    },
+    ...params
+  }
+
+  // Initiate drawing on mapview with config as interaction argument.
+  params.mapview.interactions.draw(interaction)
+}

--- a/lib/utils/polygonIntersectFeatures.mjs
+++ b/lib/utils/polygonIntersectFeatures.mjs
@@ -4,6 +4,14 @@
 @module /utils/polygonIntersectFeatures
 */
 
+/**
+ * Checks if features intersect with a drawn polygon on a map view.
+ * @function polygonIntersectFeatures
+ * @param {Object} params - The parameters for the function.
+ * @param {Object} params.mapview - The map view instance.
+ * @param {Function} [params.drawendCallback] - Callback function to be called with intersecting features.
+ * @param {Object} [params.interaction] - Additional interaction options to be merged with the default config.
+ */
 export function polygonIntersectFeatures(params) {
 
   if (!params.mapview) return;


### PR DESCRIPTION
This PR adds the  mapp.utils.polygonIntersectFeatures() method.

A type:polygon draw interaction will check for snap features coordinates to intersect the drawn polygon feature geometry.

Intersecting features are returned to the drawendCallback method.

The drawendCallback can be defined to store the feature id in a set and add the feature to a custom vector layer for visualisation.

```js
function drawendCallback(features) {

  features.forEach(feature => {

    const id = feature.get('id')

    if (layer.selectedLocations.ids.has(id)) return;
    layer.selectedLocations.ids.add(id)
    cloneSource.addFeature(feature)
  })
}
```