### PR TITLE
Add layer.params.default_fields array

### DIFF
--- a/lib/layer/format/mvt.mjs
+++ b/lib/layer/format/mvt.mjs
@@ -201,6 +201,7 @@ function tileUrlFunction(layer) {
 
     // Create a set of feature properties for styling.
     layer.params.fields = [...new Set([
+      layer.params.default_fields,
       Array.isArray(layer.style.theme?.fields) ?
         layer.style.theme.fields : layer.style.theme?.field,
       layer.style.theme?.field,
@@ -265,10 +266,11 @@ function changeEndLoad(layer) {
 
   // Create a set of feature properties for styling.
   layer.params.fields = [...new Set([
+    layer.params.default_fields,
     Array.isArray(layer.style.theme?.fields) ?
       layer.style.theme.fields : layer.style.theme?.field,
     layer.style.theme?.field,
-    layer.style.label?.field
+    layer.style.label?.field,
   ].flat().filter(field => !!field))]
 
   const bounds = layer.mapview.getBounds()

--- a/lib/layer/format/vector.mjs
+++ b/lib/layer/format/vector.mjs
@@ -82,7 +82,8 @@ export default layer => {
         layer.style.theme.fields : layer.style.theme?.field,
       layer.style.theme?.field,
       layer.style.label?.field,
-      layer.cluster?.label
+      layer.cluster?.label,
+      ...layer.params.default_fields
     ].flat().filter(field => !!field))]
 
 

--- a/lib/layer/format/vector.mjs
+++ b/lib/layer/format/vector.mjs
@@ -78,12 +78,12 @@ export default layer => {
 
     // Create a set of feature properties for styling.
     layer.params.fields = [...new Set([
+      layer.params.default_fields,
       Array.isArray(layer.style.theme?.fields) ?
         layer.style.theme.fields : layer.style.theme?.field,
       layer.style.theme?.field,
       layer.style.label?.field,
       layer.cluster?.label,
-      ...layer.params.default_fields
     ].flat().filter(field => !!field))]
 
 


### PR DESCRIPTION
This PR introduces the `layer.params.default_fields[]` option. 
This is useful to add additional fields to the layer.params.fields that are not coming from the style (theme or labels). 
This allows flexibility when working with bespoke plugins that required multiple feature fields to style on. 

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1207159826616127