### PR TITLE
Add check on cluster distance being less than 1

### DIFF
--- a/lib/layer/format/vector.mjs
+++ b/lib/layer/format/vector.mjs
@@ -206,7 +206,7 @@ function clusterConfig(layer) {
    // Check if distance is defined as <1 and layer is a format wkt
    if (layer.cluster.distance < 1) {
 
-    console.warn(`Layer: ${layer.key}, cluster.distance is less than 1. Clustering is in pixels. Either remove the cluster object to have no clustering, or set the cluster value to an integer of more than 1.`)
+    console.warn(`Layer: ${layer.key}, cluster.distance is less than 1 [pixel]. The cluster config will be removed.`)
     
     // Remove the cluster object
     delete layer.cluster; 

--- a/lib/layer/format/vector.mjs
+++ b/lib/layer/format/vector.mjs
@@ -207,6 +207,10 @@ function clusterConfig(layer) {
    if (layer.cluster.distance < 1) {
 
     console.warn(`Layer: ${layer.key}, cluster.distance is less than 1. Clustering is in pixels. Either remove the cluster object to have no clustering, or set the cluster value to an integer of more than 1.`)
+    
+    // Remove the cluster object
+    delete layer.cluster; 
+    return;
   }
 
   // If cluster.resolution is used, the layer srid must be set to 3857.

--- a/lib/layer/format/vector.mjs
+++ b/lib/layer/format/vector.mjs
@@ -203,6 +203,12 @@ function clusterConfig(layer) {
     return;
   };
 
+   // Check if distance is defined as <1 and layer is a format wkt
+   if (layer.cluster.distance < 1) {
+
+    console.warn(`Layer: ${layer.key}, cluster.distance is less than 1. Clustering is in pixels. Either remove the cluster object to have no clustering, or set the cluster value to an integer of more than 1.`)
+  }
+
   // If cluster.resolution is used, the layer srid must be set to 3857.
   if (layer.cluster.resolution) {
 


### PR DESCRIPTION
This PR adds a check to the `cluster.distance` value to ensure it is more than 1. 
I noticed a lot of configuration using values less than 1, but this currently silently fails. 
This PR simply warns about the issue, forcing the developer to resolve it to remove the warning.

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1207208979036434