### PR TITLE
Fix for Numeric Filter on field with no data

### DIFF
--- a/lib/ui/layers/filters.mjs
+++ b/lib/ui/layers/filters.mjs
@@ -101,7 +101,7 @@ async function generateMinMax(layer, filter, minmax) {
 
   // If the response contains response.min or response.max - we can assume the query was successful.
   if (response[minmax]) {
-    filter[minmax] = filter.type === 'integer' ? parseInt(response[minmax]) : parseFloat(response[minmax]);
+    filter[minmax] = filter.type === 'integer' ? Math.round(response[minmax]) : parseFloat(response[minmax]);
   }
 
 }

--- a/lib/ui/layers/filters.mjs
+++ b/lib/ui/layers/filters.mjs
@@ -13,6 +13,12 @@ export default {
 
 let timeout;
 
+mapp.utils.merge(mapp.dictionaries, {
+  en: {
+    no_data_filter: 'This field contains no data, so cannot be filtered on.'
+  }
+});
+
 function applyFilter(layer) {
 
   clearTimeout(timeout);
@@ -27,7 +33,7 @@ function applyFilter(layer) {
   }, 500);
 }
 
-function filter_text(layer, filter){
+function filter_text(layer, filter) {
   return mapp.utils.html.node`
   <input
     type="text"
@@ -84,7 +90,7 @@ function filter_null(layer, filter) {
   })
 }
 
-async function filter_numeric(layer, filter){
+async function filter_numeric(layer, filter) {
 
   if (!filter.max) {
 
@@ -96,7 +102,10 @@ async function filter_numeric(layer, filter){
       field: filter.field,
     })}`);
 
-    filter.max = filter.type === 'integer' ? parseInt(response.max) : parseFloat(response.max);
+    // If the response contains response.max - we can assume the query was successful.
+    if (response?.max) {
+      filter.max = filter.type === 'integer' ? parseInt(response.max) : parseFloat(response.max);
+    }
   }
 
   if (!filter.min) {
@@ -109,7 +118,10 @@ async function filter_numeric(layer, filter){
       field: filter.field,
     })}`);
 
-    filter.min = filter.type === 'integer' ? parseInt(response.min) : parseFloat(response.min);
+    // If the response contains response.min - we can assume the query was successful.
+    if (response?.min) {
+      filter.min = filter.type === 'integer' ? parseInt(response.min) : parseFloat(response.min);
+    }
   }
 
   if (!filter.step) {
@@ -130,20 +142,27 @@ async function filter_numeric(layer, filter){
   affix = affix ? `(${affix.trim()})` : ''
   entry.filterInput = true
   applyFilter(layer);
+
+  // Only if filter.min and filter.max are defined should the slider be rendered.
+  if (!filter.min || !filter.max) {
+    // Return text to indicate that the min and max values are not defined.
+    return mapp.utils.html.node`<div>${mapp.dictionary.no_data_filter}</div>`
+  };
+
   return mapp.ui.elements.slider_ab({
     min: Number(filter.min),
     max: Number(filter.max),
     step: filter.step,
     entry: entry,
     label_a: `${mapp.dictionary.layer_filter_greater_than} ${affix}`, // Greater than
-    val_a: mapp.ui.elements.numericFormatter(entry,filter.min),
+    val_a: mapp.ui.elements.numericFormatter(entry, filter.min),
     slider_a: Number(filter.min),
     callback_a: e => {
       layer.filter.current[filter.field].gte = Number(e)
       applyFilter(layer)
     },
     label_b: `${mapp.dictionary.layer_filter_less_than}  ${affix}`, // Less than
-    val_b: mapp.ui.elements.numericFormatter(entry,filter.max),
+    val_b: mapp.ui.elements.numericFormatter(entry, filter.max),
     slider_b: Number(filter.max),
     callback_b: e => {
       layer.filter.current[filter.field].lte = Number(e)
@@ -208,7 +227,7 @@ async function filter_in(layer, filter) {
 
           // Set filter values array from options.
           Object.assign(layer.filter.current, {
-            [filter.field]:{
+            [filter.field]: {
               [filter.type]: options
             }
           })
@@ -226,37 +245,37 @@ async function filter_in(layer, filter) {
     label: val,
     checked: chkSet.has(val),
     onchange: (checked, val) => {
-  
+
       if (checked) {
-  
+
         // Create filter object if it doesn't exist.
         if (!layer.filter.current[filter.field]) {
           layer.filter.current[filter.field] = {}
         }
-  
+
         // Create empty in array if it doesn't exist.
         if (!layer.filter.current[filter.field][filter.type]) {
           layer.filter.current[filter.field][filter.type] = []
         }
-  
+
         // Add value to filter array.
         layer.filter.current[filter.field][filter.type].push(val);
-                  
+
       } else {
-  
+
         // Get index of value in filter array.
         const idx = layer.filter.current[filter.field][filter.type].indexOf(val);
-  
+
         // Splice filter array on idx.
         layer.filter.current[filter.field][filter.type].splice(idx, 1);
-  
+
         // Remove filter object if it is empty.
         if (!layer.filter.current[filter.field][filter.type].length) {
           delete layer.filter.current[filter.field]
         }
-  
+
       }
-  
+
       applyFilter(layer)
     }
   }))
@@ -287,7 +306,7 @@ function filter_date(layer, filter) {
         {
           gt: new Date(e.target.value).getTime() / 1000
         })
-      
+
     }
 
     if (e.target.dataset.id === 'inputBefore') {
@@ -297,7 +316,7 @@ function filter_date(layer, filter) {
         {
           lt: new Date(e.target.value).getTime() / 1000
         })
-      
+
     }
 
     applyFilter(layer)

--- a/lib/ui/layers/filters.mjs
+++ b/lib/ui/layers/filters.mjs
@@ -15,7 +15,10 @@ let timeout;
 
 mapp.utils.merge(mapp.dictionaries, {
   en: {
-    no_data_filter: 'This field contains no data, so cannot be filtered on.'
+    no_data_filter: 'This field contains no data and cannot be filtered on.'
+  },
+  de: {
+    no_data_filter: 'Dieses Feld enthält keine Daten und kann nicht gefiltert werden.'
   }
 });
 

--- a/lib/ui/layers/filters.mjs
+++ b/lib/ui/layers/filters.mjs
@@ -90,40 +90,33 @@ function filter_null(layer, filter) {
   })
 }
 
+async function generateMinMax(layer, filter, minmax) {
+  let response = await mapp.utils.xhr(`${layer.mapview.host}/api/query?${mapp.utils.paramString({
+    template: `field_${minmax}`,
+    locale: layer.mapview.locale.key,
+    layer: layer.key,
+    table: layer.tableCurrent(),
+    field: filter.field,
+  })}`);
+
+  // If the response contains response.min or response.max - we can assume the query was successful.
+  if (response[minmax]) {
+    filter[minmax] = filter.type === 'integer' ? parseInt(response[minmax]) : parseFloat(response[minmax]);
+  }
+
+}
 async function filter_numeric(layer, filter) {
 
   if (!filter.max) {
 
-    let response = await mapp.utils.xhr(`${layer.mapview.host}/api/query?${mapp.utils.paramString({
-      template: 'field_max',
-      locale: layer.mapview.locale.key,
-      layer: layer.key,
-      table: layer.tableCurrent(),
-      field: filter.field,
-    })}`);
+    generateMinMax(layer, filter, 'max');
+  }  
+  
+if (!filter.min) {
 
-    // If the response contains response.max - we can assume the query was successful.
-    if (response?.max) {
-      filter.max = filter.type === 'integer' ? parseInt(response.max) : parseFloat(response.max);
-    }
+    generateMinMax(layer, filter, 'min');
   }
-
-  if (!filter.min) {
-
-    let response = await mapp.utils.xhr(`${layer.mapview.host}/api/query?${mapp.utils.paramString({
-      template: 'field_min',
-      locale: layer.mapview.locale.key,
-      layer: layer.key,
-      table: layer.tableCurrent(),
-      field: filter.field,
-    })}`);
-
-    // If the response contains response.min - we can assume the query was successful.
-    if (response?.min) {
-      filter.min = filter.type === 'integer' ? parseInt(response.min) : parseFloat(response.min);
-    }
-  }
-
+  
   if (!filter.step) {
 
     filter.step = filter.type === 'integer' ? 1 : 0.01;

--- a/lib/ui/layers/filters.mjs
+++ b/lib/ui/layers/filters.mjs
@@ -1,3 +1,11 @@
+/**
+## mapp.ui.layers.filters[type](layer, filter)
+
+Provides filter functions for various data types in a layer.
+
+@module /ui/layers/filters
+*/
+
 export default {
   like: filter_text,
   match: filter_text,
@@ -22,6 +30,11 @@ mapp.utils.merge(mapp.dictionaries, {
   }
 });
 
+/**
+ * @function applyFilter
+ * @description Applies the filter to the layer and reloads it with a debounce of 500ms.
+ * @param {Object} layer - The layer object to apply the filter to.
+ */
 function applyFilter(layer) {
 
   clearTimeout(timeout);
@@ -36,6 +49,13 @@ function applyFilter(layer) {
   }, 500);
 }
 
+/**
+ * @function filter_text
+ * @description Creates an input element for filtering text values.
+ * @param {Object} layer - The layer object to apply the filter to.
+ * @param {Object} filter - The filter configuration object.
+ * @returns {HTMLElement} The input element for text filtering.
+ */
 function filter_text(layer, filter) {
   return mapp.utils.html.node`
   <input
@@ -59,6 +79,13 @@ function filter_text(layer, filter) {
     }}>`;
 }
 
+/**
+ * @function filter_boolean
+ * @description Creates a checkbox element for filtering boolean values.
+ * @param {Object} layer - The layer object to apply the filter to.
+ * @param {Object} filter - The filter configuration object.
+ * @returns {HTMLElement} The checkbox element for boolean filtering.
+ */
 function filter_boolean(layer, filter) {
 
   function booleanFilter(checked) {
@@ -76,6 +103,13 @@ function filter_boolean(layer, filter) {
   })
 }
 
+/**
+ * @function filter_null
+ * @description Creates a checkbox element for filtering null values.
+ * @param {Object} layer - The layer object to apply the filter to.
+ * @param {Object} filter - The filter configuration object.
+ * @returns {HTMLElement} The checkbox element for null filtering.
+ */
 function filter_null(layer, filter) {
 
   function nullFilter(checked) {
@@ -93,6 +127,14 @@ function filter_null(layer, filter) {
   })
 }
 
+/**
+ * @function generateMinMax
+ * @description Generates the minimum and maximum values for numeric filtering.
+ * @param {Object} layer - The layer object to apply the filter to.
+ * @param {Object} filter - The filter configuration object.
+ * @param {string} minmax - The type of value to generate ('min' or 'max').
+ * @returns {Promise<void>}
+ */
 async function generateMinMax(layer, filter, minmax) {
   let response = await mapp.utils.xhr(`${layer.mapview.host}/api/query?${mapp.utils.paramString({
     template: `field_${minmax}`,
@@ -108,6 +150,14 @@ async function generateMinMax(layer, filter, minmax) {
   }
 
 }
+
+/**
+ * @function filter_numeric
+ * @description Creates a slider element for filtering numeric values.
+ * @param {Object} layer - The layer object to apply the filter to.
+ * @param {Object} filter - The filter configuration object.
+ * @returns {Promise<HTMLElement>} The slider element for numeric filtering.
+ */
 async function filter_numeric(layer, filter) {
 
   if (!filter.max) {
@@ -169,6 +219,14 @@ if (!filter.min) {
 
 }
 
+
+/**
+ * @function filter_in
+ * @description Creates checkbox or dropdown elements for filtering values in a list.
+ * @param {Object} layer - The layer object to apply the filter to.
+ * @param {Object} filter - The filter configuration object.
+ * @returns {Promise<HTMLElement>} The checkbox or dropdown elements for list filtering.
+ */
 async function filter_in(layer, filter) {
 
   if (!Array.isArray(filter[filter.type])) {
@@ -279,6 +337,13 @@ async function filter_in(layer, filter) {
   return mapp.utils.html.node`<div class="filter">${chkBoxes}`
 }
 
+/**
+ * @function filter_date
+ * @description Creates input elements for filtering date values.
+ * @param {Object} layer - The layer object to apply the filter to.
+ * @param {Object} filter - The filter configuration object.
+ * @returns {HTMLElement} The input elements for date filtering.
+ */
 function filter_date(layer, filter) {
 
   const inputAfter = mapp.utils.html.node`


### PR DESCRIPTION
A numeric filter on a field that contains no data will currently fail. 
This is as the response from the `template_max` and `template_min` are undefined.
![image](https://github.com/GEOLYTIX/xyz/assets/56163132/2a506a0f-37ef-40c8-982d-b8224c544a8f)


This PR: 
1.  checks for the response, removing the error, 
2.  if no response is returned - returns text instead of a slider to tell the user of this. 
![unnamed](https://github.com/GEOLYTIX/xyz/assets/56163132/141d5219-258c-43b5-8686-586cfe9fafe6)
3. Fixes `parseInt` to `Math.round` as values of say 1001.99 would be rounded to 1001 not 1002 previously.

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1207110786328348