### PR TITLE
Prevent update of ID field

### DIFF
--- a/mod/workspace/templates/location_new.js
+++ b/mod/workspace/templates/location_new.js
@@ -4,9 +4,9 @@ module.exports = _ => {
   const selects = []
 
   // The location ID must not be altered.
-  if (Object.keys(_.body).some(key => key === _.layer.qID)) {
+  if (Object.keys(_.body).some(key => key === _.layer.qID || key === 'id')) {
 
-    throw new Error(`Layer ${_.layer}: You cannot update the ${_.layer.qID} field as it is a reserved parameter.`)
+    throw new Error(`Layer ${_.layer}: You cannot update the ${_.layer.qID} or ID field as it is a reserved parameter.`)
   }
 
   // keys array for insert statement

--- a/mod/workspace/templates/location_update.js
+++ b/mod/workspace/templates/location_update.js
@@ -1,9 +1,9 @@
 module.exports = _ => {
 
   // The location ID must not be altered.
-  if (Object.keys(_.body).some(key => key === _.layer.qID)) {
+  if (Object.keys(_.body).some(key => key === _.layer.qID || key === 'id')) {
 
-    throw new Error(`Layer ${_.layer}: You cannot update the ${_.layer.qID} field as it is a reserved parameter.`)
+    throw new Error(`Layer ${_.layer}: You cannot update the ${_.layer.qID} or ID field as it is a reserved parameter.`)
   }
 
   const fields = Object.keys(_.body).map(key => {


### PR DESCRIPTION
In this PR - https://github.com/GEOLYTIX/xyz/pull/1283 We fixed an issue so you cannot update  the layer qID. 
However, we also need to check on specifically editing an id field - as we use %{id} for the location ID.

If you have a location of qID 123 and want to update ID to 5
You would expect it to run 
```sql 
UPDATE X set field = 5 WHERE qID = 123
```
It will actually run
``` sql 
UPDATE X set field = 5 WHERE qID = 5
```
So this PR just checks on specifically editing an id field - as we use %{id} for the location ID, and prevents it.