### PR TITLE
Legend icon - now datauri set as image element;

### DIFF
--- a/lib/ui/elements/legendIcon.mjs
+++ b/lib/ui/elements/legendIcon.mjs
@@ -96,15 +96,20 @@ function createIconFromArray(style) {
 }
 
 function createIconFromInlineStyle(style) {
-  const inlineStyle = `
-    background-position: center;
-    background-repeat: no-repeat;
-    background-size: contain;
-    width: ${style.width + 'px' || '100%'};
-    height: ${style.height + 'px' || '100%'};
-    background-image: url(${style.icon?.svg || style.svg || style.icon?.url || style.url || mapp.utils.svgSymbols[style.icon?.type || style.type](style.icon || style)})`;
 
-  return mapp.utils.html`<div style=${inlineStyle}>`;
+  const inlineStyle = `
+  background-position: center;
+  background-repeat: no-repeat;
+  background-size: contain;`
+
+  const imgInlineStyle = `
+  width: ${(style.width + 'px') || '100%'};
+  height: ${(style.height + 'px') || '100%'};
+  `;
+
+  const src = style.icon?.svg || style.svg || style.icon?.url || style.url || mapp.utils.svgSymbols[style.icon?.type || style.type](style.icon || style);
+
+  return mapp.utils.html`<div style=${inlineStyle}><img style=${imgInlineStyle} src=${src}>`
 }
 
 function createLineSymbol(style) {


### PR DESCRIPTION
Chrome would invalidate datauri set as background-image on a div which resulted in missing icons in the legend.
Let me know if this fix works for you.