### PR TITLE
Bump Codi 🐶 to v0.0.15: Transition Buntime 🥟

### DIFF
--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -24,4 +24,4 @@ jobs:
       run: npm install bun -g
 
     - name: Run tests
-      run: npm run test
+      run: bun run test

--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -20,5 +20,8 @@ jobs:
     - name: Install Dependencies
       run: npm install
 
+    - name: Install Dependencies
+      run: npm install bun -g
+
     - name: Run tests
       run: npm run test

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
   },
   "devDependencies": {
     "clean-jsdoc-theme": "^4.2.17",
-    "codi-test-framework": "^0.0.10",
+    "codi-test-framework": "^0.0.14",
     "cookie-parser": "^1.4.5",
     "dotenv": "^16.4.5",
     "esbuild": "^0.19.11",

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
   },
   "devDependencies": {
     "clean-jsdoc-theme": "^4.2.17",
-    "codi-test-framework": "^0.0.14",
+    "codi-test-framework": "^0.0.15",
     "cookie-parser": "^1.4.5",
     "dotenv": "^16.4.5",
     "esbuild": "^0.19.11",

--- a/public/tests/_default.test.mjs
+++ b/public/tests/_default.test.mjs
@@ -1,4 +1,4 @@
-import { describe, it, assertEqual, assertNotEqual, assertTrue, assertFalse, assertThrows } from 'https://esm.sh/codi-test-framework@0.0.12';
+import { describe, it, assertEqual, assertNotEqual, assertTrue, assertFalse, assertThrows } from 'https://esm.sh/codi-test-framework@0.0.14';
 import { layerTest } from './layer.test.mjs';
 
 describe('Mapview test', async () => {

--- a/public/tests/_default.test.mjs
+++ b/public/tests/_default.test.mjs
@@ -1,4 +1,4 @@
-import { describe, it, assertEqual, assertNotEqual, assertTrue, assertFalse, assertThrows } from 'https://esm.sh/codi-test-framework@0.0.14';
+import { describe, it, assertEqual, assertNotEqual, assertTrue, assertFalse, assertThrows } from 'https://esm.sh/codi-test-framework@0.0.15';
 import { layerTest } from './layer.test.mjs';
 
 describe('Mapview test', async () => {

--- a/public/tests/layer.test.mjs
+++ b/public/tests/layer.test.mjs
@@ -1,4 +1,4 @@
-import { describe, it, assertEqual, assertNotEqual, assertTrue, assertFalse, assertThrows } from 'https://esm.sh/codi-test-framework@0.0.14';
+import { describe, it, assertEqual, assertNotEqual, assertTrue, assertFalse, assertThrows } from 'https://esm.sh/codi-test-framework@0.0.15';
 
 export async function layerTest(mapview) {
 

--- a/public/tests/layer.test.mjs
+++ b/public/tests/layer.test.mjs
@@ -1,4 +1,4 @@
-import { describe, it, assertEqual, assertNotEqual, assertTrue, assertFalse, assertThrows } from 'https://esm.sh/codi-test-framework@0.0.12';
+import { describe, it, assertEqual, assertNotEqual, assertTrue, assertFalse, assertThrows } from 'https://esm.sh/codi-test-framework@0.0.14';
 
 export async function layerTest(mapview) {
 

--- a/tests/mod/utils/roles.test.mjs
+++ b/tests/mod/utils/roles.test.mjs
@@ -1,8 +1,8 @@
 import { describe, it, assertEqual } from 'codi-test-framework';
 import { check, objMerge, get } from '../../../mod/utils/roles.js';
 
-describe('Roles Module', () => {
-  describe('check()', () => {
+await describe('Roles Module', async () => {
+  await describe('check()', () => {
     it('should return the object if it has no roles', () => {
       const obj = { layer: 'I am a layer!' };
       const result = check(obj, ['user']);
@@ -46,7 +46,7 @@ describe('Roles Module', () => {
     });
   });
 
-  describe('get()', () => {
+  await describe('get()', () => {
     it('should return an array of roles from the object', () => {
       const obj = { roles: { admin: true, user: true, '!guest': true } };
       const result = get(obj);


### PR DESCRIPTION
## Codi 🐶 v0.0.15: Transition to Bun 🥟 Runtime

### Overview
Codi has been updated to version 0.0.15, which now utilizes the [Bun runtime](https://bun.sh) for improved performance and developer experience.

### Developer Requirements
To run tests and work with the updated Codi codebase, developers will need to have [Bun v1.1.0](https://bun.sh) or later installed on their systems.

### Benefits of Bun
Bun offers several advantages over traditional Node.js runtime:
- Faster startup times
- Improved performance
- Built-in bundling and transpilation
- Simplified package management

### Transition Guide
1. Install Bun v1.1.0 or later by following the instructions on the [official Bun website](https://bun.sh).
2. Run tests and verify that everything works as expected with the Bun runtime.

If you encounter any issues during the transition process, please consult the documentation or reach out to the maintainers for assistance.
