### PR TITLE
Encode Roles in Admin Panel

### DIFF
--- a/public/views/_user.html
+++ b/public/views/_user.html
@@ -483,7 +483,7 @@
 
       if (JSON.stringify(e._cell.value) === JSON.stringify(e._cell.oldValue)) return;
 
-      xhrPromise(`${document.head.dataset.dir}/api/user/update?email=${e._cell.row.data.email}&field=roles&value=${e._cell.value}`)
+      xhrPromise(`${document.head.dataset.dir}/api/user/update?email=${e._cell.row.data.email}&field=roles&value=${encodeURIComponent(e._cell.value)}`)
     }
   }
 


### PR DESCRIPTION
The roles need to be `encoded` when passed to the database. 
This is to prevent a role of e.g. `Test&Test_more` being passed to the database as just `Test`. 