### PR TITLE
Deep merge [clone] locale for storage in userIDB

### DIFF
--- a/lib/layer/decorate.mjs
+++ b/lib/layer/decorate.mjs
@@ -117,9 +117,10 @@ export default async function decorate(layer) {
   };
 
   // Set layer filter.
-  layer.filter = Object.assign({
-    current: {}
-  }, layer.filter);
+  layer.filter = {
+    current: {},
+    ...layer.filter
+  }
 
   // Set layer opacity from style.
   layer.L.setOpacity(layer.style?.opacity || 1);

--- a/lib/plugins/userIDB.mjs
+++ b/lib/plugins/userIDB.mjs
@@ -19,14 +19,16 @@ export function userIDB(plugin, mapview) {
       title=${plugin.title}
       onclick=${()=>{
 
-        mapview.locale.layers.forEach(layer => {
+        const locale = mapp.utils.merge({}, mapview.locale)
+
+        locale.layers.forEach(layer => {
 
           if (typeof layer !== 'object') return;
 
           updateLayer(layer, mapview.layers[layer.key])
         })
-
-        mapp.utils.userIndexedDB.put('locales', mapview.locale)
+        
+        mapp.utils.userIndexedDB.put('locales', locale)
 
         alert(`User ${mapp.user.email} IndexedDB updated.`)
 

--- a/lib/plugins/userIDB.mjs
+++ b/lib/plugins/userIDB.mjs
@@ -11,7 +11,7 @@ export function userIDB(plugin, mapview) {
 
   if (!btnColumn) return;
 
-  plugin.title ??= "Update userIDB locale"
+  plugin.title ??= 'Update userIDB locale'
 
   // Append the plugin btn to the btnColumn.
   btnColumn.append(mapp.utils.html.node`

--- a/lib/utils/merge.mjs
+++ b/lib/utils/merge.mjs
@@ -26,11 +26,11 @@ export default function mergeDeep(target, ...sources) {
       if (proto[key]) {
         console.warn(`Prototype polution detected for key: ${key}`)
 
+      // HTMLElement objects must not be merged.
       } else if (source[key] instanceof HTMLElement) {
-
-        // HTMLElement objects must not be merged.
         console.warn(source[key])
 
+      // source[key] is object with potential nesting.
       } else if (isObject(source[key])) {
 
         // Target key must be an object.
@@ -39,9 +39,9 @@ export default function mergeDeep(target, ...sources) {
         // Call recursive merge for target key object.
         mergeDeep(target[key], source[key]);
 
+      // source[key] could be null, true, false, or Array object
       } else {
 
-        // source[key] is neither null nor object.
         target[key] = source[key]
       }
     }

--- a/lib/utils/merge.mjs
+++ b/lib/utils/merge.mjs
@@ -25,16 +25,11 @@ export default function mergeDeep(target, ...sources) {
       // Key must not be in target object prototype.
       if (proto[key]) {
         console.warn(`Prototype polution detected for key: ${key}`)
-        continue;
-        
+
       } else if (source[key] instanceof HTMLElement) {
 
         // HTMLElement objects must not be merged.
         console.warn(source[key])
-        continue;
-
-      } else if (source[key] === null) {
-        target[key] = null;
 
       } else if (isObject(source[key])) {
 
@@ -57,7 +52,12 @@ export default function mergeDeep(target, ...sources) {
 
 function isObject(item) {
 
-  // item is an array.
+  if (item === true) return false;
+
+  if (item === false) return false;
+
+  if (item === null) return false;
+
   if (Array.isArray(item)) return false;
 
   if (typeof item === 'object') return true;

--- a/lib/utils/merge.mjs
+++ b/lib/utils/merge.mjs
@@ -1,7 +1,27 @@
 /**
-## mapp.utils.merge()
+## merge.mjs
+
+Imported by _utils.mjs to assign the exported default method mergeDeep as mapp.utils.merge().
 
 @module /utils/merge
+*/
+
+/**
+### mapp.utils.merge()
+
+The mergeDeep utility method will set the source object's own enumerable string-keyed property values on a target object.
+
+mergeDeep will call itself recursively allowing to merge nested objects.
+
+An empty target object can be provided to effectively clone a source object.
+
+Instances of HTMLElement objects will be ignored by the merge method.
+
+Arrays will not be merged. The source array will overwrite a target array.
+
+@function mergeDeep
+@param {*} target 
+@param  {...any} sources 
 */
 
 export default function mergeDeep(target, ...sources) {

--- a/lib/utils/merge.mjs
+++ b/lib/utils/merge.mjs
@@ -26,16 +26,14 @@ export default function mergeDeep(target, ...sources) {
       if (proto[key]) {
         console.warn(`Prototype polution detected for key: ${key}`)
         continue;
-      }
-
-      if (source[key] instanceof HTMLElement) {
+        
+      } else if (source[key] instanceof HTMLElement) {
 
         // HTMLElement objects must not be merged.
         console.warn(source[key])
         continue;
-      }
 
-      if (source[key] === null) {
+      } else if (source[key] === null) {
         target[key] = null;
 
       } else if (isObject(source[key])) {

--- a/lib/utils/merge.mjs
+++ b/lib/utils/merge.mjs
@@ -33,6 +33,13 @@ export default function mergeDeep(target, ...sources) {
 
       } else if (isObject(source[key])) {
 
+        if (source[key] instanceof HTMLElement) {
+
+          // HTMLElement objects must not be merged.
+          console.warn(source[key])
+          return;
+        }
+
         // Target key must be an object.
         target[key] ??= {}
 
@@ -51,12 +58,6 @@ export default function mergeDeep(target, ...sources) {
 }
 
 function isObject(item) {
-
-  // item is an HTMLElement 
-  if (item instanceof HTMLElement) {
-    console.warn(item)
-    return false;
-  }
 
   // item is an array.
   if (Array.isArray(item)) return false;

--- a/lib/utils/merge.mjs
+++ b/lib/utils/merge.mjs
@@ -28,17 +28,17 @@ export default function mergeDeep(target, ...sources) {
         continue;
       }
 
+      if (source[key] instanceof HTMLElement) {
+
+        // HTMLElement objects must not be merged.
+        console.warn(source[key])
+        continue;
+      }
+
       if (source[key] === null) {
         target[key] = null;
 
       } else if (isObject(source[key])) {
-
-        if (source[key] instanceof HTMLElement) {
-
-          // HTMLElement objects must not be merged.
-          console.warn(source[key])
-          return;
-        }
 
         // Target key must be an object.
         target[key] ??= {}

--- a/tests/mod/utils/merge.test.mjs
+++ b/tests/mod/utils/merge.test.mjs
@@ -81,23 +81,23 @@ describe('mergeDeep Module', () => {
     it('should handle merging with unequal arrays', () => {
         const filter = {
             current: {
-                "country": {
-                    "in": ["ROI"]
+                'country': {
+                    'in': ['ROI']
                 }
             }
         };
         const filter2 = {
             current: {
-                "country": {
-                    "in": ["UK"]
+                'country': {
+                    'in': ['UK']
                 }
             }
         };
 
         const expected = {
             current: {
-                "country": {
-                    "in": ["ROI","UK"]
+                'country': {
+                    'in': ['ROI','UK']
                 }
             }
         };


### PR DESCRIPTION
The locale must be merged [deep cloned] into an empty locale object in order to scrub htmlelements which might be in the plugin objects.

The merge util must warn and not assign the htmlelement to the clone target.

The layer filter should use spread instead of object assign in decorator.