### PR TITLE
Ability to Test for the creation/ deletion of locations

### DIFF
--- a/public/tests/layer.test.mjs
+++ b/public/tests/layer.test.mjs
@@ -76,8 +76,12 @@ export async function layerTest(mapview) {
 
                                     if (layer?.draw?.point) {
                                         geometry = pin.geometry;
-                                    } else {
+                                    } else if (layer?.draw?.polygon || layer?.draw?.line || layer?.draw?.rectangle || layer?.draw?.circle) {
                                         geometry = polygon.geometry;
+                                    } else {
+                                        // We don't want to test this layer as it doesn't have a core draw object method
+                                        // If may have plugin draw methods but we can't test those
+                                        return;
                                     }
 
                                     // Create a new location

--- a/public/tests/layer.test.mjs
+++ b/public/tests/layer.test.mjs
@@ -4,9 +4,9 @@ export async function layerTest(mapview) {
 
     function delayFunction(delay) {
         return new Promise(resolve => {
-          setTimeout(resolve, delay);
+            setTimeout(resolve, delay);
         });
-      }
+    }
 
     const default_zoom = mapview.view.z;
 
@@ -19,16 +19,14 @@ export async function layerTest(mapview) {
                     if (layer.tables) {
                         const layerZoom = parseInt(Object.entries(layer.tables).find(([key, value]) => value !== null)[0]);
                         mapview.Map.getView().setZoom(layerZoom);
-                        //console.log(mapview.Map.getView().getZoom());
                     }
                     else {
                         mapview.Map.getView().setZoom(default_zoom);
-                        //console.log(mapview.Map.getView().getZoom());
                     }
 
-                    if(layer.dataviews){
-                        for(const dataview in layer.dataview){
-                            dataview = { ...dataview, display: true}
+                    if (layer.dataviews) {
+                        for (const dataview in layer.dataview) {
+                            dataview = { ...dataview, display: true }
                         }
                     }
 
@@ -51,8 +49,8 @@ export async function layerTest(mapview) {
                         if (lastLocation?.id) {
 
                             layer.infoj = layer.infoj.map(entry => {
-                                if(entry.type === 'dataview'){
-                                    return { ...entry, display: true}
+                                if (entry.type === 'dataview') {
+                                    return { ...entry, display: true };
                                 }
                                 return entry;
                             });
@@ -63,13 +61,81 @@ export async function layerTest(mapview) {
                             });
 
                             assertTrue(location !== undefined, 'The location is undefined');
-                            //await delayFunction(3000);
-                            location.remove();
-                        }
-                    }
 
-                    if (!['maplibre', 'tiles'].includes(layer.format)) {
-                        layer.hide();
+                            // Add a new location to the layer using the last location
+                            if (layer?.draw) {
+                                await it('Add a new location to the layer using the last location coordinates', async () => {
+                                    // Use the value of the infoj pin field to create a new location
+                                    const pin = location.infoj.find(entry => entry.type === 'pin');
+
+                                    // Get the geometry of the last location (for polygon layers)
+                                    const polygon = location.infoj.find(entry => entry.type === 'geometry' && entry.field === layer.geomCurrent());
+
+                                    // Set the pin or polygon based on the draw object
+                                    let geometry;
+
+                                    if (layer?.draw?.point) {
+                                        geometry = pin.geometry;
+                                    } else {
+                                        geometry = polygon.geometry;
+                                    }
+
+                                    // Create a new location
+                                    const newLocation = {
+                                        layer,
+                                        table: layer.tableCurrent(),
+                                        new: true
+                                    };
+
+                                    newLocation.id = await mapp.utils.xhr({
+                                        method: "POST",
+                                        url: `${mapp.host}/api/query?` +
+                                            mapp.utils.paramString({
+                                                template: 'location_new',
+                                                locale: layer.mapview.locale.key,
+                                                layer: layer.key,
+                                                table: newLocation.table
+                                            }),
+                                        body: JSON.stringify({
+                                            [layer.geom]: geometry,
+
+                                            // Spread in defaults.
+                                            ...layer.draw?.defaults
+                                        })
+                                    });
+
+                                    // Layer must be reloaded to reflect geometry changes.
+                                    layer.reload();
+
+                                    // Get the newly created location.
+                                    const newLoc = await mapp.location.get(newLocation);
+
+                                    // If layer.deleteLocation is defined, delete the location
+                                    if (layer.deleteLocation) {
+
+                                        await it('Delete the location', async () => {
+                                            // Test deleting a location
+                                            await mapp.utils.xhr(`${mapp.host}/api/query?` +
+                                                mapp.utils.paramString({
+                                                    template: 'location_delete',
+                                                    locale: mapview.locale.key,
+                                                    layer: newLocation.layer.key,
+                                                    table: newLocation.table,
+                                                    id: newLocation.id
+                                                }));
+
+                                            newLoc.remove();
+                                        });
+                                    }
+                                });
+                            }
+
+                            location.remove();
+
+                            if (!['maplibre', 'tiles'].includes(layer.format)) {
+                                layer.hide();
+                            }
+                        }
                     }
                 });
             }

--- a/public/tests/layer.test.mjs
+++ b/public/tests/layer.test.mjs
@@ -92,7 +92,7 @@ export async function layerTest(mapview) {
                                     }
 
                                     newLocation.id = await mapp.utils.xhr({
-                                        method: "POST",
+                                        method: 'POST',
                                         url: `${mapp.host}/api/query?` +
                                             mapp.utils.paramString({
                                                 template: 'location_new',

--- a/public/tests/layer.test.mjs
+++ b/public/tests/layer.test.mjs
@@ -112,26 +112,26 @@ export async function layerTest(mapview) {
                                     layer.reload();
 
                                     // Get the newly created location.
-                                    const newLoc = await mapp.location.get(newLocation);
-
-                                    // If layer.deleteLocation is defined, delete the location
-                                    if (layer.deleteLocation) {
-
-                                        await it('Delete the location', async () => {
-                                            // Test deleting a location
-                                            await mapp.utils.xhr(`${mapp.host}/api/query?` +
-                                                mapp.utils.paramString({
-                                                    template: 'location_delete',
-                                                    locale: mapview.locale.key,
-                                                    layer: newLocation.layer.key,
-                                                    table: newLocation.table,
-                                                    id: newLocation.id
-                                                }));
-
-                                            newLoc.remove();
-                                        });
-                                    }
+                                    await mapp.location.get(newLocation);
                                 });
+
+                                // If layer.deleteLocation is defined, delete the location
+                                if (layer.deleteLocation === true) {
+
+                                    await it('Delete the location', async () => {
+                                        // Test deleting a location
+                                        await mapp.utils.xhr(`${mapp.host}/api/query?` +
+                                            mapp.utils.paramString({
+                                                template: 'location_delete',
+                                                locale: mapview.locale.key,
+                                                layer: newLocation.layer.key,
+                                                table: newLocation.table,
+                                                id: newLocation.id
+                                            }));
+
+                                        newLoc.remove();
+                                    });
+                                }
                             }
 
                             location.remove();

--- a/public/tests/layer.test.mjs
+++ b/public/tests/layer.test.mjs
@@ -62,6 +62,13 @@ export async function layerTest(mapview) {
 
                             assertTrue(location !== undefined, 'The location is undefined');
 
+                            // Create a new location
+                            const newLocation = {
+                                layer,
+                                table: layer.tableCurrent(),
+                                new: true
+                            };
+
                             // Add a new location to the layer using the last location
                             if (layer?.draw) {
                                 await it('Add a new location to the layer using the last location coordinates', async () => {
@@ -84,13 +91,6 @@ export async function layerTest(mapview) {
                                         return;
                                     }
 
-                                    // Create a new location
-                                    const newLocation = {
-                                        layer,
-                                        table: layer.tableCurrent(),
-                                        new: true
-                                    };
-
                                     newLocation.id = await mapp.utils.xhr({
                                         method: "POST",
                                         url: `${mapp.host}/api/query?` +
@@ -112,7 +112,10 @@ export async function layerTest(mapview) {
                                     layer.reload();
 
                                     // Get the newly created location.
-                                    await mapp.location.get(newLocation);
+                                    const newLoc = await mapp.location.get(newLocation);
+
+                                    // Remove the location
+                                    newLoc.remove();
                                 });
 
                                 // If layer.deleteLocation is defined, delete the location
@@ -128,8 +131,6 @@ export async function layerTest(mapview) {
                                                 table: newLocation.table,
                                                 id: newLocation.id
                                             }));
-
-                                        newLoc.remove();
                                     });
                                 }
                             }


### PR DESCRIPTION
**What?**

- This PR extends the functionality of the existing test_view to test for the creation / deletion of locations. 
- This is a very useful feature as this allows us to test that any database triggers / functions are working correctly, and permissions on tables that are editable are set up correctly.

**How?**

- After we get the last location on a layer, we can then access its `infoj`. 
- Using the infoj, we have access to the pin entry and geometry entry types.
- If the layer uses `layer.draw.point` we pass the last location pin geometry to the `location_new` template to create a new location.
- If the layer uses a polygon draw method (`layer.draw.circle`) for example, we pass the last location geometry entry of the same field as the `layer.geom` to the `location_new` template to create a new location.
- We then `get` the new location to check we can open it in the location panel.
- If the layer has `layer.deleteLocation`, we then test deleting this location and removing it from the location panel. 
- Note - we only test deleting locations if the layer has a `layer.draw` method, as otherwise we could be deleting locations that didn't create in the testview - impacting client data. 
- Note - the infoj must therefore contain the `pin` and/or the `geometry` required for this testing. This can be `class: display-none` if the client does not want to see it. 

![image](https://github.com/GEOLYTIX/xyz/assets/56163132/9a7912d8-8ffa-4d1c-8463-c1a34b08ea78)


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1207373884014202