### PR TITLE
Update keyvalue_dictionary.mjs

### DIFF
--- a/lib/plugins/keyvalue_dictionary.mjs
+++ b/lib/plugins/keyvalue_dictionary.mjs
@@ -12,7 +12,7 @@ Replaces key-value pairs in the mapview locale object with dictionary entries.
 @returns {void}
  */
 export function keyvalue_dictionary(keyvalue_dictionary, mapview) {
-  if (!mapp?.user?.language || mapp.language) return;
+  if (!mapp?.user?.language || !mapp.language) return;
   if (!mapview.locale) return;
   parseObject(mapview.locale, keyvalue_dictionary);
 }
@@ -65,5 +65,5 @@ function replaceKeyValue(obj, key, value, dictionary) {
     .find(entry => entry.value === value);
   if (!entry) return;
   // Replace object key value with entry language lookup or default.
-  obj[key] = entry[mapp.user.language] || entry.default || value;
+  obj[key] = entry[mapp?.user?.language || mapp.language] || entry.default || value;
 }


### PR DESCRIPTION
Fix for the custom view key value dictionary, but having an issue with the replaceKeyValue function as it doesn't assign the dictionary doesn't filter correctly 
const entry = dictionary.filter(entry => entry.key === key).find(entry => entry.value === value);