### PR TITLE
Text Entry - distinct query fix field fix

### DIFF
--- a/lib/ui/locations/entries/text.mjs
+++ b/lib/ui/locations/entries/text.mjs
@@ -84,14 +84,14 @@ function edit(entry) {
       mapp.utils.xhr(
         `${entry.location.layer.mapview.host}/api/query?` +
         mapp.utils.paramString({
-          template: entry.edit.query || entry.json_field ? 'distinct_values_json' : 'distinct_values',
+          template: entry.edit.query || (entry.jsonb_field ? 'distinct_values_json' : 'distinct_values'),
           dbs: entry.location.layer.dbs,
           locale: entry.location.layer.mapview.locale.key,
           layer: entry.location.layer.key,
           filter: entry.location.layer.filter?.current,
           table: entry.location.layer.tableCurrent(),
-          field: entry.field || entry.json_field,
-          key: entry.json_key,
+          field: entry.field || entry.jsonb_field,
+          key: entry.jsonb_key,
           id: entry.location.id
         })).then(response => {
 

--- a/lib/ui/locations/entries/text.mjs
+++ b/lib/ui/locations/entries/text.mjs
@@ -90,7 +90,7 @@ function edit(entry) {
           layer: entry.location.layer.key,
           filter: entry.location.layer.filter?.current,
           table: entry.location.layer.tableCurrent(),
-          field: entry.field || entry.jsonb_field,
+          field: entry.jsonb_field || entry.field,
           key: entry.jsonb_key,
           id: entry.location.id
         })).then(response => {


### PR DESCRIPTION
The `entry.edit.query` is currently being ignore as:

```js
template: entry.edit.query || entry.json_field ? 'distinct_values_json' : 'distinct_values'
```
(ui/locations/text.mjs/line87)

Will cause `distinct_values_json` to be used if either `entry.edit.query` is supplied or if `json_field` is supplied.

This PR will fix that behaviour.

