### PR TITLE
Key is ID = Throw Error

### DIFF
--- a/lib/location/decorate.mjs
+++ b/lib/location/decorate.mjs
@@ -93,7 +93,7 @@ async function update() {
 
   if (!Object.keys(newValues).length) return;
 
-  await mapp.utils.xhr({
+  const location_update = await mapp.utils.xhr({
     method: 'POST',
     url:
       `${this.layer.mapview.host}/api/query?` +
@@ -106,6 +106,12 @@ async function update() {
       }),
     body: JSON.stringify(newValues),
   });
+
+  if (location_update instanceof Error) {
+    alert(`Location update has failed.`)
+    this.view?.classList.remove('disabled')
+    return;
+  }
 
   // Update entry.values with newValues.
   // Return dependents from updated entries.

--- a/mod/workspace/templates/location_new.js
+++ b/mod/workspace/templates/location_new.js
@@ -6,7 +6,7 @@ module.exports = _ => {
   // The location ID must not be altered.
   if (Object.keys(_.body).some(key => key === _.layer.qID)) {
 
-    throw new Error('You cannot update the id field as it is a reserved parameter.')
+    throw new Error(`Layer ${_.layer}: You cannot update the ${key} field as it is a reserved parameter.`)
   }
 
   // keys array for insert statement

--- a/mod/workspace/templates/location_new.js
+++ b/mod/workspace/templates/location_new.js
@@ -6,7 +6,7 @@ module.exports = _ => {
   // The location ID must not be altered.
   if (Object.keys(_.body).some(key => key === _.layer.qID)) {
 
-    throw new Error(`Layer ${_.layer}: You cannot update the ${key} field as it is a reserved parameter.`)
+    throw new Error(`Layer ${_.layer}: You cannot update the ${_.layer.qID} field as it is a reserved parameter.`)
   }
 
   // keys array for insert statement

--- a/mod/workspace/templates/location_new.js
+++ b/mod/workspace/templates/location_new.js
@@ -3,13 +3,14 @@ module.exports = _ => {
   // select array for insert statement
   const selects = []
 
+  // The location ID must not be altered.
+  if (Object.keys(_.body).some(key => key === _.layer.qID)) {
+
+    throw new Error('You cannot update the id field as it is a reserved parameter.')
+  }
+
   // keys array for insert statement
   const fields = Object.keys(_.body).map(key => {
-
-    // Key is id. Throw error.
-    if (key === 'id') {
-      throw new Error('You cannot update the id field as it is a reserved parameter.')
-    }
 
     if (key === _.layer.geom) {
 

--- a/mod/workspace/templates/location_new.js
+++ b/mod/workspace/templates/location_new.js
@@ -6,6 +6,11 @@ module.exports = _ => {
   // keys array for insert statement
   const fields = Object.keys(_.body).map(key => {
 
+    // Key is id. Throw error.
+    if (key === 'id') {
+      throw new Error('You cannot update the id field as it is a reserved parameter.')
+    }
+
     if (key === _.layer.geom) {
 
       // push geometry scaffolding into selects array.

--- a/mod/workspace/templates/location_update.js
+++ b/mod/workspace/templates/location_update.js
@@ -1,16 +1,17 @@
 module.exports = _ => {
 
+  // The location ID must not be altered.
+  if (Object.keys(_.body).some(key => key === _.layer.qID)) {
+
+    throw new Error('You cannot update the id field as it is a reserved parameter.')
+  }
+
   const fields = Object.keys(_.body).map(key => {
 
     // Value is null
     if (_.body[key] === null) {
 
       return `${key} = null`
-    }
-
-    // Key is id. Throw error.
-    if (key === 'id') {
-      throw new Error('You cannot update the id field as it is a reserved parameter.')
     }
 
     // Value is string. Escape quotes.
@@ -59,7 +60,7 @@ module.exports = _ => {
 
     return `${key} = %{${key}}`
   })
-  console.log(`UPDATE ${_.table} SET ${fields.join()} WHERE ${_.layer.qID} = %{id};`)
+
   return `
     UPDATE ${_.table}
     SET ${fields.join()}

--- a/mod/workspace/templates/location_update.js
+++ b/mod/workspace/templates/location_update.js
@@ -3,7 +3,7 @@ module.exports = _ => {
   // The location ID must not be altered.
   if (Object.keys(_.body).some(key => key === _.layer.qID)) {
 
-    throw new Error('You cannot update the id field as it is a reserved parameter.')
+    throw new Error(`Layer ${_.layer}: You cannot update the ${key} field as it is a reserved parameter.`)
   }
 
   const fields = Object.keys(_.body).map(key => {

--- a/mod/workspace/templates/location_update.js
+++ b/mod/workspace/templates/location_update.js
@@ -3,7 +3,7 @@ module.exports = _ => {
   // The location ID must not be altered.
   if (Object.keys(_.body).some(key => key === _.layer.qID)) {
 
-    throw new Error(`Layer ${_.layer}: You cannot update the ${key} field as it is a reserved parameter.`)
+    throw new Error(`Layer ${_.layer}: You cannot update the ${_.layer.qID} field as it is a reserved parameter.`)
   }
 
   const fields = Object.keys(_.body).map(key => {

--- a/mod/workspace/templates/location_update.js
+++ b/mod/workspace/templates/location_update.js
@@ -8,6 +8,11 @@ module.exports = _ => {
       return `${key} = null`
     }
 
+    // Key is id. Throw error.
+    if (key === 'id') {
+      throw new Error('You cannot update the id field as it is a reserved parameter.')
+    }
+
     // Value is string. Escape quotes.
     if (typeof _.body[key] === 'string') {
 
@@ -22,7 +27,7 @@ module.exports = _ => {
 
     // Value is an object and must be stringified.
     if (typeof _.body[key] === 'object' && !Array.isArray(_.body[key])) {
-      
+
       _[key] = JSON.stringify(_.body[key])
       if (_.body[key]['jsonb']) {
 
@@ -31,13 +36,13 @@ module.exports = _ => {
         const jsonb_field = Object.keys(jsonb)[0]
 
         let updateObject = []
-        Object.keys(jsonb[jsonb_field]).forEach( key => {
-          let value = typeof jsonb[jsonb_field][key] === 'string' ? `"${jsonb[jsonb_field][key]}"`: jsonb[jsonb_field][key]
+        Object.keys(jsonb[jsonb_field]).forEach(key => {
+          let value = typeof jsonb[jsonb_field][key] === 'string' ? `"${jsonb[jsonb_field][key]}"` : jsonb[jsonb_field][key]
           updateObject.push(`"${key}":${value}`)
         })
 
         return `${jsonb_field} = coalesce(json_field::jsonb,'{}'::jsonb)::jsonb || '{${updateObject.join(',')}}'::jsonb`
-      }      
+      }
     }
 
     // Value is an array (of strings)
@@ -54,7 +59,7 @@ module.exports = _ => {
 
     return `${key} = %{${key}}`
   })
-
+  console.log(`UPDATE ${_.table} SET ${fields.join()} WHERE ${_.layer.qID} = %{id};`)
   return `
     UPDATE ${_.table}
     SET ${fields.join()}


### PR DESCRIPTION
In the `location_update` and `location_new` queries, it is possible to update the `id` field on the table on the db. 
However, doing so will actually overwrite the `%{id}` reserved parameter.
Example using location_update
``` sql 
UPDATE ${_.table} SET ${fields.join()} WHERE ${_.layer.qID} = %{id};
```

You are on location unique_id = 777. 
You want to update id field to be 123. 
The query you would expect to look like
``` sql
UPDATE schema.table SET id = 123 WHERE unique_id = 777`
```
It actually does this 
``` sql
UPDATE  schema.table SET id = 123 WHERE unique_id = 123`
```

**Proposed Fix**
- Simply don't allow the id field to be updated. 

**Long-Term Fix**
- We should replace %{id} with a better unique descriptor, such as %{infoj_id} or similar that wouldn't be used a field name on the db