### PR TITLE
Circle Button Only ; Geometry GeoJSON Import

### DIFF
--- a/lib/ui/elements/drawing.mjs
+++ b/lib/ui/elements/drawing.mjs
@@ -5,7 +5,8 @@ export default {
   rectangle,
   circle_2pt,
   circle,
-  locator
+  locator,
+  geojson_import
 }
 
 mapp.utils.merge(mapp.dictionaries, {
@@ -551,15 +552,22 @@ function circle(layer) {
 
     }}>${label}`
 
-  // Return the config element in a drawer with the interaction toggle button as sibling.
-  return mapp.utils.html.node`<div>
+  // If you pass a radius and unit, just return the button.
+  if (layer.draw.circle.radius && layer.draw.circle.units) {
+    return layer.draw.circle.btn
+  } else {
+
+    // Return the config element in a drawer with the interaction toggle button as sibling.
+    return mapp.utils.html.node`<div>
     ${mapp.ui.elements.drawer({
-    header: mapp.utils.html`
+      header: mapp.utils.html`
         <h3>${mapp.dictionary.circle_config}</h3>
         <div class="mask-icon expander"></div>`,
-    content: layer.draw.circle.panel
-  })}
-    ${layer.draw.circle.btn}`
+      content: layer.draw.circle.panel
+    })}
+    ${layer.draw.circle.btn}
+}`
+  }
 }
 
 function locator(layer) {
@@ -609,4 +617,61 @@ function locator(layer) {
     }}>${mapp.dictionary.draw_position}`
 
   return layer.draw.locator.btn
+}
+
+function geojson_import(layer) {
+  
+  layer.draw.btn = mapp.utils.html.node`
+  <button class="flat bold wide primary-colour">
+      ${layer.draw.geojson_import.label}
+  </button>
+`;
+
+layer.draw.btn.onclick = (e) => {
+
+  // Allow the user to import a geojson file
+  const input = document.createElement('input');
+  input.type = 'file';
+  input.accept = '.json';
+  input.onchange = (e) => {
+      const file = e.target.files[0];
+      const reader = new FileReader();
+      reader.readAsText(file);
+      reader.onload = async (e) => {
+
+          // Disable the layer view
+          layer.location.view.classList.add('disabled');
+
+          const geojson = JSON.parse(reader.result);
+
+          // Set options.value to the geojson
+          layer.value = geojson[0].geojson;
+
+          // Store to the database 
+          await mapp.utils.xhr({
+              method: 'POST',
+              url:
+                  `${mapp.host}/api/query?` +
+                  mapp.utils.paramString({
+                      template: 'location_update',
+                      locale: layer.location.layer.mapview.locale.key,
+                      layer: layer.location.layer.key,
+                      table: layer.location.table,
+                      id: layer.location.id,
+                  }),
+              body: JSON.stringify({ [layer.field]: layer.value }),
+          })
+
+          if (layer.dependents) {
+              await layer.location.syncFields(layer.dependents)
+          }
+
+          // Reload the layer if the layers geom field has been updated.
+          layer.location.view.dispatchEvent(new Event('updateInfo'))
+      };
+  };
+  input.click();
+};
+
+return layer.draw.btn;
 }


### PR DESCRIPTION
Opening this up as a draft as its not ready yet. 

Changes Included: 
1. If you provide a `circle.radius` and `circle.units` then the panel is not provided, and instead you just have the button to begin drawing. 
``` json 
  "circle": {
          "label": "1km Catchment",
          "radius": 1000,
          "units": "meter"
        }
```
2. Added a `geojson_import` option that allows you to import a geojson location. This is still in draft as it's not set up in the correct way. 

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1207171659105005