### PR TITLE
jsonb location update and infoj

### DIFF
--- a/lib/location/decorate.mjs
+++ b/lib/location/decorate.mjs
@@ -57,6 +57,21 @@ Update a location from host
 async function update() {
 
   this.infoj
+  .filter(entry => entry.jsonb_key)
+  .filter(entry => entry.jsonb_field)
+  .filter(entry => typeof entry.newValue !== 'undefined')
+  .forEach(entry => {
+
+    entry.newValue = {
+      'jsonb': {
+        [entry.jsonb_field]: {
+          [entry.jsonb_key]: entry.newValue
+        }
+      }
+    }
+  })
+
+  this.infoj
     .filter(entry => entry.json_field)
     .filter(entry => entry.json_key)
     .filter(entry => typeof entry.newValue !== 'undefined')

--- a/lib/ui/locations/infoj.mjs
+++ b/lib/ui/locations/infoj.mjs
@@ -277,12 +277,15 @@ function entryObject(entry) {
   if (typeof fieldEntry.value !== 'object') return;
 
   // Lookup for json value field entry
-  if(entry.json_field) {
+  if (entry.json_field) {
 
-    if(!entry.json_key){
+    if (!entry.json_key) {
       console.warn('json_field requires entry.json_key to be specified')
       return;
     }
+
+    // The fieldEntry value may be null or undefined.
+    if (!fieldEntry.value) return;
 
     entry.value = fieldEntry.value[entry.json_key]
   }

--- a/lib/ui/locations/infoj.mjs
+++ b/lib/ui/locations/infoj.mjs
@@ -298,14 +298,6 @@ function entryObject(entry) {
   if (entry.objectMergeFromField) {
 
     mapp.utils.merge(entry, fieldEntry.value)
-
-    // // Find the entry to merge.
-    // let fieldEntry = entry.location.infoj.find(_entry => _entry.type === entry.objectMergeFromEntry)
-
-    // // Only merge the entry.merge object.
-    // fieldEntry
-    // && fieldEntry.merge instanceof Object
-    // && mapp.utils.merge(entry, fieldEntry.merge)
   }
 }
 

--- a/lib/ui/locations/infoj.mjs
+++ b/lib/ui/locations/infoj.mjs
@@ -65,6 +65,8 @@ export default (location, infoj_order) => {
     // The default entry type is text.
     entry.type = entry.type || 'text'
 
+    entryJSONB(entry)
+
     entryObject(entry)
 
     // Skip entry depending on flag and value.
@@ -239,6 +241,16 @@ function entryQuery(entry) {
 
     console.warn(`field:"${entry.field}" has a query:"${entry.query}" which is not set to run. To resolve this, add queryCheck:true or run:true to the entry.`)
   }
+}
+
+function entryJSONB(entry) {
+  if (!entry.jsonb_field) return;
+  if (!entry.jsonb_key) return;
+  if (entry.value === null) return;
+  if (typeof entry.value !== 'object') return;
+  if (!entry.value.jsonb) return;
+
+  entry.value = entry.value.jsonb[entry.jsonb_field][entry.jsonb_key]
 }
 
 /**

--- a/mod/workspace/templates/location_update.js
+++ b/mod/workspace/templates/location_update.js
@@ -22,7 +22,8 @@ module.exports = _ => {
 
     // Value is an object and must be stringified.
     if (typeof _.body[key] === 'object' && !Array.isArray(_.body[key])) {
-
+      
+      _[key] = JSON.stringify(_.body[key])
       if (_.body[key]['jsonb']) {
 
         const jsonb = _.body[key]['jsonb']
@@ -30,16 +31,12 @@ module.exports = _ => {
         const jsonb_field = Object.keys(jsonb)[0]
 
         let updateObject = []
-        for(let key of Object.keys(jsonb[jsonb_field])){
+        Object.keys(jsonb[jsonb_field]).forEach( key => {
           let value = typeof jsonb[jsonb_field][key] === 'string' ? `"${jsonb[jsonb_field][key]}"`: jsonb[jsonb_field][key]
           updateObject.push(`"${key}":${value}`)
-        }
+        })
 
         return `${jsonb_field} = coalesce(json_field::jsonb,'{}'::jsonb)::jsonb || '{${updateObject.join(',')}}'::jsonb`
-
-      } else {
-
-        _[key] = JSON.stringify(_.body[key])
       }      
     }
 

--- a/mod/workspace/templates/location_update.js
+++ b/mod/workspace/templates/location_update.js
@@ -23,7 +23,20 @@ module.exports = _ => {
     // Value is an object and must be stringified.
     if (typeof _.body[key] === 'object' && !Array.isArray(_.body[key])) {
 
-      _[key] = JSON.stringify(_.body[key])
+      if (_.body[key]['jsonb']) {
+
+        const jsonb = _.body[key]['jsonb']
+
+        const jsonb_field = Object.keys(jsonb)[0]
+
+        const jsonb_entry = Object.entries(jsonb[jsonb_field])[0]
+
+        return `${jsonb_field} = coalesce(json_field::jsonb,'{}'::jsonb)::jsonb || '{"${jsonb_entry[0]}":${jsonb_entry[1]}}'::jsonb`
+
+      } else {
+
+        _[key] = JSON.stringify(_.body[key])
+      }      
     }
 
     // Value is an array (of strings)

--- a/mod/workspace/templates/location_update.js
+++ b/mod/workspace/templates/location_update.js
@@ -29,9 +29,13 @@ module.exports = _ => {
 
         const jsonb_field = Object.keys(jsonb)[0]
 
-        const jsonb_entry = Object.entries(jsonb[jsonb_field])[0]
+        let updateObject = []
+        for(let key of Object.keys(jsonb[jsonb_field])){
+          let value = typeof jsonb[jsonb_field][key] === 'string' ? `"${jsonb[jsonb_field][key]}"`: jsonb[jsonb_field][key]
+          updateObject.push(`"${key}":${value}`)
+        }
 
-        return `${jsonb_field} = coalesce(json_field::jsonb,'{}'::jsonb)::jsonb || '{"${jsonb_entry[0]}":${jsonb_entry[1]}}'::jsonb`
+        return `${jsonb_field} = coalesce(json_field::jsonb,'{}'::jsonb)::jsonb || '{${updateObject.join(',')}}'::jsonb`
 
       } else {
 


### PR DESCRIPTION
By defining a jsonb_field and jsonb_key it should be possible to update the a key value in a json field by casting the new key value.

The fieldfx can retrieve a single value.

The field must be unique for lookup of the value returned.

```json
{
  "title": "Age",
  "field": "json_field_age",
  "fieldfx": "json_field -> 'age'",
  "jsonb_field": "json_field",
  "jsonb_key": "age",
  "edit": true,
  "inline": true
}
```

The location update will create a jsonb object with the field, key, and value to update.

The location_update query can create a coalesce update statement for the field.

The infoj must transform the value object from the newValue object into a simple value.