### PR TITLE
Add Filter Current to distinct_values query

### DIFF
--- a/lib/ui/layers/filters.mjs
+++ b/lib/ui/layers/filters.mjs
@@ -165,13 +165,13 @@ async function filter_numeric(layer, filter) {
   if (!filter.max) {
 
     await generateMinMax(layer, filter, 'max');
-  }  
-  
-if (!filter.min) {
+  }
+
+  if (!filter.min) {
 
     await generateMinMax(layer, filter, 'min');
   }
-  
+
   if (!filter.step) {
 
     filter.step = filter.type === 'integer' ? 1 : 0.01;
@@ -241,12 +241,14 @@ async function filter_in(layer, filter) {
         locale: layer.mapview.locale.key,
         layer: layer.key,
         table: layer.tableCurrent(),
-        field: filter.field
+        field: filter.field,
+        filter: layer?.filter?.current
       }))
 
     if (!response) {
       console.warn(`Distinct values query did not return any values for field ${filter.field}`)
-      return;
+      // Set a div with a message that the field contains no data. 
+      return mapp.utils.html.node`<div>${mapp.dictionary.no_data_filter}</div>`
     }
 
     filter[filter.type] = [response]


### PR DESCRIPTION
The `distinct_values` query did not take `layer.filter.current` even though it was part of the query already. 

I have added the layer.filter.current to the query.
I have also added a simple div element to return `mapp.dictionary.no_data_filter` when no data is returned from the `distinct_values` query. 

![image](https://github.com/GEOLYTIX/xyz/assets/56163132/025e20e2-4218-4c80-84b6-4f48c611154f)
