### PR TITLE
add ID to location_get warning

### DIFF
--- a/lib/location/decorate.mjs
+++ b/lib/location/decorate.mjs
@@ -115,7 +115,7 @@ async function syncFields(fields) {
 
   // Return if response is falsy or error.
   if (!response || response instanceof Error) {
-    console.warn('No data returned from location_get request.')
+    console.warn('No data returned from location_get request using ID:', this.id)
     return
   }
   // Check if the response is an array.

--- a/lib/location/get.mjs
+++ b/lib/location/get.mjs
@@ -87,7 +87,7 @@ export async function getInfoj(location) {
 
   // Check if the response is empty.
   if (!response || response instanceof Error) {
-    console.warn('No data returned from location_get request.')
+    console.warn('No data returned from location_get request using ID:', location.id)
     return
   }
   // Check if the response is an array.


### PR DESCRIPTION
When running the test_view it is useful to get the ID of a failed location request for diagnosing the issue. I updated the console warnings to return the ID.