### PR TITLE
Tabulator 'Set' Headerfilter - no data from distinct query

### DIFF
--- a/lib/ui/utils/tabulator.mjs
+++ b/lib/ui/utils/tabulator.mjs
@@ -515,7 +515,7 @@ function set(_this) {
     // Create dropdown for render.
     let dropdown = mapp.utils.html.node`<div class="ul-parent">`
 
-    if (headerFilterParams.distinct) {
+      if (!headerFilterParams.options || headerFilterParams.options.length === 0) {
 
       // Query distinct field values.
       mapp.utils.xhr(`${_this.layer.mapview.host}/api/query?` +
@@ -526,40 +526,29 @@ function set(_this) {
           field
         })).then(response => {
 
-          if (response){
+          //Check if response is null, set to default no data response if it is.
+          response ??= response = [{'field':mapp.dictionary.no_options_available}]
 
-            // If response is not an array, make it an array.
-            if (!Array.isArray(response)) response = [response];
+          // If response is not an array, make it an array.
+          if (!Array.isArray(response)) response = [response];
 
-            // Render dropdown with distinct values from response.
-            mapp.utils.render(dropdown, mapp.ui.elements.dropdown({
-              multi: true,
-              placeholder: headerFilterParams.placeholder || `${mapp.dictionary.layer_filter_set_filter}`,
-              entries: response.map(row => ({
-                title: row[field],
-                option: row[field],
-                //selected: chkSet.has(val)
-              })),
-              callback
-            }))
-          }
-          else{
+          //Build up options array
+          headerFilterParams.options ??= []
+          response.forEach(row => headerFilterParams.options.push(row.field))
 
-            response = [{'field':mapp.dictionary.no_options_available}]
-            mapp.utils.render(dropdown, mapp.ui.elements.dropdown({
-              multi: true,
-              placeholder: headerFilterParams.placeholder || `${mapp.dictionary.layer_filter_set_filter}`,
-              entries: response.map(row => ({
-                title: mapp.dictionary.no_options_available,
-                option: mapp.dictionary.no_options_available,
-                selected: false
-                //selected: chkSet.has(val)
-              })),
-            }))
-          }
+          mapp.utils.render(dropdown, mapp.ui.elements.dropdown({
+            multi: true,
+            placeholder: headerFilterParams.placeholder || `${mapp.dictionary.layer_filter_set_filter}`,
+            entries: headerFilterParams.options.map(option => ({
+              title: option,
+              option: option,
+              //selected: chkSet.has(val)
+            })),
+            callback
+          }))
+
         })
-
-      return dropdown
+        return dropdown;
     }
 
     mapp.utils.render(dropdown, mapp.ui.elements.dropdown({

--- a/lib/ui/utils/tabulator.mjs
+++ b/lib/ui/utils/tabulator.mjs
@@ -545,11 +545,17 @@ function set(_this) {
           }
           else{
 
-            dropdown.append(mapp.utils.html.node`<div class="dropdown">
-                                                  <div class="head">
-                                                    <span data-id="header-span">No data for filter</span>
-                                                    <div class="icon"></div>
-                                                  </div`)
+            response = [{'field':mapp.dictionary.no_options_available}]
+            mapp.utils.render(dropdown, mapp.ui.elements.dropdown({
+              multi: true,
+              placeholder: headerFilterParams.placeholder || `${mapp.dictionary.layer_filter_set_filter}`,
+              entries: response.map(row => ({
+                title: mapp.dictionary.no_options_available,
+                option: mapp.dictionary.no_options_available,
+                selected: false
+                //selected: chkSet.has(val)
+              })),
+            }))
           }
         })
 

--- a/lib/ui/utils/tabulator.mjs
+++ b/lib/ui/utils/tabulator.mjs
@@ -526,20 +526,31 @@ function set(_this) {
           field
         })).then(response => {
 
-          // If response is not an array, make it an array.
-          if (!Array.isArray(response)) response = [response];
+          if (response){
 
-          // Render dropdown with distinct values from response.
-          mapp.utils.render(dropdown, mapp.ui.elements.dropdown({
-            multi: true,
-            placeholder: headerFilterParams.placeholder || `${mapp.dictionary.layer_filter_set_filter}`,
-            entries: response.map(row => ({
-              title: row[field],
-              option: row[field],
-              //selected: chkSet.has(val)
-            })),
-            callback
-          }))
+            // If response is not an array, make it an array.
+            if (!Array.isArray(response)) response = [response];
+
+            // Render dropdown with distinct values from response.
+            mapp.utils.render(dropdown, mapp.ui.elements.dropdown({
+              multi: true,
+              placeholder: headerFilterParams.placeholder || `${mapp.dictionary.layer_filter_set_filter}`,
+              entries: response.map(row => ({
+                title: row[field],
+                option: row[field],
+                //selected: chkSet.has(val)
+              })),
+              callback
+            }))
+          }
+          else{
+
+            dropdown.append(mapp.utils.html.node`<div class="dropdown">
+                                                  <div class="head">
+                                                    <span data-id="header-span">No data for filter</span>
+                                                    <div class="icon"></div>
+                                                  </div`)
+          }
         })
 
       return dropdown


### PR DESCRIPTION
### What
Using the `set` `headerfilter` and `distinct` in the `headerFilterParams` would create an error, as the dropdown would attempt to iterate an empty list .

This PR should correct that by making a dropdown that has a no data message.

### Test Space
[`bugs_testing/dataviews_filter/workspace.json`](https://github.com/GEOLYTIX/xyz_resources/tree/bugs-testing/bugs_testing/dataviews_filter)



---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1207190169901915