### PR TITLE
Check and remove filter params from request for query templates without a filter placeholder.

### DIFF
--- a/mod/query.js
+++ b/mod/query.js
@@ -154,6 +154,14 @@ module.exports = async (req, res) => {
     // Reserved params may not be substituted.
     const reserved = new Set(['viewport', 'filter'])
 
+    // Returns -1 if ${filter} not found in template
+    if (template.template.search(/\$\{filter\}/)<0) {
+
+      // Ensure that the $n substitute params match the SQL length on layer queries without a ${filter}
+      delete req.params.filter
+      req.params.SQL = []
+    }
+
     query = template.template
 
       // Replace parameter for identifiers, e.g. table, schema, columns


### PR DESCRIPTION
The location_new layer query template does not have a ${filter} substitute param and will crash if a query is sent for a layer with a default filter.

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1207135159328593