### PR TITLE
mvt_clone - reduce instances where the layer has to be removed or added.

### DIFF
--- a/lib/ui/locations/entries/mvt_clone.mjs
+++ b/lib/ui/locations/entries/mvt_clone.mjs
@@ -43,31 +43,34 @@ export default entry => {
   // Add the clone layer to the mvt layer clones.
   entry.Layer.clones.add(entry.L)
 
+  // Remove zoom level check from mapview changeEnd event.
+  entry.location.removeCallbacks.push(() => {
+
+    entry.mapview.Map.removeLayer(entry.L)
+
+    entry.Layer.clones.delete(entry.L)
+
+    entry.mapview.Map.getTargetElement().removeEventListener('changeEnd', chkZoom)
+  })
+
   if (entry.style.themes) {
 
     // Assign the first theme from themes if undefined.
-    entry.style.theme ||= entry.style.themes[Object.keys(entry.style.themes)[0]]
+    entry.style.theme ??= entry.style.themes[Object.keys(entry.style.themes)[0]]
+  }
+
+  // Create a style panel as entry.style.panel and append to entry.node.
+  entry.style.panel = mapp.ui.layers.panels.style(entry)
+
+  if (entry.style.panel) {
+    entry.style.panel.style.display = 'none'
+    entry.view = entry.panel
   }
 
   // Assign method to show the clone layer.
   entry.show = async () => {
 
     entry.display = true;
-
-    // The OL clone layer already exists.
-    if (entry.L && entry.featureLookup) {
-
-      if (entry.style.panel) entry.style.panel.style.display = 'block'
-
-      try {
-        entry.mapview.Map.addLayer(entry.L)
-
-      } catch {
-        // Will catch assertation error when layer is already added.
-      }
-
-      return;
-    }
 
     // Create query paramString from the entry object.
     const paramString = mapp.utils.paramString(mapp.utils.queryParams(entry))
@@ -85,15 +88,11 @@ export default entry => {
       return;
     }
 
-    // Create a style panel as entry.style.panel and append to entry.node.
-    entry.style.panel = mapp.ui.layers.panels.style(entry)
-    
-    if (entry.style.panel) {
-      entry.panel.append(entry.style.panel)
-      entry.view = entry.panel
+    if (!Array.isArray(entry.featureLookup)) {
+
+      entry.featureLookup = [entry.featureLookup]
     }
-    
-    // Add the clone layer to the mapview.Map.
+
     try {
       entry.mapview.Map.addLayer(entry.L)
 
@@ -101,12 +100,9 @@ export default entry => {
       // Will catch assertation error when layer is already added.
     }
 
-    // Add a location.removeCallback to remove the clone from mapview.Map as well as the mvt layer clones.
-    entry.location.removeCallbacks.push(() => {
-      entry.mapview.Map.removeLayer(entry.L)
-      entry.Layer.clones.delete(entry.L)
-    })
-
+    if (entry.style.panel) {
+      entry.style.panel.style.display = 'block'
+    }
   };
 
   // Assign method to hide the clone layer.
@@ -114,14 +110,16 @@ export default entry => {
 
     entry.display = false
 
-    // Hide the style drawer.
-    if (entry.style.panel) entry.style.panel.style.display = 'none'
-
     // Remove the geometry layer from map.
     entry.mapview.Map.removeLayer(entry.L)
 
     // Remove the clone from the mvt layer clones.
     entry.Layer.clones.delete(entry.L)
+
+    // Hide the style drawer.
+    if (entry.style.panel) {
+      entry.style.panel.style.display = 'none'
+    }
   }
 
   entry.reload = () => entry.L?.changed()
@@ -134,11 +132,13 @@ export default entry => {
     onchange: (checked) => checked ? entry.show() : entry.hide()
   })
 
+  // Create a node consistent of the chkbox and the style drawer.
+  entry.panel = mapp.utils.html.node`<div>
+    ${chkbox}
+    ${entry.style.panel}`
+
   // Show geometry if entry is set to display.
   entry.display && entry.show()
-
-  // Create a node consistent of the chkbox and the style drawer.
-  entry.panel = mapp.utils.html.node`<div>${chkbox}`
 
   // Disable chkbox if layer is out of zoom range
   function chkZoom() {
@@ -159,9 +159,6 @@ export default entry => {
       // Hide style drawer if present.
       if (entry.style.panel) entry.style.panel.style.display = 'none'
 
-      // Remove clone layer if present in set but should not be displayed.
-      !entry.display && entry.mapview.Map.removeLayer(entry.L)
-
       return;
     }
 
@@ -170,29 +167,12 @@ export default entry => {
 
     // Display style drawer if present.
     if (entry.style.panel) entry.style.panel.style.display = 'block'
-
-    // Try to add entry.L to mapview.Map
-    try {
-      entry.display && entry.mapview.Map.addLayer(entry.L)
-    } catch {
-      // Will catch assertation error when layer is already added.
-    }
-
   }
 
   chkZoom()
 
   // Add zoom level check to mapview changeEnd event.
   entry.mapview.Map.getTargetElement().addEventListener('changeEnd', chkZoom)
-
-  // Remove zoom level check from mapview changeEnd event.
-  entry.location.removeCallbacks.push(() => {
-
-    // Remove layer from map when location is removed.
-    entry.mapview.Map.removeLayer(entry.L)
-
-    entry.mapview.Map.getTargetElement().removeEventListener('changeEnd', chkZoom)
-  })
 
   // Return the node to the location view.
   return entry.panel

--- a/lib/ui/locations/entries/mvt_clone.mjs
+++ b/lib/ui/locations/entries/mvt_clone.mjs
@@ -84,7 +84,10 @@ export default entry => {
       // Disable the chkbox input.
       entry.panel.querySelector('input').disabled = true
 
-      // The entry.style.panel will not be created.
+      if (entry.style.panel) {
+        entry.style.panel.style.display = 'none'
+      }
+
       return;
     }
 
@@ -113,16 +116,11 @@ export default entry => {
     // Remove the geometry layer from map.
     entry.mapview.Map.removeLayer(entry.L)
 
-    // Remove the clone from the mvt layer clones.
-    entry.Layer.clones.delete(entry.L)
-
     // Hide the style drawer.
     if (entry.style.panel) {
       entry.style.panel.style.display = 'none'
     }
   }
-
-  entry.reload = () => entry.L?.changed()
 
   // Create checkbox to control geometry display.
   const chkbox = mapp.ui.elements.chkbox({
@@ -157,7 +155,9 @@ export default entry => {
       entry.panel.querySelector('input').disabled = true
 
       // Hide style drawer if present.
-      if (entry.style.panel) entry.style.panel.style.display = 'none'
+      if (entry.style.panel) {
+        entry.style.panel.style.display = 'none'
+      }
 
       return;
     }
@@ -166,7 +166,9 @@ export default entry => {
     entry.panel.querySelector('input').disabled = false
 
     // Display style drawer if present.
-    if (entry.style.panel) entry.style.panel.style.display = 'block'
+    if (entry.style.panel) {
+      entry.style.panel.style.display = 'block'
+    }
   }
 
   chkZoom()

--- a/lib/ui/locations/entries/vector_layer.mjs
+++ b/lib/ui/locations/entries/vector_layer.mjs
@@ -23,7 +23,7 @@ export default entry => {
 
   // Create checkbox to control geometry display.
   const chkbox = mapp.ui.elements.chkbox({
-    label: entry.label || 'MVT Clone',
+    label: entry.label || 'Vector Layer',
     data_id: `${entry.field}-chkbox`,
     checked: !!entry.display,
     onchange: (checked) => checked ? show(entry) : hide(entry)


### PR DESCRIPTION
Only the show() / hide() methods should require the layer L to be added or removed from the mapview.