### PR TITLE
mvt_clone add layer

### DIFF
--- a/lib/ui/locations/entries/mvt_clone.mjs
+++ b/lib/ui/locations/entries/mvt_clone.mjs
@@ -93,6 +93,14 @@ export default entry => {
       entry.view = entry.panel
     }
     
+    // Add the clone layer to the mapview.Map.
+    try {
+      entry.mapview.Map.addLayer(entry.L)
+
+    } catch {
+      // Will catch assertation error when layer is already added.
+    }
+
     // Add a location.removeCallback to remove the clone from mapview.Map as well as the mvt layer clones.
     entry.location.removeCallbacks.push(() => {
       entry.mapview.Map.removeLayer(entry.L)

--- a/lib/ui/locations/entries/mvt_clone.mjs
+++ b/lib/ui/locations/entries/mvt_clone.mjs
@@ -93,9 +93,6 @@ export default entry => {
       entry.view = entry.panel
     }
     
-    // Add the clone layer to the mapview.Map.
-    entry.mapview.Map.addLayer(entry.L)
-
     // Add a location.removeCallback to remove the clone from mapview.Map as well as the mvt layer clones.
     entry.location.removeCallbacks.push(() => {
       entry.mapview.Map.removeLayer(entry.L)


### PR DESCRIPTION
Adding `entry.L` layer to the mapview.map needs to be try...catched to prevent error on adding the same layer multiple times.