### PR TITLE
Modal Target Adjustment 🎯

### DIFF
--- a/lib/ui/elements/modal.mjs
+++ b/lib/ui/elements/modal.mjs
@@ -26,17 +26,18 @@ export default (modal) => {
     // Calc left from right and offSetWidth
     modal.left = modal.target.offsetWidth - modal.node.offsetWidth - parseInt(modal.right)
   }
-  
+
   modal.node.style.top = `${modal.top || 0}px`
   modal.node.style.left = `${modal.left || 0}px`
 
   modal.node.addEventListener('mousedown', handleStartEvent);
-  modal.node.addEventListener('touchstart', handleStartEvent);      
+  modal.node.addEventListener('touchstart', handleStartEvent);
 
   // Function to handle the modal closure
   function closeModal(e) {
     e.target.closest('.modal').remove();
     modal?.close?.(e);
+    resizeObserver.disconnect();
   }
 
   // Function to handle the start of a drag event, setting up the necessary event listeners for moving and ending the drag
@@ -62,6 +63,26 @@ export default (modal) => {
 
     modal.target.addEventListener(moveEvent, shiftEvent);
     window.addEventListener(endEvent, stopShift);
+  }
+
+  // Create a ResizeObserver to observe changes in the map's dimensions
+  const resizeObserver = new ResizeObserver(adjustModalPosition);
+  resizeObserver.observe(modal.target);
+
+  function adjustModalPosition() {
+
+    const { offsetWidth: mapWidth, offsetHeight: mapHeight } = modal.target;
+    const { offsetWidth: modalWidth, offsetHeight: modalHeight } = modal.node;
+
+    // Calculate the maximum allowed positions for the modal
+    const maxLeft = mapWidth - modalWidth;
+    const maxTop = mapHeight - modalHeight;
+
+    // Adjust the modal's position if it exceeds the map boundaries
+    modal.node.style.left = `${Math.min(Math.max(modal.node.offsetLeft, 0), maxLeft)}px`;
+    modal.node.style.top = `${Math.min(Math.max(modal.node.offsetTop, 0), maxTop)}px`;
+
+    console.log('Adjusting Modal');
   }
 
   // Function to end the drag event, resetting cursor style and removing the move and end event listeners
@@ -119,13 +140,13 @@ function shiftContained(modal, leftShift, topShift) {
   if ((modal.node.offsetLeft + leftShift) < 0) {
 
     modal.node.style.left = 0
-  
-  // Shifts left
+
+    // Shifts left
   } else if (leftShift < 0) {
 
     modal.node.style.left = `${modal.node.offsetLeft + leftShift}px`
 
-  // Does NOT exceed right offset
+    // Does NOT exceed right offset
   } else if ((modal.target.offsetWidth - modal.node.offsetWidth - modal.node.offsetLeft) > 0) {
 
     // Shifts right
@@ -137,13 +158,13 @@ function shiftContained(modal, leftShift, topShift) {
   if ((modal.node.offsetTop + topShift) < 0) {
 
     modal.node.style.top = 0
-  
-  // Shift top
+
+    // Shift top
   } else if (topShift < 0) {
 
     modal.node.style.top = `${modal.node.offsetTop + topShift}px`
 
-  // Does NOT exceed bottom offset
+    // Does NOT exceed bottom offset
   } else if ((modal.target.offsetHeight - modal.node.offsetHeight - modal.node.offsetTop) > 0) {
 
     // Shift bottom
@@ -188,3 +209,5 @@ function shiftContainedCentre(modal, leftShift, topShift) {
     modal.node.style.top = `${modal.node.offsetTop + topShift}px`
   }
 }
+
+

--- a/lib/ui/elements/modal.mjs
+++ b/lib/ui/elements/modal.mjs
@@ -81,8 +81,6 @@ export default (modal) => {
     // Adjust the modal's position if it exceeds the map boundaries
     modal.node.style.left = `${Math.min(Math.max(modal.node.offsetLeft, 0), maxLeft)}px`;
     modal.node.style.top = `${Math.min(Math.max(modal.node.offsetTop, 0), maxTop)}px`;
-
-    console.log('Adjusting Modal');
   }
 
   // Function to end the drag event, resetting cursor style and removing the move and end event listeners
@@ -209,5 +207,3 @@ function shiftContainedCentre(modal, leftShift, topShift) {
     modal.node.style.top = `${modal.node.offsetTop + topShift}px`
   }
 }
-
-


### PR DESCRIPTION
## Modal Target Adjustment 🎯

This PR addresses the issue where the modal goes out of view when the map is resized. The changes ensure that the modal's position is adjusted dynamically to stay within the target/map boundaries. Note the modal adjust's to a target, so in plugins and other uses of the modal it needs to be the map target if it needs to work with tabs at the bottom of the map.

## Changes ✍️ 

- Introduced a [`ResizeObserver`](https://developer.mozilla.org/en-US/docs/Web/API/ResizeObserver) to observe changes in the map's dimensions.
- Created an `adjustModalPosition()` function to calculate the maximum allowed positions for the modal based on the current map dimensions and adjust the modal's position accordingly.
- Modified the `closeModal()` function to disconnect the `ResizeObserver` when the modal is closed.

## Implementation Details

1. A new [`ResizeObserver`](https://developer.mozilla.org/en-US/docs/Web/API/ResizeObserver) instance named `resizeObserver` is created, and the `adjustModalPosition()` function is passed as the callback. This function will be called whenever the observed element's dimensions change.

2. The `resizeObserver.observe(modal.target)` method is used to start observing changes in the map's dimensions.

3. Inside the `closeModal()` function, the `resizeObserver.disconnect()` method is called to stop observing changes when the modal is closed.

4. The `adjustModalPosition()` function calculates the maximum allowed positions for the modal based on the current dimensions of the target. It adjusts the modal's `left` and `top` positions using `Math.min()` and `Math.max()` to ensure that the modal stays within the target(map) boundaries. If the modal's position exceeds the map boundaries, it will be adjusted to the nearest valid position.

## Testing 🧪 

- Tested the changes by resizing the map and verifying that the modal stays within the view.
- Ensured that the modal can still be dragged and positioned within the map boundaries.
- Confirmed that the modal closes properly and the `ResizeObserver` is disconnected when the modal is closed.

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1207053242940136