### PR TITLE
Add locale.xss_check for infotip content

### DIFF
--- a/lib/mapview/infotip.mjs
+++ b/lib/mapview/infotip.mjs
@@ -31,13 +31,13 @@ export default function(content) {
   // Content type object but not HTMLElement cannot be rendered.
   } else if (typeof content === 'object') {
 
-    console.log(content)
+    console.warn(`Content type object cannot be rendered in infotip: ${JSON.stringify(content)}`)
     return;
 
   } else {
 
     // Check for braces in content string.
-    if (/[()]/.test(content)) {
+    if (mapview.locale.xss_check && /[()]/.test(content)) {
 
       console.warn(`Potential XSS detected in infotip content ${content}`)
     }


### PR DESCRIPTION
The infotip should only check and warn for possible xss injection in the content if the xss_check flag is set in the locale.

The log for object content should be a warn and add detail on the nature of the warning.