### PR TITLE
Add query to count number of points within a polygon

### DIFF
--- a/mod/workspace/templates/_queries.js
+++ b/mod/workspace/templates/_queries.js
@@ -53,10 +53,13 @@ module.exports = {
   },
   st_distance_ab: {
     template: require('./st_distance_ab'),
-  },  
+  },
   st_distance_ab_multiple: {
     template: require('./st_distance_ab_multiple'),
-  },  
+  },
+  st_count_intersects: {
+    template: require('./st_count_intersects'),
+  },
   location_get: {
     render: require('./location_get'),
   },

--- a/mod/workspace/templates/st_count_intersects.js
+++ b/mod/workspace/templates/st_count_intersects.js
@@ -1,0 +1,10 @@
+module.exports = `
+SELECT 
+   COUNT(b.*) AS count
+FROM
+    \${table} a
+LEFT JOIN
+    \${table_b} b
+ON ST_INTERSECTS(a.\${geom}, b.\${geom_b})
+WHERE a.\${qID} = %{id}
+`


### PR DESCRIPTION
Adds a new template query for counting the number of locations that intersect a geometry. 

Example set up here - 
``` json 
"infoj": [
  {
      "title": "Points in the Polygon",
      "inline": true,
      "field": "count",
      "query": "st_count_intersects",
      "queryparams": {
        "id": true,
        "qID": true,
        "table": true,
        "geom": "geom_4326",
        "table_b": "schema.table_name",
        "geom_b": "geom_p_4326"
      },
      "run": true
    }
]

```