### PR TITLE
Fix key value dictionary for the custom views

### DIFF
--- a/lib/plugins/keyvalue_dictionary.mjs
+++ b/lib/plugins/keyvalue_dictionary.mjs
@@ -12,7 +12,7 @@ Replaces key-value pairs in the mapview locale object with dictionary entries.
 @returns {void}
  */
 export function keyvalue_dictionary(keyvalue_dictionary, mapview) {
-  if (!mapp.user.language) return;
+  if (!mapp?.user?.language || mapp.language) return;
   if (!mapview.locale) return;
   parseObject(mapview.locale, keyvalue_dictionary);
 }


### PR DESCRIPTION
Custom views don't have a mapp.user obj. This pull request checks for this and uses mapp.language which is in the custom view.

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1207220592858068