### PR TITLE
Infoj Order Issue

### DIFF
--- a/lib/ui/locations/infoj.mjs
+++ b/lib/ui/locations/infoj.mjs
@@ -28,7 +28,7 @@ export default (location, infoj_order) => {
   groups = {}
 
   // The infoj_order may be assigned to the layer.
-  infoj_order ??= location.layer.infoj_order
+  infoj_order ??= location?.layer?.infoj_order
 
   // infoj argument is provided as an array of strings to filter the location infoj entries.
   const infoj = Array.isArray(infoj_order) ?


### PR DESCRIPTION
If `layer.infoj_order` is undefined, previously custom views calling `mapp.ui.locations.infoj` would crash with this error. 
![image](https://github.com/GEOLYTIX/xyz/assets/56163132/89548fb2-160d-4b77-8760-a5cbdaa90b4c)

This PR simply adds optional chaining operators to prevent this error. 

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1207324780035008