### PR TITLE
Add SRC env subtitution to the getLayer Module

### DIFF
--- a/mod/workspace/getLayer.js
+++ b/mod/workspace/getLayer.js
@@ -68,10 +68,16 @@ module.exports = async (params) => {
     // Merge the workspace template into the layer.
     layer = merge(layer, template)
   }
+
   // Subtitutes ${*} with process.env.SRC_* key values.
   layer = JSON.parse(
     JSON.stringify(layer).replace(/\$\{(.*?)\}/g,
-      matched => process.env[`SRC_${matched.replace(/(^\${)|(}$)/g, '')}`])
+      matched => {
+        const SRC_x = `SRC_${matched.replace(/(^\${)|(}$)/g, '')}`
+        return Object.hasOwn(process.env, SRC_x)
+          ? process.env[SRC_x]
+          : matched
+      })
   )
   
   // Assign layer key as name with no existing name on layer object.

--- a/mod/workspace/getLayer.js
+++ b/mod/workspace/getLayer.js
@@ -68,7 +68,12 @@ module.exports = async (params) => {
     // Merge the workspace template into the layer.
     layer = merge(layer, template)
   }
-
+  // Subtitutes ${*} with process.env.SRC_* key values.
+  layer = JSON.parse(
+    JSON.stringify(layer).replace(/\$\{(.*?)\}/g,
+      matched => process.env[`SRC_${matched.replace(/(^\${)|(}$)/g, '')}`])
+  )
+  
   // Assign layer key as name with no existing name on layer object.
   layer.name ??= layer.key
 


### PR DESCRIPTION
The replacement of keys `${HOST}` for example was previously only happening in the `getLocale` module. 
This PR adds it to the `getLayer` module too - which means that file paths within for example `layer.meta` can substitute ENV variables. 

The below would now resolve to whatever `SRC_HOST` is defined to in the ENV settings
``` json 
  "meta": "<a target='_blank' href='${HOST}/...`>Click here for User Guide</a></div>",
```

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1207220364404463