### PR TITLE
Update _mapview.mjs

### DIFF
--- a/lib/mapview/_mapview.mjs
+++ b/lib/mapview/_mapview.mjs
@@ -196,7 +196,20 @@ export default (mapview) => {
     }))
   }
 
-  // ScaleBar
+  // Check on old configuration of showScaleBar, scalebar and set to ScaleLine, and warn.
+  if (mapview.locale.showScaleBar) {
+    console.warn('locale.showScaleBar is deprecated. Use locale.ScaleLine.metric or locale.ScaleLine.imperial instead.')
+    // showScaleBar is set to true - so use metric default.
+    mapview.locale.ScaleLine = 'metric'
+  }
+
+  // scalebar 
+  if (mapview.locale.scalebar) {
+    console.warn('locale.scalebar is deprecated. Use locale.ScaleLine.metric or locale.ScaleLine.imperial instead.')
+    mapview.locale.ScaleLine = mapview.locale.scalebar
+  }
+
+  // ScaleLine
   mapview.locale.ScaleLine && mapview.Map.addControl(new ol.control.ScaleLine({
     units: mapview.locale.ScaleLine === 'imperial' ? 'imperial' : 'metric',
   }))
@@ -272,7 +285,7 @@ export default (mapview) => {
 
   if (mapview.loadPlugins) {
 
-    return (async (mapview)=>{
+    return (async (mapview) => {
 
       await mapp.utils.loadPlugins(mapview.locale.plugins);
 


### PR DESCRIPTION
Added checks for outdated configuration of `showScaleBar:true` and `scalebar:metric // or imperial` 
These are simply set to `ScaleLine` and warnings provided.

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1207002311648376