### PR TITLE
style.contextFilter for tile format

### DIFF
--- a/lib/layer/format/tiles.mjs
+++ b/lib/layer/format/tiles.mjs
@@ -43,4 +43,19 @@ export default layer => {
     zIndex: layer.style?.zIndex || 0
   })
 
+  if (layer.style?.contextFilter) {
+
+    layer.L.on('prerender', (evt) => {
+      if (evt.context) {
+        evt.context.filter = layer.style.contextFilter;
+        evt.context.globalCompositeOperation = 'source-over';
+      }
+    });
+    
+    layer.L.on('postrender', (evt) => {
+      if (evt.context) {
+        evt.context.filter = 'none';
+      }
+    });
+  }
 }


### PR DESCRIPTION
Allow for contextFilter to be applied to the tile render.

```json
      "OSM": {
        "display": true,
        "format": "tiles",
        "URI": "https://{a-c}.tile.openstreetmap.org/{z}/{x}/{y}.png",
        "style": {
          "contextFilter": "grayscale(100%)"
        },
        "attribution": {
          "© OpenStreetMap": "http://www.openstreetmap.org/copyright"
        }
      },
```

![image](https://github.com/GEOLYTIX/xyz/assets/22201617/37bf3616-033b-43f4-816b-e2a093c8a020)
