### PR TITLE
Drawing Instructions Modal

### DIFF
--- a/lib/mapview/interactions/draw.mjs
+++ b/lib/mapview/interactions/draw.mjs
@@ -38,6 +38,8 @@ export default function(params){
     // Whether the draw interaction event should be handled.
     condition: e => {
 
+      if (mapview.interaction.wait) return false;
+
       // Right click
       if (e.originalEvent.buttons === 2) {
 

--- a/lib/ui/elements/_elements.mjs
+++ b/lib/ui/elements/_elements.mjs
@@ -15,6 +15,7 @@ import dropdown_multi from './dropdown_multi.mjs';
 import btnPanel from './btnPanel.mjs';
 import legendIcon from './legendIcon.mjs';
 import modal from './modal.mjs';
+import helpModal from './helpModal.mjs';
 import searchbox from './searchbox.mjs';
 import slider from './slider.mjs';
 import slider_ab from './slider_ab.mjs';
@@ -55,6 +56,7 @@ export default {
   dropdown_multi,
   legendIcon,
   modal,
+  helpModal,
   searchbox,
   slider,
   slider_ab,

--- a/lib/ui/elements/drawing.mjs
+++ b/lib/ui/elements/drawing.mjs
@@ -161,11 +161,11 @@ mapp.utils.merge(mapp.dictionaries, {
 })
 
 function deleteModal() {
-  if (document.querySelector("#Map > div.modal")) {
-    document.querySelector("#Map > div.modal").remove();
-  }
-
+  const modal = document.querySelector('[data-id=modal_drawing]')
+  
+  modal && modal.remove()
 }
+
 function GenerateModal(type) {
 
   // If a modal is already present, remove it
@@ -192,6 +192,7 @@ function GenerateModal(type) {
     <ul>${mapp.dictionary.draw_modal_save_single}</ul>
     </li>`
   }
+
   // Add the header
   const header = mapp.utils.html`<h3>${mapp.dictionary.draw_modal_title}</h3>`;
 
@@ -229,53 +230,41 @@ function point(layer) {
       class="flat wide bold primary-colour"
       onclick=${e => {
 
-      const btn = e.target
+        const btn = e.target
 
-      if (btn.classList.contains('active')) {
+        if (!btn.classList.toggle('active')) {
 
-        // Cancel draw interaction.
-        btn.classList.remove('active')
-        layer.mapview.interactions.highlight()
-        // If the modal was drawn, we can call the function to remove it 
-        if (layer.draw.point.infoModal) {
           deleteModal();
+          return;
         }
-        return;
-      } else {
 
-        btn.classList.add('active')
         // Generate the modal 
         if (layer.draw.point.infoModal) {
           GenerateModal();
         }
-      }
 
-      !layer.display && layer.show()
+        !layer.display && layer.show()
 
-      layer.draw.point.callback = feature => {
+        layer.draw.point.callback = feature => {
 
-        layer.draw.callback(feature, layer.draw.point)
+          layer.draw.callback(feature, layer.draw.point)
 
-        btn.classList.remove('active')
+          btn.classList.remove('active')
 
-        delete layer.mapview.interaction
+          delete layer.mapview.interaction
 
-        // If the modal was drawn, we can call the function to remove it 
-        if (layer.draw.point.infoModal) {
           deleteModal();
+
+          // Set highlight interaction if no other interaction is current after 400ms.
+          setTimeout(() => {
+            !layer.mapview.interaction && layer.mapview.interactions.highlight()
+          }, 400)
+
         }
 
-        // Set highlight interaction if no other interaction is current after 400ms.
-        setTimeout(() => {
-          !layer.mapview.interaction && layer.mapview.interactions.highlight()
-        }, 400)
+        layer.mapview.interactions.draw(layer.draw.point)
 
-      }
-
-      layer.mapview.interactions.draw(layer.draw.point)
-
-    }}>
-      ${label}`
+      }}>${label}`
 
   return layer.draw.point.btn
 }
@@ -291,60 +280,47 @@ function line(layer) {
   // If a label is provided, use it, otherwise use the default
   let label = layer.draw.line?.label || mapp.dictionary.draw_line
 
-
   // Create the button
   layer.draw.line.btn = mapp.utils.html.node`
     <button
       class="flat wide bold primary-colour"
       onclick=${e => {
 
-      const btn = e.target
+        const btn = e.target
 
-      if (btn.classList.contains('active')) {
+        if (!btn.classList.toggle('active')) {
 
-        // Cancel draw interaction.
-        btn.classList.remove('active')
-        layer.mapview.interactions.highlight()
-
-        // If the modal was drawn, we can call the function to remove it 
-        if (layer.draw.line.infoModal) {
-          deleteModal();
+          layer.mapview.interaction.finish()
+          return;
         }
 
-      } else {
+        // Generate the modal 
+        GenerateModal();
+
+        !layer.display && layer.show()
+
+        layer.draw.line.callback = feature => {
+
+          layer.draw.callback(feature, layer.draw.polygon)
+
+          btn.classList.remove('active')
+
+          delete layer.mapview.interaction
+
+          deleteModal();
+
+          // Set highlight interaction if no other interaction is current after 400ms.
+          setTimeout(() => {
+            !layer.mapview.interaction && layer.mapview.interactions.highlight()
+          }, 400)
+
+        }
+
+        layer.mapview.interactions.draw(layer.draw.line)
 
         btn.classList.add('active')
-        // Generate the modal 
-        if (layer.draw.line.infoModal) {
-          GenerateModal();
-        }
-      }
 
-      !layer.display && layer.show()
-
-      layer.draw.line.callback = feature => {
-
-        layer.draw.callback(feature, layer.draw.polygon)
-
-        btn.classList.remove('active')
-
-        delete layer.mapview.interaction
-
-        // If the modal was drawn, we can call the function to remove it 
-        if (layer.draw.line.infoModal) {
-          deleteModal();
-        }
-        // Set highlight interaction if no other interaction is current after 400ms.
-        setTimeout(() => {
-          !layer.mapview.interaction && layer.mapview.interactions.highlight()
-        }, 400)
-
-      }
-
-      layer.mapview.interactions.draw(layer.draw.line)
-
-    }}>
-      ${label}`
+      }}>${label}`
 
   return layer.draw.line.btn
 }
@@ -374,10 +350,7 @@ function polygon(layer) {
         btn.classList.remove('active')
         layer.mapview.interactions.highlight()
 
-        // If the modal was drawn, we can call the function to remove it 
-        if (layer.draw.polygon.infoModal) {
-          deleteModal();
-        }
+        deleteModal();
 
       } else {
 
@@ -397,10 +370,7 @@ function polygon(layer) {
 
         delete layer.mapview.interaction;
 
-        // If the modal was drawn, we can call the function to remove it 
-        if (layer.draw.polygon.infoModal) {
-          deleteModal();
-        }
+        deleteModal();
 
         // Set highlight interaction if no other interaction is current after 400ms.
         setTimeout(() => {
@@ -444,10 +414,7 @@ function rectangle(layer) {
         btn.classList.remove('active')
         layer.mapview.interactions.highlight()
 
-        // If the modal was drawn, we can call the function to remove it 
-        if (layer.draw.rectangle.infoModal) {
-          deleteModal();
-        }
+        deleteModal();
 
       } else {
 
@@ -466,11 +433,8 @@ function rectangle(layer) {
 
         btn.classList.remove('active')
 
-        // If the modal was drawn, we can call the function to remove it 
-        if (layer.draw.rectangle.infoModal) {
-          deleteModal();
+        deleteModal();
 
-        }
         delete layer.mapview.interaction
 
         // Set highlight interaction if no other interaction is current after 400ms.
@@ -515,10 +479,7 @@ function circle_2pt(layer) {
       btn.classList.remove('active')
       layer.mapview.interactions.highlight()
 
-      // If the modal was drawn, we can call the function to remove it 
-      if (layer.draw.circle_2pt.infoModal) {
-        deleteModal();
-      }
+      deleteModal();
 
     } else {
 
@@ -537,10 +498,7 @@ function circle_2pt(layer) {
 
       btn.classList.remove('active')
 
-      // If the modal was drawn, we can call the function to remove it 
-      if (layer.draw.circle_2pt.infoModal) {
-        deleteModal();
-      }
+      deleteModal();
 
       delete layer.mapview.interaction
 
@@ -653,10 +611,7 @@ function circle(layer) {
       btn.classList.remove('active')
       layer.mapview.interactions.highlight()
 
-      // If the modal was drawn, we can call the function to remove it 
-      if (layer.draw.circle.infoModal) {
-        deleteModal();
-      }
+      deleteModal();
 
     } else {
 
@@ -678,10 +633,7 @@ function circle(layer) {
 
       btn.classList.remove('active')
 
-      // If the modal was drawn, we can call the function to remove it 
-      if (layer.draw.circle.infoModal) {
-        deleteModal();
-      }
+      deleteModal();
 
       delete layer.mapview.interaction
 

--- a/lib/ui/elements/drawing.mjs
+++ b/lib/ui/elements/drawing.mjs
@@ -5,7 +5,8 @@ export default {
   rectangle,
   circle_2pt,
   circle,
-  locator
+  locator,
+  drawOnclick
 }
 
 mapp.utils.merge(mapp.dictionaries, {

--- a/lib/ui/elements/drawing.mjs
+++ b/lib/ui/elements/drawing.mjs
@@ -10,6 +10,11 @@ export default {
 
 mapp.utils.merge(mapp.dictionaries, {
   en: {
+    draw_modal_title: "Drawing Instructions",
+    draw_modal_begin_drawing: "Begin Drawing - Click anywhere on the map",
+    draw_modal_cancel_drawing: "Cancel Drawing - ESC Key",
+    draw_modal_remove_vertex: "Remove Last Vertex - Right-Click",
+    draw_modal_save: "Save - Double Click",
     draw_point: 'Point',
     draw_position: 'Current Position',
     draw_polygon: 'Polygon',
@@ -154,6 +159,34 @@ mapp.utils.merge(mapp.dictionaries, {
   }
 })
 
+function GenerateModal() {
+
+  // Add a content div 
+  const content = mapp.utils.html.node`
+  <li>
+  <ul>${mapp.dictionary.draw_modal_begin_drawing}</ul>
+  <ul>${mapp.dictionary.draw_modal_cancel_drawing}
+  <ul>${mapp.dictionary.draw_modal_remove_vertex}</ul>
+  <ul>${mapp.dictionary.draw_modal_save}</ul>
+  </li>`
+
+  // Create the modal
+  mapp.ui.elements.modal({
+    data_id: 'modal_drawing',
+    header: mapp.utils.html.node`<h3>${mapp.dictionary.draw_modal_title}</h3>`,
+    target: document.getElementById('Map'),
+    content: content,
+    height: 'auto',
+    width: '200px',
+    css_style: 'padding: 0.5em;',
+    top: 30,
+    left: 60,
+    contained: true,
+    close: () => { }
+  });
+
+}
+
 function point(layer) {
 
   // Set the default values
@@ -226,6 +259,10 @@ function line(layer) {
       class="flat wide bold primary-colour"
       onclick=${e => {
 
+
+      // Generate the modal 
+      GenerateModal();
+
       const btn = e.target
 
       if (btn.classList.contains('active')) {
@@ -280,6 +317,9 @@ function polygon(layer) {
       class="flat wide bold primary-colour"
       onclick=${e => {
 
+      // Generate the modal 
+      GenerateModal();
+
       const btn = e.target
 
       if (btn.classList.contains('active')) {
@@ -287,6 +327,8 @@ function polygon(layer) {
         // Cancel draw interaction.
         btn.classList.remove('active')
         layer.mapview.interactions.highlight()
+        // Remove the modal
+        document.querySelector("#Map > div.modal ").remove();
         return;
       }
 
@@ -301,6 +343,9 @@ function polygon(layer) {
         btn.classList.remove('active')
 
         delete layer.mapview.interaction
+
+        // Remove the modal
+        document.querySelector("#Map > div.modal ").remove();
 
         // Set highlight interaction if no other interaction is current after 400ms.
         setTimeout(() => {
@@ -335,6 +380,10 @@ function rectangle(layer) {
       class="flat wide bold primary-colour"
       onclick=${e => {
 
+
+      // Generate the modal 
+      GenerateModal();
+
       const btn = e.target
 
       if (btn.classList.contains('active')) {
@@ -342,6 +391,8 @@ function rectangle(layer) {
         // Cancel draw interaction.
         btn.classList.remove('active')
         layer.mapview.interactions.highlight()
+        // Remove the modal
+        document.querySelector("#Map > div.modal ").remove();
         return;
       }
 
@@ -356,6 +407,9 @@ function rectangle(layer) {
         btn.classList.remove('active')
 
         delete layer.mapview.interaction
+
+        // Remove the modal
+        document.querySelector("#Map > div.modal ").remove();
 
         // Set highlight interaction if no other interaction is current after 400ms.
         setTimeout(() => {
@@ -391,6 +445,10 @@ function circle_2pt(layer) {
 
   function drawCircle_2pt(e) {
 
+
+    // Generate the modal 
+    GenerateModal();
+
     const btn = e.target
 
     if (btn.classList.contains('active')) {
@@ -398,6 +456,8 @@ function circle_2pt(layer) {
       // Cancel draw interaction.
       btn.classList.remove('active')
       layer.mapview.interactions.highlight()
+      // Remove the modal
+      document.querySelector("#Map > div.modal ").remove();
       return;
     }
 
@@ -412,6 +472,8 @@ function circle_2pt(layer) {
       btn.classList.remove('active')
 
       delete layer.mapview.interaction
+      // Remove the modal
+      document.querySelector("#Map > div.modal ").remove();
 
       // Set highlight interaction if no other interaction is current after 400ms.
       setTimeout(() => {
@@ -514,6 +576,10 @@ function circle(layer) {
 
   function drawCircle(e) {
 
+
+    // Generate the modal 
+    GenerateModal();
+
     const btn = e.target
 
     if (btn.classList.contains('active')) {
@@ -521,6 +587,8 @@ function circle(layer) {
       // Cancel draw interaction.
       btn.classList.remove('active')
       layer.mapview.interactions.highlight()
+      // Remove the modal
+      document.querySelector("#Map > div.modal ").remove();
       return;
     }
 
@@ -538,6 +606,8 @@ function circle(layer) {
       btn.classList.remove('active')
 
       delete layer.mapview.interaction
+      // Remove the modal
+      document.querySelector("#Map > div.modal ").remove();
 
       // Set highlight interaction if no other interaction is current after 400ms.
       setTimeout(() => {
@@ -546,7 +616,7 @@ function circle(layer) {
     }
 
     layer.mapview.interactions.draw(layer.draw.circle)
-  } 
+  }
 
   // The config elements are not shown.
   if (layer.draw.circle.hidePanel) return layer.draw.circle.btn
@@ -554,11 +624,11 @@ function circle(layer) {
   // Return the config element in a drawer with the interaction toggle button as sibling.
   return mapp.utils.html.node`<div>
     ${mapp.ui.elements.drawer({
-      header: mapp.utils.html`
+    header: mapp.utils.html`
         <h3>${mapp.dictionary.circle_config}</h3>
         <div class="mask-icon expander"></div>`,
-      content: layer.draw.circle.panel
-    })}
+    content: layer.draw.circle.panel
+  })}
     ${layer.draw.circle.btn}`
 }
 

--- a/lib/ui/elements/drawing.mjs
+++ b/lib/ui/elements/drawing.mjs
@@ -190,7 +190,6 @@ function drawOnclick(e, layer, interaction) {
 
   layer.mapview.interactions.draw(interaction)
 
-  // Add the header
   interaction.helpModal.header = mapp.utils.html`<h3>${mapp.dictionary.draw_modal_title}</h3>`;
 
   interaction.helpModal.data_id = 'modal_drawing';
@@ -202,73 +201,62 @@ function drawOnclick(e, layer, interaction) {
 
 function point(layer) {
 
-  // Set the default values
-  layer.draw.point = Object.assign({
-    layer,
-    type: 'Point',
-  }, typeof layer.draw.point === 'object' && layer.draw.point || {})
-
-
-  layer.draw.point.helpModal ??= {
+  const helpModal = {
     content: mapp.utils.html.node`<li>
     <ul>${mapp.dictionary.draw_modal_begin_drawing}</ul>
     <ul>${mapp.dictionary.draw_modal_save_single}</ul>`
   }
 
-  // If a label is provided, use it, otherwise use the default
-  let label = layer.draw.point?.label || mapp.dictionary.draw_point
-
+  // Set the default values
+  layer.draw.point = {
+    layer,
+    label: mapp.dictionary.draw_point,
+    helpModal,
+    type: 'Point',
+    ...layer.draw.point
+  }
 
   // Create the button
   layer.draw.point.btn = mapp.utils.html.node`
     <button
       class="flat wide bold primary-colour"
       onclick=${e => drawOnclick(e, layer, layer.draw.point)}>
-      ${label}`
+      ${layer.draw.point.label}`
 
   return layer.draw.point.btn
 }
 
 function line(layer) {
 
-  // Set the default values
-  layer.draw.line = Object.assign({
-    layer,
-    type: 'LineString',
-  }, typeof layer.draw.line === 'object' && layer.draw.line || {})
-
-  layer.draw.line.helpModal ??= {
+  const helpModal = {
     content: mapp.utils.html.node`<li>
     <ul>${mapp.dictionary.draw_modal_begin_drawing}</ul>
     <ul>${mapp.dictionary.draw_modal_remove_vertex}</ul>
     <ul>${mapp.dictionary.draw_modal_save_single}</ul>`
   }
 
-  // If a label is provided, use it, otherwise use the default
-  let label = layer.draw.line?.label || mapp.dictionary.draw_line
+  // Set the default values
+  layer.draw.line = {
+    layer,
+    label: mapp.dictionary.draw_line,
+    helpModal,
+    type: 'LineString',
+    ...layer.draw.line
+  }
 
   // Create the button
   layer.draw.line.btn = mapp.utils.html.node`
     <button
       class="flat wide bold primary-colour"
       onclick=${e => drawOnclick(e, layer, layer.draw.line)}>
-      ${label}`
+      ${layer.draw.line.label}`
 
   return layer.draw.line.btn
 }
 
 function polygon(layer) {
 
-  // Set the default values
-  layer.draw.polygon = Object.assign({
-    layer,
-    type: 'Polygon',
-  }, typeof layer.draw.polygon === 'object' && layer.draw.polygon || {})
-
-  // If a label is provided, use it, otherwise use the default
-  let label = layer.draw.polygon?.label || mapp.dictionary.draw_polygon
-
-  layer.draw.polygon.helpModal ??= {
+  const helpModal = {
     content: mapp.utils.html.node`<li>
     <ul>${mapp.dictionary.draw_modal_begin_drawing}</ul>
     <ul>${mapp.dictionary.draw_modal_cancel_drawing}
@@ -276,59 +264,69 @@ function polygon(layer) {
     <ul>${mapp.dictionary.draw_modal_save}</ul>`
   }
 
+  // Set the default values
+  layer.draw.polygon = {
+    layer,
+    label: mapp.dictionary.draw_polygon,
+    helpModal,
+    type: 'Polygon',
+    ...layer.draw.polygon
+  }
+
   // Create the button
   layer.draw.polygon.btn = mapp.utils.html.node`
     <button
       class="flat wide bold primary-colour"
       onclick=${e => drawOnclick(e, layer, layer.draw.polygon)}>
-      ${label}`
+      ${layer.draw.polygon.label}`
 
   return layer.draw.polygon.btn
 }
 
 function rectangle(layer) {
 
-  // Set the default values
-  layer.draw.rectangle = Object.assign({
-    layer,
-    type: 'Circle',
-    geometryFunction: ol.interaction.Draw.createBox(),
-  }, typeof layer.draw.rectangle === 'object' && layer.draw.rectangle || {})
-
-  layer.draw.rectangle.helpModal ??= {
+  const helpModal = {
     content: mapp.utils.html.node`<li>
     <ul>${mapp.dictionary.draw_modal_begin_drawing}</ul>
     <ul>${mapp.dictionary.draw_modal_save_single}</ul>`
   }
 
-  // If a label is provided, use it, otherwise use the default
-  let label = layer.draw.rectangle?.label || mapp.dictionary.draw_rectangle
+  // Set the default values
+  layer.draw.rectangle = {
+    layer,
+    label: mapp.dictionary.draw_rectangle,
+    helpModal,
+    type: 'Circle',
+    geometryFunction: ol.interaction.Draw.createBox(),
+    ...layer.draw.rectangle
+  }
 
   // Create the button
   layer.draw.rectangle.btn = mapp.utils.html.node`
   <button
     class="flat wide bold primary-colour"
     onclick=${e => drawOnclick(e, layer, layer.draw.rectangle)}>
-    ${label}`
+    ${layer.draw.rectangle.label}`
 
   return layer.draw.rectangle.btn
 }
 
 function circle_2pt(layer) {
 
+  const helpModal = {
+    content: mapp.utils.html.node`<li>
+    <ul>${mapp.dictionary.draw_modal_begin_drawing}</ul>
+    <ul>${mapp.dictionary.draw_modal_save_single}</ul>`
+  }
+
   // Set the default values
   layer.draw.circle_2pt = {
     layer,
     type: 'Circle',
+    helpModal,
     geometryFunction: ol.interaction.Draw.createRegularPolygon(33),
     label: mapp.dictionary.draw_circle_2pt,
     ...layer.draw.circle_2pt
-  }
-
-  layer.draw.circle_2pt.helpModal ??= {
-    content: mapp.utils.html.node`<li>
-    <ul>${mapp.dictionary.draw_modal_begin_drawing}</ul>
-    <ul>${mapp.dictionary.draw_modal_save_single}</ul>`
   }
 
   // Create the button
@@ -343,9 +341,16 @@ function circle_2pt(layer) {
 
 function circle(layer) {
 
+  const helpModal = {
+    content: mapp.utils.html.node`<li>
+    <ul>${mapp.dictionary.draw_modal_begin_drawing}</ul>
+    <ul>${mapp.dictionary.draw_modal_save_single}</ul>`
+  }
+
   // Set the default values
   layer.draw.circle = {
     layer,
+    helpModal,
     type: 'Point',
     units: 'meter',
     radius: 100,
@@ -372,12 +377,6 @@ function circle(layer) {
     },
     label: mapp.dictionary.draw_circle,
     ...layer.draw.circle
-  }
-
-  layer.draw.circle.helpModal ??= {
-    content: mapp.utils.html.node`<li>
-    <ul>${mapp.dictionary.draw_modal_begin_drawing}</ul>
-    <ul>${mapp.dictionary.draw_modal_save_single}</ul>`
   }
 
   const unitsDropDown = mapp.utils.html.node`
@@ -449,10 +448,12 @@ function circle(layer) {
 
 function locator(layer) {
 
-  layer.draw.locator = Object.assign({
+  layer.draw.locator = {
     layer,
+    label: mapp.dictionary.draw_position,
     type: 'Point',
-  }, typeof layer.draw.locator === 'object' && layer.draw.locator || {})
+    ...layer.draw.locator
+  }
 
   layer.draw.locator.btn = mapp.utils.html.node`
     <button
@@ -491,7 +492,7 @@ function locator(layer) {
         mapp.location.get(location)
       })
 
-    }}>${mapp.dictionary.draw_position}`
+    }}>${layer.draw.locator.label}`
 
   return layer.draw.locator.btn
 }

--- a/lib/ui/elements/drawing.mjs
+++ b/lib/ui/elements/drawing.mjs
@@ -13,8 +13,9 @@ mapp.utils.merge(mapp.dictionaries, {
     draw_modal_title: "Drawing Instructions",
     draw_modal_begin_drawing: "Begin Drawing - Click anywhere on the map",
     draw_modal_cancel_drawing: "Cancel Drawing - ESC Key",
-    draw_modal_remove_vertex: "Remove Last Vertex - Right-Click",
+    draw_modal_remove_vertex: "Remove Last Vertex - Right Click",
     draw_modal_save: "Save - Double Click",
+    draw_modal_save_single: "Save - Single Click",
     draw_point: 'Point',
     draw_position: 'Current Position',
     draw_polygon: 'Polygon',
@@ -159,21 +160,45 @@ mapp.utils.merge(mapp.dictionaries, {
   }
 })
 
-function GenerateModal() {
+function deleteModal() {
+  if (document.querySelector("#Map > div.modal")) {
+    document.querySelector("#Map > div.modal").remove();
+  }
 
-  // Add a content div 
-  const content = mapp.utils.html.node`
-  <li>
-  <ul>${mapp.dictionary.draw_modal_begin_drawing}</ul>
-  <ul>${mapp.dictionary.draw_modal_cancel_drawing}
-  <ul>${mapp.dictionary.draw_modal_remove_vertex}</ul>
-  <ul>${mapp.dictionary.draw_modal_save}</ul>
-  </li>`
+}
+function GenerateModal(type) {
+
+  // If a modal is already present, remove it
+  deleteModal();
+
+  // Define the content
+  let content;
+
+  // If type is polygon, generate the verbose content
+  if (type === 'polygon') {
+    content = mapp.utils.html.node`
+    <li>
+    <ul>${mapp.dictionary.draw_modal_begin_drawing}</ul>
+    <ul>${mapp.dictionary.draw_modal_cancel_drawing}
+    <ul>${mapp.dictionary.draw_modal_remove_vertex}</ul>
+    <ul>${mapp.dictionary.draw_modal_save}</ul>
+    </li>`
+  } else {
+
+    // Generate the default content
+    content = mapp.utils.html.node`
+    <li>
+    <ul>${mapp.dictionary.draw_modal_begin_drawing}</ul>
+    <ul>${mapp.dictionary.draw_modal_save_single}</ul>
+    </li>`
+  }
+  // Add the header
+  const header = mapp.utils.html`<h3>${mapp.dictionary.draw_modal_title}</h3>`;
 
   // Create the modal
   mapp.ui.elements.modal({
     data_id: 'modal_drawing',
-    header: mapp.utils.html.node`<h3>${mapp.dictionary.draw_modal_title}</h3>`,
+    header: header,
     target: document.getElementById('Map'),
     content: content,
     height: 'auto',
@@ -182,7 +207,7 @@ function GenerateModal() {
     top: 30,
     left: 60,
     contained: true,
-    close: () => { }
+    close: true
   });
 
 }
@@ -211,10 +236,19 @@ function point(layer) {
         // Cancel draw interaction.
         btn.classList.remove('active')
         layer.mapview.interactions.highlight()
+        // If the modal was drawn, we can call the function to remove it 
+        if (layer.draw.point.infoModal) {
+          deleteModal();
+        }
         return;
-      }
+      } else {
 
-      btn.classList.add('active')
+        btn.classList.add('active')
+        // Generate the modal 
+        if (layer.draw.point.infoModal) {
+          GenerateModal();
+        }
+      }
 
       !layer.display && layer.show()
 
@@ -225,6 +259,11 @@ function point(layer) {
         btn.classList.remove('active')
 
         delete layer.mapview.interaction
+
+        // If the modal was drawn, we can call the function to remove it 
+        if (layer.draw.point.infoModal) {
+          deleteModal();
+        }
 
         // Set highlight interaction if no other interaction is current after 400ms.
         setTimeout(() => {
@@ -259,10 +298,6 @@ function line(layer) {
       class="flat wide bold primary-colour"
       onclick=${e => {
 
-
-      // Generate the modal 
-      GenerateModal();
-
       const btn = e.target
 
       if (btn.classList.contains('active')) {
@@ -270,10 +305,20 @@ function line(layer) {
         // Cancel draw interaction.
         btn.classList.remove('active')
         layer.mapview.interactions.highlight()
-        return;
-      }
 
-      btn.classList.add('active')
+        // If the modal was drawn, we can call the function to remove it 
+        if (layer.draw.line.infoModal) {
+          deleteModal();
+        }
+
+      } else {
+
+        btn.classList.add('active')
+        // Generate the modal 
+        if (layer.draw.line.infoModal) {
+          GenerateModal();
+        }
+      }
 
       !layer.display && layer.show()
 
@@ -285,6 +330,10 @@ function line(layer) {
 
         delete layer.mapview.interaction
 
+        // If the modal was drawn, we can call the function to remove it 
+        if (layer.draw.line.infoModal) {
+          deleteModal();
+        }
         // Set highlight interaction if no other interaction is current after 400ms.
         setTimeout(() => {
           !layer.mapview.interaction && layer.mapview.interactions.highlight()
@@ -317,9 +366,6 @@ function polygon(layer) {
       class="flat wide bold primary-colour"
       onclick=${e => {
 
-      // Generate the modal 
-      GenerateModal();
-
       const btn = e.target
 
       if (btn.classList.contains('active')) {
@@ -327,13 +373,20 @@ function polygon(layer) {
         // Cancel draw interaction.
         btn.classList.remove('active')
         layer.mapview.interactions.highlight()
-        // Remove the modal
-        document.querySelector("#Map > div.modal ").remove();
-        return;
+
+        // If the modal was drawn, we can call the function to remove it 
+        if (layer.draw.polygon.infoModal) {
+          deleteModal();
+        }
+
+      } else {
+
+        btn.classList.add('active')
+        // Generate the modal 
+        if (layer.draw.polygon.infoModal) {
+          GenerateModal('polygon');
+        }
       }
-
-      btn.classList.add('active')
-
       !layer.display && layer.show()
 
       layer.draw.polygon.callback = feature => {
@@ -342,10 +395,12 @@ function polygon(layer) {
 
         btn.classList.remove('active')
 
-        delete layer.mapview.interaction
+        delete layer.mapview.interaction;
 
-        // Remove the modal
-        document.querySelector("#Map > div.modal ").remove();
+        // If the modal was drawn, we can call the function to remove it 
+        if (layer.draw.polygon.infoModal) {
+          deleteModal();
+        }
 
         // Set highlight interaction if no other interaction is current after 400ms.
         setTimeout(() => {
@@ -381,9 +436,6 @@ function rectangle(layer) {
       onclick=${e => {
 
 
-      // Generate the modal 
-      GenerateModal();
-
       const btn = e.target
 
       if (btn.classList.contains('active')) {
@@ -391,12 +443,20 @@ function rectangle(layer) {
         // Cancel draw interaction.
         btn.classList.remove('active')
         layer.mapview.interactions.highlight()
-        // Remove the modal
-        document.querySelector("#Map > div.modal ").remove();
-        return;
-      }
 
-      btn.classList.add('active')
+        // If the modal was drawn, we can call the function to remove it 
+        if (layer.draw.rectangle.infoModal) {
+          deleteModal();
+        }
+
+      } else {
+
+        btn.classList.add('active')
+        // Generate the modal 
+        if (layer.draw.rectangle.infoModal) {
+          GenerateModal();
+        }
+      }
 
       !layer.display && layer.show()
 
@@ -406,10 +466,12 @@ function rectangle(layer) {
 
         btn.classList.remove('active')
 
-        delete layer.mapview.interaction
+        // If the modal was drawn, we can call the function to remove it 
+        if (layer.draw.rectangle.infoModal) {
+          deleteModal();
 
-        // Remove the modal
-        document.querySelector("#Map > div.modal ").remove();
+        }
+        delete layer.mapview.interaction
 
         // Set highlight interaction if no other interaction is current after 400ms.
         setTimeout(() => {
@@ -445,10 +507,6 @@ function circle_2pt(layer) {
 
   function drawCircle_2pt(e) {
 
-
-    // Generate the modal 
-    GenerateModal();
-
     const btn = e.target
 
     if (btn.classList.contains('active')) {
@@ -456,12 +514,20 @@ function circle_2pt(layer) {
       // Cancel draw interaction.
       btn.classList.remove('active')
       layer.mapview.interactions.highlight()
-      // Remove the modal
-      document.querySelector("#Map > div.modal ").remove();
-      return;
-    }
 
-    btn.classList.add('active')
+      // If the modal was drawn, we can call the function to remove it 
+      if (layer.draw.circle_2pt.infoModal) {
+        deleteModal();
+      }
+
+    } else {
+
+      btn.classList.add('active')
+      // Generate the modal 
+      if (layer.draw.circle_2pt.infoModal) {
+        GenerateModal();
+      }
+    }
 
     !layer.display && layer.show()
 
@@ -471,9 +537,12 @@ function circle_2pt(layer) {
 
       btn.classList.remove('active')
 
+      // If the modal was drawn, we can call the function to remove it 
+      if (layer.draw.circle_2pt.infoModal) {
+        deleteModal();
+      }
+
       delete layer.mapview.interaction
-      // Remove the modal
-      document.querySelector("#Map > div.modal ").remove();
 
       // Set highlight interaction if no other interaction is current after 400ms.
       setTimeout(() => {
@@ -576,10 +645,6 @@ function circle(layer) {
 
   function drawCircle(e) {
 
-
-    // Generate the modal 
-    GenerateModal();
-
     const btn = e.target
 
     if (btn.classList.contains('active')) {
@@ -587,15 +652,23 @@ function circle(layer) {
       // Cancel draw interaction.
       btn.classList.remove('active')
       layer.mapview.interactions.highlight()
-      // Remove the modal
-      document.querySelector("#Map > div.modal ").remove();
-      return;
+
+      // If the modal was drawn, we can call the function to remove it 
+      if (layer.draw.circle.infoModal) {
+        deleteModal();
+      }
+
+    } else {
+
+      btn.classList.add('active')
+      // Generate the modal 
+      if (layer.draw.circle.infoModal) {
+        GenerateModal();
+      }
     }
 
     // Expand the config drawer.
     btn.previousElementSibling.classList.add('expanded')
-
-    btn.classList.add('active')
 
     !layer.display && layer.show()
 
@@ -605,9 +678,13 @@ function circle(layer) {
 
       btn.classList.remove('active')
 
+      // If the modal was drawn, we can call the function to remove it 
+      if (layer.draw.circle.infoModal) {
+        deleteModal();
+      }
+
       delete layer.mapview.interaction
-      // Remove the modal
-      document.querySelector("#Map > div.modal ").remove();
+
 
       // Set highlight interaction if no other interaction is current after 400ms.
       setTimeout(() => {

--- a/lib/ui/elements/drawing.mjs
+++ b/lib/ui/elements/drawing.mjs
@@ -193,6 +193,8 @@ function drawOnclick(e, layer, interaction) {
   // Add the header
   interaction.helpModal.header = mapp.utils.html`<h3>${mapp.dictionary.draw_modal_title}</h3>`;
 
+  interaction.helpModal.data_id = 'modal_drawing';
+
   mapp.ui.elements.helpModal(interaction.helpModal);
 
   btn.classList.add('active')

--- a/lib/ui/elements/drawing.mjs
+++ b/lib/ui/elements/drawing.mjs
@@ -160,36 +160,14 @@ mapp.utils.merge(mapp.dictionaries, {
   }
 })
 
-function deleteModal() {
+function helpModal(content) {
+
+  // If a modal is already present, remove it
   const modal = document.querySelector('[data-id=modal_drawing]')
   
   modal && modal.remove()
-}
 
-function helpModal(type) {
-
-  // If a modal is already present, remove it
-  deleteModal();
-
-  // Define the content
-  let content;
-
-  // If type is polygon, generate the verbose content
-  if (type === 'polygon') {
-
-    content = mapp.utils.html.node`<li>
-      <ul>${mapp.dictionary.draw_modal_begin_drawing}</ul>
-      <ul>${mapp.dictionary.draw_modal_cancel_drawing}
-      <ul>${mapp.dictionary.draw_modal_remove_vertex}</ul>
-      <ul>${mapp.dictionary.draw_modal_save}</ul>`
-
-  } else {
-
-    // Generate the default content
-    content = mapp.utils.html.node`<li>
-      <ul>${mapp.dictionary.draw_modal_begin_drawing}</ul>
-      <ul>${mapp.dictionary.draw_modal_save_single}</ul>`
-  }
+  if (!content) return;
 
   // Add the header
   const header = mapp.utils.html`<h3>${mapp.dictionary.draw_modal_title}</h3>`;
@@ -208,7 +186,41 @@ function helpModal(type) {
     contained: true,
     close: true
   });
+}
 
+function drawOnclick(e, layer, interaction) {
+
+  const btn = e.target
+
+  if (!btn.classList.toggle('active')) {
+
+    layer.mapview.interaction.finish()
+    return;
+  }
+
+  !layer.display && layer.show()
+
+  interaction.callback = feature => {
+
+    layer.draw.callback(feature, interaction)
+
+    btn.classList.remove('active')
+
+    delete layer.mapview.interaction
+
+    helpModal();
+
+    // Set highlight interaction if no other interaction is current after 400ms.
+    setTimeout(() => {
+      !layer.mapview.interaction && layer.mapview.interactions.highlight()
+    }, 400)
+  }
+
+  layer.mapview.interactions.draw(interaction)
+
+  helpModal(interaction.helpModal);
+
+  btn.classList.add('active')
 }
 
 function point(layer) {
@@ -219,48 +231,21 @@ function point(layer) {
     type: 'Point',
   }, typeof layer.draw.point === 'object' && layer.draw.point || {})
 
+
+  layer.draw.point.helpModal ??= mapp.utils.html.node`<li>
+    <ul>${mapp.dictionary.draw_modal_begin_drawing}</ul>
+    <ul>${mapp.dictionary.draw_modal_save_single}</ul>`
+
   // If a label is provided, use it, otherwise use the default
   let label = layer.draw.point?.label || mapp.dictionary.draw_point
+
 
   // Create the button
   layer.draw.point.btn = mapp.utils.html.node`
     <button
       class="flat wide bold primary-colour"
-      onclick=${e => {
-
-        const btn = e.target
-
-        if (!btn.classList.toggle('active')) {
-
-          layer.mapview.interaction.finish()
-          return;
-        }
-
-        !layer.display && layer.show()
-
-        layer.draw.point.callback = feature => {
-
-          layer.draw.callback(feature, layer.draw.point)
-
-          btn.classList.remove('active')
-
-          delete layer.mapview.interaction
-
-          deleteModal();
-
-          // Set highlight interaction if no other interaction is current after 400ms.
-          setTimeout(() => {
-            !layer.mapview.interaction && layer.mapview.interactions.highlight()
-          }, 400)
-        }
-
-        layer.mapview.interactions.draw(layer.draw.point)
-
-        helpModal();
-
-        btn.classList.add('active')
-
-      }}>${label}`
+      onclick=${e => drawOnclick(e, layer, layer.draw.point)}>
+      ${label}`
 
   return layer.draw.point.btn
 }
@@ -273,6 +258,11 @@ function line(layer) {
     type: 'LineString',
   }, typeof layer.draw.line === 'object' && layer.draw.line || {})
 
+  layer.draw.line.helpModal ??= mapp.utils.html.node`<li>
+  <ul>${mapp.dictionary.draw_modal_begin_drawing}</ul>
+  <ul>${mapp.dictionary.draw_modal_remove_vertex}</ul>
+  <ul>${mapp.dictionary.draw_modal_save_single}</ul>`
+
   // If a label is provided, use it, otherwise use the default
   let label = layer.draw.line?.label || mapp.dictionary.draw_line
 
@@ -280,43 +270,8 @@ function line(layer) {
   layer.draw.line.btn = mapp.utils.html.node`
     <button
       class="flat wide bold primary-colour"
-      onclick=${e => {
-
-        const btn = e.target
-
-        if (!btn.classList.toggle('active')) {
-
-          layer.mapview.interaction.finish()
-          return;
-        }
-
-        helpModal();
-
-        !layer.display && layer.show()
-
-        layer.draw.line.callback = feature => {
-
-          layer.draw.callback(feature, layer.draw.polygon)
-
-          btn.classList.remove('active')
-
-          delete layer.mapview.interaction
-
-          deleteModal();
-
-          // Set highlight interaction if no other interaction is current after 400ms.
-          setTimeout(() => {
-            !layer.mapview.interaction && layer.mapview.interactions.highlight()
-          }, 400)
-        }
-
-        layer.mapview.interactions.draw(layer.draw.line)
-
-        helpModal();
-
-        btn.classList.add('active')
-
-      }}>${label}`
+      onclick=${e => drawOnclick(e, layer, layer.draw.line)}>
+      ${label}`
 
   return layer.draw.line.btn
 }
@@ -332,47 +287,18 @@ function polygon(layer) {
   // If a label is provided, use it, otherwise use the default
   let label = layer.draw.polygon?.label || mapp.dictionary.draw_polygon
 
+  layer.draw.polygon.helpModal ??= mapp.utils.html.node`<li>
+    <ul>${mapp.dictionary.draw_modal_begin_drawing}</ul>
+    <ul>${mapp.dictionary.draw_modal_cancel_drawing}
+    <ul>${mapp.dictionary.draw_modal_remove_vertex}</ul>
+    <ul>${mapp.dictionary.draw_modal_save}</ul>`
+
   // Create the button
   layer.draw.polygon.btn = mapp.utils.html.node`
     <button
       class="flat wide bold primary-colour"
-      onclick=${e => {
-
-        const btn = e.target
-
-        if (!btn.classList.toggle('active')) {
-
-          layer.mapview.interaction.finish()
-          return;
-        }
-
-        helpModal();
-
-        !layer.display && layer.show()
-
-        layer.draw.polygon.callback = feature => {
-
-          layer.draw.callback(feature, layer.draw.polygon)
-
-          btn.classList.remove('active')
-
-          delete layer.mapview.interaction;
-
-          deleteModal();
-
-          // Set highlight interaction if no other interaction is current after 400ms.
-          setTimeout(() => {
-            !layer.mapview.interaction && layer.mapview.interactions.highlight()
-          }, 400)
-        }
-
-        layer.mapview.interactions.draw(layer.draw.polygon)
-
-        helpModal();
-
-        btn.classList.add('active')
-
-      }}>${label}`
+      onclick=${e => drawOnclick(e, layer, layer.draw.polygon)}>
+      ${label}`
 
   return layer.draw.polygon.btn
 }
@@ -386,50 +312,19 @@ function rectangle(layer) {
     geometryFunction: ol.interaction.Draw.createBox(),
   }, typeof layer.draw.rectangle === 'object' && layer.draw.rectangle || {})
 
+  layer.draw.rectangle.helpModal ??= mapp.utils.html.node`<li>
+    <ul>${mapp.dictionary.draw_modal_begin_drawing}</ul>
+    <ul>${mapp.dictionary.draw_modal_save_single}</ul>`
+
   // If a label is provided, use it, otherwise use the default
   let label = layer.draw.rectangle?.label || mapp.dictionary.draw_rectangle
 
   // Create the button
   layer.draw.rectangle.btn = mapp.utils.html.node`
-    <button
-      class="flat wide bold primary-colour"
-      onclick=${e => {
-
-        const btn = e.target
-
-        if (!btn.classList.toggle('active')) {
-
-          layer.mapview.interaction.finish()
-          return;
-        }
-
-        helpModal();
-
-        !layer.display && layer.show()
-
-        layer.draw.rectangle.callback = feature => {
-
-          layer.draw.callback(feature, layer.draw.rectangle)
-
-          btn.classList.remove('active')
-
-          deleteModal();
-
-          delete layer.mapview.interaction
-
-          // Set highlight interaction if no other interaction is current after 400ms.
-          setTimeout(() => {
-            !layer.mapview.interaction && layer.mapview.interactions.highlight()
-          }, 400)
-        }
-
-        layer.mapview.interactions.draw(layer.draw.rectangle)
-
-        helpModal();
-
-        btn.classList.add('active')
-
-      }}>${label}`
+  <button
+    class="flat wide bold primary-colour"
+    onclick=${e => drawOnclick(e, layer, layer.draw.rectangle)}>
+    ${label}`
 
   return layer.draw.rectangle.btn
 }
@@ -445,48 +340,16 @@ function circle_2pt(layer) {
     ...layer.draw.circle_2pt
   }
 
+  layer.draw.circle_2pt.helpModal ??= mapp.utils.html.node`<li>
+    <ul>${mapp.dictionary.draw_modal_begin_drawing}</ul>
+    <ul>${mapp.dictionary.draw_modal_save_single}</ul>`
+
   // Create the button
   layer.draw.circle_2pt.btn = mapp.utils.html.node`
-    <button
-      class="flat wide bold primary-colour"
-      onclick=${drawCircle_2pt}>${layer.draw.circle_2pt.label}`
-
-  function drawCircle_2pt(e) {
-
-    const btn = e.target
-
-    if (!btn.classList.toggle('active')) {
-
-      layer.mapview.interaction.finish()
-      return;
-    }
-
-    helpModal();
-
-    !layer.display && layer.show()
-
-    layer.draw.circle_2pt.callback = feature => {
-
-      layer.draw.callback(feature, layer.draw.circle_2pt)
-
-      btn.classList.remove('active')
-
-      deleteModal();
-
-      delete layer.mapview.interaction
-
-      // Set highlight interaction if no other interaction is current after 400ms.
-      setTimeout(() => {
-        !layer.mapview.interaction && layer.mapview.interactions.highlight()
-      }, 400)
-    }
-
-    layer.mapview.interactions.draw(layer.draw.circle_2pt)
-
-    helpModal();
-
-    btn.classList.add('active')
-  }
+  <button
+    class="flat wide bold primary-colour"
+    onclick=${e => drawOnclick(e, layer, layer.draw.circle_2pt)}>
+    ${layer.draw.circle_2pt.label}`
 
   return layer.draw.circle_2pt.btn
 }
@@ -523,6 +386,10 @@ function circle(layer) {
     label: mapp.dictionary.draw_circle,
     ...layer.draw.circle
   }
+
+  layer.draw.circle.helpModal ??= mapp.utils.html.node`<li>
+    <ul>${mapp.dictionary.draw_modal_begin_drawing}</ul>
+    <ul>${mapp.dictionary.draw_modal_save_single}</ul>`
 
   const unitsDropDown = mapp.utils.html.node`
     <div style="display: grid; grid-template-columns: 100px 1fr; align-items: center;">
@@ -575,47 +442,8 @@ function circle(layer) {
   layer.draw.circle.btn = mapp.utils.html.node`
   <button
     class="flat wide bold primary-colour"
-    onclick=${drawCircle}>${layer.draw.circle.label}`
-
-  function drawCircle(e) {
-
-    const btn = e.target
-
-    if (!btn.classList.toggle('active')) {
-
-      layer.mapview.interaction.finish()
-      return;
-    }
-
-    helpModal();
-
-    !layer.display && layer.show()
-
-    // Expand the config drawer.
-    btn.previousElementSibling.classList.add('expanded')
-
-    layer.draw.circle.callback = feature => {
-
-      layer.draw.callback(feature, layer.draw.circle)
-
-      btn.classList.remove('active')
-
-      deleteModal();
-
-      delete layer.mapview.interaction
-
-      // Set highlight interaction if no other interaction is current after 400ms.
-      setTimeout(() => {
-        !layer.mapview.interaction && layer.mapview.interactions.highlight()
-      }, 400)
-    }
-
-    layer.mapview.interactions.draw(layer.draw.circle)
-
-    helpModal();
-
-    btn.classList.add('active')
-  }
+    onclick=${e => drawOnclick(e, layer, layer.draw.circle)}>
+    ${layer.draw.circle.label}`
 
   // The config elements are not shown.
   if (layer.draw.circle.hidePanel) return layer.draw.circle.btn

--- a/lib/ui/elements/drawing.mjs
+++ b/lib/ui/elements/drawing.mjs
@@ -166,7 +166,7 @@ function deleteModal() {
   modal && modal.remove()
 }
 
-function GenerateModal(type) {
+function helpModal(type) {
 
   // If a modal is already present, remove it
   deleteModal();
@@ -176,21 +176,19 @@ function GenerateModal(type) {
 
   // If type is polygon, generate the verbose content
   if (type === 'polygon') {
-    content = mapp.utils.html.node`
-    <li>
-    <ul>${mapp.dictionary.draw_modal_begin_drawing}</ul>
-    <ul>${mapp.dictionary.draw_modal_cancel_drawing}
-    <ul>${mapp.dictionary.draw_modal_remove_vertex}</ul>
-    <ul>${mapp.dictionary.draw_modal_save}</ul>
-    </li>`
+
+    content = mapp.utils.html.node`<li>
+      <ul>${mapp.dictionary.draw_modal_begin_drawing}</ul>
+      <ul>${mapp.dictionary.draw_modal_cancel_drawing}
+      <ul>${mapp.dictionary.draw_modal_remove_vertex}</ul>
+      <ul>${mapp.dictionary.draw_modal_save}</ul>`
+
   } else {
 
     // Generate the default content
-    content = mapp.utils.html.node`
-    <li>
-    <ul>${mapp.dictionary.draw_modal_begin_drawing}</ul>
-    <ul>${mapp.dictionary.draw_modal_save_single}</ul>
-    </li>`
+    content = mapp.utils.html.node`<li>
+      <ul>${mapp.dictionary.draw_modal_begin_drawing}</ul>
+      <ul>${mapp.dictionary.draw_modal_save_single}</ul>`
   }
 
   // Add the header
@@ -234,13 +232,8 @@ function point(layer) {
 
         if (!btn.classList.toggle('active')) {
 
-          deleteModal();
+          layer.mapview.interaction.finish()
           return;
-        }
-
-        // Generate the modal 
-        if (layer.draw.point.infoModal) {
-          GenerateModal();
         }
 
         !layer.display && layer.show()
@@ -259,10 +252,13 @@ function point(layer) {
           setTimeout(() => {
             !layer.mapview.interaction && layer.mapview.interactions.highlight()
           }, 400)
-
         }
 
         layer.mapview.interactions.draw(layer.draw.point)
+
+        helpModal();
+
+        btn.classList.add('active')
 
       }}>${label}`
 
@@ -294,8 +290,7 @@ function line(layer) {
           return;
         }
 
-        // Generate the modal 
-        GenerateModal();
+        helpModal();
 
         !layer.display && layer.show()
 
@@ -313,10 +308,11 @@ function line(layer) {
           setTimeout(() => {
             !layer.mapview.interaction && layer.mapview.interactions.highlight()
           }, 400)
-
         }
 
         layer.mapview.interactions.draw(layer.draw.line)
+
+        helpModal();
 
         btn.classList.add('active')
 
@@ -342,47 +338,41 @@ function polygon(layer) {
       class="flat wide bold primary-colour"
       onclick=${e => {
 
-      const btn = e.target
+        const btn = e.target
 
-      if (btn.classList.contains('active')) {
+        if (!btn.classList.toggle('active')) {
 
-        // Cancel draw interaction.
-        btn.classList.remove('active')
-        layer.mapview.interactions.highlight()
+          layer.mapview.interaction.finish()
+          return;
+        }
 
-        deleteModal();
+        helpModal();
 
-      } else {
+        !layer.display && layer.show()
+
+        layer.draw.polygon.callback = feature => {
+
+          layer.draw.callback(feature, layer.draw.polygon)
+
+          btn.classList.remove('active')
+
+          delete layer.mapview.interaction;
+
+          deleteModal();
+
+          // Set highlight interaction if no other interaction is current after 400ms.
+          setTimeout(() => {
+            !layer.mapview.interaction && layer.mapview.interactions.highlight()
+          }, 400)
+        }
+
+        layer.mapview.interactions.draw(layer.draw.polygon)
+
+        helpModal();
 
         btn.classList.add('active')
-        // Generate the modal 
-        if (layer.draw.polygon.infoModal) {
-          GenerateModal('polygon');
-        }
-      }
-      !layer.display && layer.show()
 
-      layer.draw.polygon.callback = feature => {
-
-        layer.draw.callback(feature, layer.draw.polygon)
-
-        btn.classList.remove('active')
-
-        delete layer.mapview.interaction;
-
-        deleteModal();
-
-        // Set highlight interaction if no other interaction is current after 400ms.
-        setTimeout(() => {
-          !layer.mapview.interaction && layer.mapview.interactions.highlight()
-        }, 400)
-
-      }
-
-      layer.mapview.interactions.draw(layer.draw.polygon)
-
-    }}>
-      ${label}`
+      }}>${label}`
 
   return layer.draw.polygon.btn
 }
@@ -405,49 +395,41 @@ function rectangle(layer) {
       class="flat wide bold primary-colour"
       onclick=${e => {
 
+        const btn = e.target
 
-      const btn = e.target
+        if (!btn.classList.toggle('active')) {
 
-      if (btn.classList.contains('active')) {
+          layer.mapview.interaction.finish()
+          return;
+        }
 
-        // Cancel draw interaction.
-        btn.classList.remove('active')
-        layer.mapview.interactions.highlight()
+        helpModal();
 
-        deleteModal();
+        !layer.display && layer.show()
 
-      } else {
+        layer.draw.rectangle.callback = feature => {
+
+          layer.draw.callback(feature, layer.draw.rectangle)
+
+          btn.classList.remove('active')
+
+          deleteModal();
+
+          delete layer.mapview.interaction
+
+          // Set highlight interaction if no other interaction is current after 400ms.
+          setTimeout(() => {
+            !layer.mapview.interaction && layer.mapview.interactions.highlight()
+          }, 400)
+        }
+
+        layer.mapview.interactions.draw(layer.draw.rectangle)
+
+        helpModal();
 
         btn.classList.add('active')
-        // Generate the modal 
-        if (layer.draw.rectangle.infoModal) {
-          GenerateModal();
-        }
-      }
 
-      !layer.display && layer.show()
-
-      layer.draw.rectangle.callback = feature => {
-
-        layer.draw.callback(feature, layer.draw.rectangle)
-
-        btn.classList.remove('active')
-
-        deleteModal();
-
-        delete layer.mapview.interaction
-
-        // Set highlight interaction if no other interaction is current after 400ms.
-        setTimeout(() => {
-          !layer.mapview.interaction && layer.mapview.interactions.highlight()
-        }, 400)
-
-      }
-
-      layer.mapview.interactions.draw(layer.draw.rectangle)
-
-    }}>
-      ${label}`
+      }}>${label}`
 
   return layer.draw.rectangle.btn
 }
@@ -473,22 +455,13 @@ function circle_2pt(layer) {
 
     const btn = e.target
 
-    if (btn.classList.contains('active')) {
+    if (!btn.classList.toggle('active')) {
 
-      // Cancel draw interaction.
-      btn.classList.remove('active')
-      layer.mapview.interactions.highlight()
-
-      deleteModal();
-
-    } else {
-
-      btn.classList.add('active')
-      // Generate the modal 
-      if (layer.draw.circle_2pt.infoModal) {
-        GenerateModal();
-      }
+      layer.mapview.interaction.finish()
+      return;
     }
+
+    helpModal();
 
     !layer.display && layer.show()
 
@@ -506,10 +479,13 @@ function circle_2pt(layer) {
       setTimeout(() => {
         !layer.mapview.interaction && layer.mapview.interactions.highlight()
       }, 400)
-
     }
 
     layer.mapview.interactions.draw(layer.draw.circle_2pt)
+
+    helpModal();
+
+    btn.classList.add('active')
   }
 
   return layer.draw.circle_2pt.btn
@@ -605,27 +581,18 @@ function circle(layer) {
 
     const btn = e.target
 
-    if (btn.classList.contains('active')) {
+    if (!btn.classList.toggle('active')) {
 
-      // Cancel draw interaction.
-      btn.classList.remove('active')
-      layer.mapview.interactions.highlight()
-
-      deleteModal();
-
-    } else {
-
-      btn.classList.add('active')
-      // Generate the modal 
-      if (layer.draw.circle.infoModal) {
-        GenerateModal();
-      }
+      layer.mapview.interaction.finish()
+      return;
     }
+
+    helpModal();
+
+    !layer.display && layer.show()
 
     // Expand the config drawer.
     btn.previousElementSibling.classList.add('expanded')
-
-    !layer.display && layer.show()
 
     layer.draw.circle.callback = feature => {
 
@@ -637,7 +604,6 @@ function circle(layer) {
 
       delete layer.mapview.interaction
 
-
       // Set highlight interaction if no other interaction is current after 400ms.
       setTimeout(() => {
         !layer.mapview.interaction && layer.mapview.interactions.highlight()
@@ -645,6 +611,10 @@ function circle(layer) {
     }
 
     layer.mapview.interactions.draw(layer.draw.circle)
+
+    helpModal();
+
+    btn.classList.add('active')
   }
 
   // The config elements are not shown.
@@ -654,11 +624,10 @@ function circle(layer) {
   return mapp.utils.html.node`<div>
     ${mapp.ui.elements.drawer({
     header: mapp.utils.html`
-        <h3>${mapp.dictionary.circle_config}</h3>
-        <div class="mask-icon expander"></div>`,
+      <h3>${mapp.dictionary.circle_config}</h3>
+      <div class="mask-icon expander"></div>`,
     content: layer.draw.circle.panel
-  })}
-    ${layer.draw.circle.btn}`
+  })}${layer.draw.circle.btn}`
 }
 
 function locator(layer) {

--- a/lib/ui/elements/drawing.mjs
+++ b/lib/ui/elements/drawing.mjs
@@ -160,34 +160,6 @@ mapp.utils.merge(mapp.dictionaries, {
   }
 })
 
-function helpModal(content) {
-
-  // If a modal is already present, remove it
-  const modal = document.querySelector('[data-id=modal_drawing]')
-  
-  modal && modal.remove()
-
-  if (!content) return;
-
-  // Add the header
-  const header = mapp.utils.html`<h3>${mapp.dictionary.draw_modal_title}</h3>`;
-
-  // Create the modal
-  mapp.ui.elements.modal({
-    data_id: 'modal_drawing',
-    header: header,
-    target: document.getElementById('Map'),
-    content: content,
-    height: 'auto',
-    width: '200px',
-    css_style: 'padding: 0.5em;',
-    top: 30,
-    left: 60,
-    contained: true,
-    close: true
-  });
-}
-
 function drawOnclick(e, layer, interaction) {
 
   const btn = e.target
@@ -208,7 +180,7 @@ function drawOnclick(e, layer, interaction) {
 
     delete layer.mapview.interaction
 
-    helpModal();
+    mapp.ui.elements.helpModal();
 
     // Set highlight interaction if no other interaction is current after 400ms.
     setTimeout(() => {
@@ -218,7 +190,10 @@ function drawOnclick(e, layer, interaction) {
 
   layer.mapview.interactions.draw(interaction)
 
-  helpModal(interaction.helpModal);
+  // Add the header
+  interaction.helpModal.header = mapp.utils.html`<h3>${mapp.dictionary.draw_modal_title}</h3>`;
+
+  mapp.ui.elements.helpModal(interaction.helpModal);
 
   btn.classList.add('active')
 }
@@ -232,9 +207,11 @@ function point(layer) {
   }, typeof layer.draw.point === 'object' && layer.draw.point || {})
 
 
-  layer.draw.point.helpModal ??= mapp.utils.html.node`<li>
+  layer.draw.point.helpModal ??= {
+    content: mapp.utils.html.node`<li>
     <ul>${mapp.dictionary.draw_modal_begin_drawing}</ul>
     <ul>${mapp.dictionary.draw_modal_save_single}</ul>`
+  }
 
   // If a label is provided, use it, otherwise use the default
   let label = layer.draw.point?.label || mapp.dictionary.draw_point
@@ -258,10 +235,12 @@ function line(layer) {
     type: 'LineString',
   }, typeof layer.draw.line === 'object' && layer.draw.line || {})
 
-  layer.draw.line.helpModal ??= mapp.utils.html.node`<li>
-  <ul>${mapp.dictionary.draw_modal_begin_drawing}</ul>
-  <ul>${mapp.dictionary.draw_modal_remove_vertex}</ul>
-  <ul>${mapp.dictionary.draw_modal_save_single}</ul>`
+  layer.draw.line.helpModal ??= {
+    content: mapp.utils.html.node`<li>
+    <ul>${mapp.dictionary.draw_modal_begin_drawing}</ul>
+    <ul>${mapp.dictionary.draw_modal_remove_vertex}</ul>
+    <ul>${mapp.dictionary.draw_modal_save_single}</ul>`
+  }
 
   // If a label is provided, use it, otherwise use the default
   let label = layer.draw.line?.label || mapp.dictionary.draw_line
@@ -287,11 +266,13 @@ function polygon(layer) {
   // If a label is provided, use it, otherwise use the default
   let label = layer.draw.polygon?.label || mapp.dictionary.draw_polygon
 
-  layer.draw.polygon.helpModal ??= mapp.utils.html.node`<li>
+  layer.draw.polygon.helpModal ??= {
+    content: mapp.utils.html.node`<li>
     <ul>${mapp.dictionary.draw_modal_begin_drawing}</ul>
     <ul>${mapp.dictionary.draw_modal_cancel_drawing}
     <ul>${mapp.dictionary.draw_modal_remove_vertex}</ul>
     <ul>${mapp.dictionary.draw_modal_save}</ul>`
+  }
 
   // Create the button
   layer.draw.polygon.btn = mapp.utils.html.node`
@@ -312,9 +293,11 @@ function rectangle(layer) {
     geometryFunction: ol.interaction.Draw.createBox(),
   }, typeof layer.draw.rectangle === 'object' && layer.draw.rectangle || {})
 
-  layer.draw.rectangle.helpModal ??= mapp.utils.html.node`<li>
+  layer.draw.rectangle.helpModal ??= {
+    content: mapp.utils.html.node`<li>
     <ul>${mapp.dictionary.draw_modal_begin_drawing}</ul>
     <ul>${mapp.dictionary.draw_modal_save_single}</ul>`
+  }
 
   // If a label is provided, use it, otherwise use the default
   let label = layer.draw.rectangle?.label || mapp.dictionary.draw_rectangle
@@ -340,9 +323,11 @@ function circle_2pt(layer) {
     ...layer.draw.circle_2pt
   }
 
-  layer.draw.circle_2pt.helpModal ??= mapp.utils.html.node`<li>
+  layer.draw.circle_2pt.helpModal ??= {
+    content: mapp.utils.html.node`<li>
     <ul>${mapp.dictionary.draw_modal_begin_drawing}</ul>
     <ul>${mapp.dictionary.draw_modal_save_single}</ul>`
+  }
 
   // Create the button
   layer.draw.circle_2pt.btn = mapp.utils.html.node`
@@ -387,9 +372,11 @@ function circle(layer) {
     ...layer.draw.circle
   }
 
-  layer.draw.circle.helpModal ??= mapp.utils.html.node`<li>
+  layer.draw.circle.helpModal ??= {
+    content: mapp.utils.html.node`<li>
     <ul>${mapp.dictionary.draw_modal_begin_drawing}</ul>
     <ul>${mapp.dictionary.draw_modal_save_single}</ul>`
+  }
 
   const unitsDropDown = mapp.utils.html.node`
     <div style="display: grid; grid-template-columns: 100px 1fr; align-items: center;">

--- a/lib/ui/elements/helpModal.mjs
+++ b/lib/ui/elements/helpModal.mjs
@@ -1,26 +1,24 @@
+let helpModal
+
 export default (params) => {
 
-  // If a modal is already present, remove it
-  const modal = document.querySelector('[data-id=modal_drawing]')
-
-  modal && modal.remove()
+  // Only one helpModal.node can be shown at any one time.
+  helpModal?.node && helpModal.node.remove()
 
   if (!params) return;
 
-  params.target ??= document.getElementById('Map')
-
-  // Create the modal
-  mapp.ui.elements.modal({
-    data_id: 'modal_drawing',
-    header: params.header,
-    target: params.target,
-    content: params.content,
+  helpModal = {
+    target: document.getElementById('Map'),
     height: 'auto',
     width: '200px',
     css_style: 'padding: 0.5em;',
     top: 30,
     left: 60,
     contained: true,
-    close: true
-  });
+    close: true,
+    ...params
+  }
+
+  // Create the modal
+  mapp.ui.elements.modal(helpModal);
 }

--- a/lib/ui/elements/helpModal.mjs
+++ b/lib/ui/elements/helpModal.mjs
@@ -3,7 +3,7 @@ let helpModal
 export default (params) => {
 
   // Only one helpModal.node can be shown at any one time.
-  helpModal?.node && helpModal.node.remove()
+  helpModal?.node.remove()
 
   if (!params) return;
 
@@ -19,6 +19,6 @@ export default (params) => {
     ...params
   }
 
-  // Create the modal
+  // Create the helpModal.node
   mapp.ui.elements.modal(helpModal);
 }

--- a/lib/ui/elements/helpModal.mjs
+++ b/lib/ui/elements/helpModal.mjs
@@ -1,0 +1,26 @@
+export default (params) => {
+
+  // If a modal is already present, remove it
+  const modal = document.querySelector('[data-id=modal_drawing]')
+
+  modal && modal.remove()
+
+  if (!params) return;
+
+  params.target ??= document.getElementById('Map')
+
+  // Create the modal
+  mapp.ui.elements.modal({
+    data_id: 'modal_drawing',
+    header: params.header,
+    target: params.target,
+    content: params.content,
+    height: 'auto',
+    width: '200px',
+    css_style: 'padding: 0.5em;',
+    top: 30,
+    left: 60,
+    contained: true,
+    close: true
+  });
+}

--- a/lib/ui/elements/modal.mjs
+++ b/lib/ui/elements/modal.mjs
@@ -36,7 +36,11 @@ export default (modal) => {
   // Function to handle the modal closure
   function closeModal(e) {
     e.target.closest('.modal').remove();
-    modal?.close?.(e);
+    // Run the modal close function only if it exists
+    if (modal?.close && typeof modal?.close === 'function') {
+      modal.close(e);
+    }
+    
     resizeObserver.disconnect();
   }
 


### PR DESCRIPTION
This PR addresses a common feature request I have been asked for and links to issue https://github.com/GEOLYTIX/xyz/issues/1212. 
I chose to address 1212 in this way as the user needs to know what options are available when they begin drawing, changing the context menu would only appear at the end of drawing interaction. 

Often users aren't clear exactly how to use the drawing interactions. 
This PR adds a modal element when drawing interactions are started that simply gives guidance on the drawing interaction options available. 
Hopefully this will just aid user experience a bit as it makes it clearer. 

All the text in the modal is using dictionary terms so can be translated. 
The modal is closable and will close when the drawing interaction finishes or the button state is inactive. 

![image](https://github.com/GEOLYTIX/xyz/assets/56163132/69a8adab-2ac3-4827-93a1-e31140af589f)


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1207284671598597