### PR TITLE
Location Update: fix so it updates the field in the db

### DIFF
--- a/mod/workspace/templates/location_update.js
+++ b/mod/workspace/templates/location_update.js
@@ -39,10 +39,14 @@ module.exports = _ => {
         let updateObject = []
         Object.keys(jsonb[jsonb_field]).forEach(key => {
           let value = typeof jsonb[jsonb_field][key] === 'string' ? `"${jsonb[jsonb_field][key]}"` : jsonb[jsonb_field][key]
+
+          if(Array.isArray(jsonb[jsonb_field][key])){
+            value = JSON.stringify(jsonb[jsonb_field][key])
+          }
           updateObject.push(`"${key}":${value}`)
         })
 
-        return `${jsonb_field} = coalesce(json_field::jsonb,'{}'::jsonb)::jsonb || '{${updateObject.join(',')}}'::jsonb`
+        return `${jsonb_field} = coalesce(${jsonb_field}::jsonb,'{}'::jsonb)::jsonb || '{${updateObject.join(',')}}'::jsonb`
       }
     }
 


### PR DESCRIPTION
Noticed a bug in the sql

```JS
     ${jsonb_field} = coalesce(jsonb_field::jsonb,'{}'::jsonb)::jsonb || '{${updateObject.join(',')}}'::jsonb
```

The `jsonb_field` in the coalesce should also be `${jsonb_field}` as we are trying to concatenate to the field.

I also added a stringify to the value so arrays can be in the JSON value.