### PR TITLE
Locations Delete

### DIFF
--- a/mod/query.js
+++ b/mod/query.js
@@ -289,7 +289,7 @@ async function layerQuery(req, res) {
   req.params.layer = await getLayer(req.params)
 
   if (req.params.layer instanceof Error) {
-    return res.status(400).send('Failed to access layer.')
+    return res.status(400).send(req.params.layer.message)
   }
 
   if (!Roles.check(req.params.layer, req.params.user?.roles)) {

--- a/mod/workspace/getLayer.js
+++ b/mod/workspace/getLayer.js
@@ -14,6 +14,9 @@ const getTemplate = require('./getTemplate')
 
 module.exports = async (params) => {
 
+  // Set locale as default
+  params.locale ??= 'locale'
+
   const workspace = await workspaceCache()
 
   if (workspace instanceof Error) {

--- a/mod/workspace/templates/_queries.js
+++ b/mod/workspace/templates/_queries.js
@@ -70,6 +70,9 @@ module.exports = {
   location_delete: {
     render: require('./location_delete'),
   },
+  locations_delete: {
+    render: require('./locations_delete'),
+  },
   location_update: {
     render: require('./location_update'),
   },

--- a/mod/workspace/templates/locations_delete.js
+++ b/mod/workspace/templates/locations_delete.js
@@ -1,0 +1,10 @@
+module.exports = _ => {
+
+  // If no layer parameter, return 
+  if (!_.layer) {
+    throw new Error(`You cannot delete locations data without providing the layer parameter.`)
+  }
+
+  // Delete from the table where data matches the filter
+  return `DELETE FROM ${_.table} WHERE ${filter};`
+}

--- a/mod/workspace/templates/locations_delete.js
+++ b/mod/workspace/templates/locations_delete.js
@@ -5,6 +5,18 @@ module.exports = _ => {
     throw new Error(`You cannot delete locations data without providing the layer parameter.`)
   }
 
+  let where;
+  
+  // If filter is not empty, set the where clause
+  if (_.filter.length > 1) {
+    // If the filter begins ' AND ' remove it
+    if (_.filter.startsWith(' AND ')) {
+      _.filter = _.filter.slice(5)
+    }
+    // Set the where clause
+    where = `WHERE ${_.filter}`
+  } 
+
   // Delete from the table where data matches the filter
-  return `DELETE FROM ${_.table} WHERE ${filter};`
+  return `DELETE FROM ${_.table} ${where};`
 }

--- a/mod/workspace/templates/locations_delete.js
+++ b/mod/workspace/templates/locations_delete.js
@@ -5,18 +5,7 @@ module.exports = _ => {
     throw new Error(`You cannot delete locations data without providing the layer parameter.`)
   }
 
-  let where;
-  
-  // If filter is not empty, set the where clause
-  if (_.filter.length > 1) {
-    // If the filter begins ' AND ' remove it
-    if (_.filter.startsWith(' AND ')) {
-      _.filter = _.filter.slice(5)
-    }
-    // Set the where clause
-    where = `WHERE ${_.filter}`
-  } 
-
-  // Delete from the table where data matches the filter
-  return `DELETE FROM ${_.table} ${where};`
+  return `
+    DELETE FROM ${_.table || _.layer.table}
+    WHERE TRUE ${_.viewport || ''} \${filter};`
 }


### PR DESCRIPTION
This PR addresses issue https://github.com/GEOLYTIX/xyz/issues/1289

It provides a `locations_delete` query. Which is similar to `location_delete` except it takes `filter` as a parameter to enable multiple locations to be deleted. 

This must only be able to be called as layer query.
Therefore, this query must have `_.layer` as a parameter or it will throw an error. 

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1207452903120226