### PR TITLE
Remove nanoid dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,6 @@
     "@aws-sdk/s3-request-presigner": "^3.398.0",
     "bcrypt": "^5.1.1",
     "jsonwebtoken": "^9.0.2",
-    "nanoid": "^3.2.0",
     "nodemailer": "^6.9.7",
     "pg": "^8.7.3",
     "simple-statistics": "^7.8.3"


### PR DESCRIPTION
The nanoid dependency isn't used anymore in the backend in favour of the `crypto.randomBytes()` method.

```js
user.session = crypto.randomBytes(10).toString('hex')
```