### PR TITLE
TestView Addition - Themes

### DIFF
--- a/public/tests/layer.test.mjs
+++ b/public/tests/layer.test.mjs
@@ -34,6 +34,16 @@ export async function layerTest(mapview) {
 
                     layer.show();
 
+                    // Turn on every theme on the layer to test if they work
+                    if (layer.style?.themes) {
+                        for (const theme in layer.style.themes) {
+                            console.log(`Testing theme ${theme}`);
+                            layer.style.theme = layer.style.themes[theme];
+                            layer.reload();
+                            await delayFunction(1000);
+                        }
+                    }
+
                     if (!['maplibre', 'tiles'].includes(layer.format) && layer.infoj) {
 
                         const lastLocation = await mapp.utils.xhr(`${mapp.host}/api/query?template=get_last_location&locale=${encodeURIComponent(mapview.locale.key)}&layer=${key}`);


### PR DESCRIPTION
This PR makes a small change to the testview that will turn on every theme on a layer. 
This is required as themes can use templates for the field definition on a theme, so we need to test every theme to check everything is working correctly. 

The delay is required to give time for the request to complete and reload the thematic. 
``` js
  // Turn on every theme on the layer to test if they work
                    if (layer.style?.themes) {
                        for (const theme in layer.style.themes) {
                            console.log(`Testing theme ${theme}`);
                            layer.style.theme = layer.style.themes[theme];
                            layer.reload();
                            await delayFunction(1000);
                        }
                    }

```