### PR TITLE
Add st_distance_ab and st_intersects_ab query templates

### DIFF
--- a/lib/ui/locations/infoj.mjs
+++ b/lib/ui/locations/infoj.mjs
@@ -141,8 +141,15 @@ export default (location, infoj) => {
           .xhr(`${entry.host || entry.location?.layer?.mapview?.host || mapp.host}/api/query?${paramString}`)
           .then(response => {
 
-            // Assign query response as entry value.
-            entry.value = entry.field? response[entry.field] :response;
+            if (response) {
+
+              // Assign query response as entry value.
+              entry.value = entry.field ? response[entry.field] : response;
+
+            } else {
+
+              entry.value = entry.nullValue
+            }
 
             // Check whether entry should be skipped.
             if (skipEntry(entry)) {

--- a/lib/utils/queryParams.mjs
+++ b/lib/utils/queryParams.mjs
@@ -49,9 +49,6 @@ export default _this => {
 
     // qID will be taken if a location object is provided with the params.
     qID: _this.queryparams.qID ? _this.location?.layer?.qID : undefined,
-
-    // geom will be taken if a location object is provided with the params.
-    geom: _this.queryparams.geom ? _this.location?.layer?.geom : undefined,
     
     // Email will be taken if a location object is provided with the params.
     email: _this.queryparams.email ? mapp.user.email : undefined,

--- a/lib/utils/queryParams.mjs
+++ b/lib/utils/queryParams.mjs
@@ -47,6 +47,12 @@ export default _this => {
     // ID will be taken if a location object is provided with the params.
     id: _this.queryparams.id ? _this.location?.id : undefined,
 
+    // qID will be taken if a location object is provided with the params.
+    qID: _this.queryparams.qID ? _this.location?.layer?.qID : undefined,
+
+    // geom will be taken if a location object is provided with the params.
+    geom: _this.queryparams.geom ? _this.location?.layer?.geom : undefined,
+    
     // Email will be taken if a location object is provided with the params.
     email: _this.queryparams.email ? mapp.user.email : undefined,
 

--- a/mod/workspace/templates/_queries.js
+++ b/mod/workspace/templates/_queries.js
@@ -51,6 +51,9 @@ module.exports = {
   st_distance_ab: {
     template: require('./st_distance_ab'),
   },  
+  st_distance_ab_multiple: {
+    template: require('./st_distance_ab_multiple'),
+  },  
   location_get: {
     render: require('./location_get'),
   },

--- a/mod/workspace/templates/_queries.js
+++ b/mod/workspace/templates/_queries.js
@@ -45,6 +45,12 @@ module.exports = {
   layer_extent: {
     template: require('./layer_extent'),
   },
+  st_intersects_ab: {
+    template: require('./st_intersects_ab'),
+  },
+  st_distance_ab: {
+    template: require('./st_distance_ab'),
+  },  
   location_get: {
     render: require('./location_get'),
   },

--- a/mod/workspace/templates/st_distance_ab.js
+++ b/mod/workspace/templates/st_distance_ab.js
@@ -1,13 +1,15 @@
 module.exports = `
-
 SELECT 
-    b.\${field_b} AS \${as},
-    ST_DISTANCE(a.\${geom_a}, b.\${geom_b}) AS dist
-    
+    ST_DISTANCE(st_transform(a.\${geom},4326)::geography, closest.geom ) AS dist
 FROM 
-    \${table_a} a, 
-    \${table_b} b 
-
-WHERE a.\${id_a} = %{id} 
-ORDER BY dist 
-LIMIT 1`
+    \${table} a
+LEFT JOIN LATERAL (
+    SELECT
+        st_transform(b.\${geom_b},4326)::geography as geom
+    FROM \${table_b} b 
+    ORDER BY st_transform(b.\${geom_b},4326)::geography <-> st_transform(a.\${geom},4326)::geography
+    LIMIT 1
+) closest
+on true
+WHERE a.\${qID} = %{id}
+`

--- a/mod/workspace/templates/st_distance_ab.js
+++ b/mod/workspace/templates/st_distance_ab.js
@@ -1,0 +1,13 @@
+module.exports = `
+
+SELECT 
+    b.\${field_b} AS \${as},
+    ST_DISTANCE(a.\${geom_a}, b.\${geom_b}) AS dist
+    
+FROM 
+    \${table_a} a, 
+    \${table_b} b 
+
+WHERE a.\${id_a} = %{id} 
+ORDER BY dist 
+LIMIT 1`

--- a/mod/workspace/templates/st_distance_ab_multiple.js
+++ b/mod/workspace/templates/st_distance_ab_multiple.js
@@ -1,0 +1,17 @@
+module.exports = `
+SELECT 
+    closest.field_b AS \${as},
+    ST_DISTANCE(st_transform(a.\${geom},4326)::geography, closest.geom ) AS dist
+FROM 
+    \${table} a
+LEFT JOIN LATERAL (
+    SELECT
+        b.\${field_b} as field_b,
+        st_transform(b.\${geom_b},4326)::geography as geom
+    FROM \${table_b} b 
+    ORDER BY st_transform(b.\${geom_b},4326)::geography <-> st_transform(a.\${geom},4326)::geography
+    LIMIT \${limit}
+) closest
+on true
+WHERE a.\${qID} = %{id}
+`

--- a/mod/workspace/templates/st_intersects_ab.js
+++ b/mod/workspace/templates/st_intersects_ab.js
@@ -1,12 +1,10 @@
 module.exports = `
-
 SELECT 
     b.\${field_b} AS \${as} 
-
 FROM
-    \${table_a} a,
+    \${table} a
+LEFT JOIN
     \${table_b} b
-
-WHERE
-    ST_INTERSECTS(a.\${geom_a}, b.\${geom_b})
-    AND a.\${id_a} = %{id}`
+ON ST_INTERSECTS(a.\${geom}, b.\${geom_b})
+WHERE a.\${qID} = %{id}
+`

--- a/mod/workspace/templates/st_intersects_ab.js
+++ b/mod/workspace/templates/st_intersects_ab.js
@@ -1,0 +1,12 @@
+module.exports = `
+
+SELECT 
+    b.\${field_b} AS \${as} 
+
+FROM
+    \${table_a} a,
+    \${table_b} b
+
+WHERE
+    ST_INTERSECTS(a.\${geom_a}, b.\${geom_b})
+    AND a.\${id_a} = %{id}`


### PR DESCRIPTION
Default queries for location field lookup based on the locations geometry.

The entry.nullValue can be used to assign a value if the query does not return a response.

This should make the query_fields plugin redundant.

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1207158269914913