### PR TITLE
Update val-changed CSS

### DIFF
--- a/public/css/_ui.css
+++ b/public/css/_ui.css
@@ -180,3 +180,11 @@
 .val-changed input {
   background-color: var(--color-changed)
 }
+
+.val-changed textarea {
+  background-color: var(--color-changed)
+}
+
+.val-changed button {
+  background-color: var(--color-changed)
+}

--- a/public/css/ui.css
+++ b/public/css/ui.css
@@ -1646,3 +1646,9 @@ label.checkbox {
 .val-changed input {
   background-color: var(--color-changed);
 }
+.val-changed textarea {
+  background-color: var(--color-changed);
+}
+.val-changed button {
+  background-color: var(--color-changed);
+}


### PR DESCRIPTION
The val-changed CSS class was being applied to all input types but the CSS did not reflect this. We had only updated to apply to the `input` type, but `textarea` and `button` (used for dropdowns) were not included. 

This PR addresses this by providing the CSS for `textarea` and `button` val-changed. 

Before 
![image](https://github.com/GEOLYTIX/xyz/assets/56163132/9e25d255-981a-4e21-a289-bd9e774a3f93)

After
![image](https://github.com/GEOLYTIX/xyz/assets/56163132/2b7643bf-726d-4d25-a829-fac92b74ec3b)


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1207466965068716