### PR TITLE
utils.xhr onerror resolve, post body default.

### DIFF
--- a/lib/utils/xhr.mjs
+++ b/lib/utils/xhr.mjs
@@ -1,7 +1,30 @@
 /**
-## mapp.utils.xhr()
+## mapp.utils.xhr(params)
+
+The default method of the xhr module returns a promise which resolves with an response from a XMLHttpRequest.
 
 @module /utils/xhr
+
+*/ /**
+
+The params object/string for the xhr utility method is required.
+
+The params are assumed to the request URL if provided as a string argument.
+
+The request params and response are stored in a Map() if the cache flag is set in the params object argument.
+
+The method is assumed to be 'POST' if a params.body is provided.
+
+@function default
+@param {Object} params The object containing the parameters.
+@param {string} params.url The request URL.
+@param {string} [params.method=GET] The request method.
+@param {string} [params.responseType=json] The XHR responseType.
+@param {Object} [params.requestHeader={'Content-Type': 'application/json'}] The XHR requestHeader.
+@param {string} [params.body] A stringified request body for a 'POST' request.
+@param {boolean} [params.resolveTarget] Whether the target instead of target.response should be resolved.
+@param {boolean} [params.cache] Whether the response should be cached in a Map().
+@returns {Promise} A promise that resolves with the XHR.
 */
 
 const requestMap = new Map()
@@ -26,8 +49,8 @@ export default params => new Promise(resolve => {
   // Check whether a request with the same params has already been resolved.
   if (params.cache && requestMap.has(params)) return resolve(requestMap.get(params))
 
-  // Assign 'GET' as default method.
-  params.method ??= 'GET'
+  // Assign 'GET' as default method if no body is provided.
+  params.method ??= params.body? 'POST': 'GET'
 
   const xhr = new XMLHttpRequest()
 

--- a/lib/utils/xhr.mjs
+++ b/lib/utils/xhr.mjs
@@ -60,5 +60,7 @@ export default params => new Promise(resolve => {
     resolve(params.resolveTarget ? e.target : e.target.response)
   }
 
+  xhr.onerror = (e)=>resolve(new Error(e))
+
   xhr.send(params.body)
 })


### PR DESCRIPTION
The XHR module default method must resolve if the web API errs.

The onload event method will never be called if the XHR fails on a CORS exception.

'POST' should be assumed as XHR method if a post.body is provided.

Added module and function documentation.

```js
/**
## mapp.utils.xhr(params)

The default method of the xhr module returns a promise which resolves with an response from a XMLHttpRequest.

@module /utils/xhr

*/ /**

The params object/string for the xhr utility method is required.

The params are assumed to the request URL if provided as a string argument.

The request params and response are stored in a Map() if the cache flag is set in the params object argument.

The method is assumed to be 'POST' if a params.body is provided.

@function default
@param {Object} params The object containing the parameters.
@param {string} params.url The request URL.
@param {string} [params.method=GET] The request method.
@param {string} [params.responseType=json] The XHR responseType.
@param {Object} [params.requestHeader={'Content-Type': 'application/json'}] The XHR requestHeader.
@param {string} [params.body] A stringified request body for a 'POST' request.
@param {boolean} [params.resolveTarget] Whether the target instead of target.response should be resolved.
@param {boolean} [params.cache] Whether the response should be cached in a Map().
@returns {Promise} A promise that resolves with the XHR.
*/
```

![image](https://github.com/GEOLYTIX/xyz/assets/22201617/02ba6489-149e-493a-81c2-fda9aa6ecc22)
