### PR TITLE
infoj_order mode

### DIFF
--- a/lib/ui/locations/infoj.mjs
+++ b/lib/ui/locations/infoj.mjs
@@ -74,63 +74,7 @@ export default (location, infoj_order) => {
       entry.value = entry.default || entry.value
     }
 
-    if (entry.query) {
-
-      // Assign queryparams from layer, and locale.
-      entry.queryparams = Object.assign(
-        entry.queryparams || {},
-        entry.location.layer.queryparams || {},
-        entry.location.layer.mapview.locale.queryparams || {})
-
-      // Check whether query returns data.
-      if (entry.queryCheck || entry.run === true) {
-
-        // Stringify paramString from object.
-        const paramString = mapp.utils.paramString(mapp.utils.queryParams(entry))
-
-        // Delete run 
-        delete entry.run;
-
-        // Add flag to outline it has already been ran
-        entry.hasRan = true;
-
-        // Run the entry query.
-        mapp.utils
-          .xhr(`${entry.host || entry.location?.layer?.mapview?.host || mapp.host}/api/query?${paramString}`)
-          .then(response => {
-
-            if (response) {
-
-              // Assign query response as entry value.
-              entry.value = entry.field ? response[entry.field] : response;
-
-            } else {
-
-              entry.value = entry.nullValue || null;
-            }
-
-            // Check whether entry should be skipped.
-            if (entrySkip(entry)) {
-
-              // Remove the entry.node from location view.
-              entry.node.remove();
-              return;
-            }
-
-            // Create element to be appended into empty entry.node
-            const el = mapp.ui.locations.entries[entry.type]?.(entry)
-
-            el && entry.node.appendChild(el)
-          })
-
-        continue;
-
-      } else if (entry.field && !entry.hasRan) {
-
-        console.warn(`field:"${entry.field}" has a query:"${entry.query}" which is not set to run. To resolve this, add queryCheck:true or run:true to the entry.`)
-      }
-
-    }
+    if (entryQuery(entry)) continue;
 
     if (!Object.hasOwn(mapp.ui.locations.entries, entry.type)) {
       console.warn(`entry.type:${entry.type} method not found.`)
@@ -147,6 +91,65 @@ export default (location, infoj_order) => {
   }
 
   return listview
+}
+
+function entryQuery(entry) {
+
+  if (!entry.query) return;
+
+  // Assign queryparams from layer, and locale.
+  entry.queryparams = Object.assign(
+    entry.queryparams || {},
+    entry.location.layer.queryparams || {},
+    entry.location.layer.mapview.locale.queryparams || {})
+
+  // Check whether query returns data.
+  if (entry.queryCheck || entry.run === true) {
+
+    // Stringify paramString from object.
+    const paramString = mapp.utils.paramString(mapp.utils.queryParams(entry))
+
+    // Delete run 
+    delete entry.run;
+
+    // Add flag to outline it has already been ran
+    entry.hasRan = true;
+
+    // Run the entry query.
+    mapp.utils
+      .xhr(`${entry.host || entry.location?.layer?.mapview?.host || mapp.host}/api/query?${paramString}`)
+      .then(response => {
+
+        if (response) {
+
+          // Assign query response as entry value.
+          entry.value = entry.field ? response[entry.field] : response;
+
+        } else {
+
+          entry.value = entry.nullValue || null;
+        }
+
+        // Check whether entry should be skipped.
+        if (entrySkip(entry)) {
+
+          // Remove the entry.node from location view.
+          entry.node.remove();
+          return;
+        }
+
+        // Create element to be appended into empty entry.node
+        const el = mapp.ui.locations.entries[entry.type]?.(entry)
+
+        el && entry.node.appendChild(el)
+      })
+
+    return true;
+
+  } else if (entry.field && !entry.hasRan) {
+
+    console.warn(`field:"${entry.field}" has a query:"${entry.query}" which is not set to run. To resolve this, add queryCheck:true or run:true to the entry.`)
+  }
 }
 
 function entryObject(entry) {

--- a/lib/ui/locations/infoj.mjs
+++ b/lib/ui/locations/infoj.mjs
@@ -1,3 +1,5 @@
+let groups
+
 export default (location, infoj_order) => {
 
   if (!location.infoj) return
@@ -6,7 +8,7 @@ export default (location, infoj_order) => {
   const listview = mapp.utils.html.node`<div class="location-view-grid">`
 
   // Create object to hold view groups.
-  const groups = {}
+  groups = {}
 
   // The infoj_order may be assigned to the layer.
   infoj_order ??= location.layer.infoj_order
@@ -193,7 +195,9 @@ function entryGroup(entry) {
     // If entry.expanded, then console warn to change this 
     // As the configuration has changed
     if (entry.expanded) {
+
       console.warn('entry.expanded is deprecated. Use entry.groupClassList: "expanded" instead.')
+
       // Add to the string as this can have other classes.
       entry.groupClassList += ' expanded'
     }
@@ -202,8 +206,8 @@ function entryGroup(entry) {
       mapp.ui.elements.drawer({
         class: `group ${entry.groupClassList && 'expanded' || ''}`,
         header: mapp.utils.html`
-            <h3>${entry.group}</h3>
-            <div class="mask-icon expander"></div>`,
+          <h3>${entry.group}</h3>
+          <div class="mask-icon expander"></div>`,
       }))
   }
 

--- a/lib/ui/locations/infoj.mjs
+++ b/lib/ui/locations/infoj.mjs
@@ -52,10 +52,7 @@ export default (location, infoj_order) => {
     // Groups must be checked first since it should be possible to next any type of location view element in a group.
     entryGroup(entry)
 
-    entry.node = entry.listview.appendChild(mapp.utils.html.node`
-      <div
-        data-type=${entry.type}
-        class=${`contents ${entry.type} ${entry.class || ''} ${entry.inline && 'inline' || ''}`}>`)
+    entryNode(entry)
 
     entryTitle(entry)
 
@@ -78,6 +75,16 @@ export default (location, infoj_order) => {
   }
 
   return listview
+}
+
+function entryNode(entry) {
+
+  const classString = `contents ${entry.type} ${entry.class || ''} ${entry.inline && 'inline' || ''}`
+
+  entry.node = entry.listview.appendChild(mapp.utils.html.node`
+  <div
+    data-type=${entry.type}
+    class=${classString}>`)
 }
 
 function entryNullValue(entry){

--- a/lib/ui/locations/infoj.mjs
+++ b/lib/ui/locations/infoj.mjs
@@ -35,9 +35,13 @@ export default (location, infoj_order) => {
     infoj_order.map(_entry => {
 
       if (typeof _entry === 'string') {
+        let infoj_order_field = location.infoj.find(entry => (entry.key || entry.field || entry.query || entry.group) === _entry);
+
+        // if undefined then warn the user.
+        if (!infoj_order_field) console.warn(`infoj_order field: "${_entry}" not found in location.infoj. Please add entry.key, entry.field, entry.query, or entry.group to the entry.`);
 
         // Check whether the _entry string matches an infoj entry keyvalue.
-        return location.infoj.find(entry => (entry.key || entry.field || entry.query || entry.group) === _entry);
+        return infoj_order_field
 
       } else if (typeof _entry === 'object') {
 
@@ -118,7 +122,7 @@ function entryNode(entry) {
  * @param {string} entry.defaults - Default value for the entry.
  * @param {boolean} entry.edit - If the entry is editable.
  */
-function entryNullValue(entry){
+function entryNullValue(entry) {
 
   // Assign a default nullValue
   if (!entry.nullValue) return;

--- a/lib/ui/locations/infoj.mjs
+++ b/lib/ui/locations/infoj.mjs
@@ -45,7 +45,7 @@ export default (location, infoj_order) => {
     entryObject(entry)
 
     // Skip entry depending on flag and value.
-    if (skipEntry(entry)) continue;
+    if (entrySkip(entry)) continue;
 
     // Assign a default nullValue
     if (entry.nullValue
@@ -110,7 +110,7 @@ export default (location, infoj_order) => {
             }
 
             // Check whether entry should be skipped.
-            if (skipEntry(entry)) {
+            if (entrySkip(entry)) {
 
               // Remove the entry.node from location view.
               entry.node.remove();
@@ -209,7 +209,7 @@ function entryGroup(entry) {
   entry.listview = groups[entry.group]
 }
 
-function skipEntry(entry) {
+function entrySkip(entry) {
 
   // Skip entry, no matter what.
   if (entry.skipEntry) return true;

--- a/lib/ui/locations/infoj.mjs
+++ b/lib/ui/locations/infoj.mjs
@@ -1,4 +1,4 @@
-export default (location, infoj) => {
+export default (location, infoj_order) => {
 
   if (!location.infoj) return
 
@@ -8,18 +8,28 @@ export default (location, infoj) => {
   // Create object to hold view groups.
   const groups = {}
 
+  // The infoj_order may be assigned to the layer.
+  infoj_order ??= location.layer.infoj_order
+
   // infoj argument is provided as an array of strings to filter the location infoj entries.
-  if (Array.isArray(infoj)) infoj = infoj.map(entry => {
-    if (typeof entry === 'string') {
+  let infoj = Array.isArray(infoj_order) ?
+    infoj_order.map(_entry => {
 
-      return location.infoj.find(_entry => _entry.field === entry)
-    }
+      if (typeof _entry === 'string') {
 
-    return entry
-  })
+        // Check whether the _entry string matches an infoj entry keyvalue.
+        return location.infoj.find(entry => (entry.key || entry.field || entry.query || entry.group) === _entry);
+
+      } else if (typeof _entry === 'object') {
+
+        // Return object _entry.
+        return _entry
+      }
+    }).filter(entry => entry !== undefined)
+    : location.infoj;
 
   // Iterate through info fields and add to info table.
-  for (const entry of infoj || location.infoj) {
+  for (const entry of infoj) {
 
     // The location view entries should not be processed if the view is disabled.
     if (location.view && location.view.classList.contains('disabled')) break;

--- a/lib/ui/locations/infoj.mjs
+++ b/lib/ui/locations/infoj.mjs
@@ -45,6 +45,8 @@ export default (location, infoj_order) => {
 
       } else if (typeof _entry === 'object') {
 
+        _entry.location = location
+
         // Return object _entry.
         return _entry
       }

--- a/lib/ui/locations/infoj.mjs
+++ b/lib/ui/locations/infoj.mjs
@@ -31,14 +31,14 @@ export default (location, infoj_order) => {
   infoj_order ??= location.layer.infoj_order
 
   // infoj argument is provided as an array of strings to filter the location infoj entries.
-  let infoj = Array.isArray(infoj_order) ?
+  const infoj = Array.isArray(infoj_order) ?
     infoj_order.map(_entry => {
 
       if (typeof _entry === 'string') {
-        let infoj_order_field = location.infoj.find(entry => (entry.key || entry.field || entry.query || entry.group) === _entry);
+        const infoj_order_field = location.infoj.find(entry => (entry.key || entry.field || entry.query) === _entry);
 
         // if undefined then warn the user.
-        if (!infoj_order_field) console.warn(`infoj_order field: "${_entry}" not found in location.infoj. Please add entry.key, entry.field, entry.query, or entry.group to the entry.`);
+        if (!infoj_order_field) console.warn(`infoj_order field: "${_entry}" not found in location.infoj. Please add entry.key, entry.field, or entry.query to the entry.`);
 
         // Check whether the _entry string matches an infoj entry keyvalue.
         return infoj_order_field

--- a/lib/ui/locations/infoj.mjs
+++ b/lib/ui/locations/infoj.mjs
@@ -186,10 +186,11 @@ function entryQuery(entry) {
   if (!entry.query) return;
 
   // Assign queryparams from layer, and locale.
-  entry.queryparams = Object.assign(
-    entry.queryparams || {},
-    entry.location.layer.queryparams || {},
-    entry.location.layer?.mapview?.locale?.queryparams || {})
+  entry.queryparams = {
+    ...entry.queryparams,
+    ...entry.location.layer?.queryparams,
+    ...entry.location.layer?.mapview?.locale?.queryparams
+  }
 
   // Check whether query returns data.
   if (entry.queryCheck || entry.run === true) {

--- a/lib/ui/locations/infoj.mjs
+++ b/lib/ui/locations/infoj.mjs
@@ -1,4 +1,21 @@
+/**
+ * 
+ * ## mapp.ui.locations.infoj()
+ * @module /ui/locations/infoj
+ */
+
 let groups
+
+/**
+ * infoj method that will return a HTMLDivElement with ordered entries.
+ * @function infoj
+ * @param {Object} location - The location object
+ * @param {Object} location.layer - The layer that belongs to the location.
+ * @param {Object} location.layer.infoj - The location infoj Object
+ * @param {Object} location.view - The location's view 
+ * @param {array} infoj_order - Order array for the infoj
+ * @return {HTMLDivElement} listview - Returns the listview of the infoj
+ */
 
 export default (location, infoj_order) => {
 
@@ -77,6 +94,13 @@ export default (location, infoj_order) => {
   return listview
 }
 
+/**
+ * @function entryNode
+ * @param {Object} entry
+ * @param {string} entry.type - type of entry.
+ * @param {string} entry.class - css class for entry.
+ * @param {boolean} entry.inline - Whether or not its inline.
+ */
 function entryNode(entry) {
 
   const classString = `contents ${entry.type} ${entry.class || ''} ${entry.inline && 'inline' || ''}`
@@ -87,6 +111,13 @@ function entryNode(entry) {
     class=${classString}>`)
 }
 
+/**
+ * @function entryNullValue
+ * @param {Object} entry
+ * @param {string} entry.nullValue - null value for the entry.
+ * @param {string} entry.defaults - Default value for the entry.
+ * @param {boolean} entry.edit - If the entry is editable.
+ */
 function entryNullValue(entry){
 
   // Assign a default nullValue
@@ -102,6 +133,12 @@ function entryNullValue(entry){
   entry.value ??= entry.nullValue;
 }
 
+/**
+ * @function entryDefault
+ * @param {Object} entry
+ * @param {string} entry.value - entry value.
+ * @param {string} entry.default - default value. 
+ */
 function entryDefault(entry) {
 
   // Check whether entry has a value
@@ -112,6 +149,11 @@ function entryDefault(entry) {
   }
 }
 
+/**
+ * @function entryTitle
+ * @param {Object} entry
+ * @param {Object} entry.title  
+ */
 function entryTitle(entry) {
 
   if (!entry.title) return;
@@ -120,6 +162,19 @@ function entryTitle(entry) {
   entry.node.append(mapp.ui.locations.entries.title(entry))
 }
 
+/**
+ * @function entryQuery
+ * @param {Object} entry
+ * @param {string} entry.query - Query on entry.
+ * @param {string} entry.queryparams - Params for query
+ * @param {boolean} entry.queryCheck - Query check
+ * @param {boolean} entry.run - If to run the query
+ * @param {boolean} entry.hasRan - Has the query run.
+ * @param {string} entry.value - Value for entry.
+ * @param {string} entry.nullValue - Null value for entry.
+ * @param {string} entry.type - Type of entry.
+ * @param {string} entry.field - Field of entry.   
+ */
 function entryQuery(entry) {
 
   if (!entry.query) return;
@@ -179,6 +234,14 @@ function entryQuery(entry) {
   }
 }
 
+/**
+ * @function entryObject
+ * @param {Object} entry
+ * @param {string} entry.field - entry field
+ * @param {string} entry.objectAssignFromField - Assign object from field. 
+ * @param {string} entry.objectMergeFromField - Merge object from field
+ * @param {string} entry.objectMergeFromEntry - Merge object from entry.
+ */
 function entryObject(entry) {
 
   // Lookup for json value field entry
@@ -209,6 +272,14 @@ function entryObject(entry) {
   }
 }
 
+/**
+ * @function entryGroup
+ * @param {Object} entry
+ * @param {string} entry.group - Group entry belongs to.
+ * @param {boolean} entry.expanded - Whether entry is expanded.
+ * @param {string} entry.groupClassList - the css applied to the group.
+ * @param {HTMLDivElement} entry.listview - The list view for the entry. 
+ */
 function entryGroup(entry) {
 
   if (!entry.group) return;
@@ -239,6 +310,21 @@ function entryGroup(entry) {
   entry.listview = groups[entry.group]
 }
 
+/**
+ * @function entrySkip
+ * @param {Object} entry 
+ * @param {Object} entry.skipEntry - Whether to skip entry.
+ * @param {Object} entry.key - Entry key.
+ * @param {Object} entry.field - Entry field.
+ * @param {Object} entry.query - Entry query.
+ * @param {Object} entry.type - Entry Type
+ * @param {Object} entry.group - Entry Group.
+ * @param {Object} entry.skipFalsyValue - Whether to Skip Falsy Value
+ * @param {Object} entry.skipUndefinedValue - Whether to Skip undefined Value
+ * @param {Object} entry.skipNullValue - Whether to Skip null Value
+ * @param {Object} entry.value - Entry Value
+ * @param {Object} entry.edit - Where it's editable.
+ */
 function entrySkip(entry) {
 
   // Skip entry, no matter what.

--- a/lib/ui/locations/infoj.mjs
+++ b/lib/ui/locations/infoj.mjs
@@ -114,7 +114,7 @@ function entryDefault(entry) {
 
 function entryTitle(entry) {
 
-  if (entry.title) return;
+  if (!entry.title) return;
 
   // Append title element to entry.node
   entry.node.append(mapp.ui.locations.entries.title(entry))

--- a/lib/ui/locations/infoj.mjs
+++ b/lib/ui/locations/infoj.mjs
@@ -34,7 +34,7 @@ export default (location, infoj_order) => {
   for (const entry of infoj) {
 
     // The location view entries should not be processed if the view is disabled.
-    if (location.view && location.view.classList.contains('disabled')) break;
+    if (location.view?.classList.contains('disabled')) break;
 
     // Location view elements will appended to the entry.listview element.
     entry.listview = listview

--- a/lib/ui/locations/infoj.mjs
+++ b/lib/ui/locations/infoj.mjs
@@ -42,32 +42,7 @@ export default (location, infoj_order) => {
     // The default entry type is text.
     entry.type = entry.type || 'text'
 
-    // Lookup for json value field entry
-    if (entry.objectAssignFromField) {
-
-      let fieldEntry = entry.location.infoj.find(_entry => _entry.field === entry.objectAssignFromField)
-
-      fieldEntry && Object.assign(entry, fieldEntry.value)
-    }
-
-    if (entry.objectMergeFromField) {
-
-      let fieldEntry = entry.location.infoj.find(_entry => _entry.field === entry.objectMergeFromField)
-
-      fieldEntry && mapp.utils.merge(entry, fieldEntry.value)
-    }
-
-    // Merge from another entry.
-    if (entry.objectMergeFromEntry) {
-
-      // Find the entry to merge.
-      let fieldEntry = entry.location.infoj.find(_entry => _entry.type === entry.objectMergeFromEntry)
-
-      // Only merge the entry.merge object.
-      fieldEntry
-        && fieldEntry.merge instanceof Object
-        && mapp.utils.merge(entry, fieldEntry.merge)
-    }
+    entryObject(entry)
 
     // Skip entries from infoj_skip array;
     if (Array.isArray(entry.location?.layer?.infoj_skip)) {
@@ -183,6 +158,36 @@ export default (location, infoj_order) => {
   }
 
   return listview
+}
+
+function entryObject(entry) {
+
+  // Lookup for json value field entry
+  if (entry.objectAssignFromField) {
+
+    let fieldEntry = entry.location.infoj.find(_entry => _entry.field === entry.objectAssignFromField)
+
+    fieldEntry && Object.assign(entry, fieldEntry.value)
+  }
+
+  if (entry.objectMergeFromField) {
+
+    let fieldEntry = entry.location.infoj.find(_entry => _entry.field === entry.objectMergeFromField)
+
+    fieldEntry && mapp.utils.merge(entry, fieldEntry.value)
+  }
+
+  // Merge from another entry.
+  if (entry.objectMergeFromEntry) {
+
+    // Find the entry to merge.
+    let fieldEntry = entry.location.infoj.find(_entry => _entry.type === entry.objectMergeFromEntry)
+
+    // Only merge the entry.merge object.
+    fieldEntry
+      && fieldEntry.merge instanceof Object
+      && mapp.utils.merge(entry, fieldEntry.merge)
+  }
 }
 
 function entryGroup(entry) {

--- a/lib/ui/locations/infoj.mjs
+++ b/lib/ui/locations/infoj.mjs
@@ -47,11 +47,7 @@ export default (location, infoj_order) => {
     // Skip entry depending on flag and value.
     if (entrySkip(entry)) continue;
 
-    // Assign a default nullValue
-    if (entry.nullValue
-      && entry.value === null
-      && !entry.defaults
-      && !entry.edit) entry.value = entry.nullValue;
+    entryNullValue(entry)
 
     // Groups must be checked first since it should be possible to next any type of location view element in a group.
     entryGroup(entry)
@@ -82,6 +78,21 @@ export default (location, infoj_order) => {
   }
 
   return listview
+}
+
+function entryNullValue(entry){
+
+  // Assign a default nullValue
+  if (!entry.nullValue) return;
+
+  // A default value should be assigned.
+  if (entry.defaults) return;
+
+  // The entry is editable.
+  if (entry.edit) return;
+
+  //nullish coalesce nullValue
+  entry.value ??= entry.nullValue;
 }
 
 function entryDefault(entry) {

--- a/lib/ui/locations/infoj.mjs
+++ b/lib/ui/locations/infoj.mjs
@@ -44,17 +44,6 @@ export default (location, infoj_order) => {
 
     entryObject(entry)
 
-    // Skip entries from infoj_skip array;
-    if (Array.isArray(entry.location?.layer?.infoj_skip)) {
-
-      // Check whether some val from this array is in infoj_skip set.
-      if ([entry.key, entry.field, entry.query, entry.type, entry.group]
-        .some(val => new Set(entry.location?.layer?.infoj_skip).has(val))) continue;
-    }
-
-    // Skip entry, no matter what.
-    if (entry.skipEntry) continue;
-
     // Skip entry depending on flag and value.
     if (skipEntry(entry)) continue;
 
@@ -221,6 +210,17 @@ function entryGroup(entry) {
 }
 
 function skipEntry(entry) {
+
+  // Skip entry, no matter what.
+  if (entry.skipEntry) return true;
+
+  // Skip entries from infoj_skip array;
+  if (Array.isArray(entry.location?.layer?.infoj_skip)) {
+
+    // Check whether some val from this array is in infoj_skip set.
+    if ([entry.key, entry.field, entry.query, entry.type, entry.group]
+      .some(val => new Set(entry.location?.layer?.infoj_skip).has(val))) return true;
+  }
 
   // Skip entries which are falsy if flagged.
   if (entry.skipFalsyValue

--- a/lib/ui/locations/infoj.mjs
+++ b/lib/ui/locations/infoj.mjs
@@ -88,31 +88,7 @@ export default (location, infoj_order) => {
       && !entry.edit) entry.value = entry.nullValue;
 
     // Groups must be checked first since it should be possible to next any type of location view element in a group.
-    if (entry.group) {
-
-      // Create new group
-      if (!groups[entry.group]) {
-
-        // If entry.expanded, then console warn to change this 
-        // As the configuration has changed
-        if (entry.expanded) {
-          console.warn('entry.expanded is deprecated. Use entry.groupClassList: "expanded" instead.')
-          // Add to the string as this can have other classes.
-          entry.groupClassList += ' expanded'
-        }
-
-        groups[entry.group] = entry.listview.appendChild(
-          mapp.ui.elements.drawer({
-            class: `group ${entry.groupClassList && 'expanded' || ''}`,
-            header: mapp.utils.html`
-              <h3>${entry.group}</h3>
-              <div class="mask-icon expander"></div>`,
-          }))
-      }
-
-      // The group will replace the entry listview to which elements will be appended.
-      entry.listview = groups[entry.group]
-    }
+    entryGroup(entry)
 
     entry.node = entry.listview.appendChild(mapp.utils.html.node`
       <div
@@ -199,6 +175,34 @@ export default (location, infoj_order) => {
   }
 
   return listview
+}
+
+function entryGroup(entry) {
+
+  if (!entry.group) return;
+
+  // Create new group
+  if (!groups[entry.group]) {
+
+    // If entry.expanded, then console warn to change this 
+    // As the configuration has changed
+    if (entry.expanded) {
+      console.warn('entry.expanded is deprecated. Use entry.groupClassList: "expanded" instead.')
+      // Add to the string as this can have other classes.
+      entry.groupClassList += ' expanded'
+    }
+
+    groups[entry.group] = entry.listview.appendChild(
+      mapp.ui.elements.drawer({
+        class: `group ${entry.groupClassList && 'expanded' || ''}`,
+        header: mapp.utils.html`
+            <h3>${entry.group}</h3>
+            <div class="mask-icon expander"></div>`,
+      }))
+  }
+
+  // The group will replace the entry listview to which elements will be appended.
+  entry.listview = groups[entry.group]
 }
 
 function skipEntry(entry) {

--- a/lib/ui/locations/infoj.mjs
+++ b/lib/ui/locations/infoj.mjs
@@ -61,11 +61,7 @@ export default (location, infoj_order) => {
         data-type=${entry.type}
         class=${`contents ${entry.type} ${entry.class || ''} ${entry.inline && 'inline' || ''}`}>`)
 
-    if (entry.title) {
-
-      // Append title element to entry.node
-      entry.node.append(mapp.ui.locations.entries.title(entry))
-    }
+    entryTitle(entry)
 
     // Check whether entry has a value
     if (entry.value === null || typeof entry.value === 'undefined') {
@@ -91,6 +87,14 @@ export default (location, infoj_order) => {
   }
 
   return listview
+}
+
+function entryTitle(entry) {
+
+  if (entry.title) return;
+
+  // Append title element to entry.node
+  entry.node.append(mapp.ui.locations.entries.title(entry))
 }
 
 function entryQuery(entry) {

--- a/lib/ui/locations/infoj.mjs
+++ b/lib/ui/locations/infoj.mjs
@@ -63,12 +63,7 @@ export default (location, infoj_order) => {
 
     entryTitle(entry)
 
-    // Check whether entry has a value
-    if (entry.value === null || typeof entry.value === 'undefined') {
-
-      // Assign the default value if set.
-      entry.value = entry.default || entry.value
-    }
+    entryDefault(entry)
 
     if (entryQuery(entry)) continue;
 
@@ -87,6 +82,16 @@ export default (location, infoj_order) => {
   }
 
   return listview
+}
+
+function entryDefault(entry) {
+
+  // Check whether entry has a value
+  if (entry.value === null || typeof entry.value === 'undefined') {
+
+    // Assign the default value if set.
+    entry.value = entry.default || entry.value
+  }
 }
 
 function entryTitle(entry) {

--- a/lib/ui/locations/infoj.mjs
+++ b/lib/ui/locations/infoj.mjs
@@ -189,7 +189,7 @@ function entryQuery(entry) {
   entry.queryparams = Object.assign(
     entry.queryparams || {},
     entry.location.layer.queryparams || {},
-    entry.location.layer.mapview.locale.queryparams || {})
+    entry.location.layer?.mapview?.locale?.queryparams || {})
 
   // Check whether query returns data.
   if (entry.queryCheck || entry.run === true) {


### PR DESCRIPTION
The infoj method has a second infoj_order argument. This argument can be an array of keys and entry objects.

layer.infoj entries will be filtered in the order of keys. It is checked whether the key matches the entry's key, field, query, or group key value.

The `key` key value is specifically used as an identifier for entries and serves no other purpose.

The infoj_order argument can be a mix of entry objects and keys. Entry object are directly spliced into the infoj array and don't require to be in the layer.infoj array.

The infoj_order can be defined as an array in the layer json. The infoj_order plugin will be retired in favour of this.

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1207275671216623