### PR TITLE
Filter Min = 0 Fix

### DIFF
--- a/lib/ui/layers/filters.mjs
+++ b/lib/ui/layers/filters.mjs
@@ -148,7 +148,7 @@ async function generateMinMax(layer, filter, minmax) {
   // If the response contains response.min or response.max - we can assume the query was successful.
   // Have to check that response is not null as well
   response ??= {}
-  if (response[minmax]) {
+  if (!isNaN(response[minmax])) {
     filter[minmax] = filter.type === 'integer' ? Math.round(response[minmax]) : parseFloat(response[minmax]);
   }
 

--- a/lib/ui/layers/filters.mjs
+++ b/lib/ui/layers/filters.mjs
@@ -217,8 +217,8 @@ async function filter_numeric(layer, filter) {
   // Create affix for rangeslider input label.
   const affix = (entry.prefix || entry.suffix)? `(${(entry.prefix || entry.suffix).trim()})`: ''
 
+  // Set formatter and filterInput for tabulator inputs.
   entry.formatter ??= entry.formatterParams
-
   entry.filterInput = true
 
   // Create the range slider element.

--- a/lib/ui/layers/filters.mjs
+++ b/lib/ui/layers/filters.mjs
@@ -130,13 +130,19 @@ function filter_null(layer, filter) {
 }
 
 /**
- * @function generateMinMax
- * @description Generates the minimum and maximum values for numeric filtering.
- * @param {Object} layer - The layer object to apply the filter to.
- * @param {Object} filter - The filter configuration object.
- * @returns {Promise<void>}
- */
+@function generateMinMax
+@description
+Queries the min and max bounds for a filter field. The min and max bounds can be implicit in the filter config.
+
+@param {Object} layer MAPP layer object.
+@param {Object} filter Filter object.
+@param {string} filter.field Field to filter.
+@param {numeric} [filter.min] Min bounds.
+@param {numeric} [filter.max] Max bounds.
+*/
+
 async function generateMinMax(layer, filter) {
+
   const response = await mapp.utils.xhr(`${layer.mapview.host}/api/query?${mapp.utils.paramString({
     template: `field_minmax`,
     locale: layer.mapview.locale.key,
@@ -145,31 +151,42 @@ async function generateMinMax(layer, filter) {
     field: filter.field,
   })}`);
 
-  // If min or max are defined, use them - otherwise use the response 
-  filter.minmax[0] = filter.type === 'integer' ? Math.round(filter?.min || response.minmax[0]) : parseFloat(filter?.min || response.minmax[1])
-  filter.minmax[1] = filter.type === 'integer' ? Math.round(filter?.max || response.minmax[1]) : parseFloat(filter?.max || response.minmax[0])
+  // Assign min, max from response if not a number.
+  const min = isNaN(filter.min) ? response.minmax[0]: filter.min
+  const max = isNaN(filter.max) ? response.minmax[1]: filter.max
+
+  // Parse min, max as interger or float depending on type.
+  filter.minmax[0] = filter.type === 'integer'? parseInt(min) : parseFloat(min)
+  filter.minmax[1] = filter.type === 'integer'? parseInt(max) : parseFloat(max)
 }
 
 /**
- * @function filter_numeric
- * @description Creates a slider element for filtering numeric values.
- * @param {Object} layer - The layer object to apply the filter to.
- * @param {Object} filter - The filter configuration object.
- * @returns {Promise<HTMLElement>} The slider element for numeric filtering.
- */
+@function filter_numeric
+@description
+Returns numeric inputs and range slider element as UI for numeric layer filter.
+
+@param {Object} layer MAPP layer object.
+@param {Object} filter Filter object.
+@param {string} filter.field Field to filter.
+@param {numeric} [filter.min] Min bounds.
+@param {numeric} [filter.max] Max bounds.
+@param {numeric} [filter.step] Step for renage slider.
+
+@returns {Promise<HTMLElement>}
+The filter UI elements.
+*/
+
 async function filter_numeric(layer, filter) {
 
   filter.minmax = [filter.min, filter.max];
 
-  if (!filter.max || !filter.min) {
+  // Set min and max from response if not implicit.
+  if (isNaN(filter.max) || isNaN(filter.min)) {
 
     await generateMinMax(layer, filter);
   }
 
-  if (!filter.step) {
-
-    filter.step = filter.type === 'integer' ? 1 : 0.01;
-  }
+  filter.step ??= filter.type === 'integer' ? 1 : 0.01;
 
   layer.filter.current[filter.field] = Object.assign(
     {
@@ -179,20 +196,27 @@ async function filter_numeric(layer, filter) {
     layer.filter.current[filter.field]);
 
   const entry = layer.infoj.find(entry => entry.field === filter.field)
+
   entry.formatter ??= entry.formatterParams
+
   let affix = entry.prefix || entry.suffix
+
   affix = affix ? `(${affix.trim()})` : ''
+
   entry.filterInput = true
+
   applyFilter(layer);
 
   // If filter.min and filter.max are identical, return a message.
   if (filter.minmax[0] === filter.minmax[1]) {
+
     // Return text to indicate that the field contains only one distinct value.
     return mapp.utils.html.node`<div>${mapp.dictionary.identical_values_filter}</div>`
   };
   
   // Only if filter.min and filter.max are not numeric values, return a message.
   if (isNaN(filter.minmax[0]) || isNaN(filter.minmax[1])) {
+
     // Return text to indicate that the min and max values are not defined.
     return mapp.utils.html.node`<div>${mapp.dictionary.no_data_filter}</div>`
   };
@@ -216,9 +240,7 @@ async function filter_numeric(layer, filter) {
       layer.filter.current[filter.field].lte = Number(e)
       applyFilter(layer)
     }
-
   })
-
 }
 
 

--- a/lib/ui/layers/filters.mjs
+++ b/lib/ui/layers/filters.mjs
@@ -156,8 +156,9 @@ async function generateMinMax(layer, filter) {
   const max = isNaN(filter.max) ? response.minmax[1]: filter.max
 
   // Parse min, max as interger or float depending on type.
-  filter.minmax[0] = filter.type === 'integer'? parseInt(min) : parseFloat(min)
-  filter.minmax[1] = filter.type === 'integer'? parseInt(max) : parseFloat(max)
+  // Round integer to be correct up or down.
+  filter.minmax[0] = filter.type === 'integer'? Math.round(min) : parseFloat(min)
+  filter.minmax[1] = filter.type === 'integer'? Math.round(max) : parseFloat(max)
 }
 
 /**
@@ -195,16 +196,6 @@ async function filter_numeric(layer, filter) {
     },
     layer.filter.current[filter.field]);
 
-  const entry = layer.infoj.find(entry => entry.field === filter.field)
-
-  entry.formatter ??= entry.formatterParams
-
-  let affix = entry.prefix || entry.suffix
-
-  affix = affix ? `(${affix.trim()})` : ''
-
-  entry.filterInput = true
-
   applyFilter(layer);
 
   // If filter.min and filter.max are identical, return a message.
@@ -221,6 +212,16 @@ async function filter_numeric(layer, filter) {
     return mapp.utils.html.node`<div>${mapp.dictionary.no_data_filter}</div>`
   };
 
+  const entry = layer.infoj.find(entry => entry.field === filter.field)
+
+  // Create affix for rangeslider input label.
+  const affix = (entry.prefix || entry.suffix)? `(${(entry.prefix || entry.suffix).trim()})`: ''
+
+  entry.formatter ??= entry.formatterParams
+
+  entry.filterInput = true
+
+  // Create the range slider element.
   return mapp.ui.elements.slider_ab({
     min: Number(filter.minmax[0]),
     max: Number(filter.minmax[1]),

--- a/lib/ui/layers/filters.mjs
+++ b/lib/ui/layers/filters.mjs
@@ -24,7 +24,8 @@ let timeout;
 mapp.utils.merge(mapp.dictionaries, {
   en: {
     no_data_filter: 'This field contains no data and cannot be filtered on.',
-    filter_searchbox_placeholder: 'Search'
+    filter_searchbox_placeholder: 'Search',
+    identical_values_filter: 'This field contains only one distinct value and cannot be filtered on.'
   },
   de: {
     no_data_filter: 'Dieses Feld enthält keine Daten und kann nicht gefiltert werden.'
@@ -133,25 +134,20 @@ function filter_null(layer, filter) {
  * @description Generates the minimum and maximum values for numeric filtering.
  * @param {Object} layer - The layer object to apply the filter to.
  * @param {Object} filter - The filter configuration object.
- * @param {string} minmax - The type of value to generate ('min' or 'max').
  * @returns {Promise<void>}
  */
-async function generateMinMax(layer, filter, minmax) {
-  let response = await mapp.utils.xhr(`${layer.mapview.host}/api/query?${mapp.utils.paramString({
-    template: `field_${minmax}`,
+async function generateMinMax(layer, filter) {
+  const response = await mapp.utils.xhr(`${layer.mapview.host}/api/query?${mapp.utils.paramString({
+    template: `field_minmax`,
     locale: layer.mapview.locale.key,
     layer: layer.key,
     table: layer.tableCurrent(),
     field: filter.field,
   })}`);
 
-  // If the response contains response.min or response.max - we can assume the query was successful.
-  // Have to check that response is not null as well
-  response ??= {}
-  if (!isNaN(response[minmax])) {
-    filter[minmax] = filter.type === 'integer' ? Math.round(response[minmax]) : parseFloat(response[minmax]);
-  }
-
+  // If min or max are defined, use them - otherwise use the response 
+  filter.minmax[0] = filter.type === 'integer' ? Math.round(filter?.min || response.minmax[0]) : parseFloat(filter?.min || response.minmax[1])
+  filter.minmax[1] = filter.type === 'integer' ? Math.round(filter?.max || response.minmax[1]) : parseFloat(filter?.max || response.minmax[0])
 }
 
 /**
@@ -163,14 +159,11 @@ async function generateMinMax(layer, filter, minmax) {
  */
 async function filter_numeric(layer, filter) {
 
-  if (!filter.max) {
+  filter.minmax = [filter.min, filter.max];
 
-    await generateMinMax(layer, filter, 'max');
-  }
+  if (!filter.max || !filter.min) {
 
-  if (!filter.min) {
-
-    await generateMinMax(layer, filter, 'min');
+    await generateMinMax(layer, filter);
   }
 
   if (!filter.step) {
@@ -180,8 +173,8 @@ async function filter_numeric(layer, filter) {
 
   layer.filter.current[filter.field] = Object.assign(
     {
-      gte: Number(filter.min),
-      lte: Number(filter.max)
+      gte: Number(filter.minmax[0]),
+      lte: Number(filter.minmax[1])
     },
     layer.filter.current[filter.field]);
 
@@ -192,27 +185,33 @@ async function filter_numeric(layer, filter) {
   entry.filterInput = true
   applyFilter(layer);
 
+  // If filter.min and filter.max are identical, return a message.
+  if (filter.minmax[0] === filter.minmax[1]) {
+    // Return text to indicate that the field contains only one distinct value.
+    return mapp.utils.html.node`<div>${mapp.dictionary.identical_values_filter}</div>`
+  };
+  
   // Only if filter.min and filter.max are not numeric values, return a message.
-  if (isNaN(filter.min) || isNaN(filter.max)) {
+  if (isNaN(filter.minmax[0]) || isNaN(filter.minmax[1])) {
     // Return text to indicate that the min and max values are not defined.
     return mapp.utils.html.node`<div>${mapp.dictionary.no_data_filter}</div>`
   };
 
   return mapp.ui.elements.slider_ab({
-    min: Number(filter.min),
-    max: Number(filter.max),
+    min: Number(filter.minmax[0]),
+    max: Number(filter.minmax[1]),
     step: filter.step,
     entry: entry,
     label_a: `${mapp.dictionary.layer_filter_greater_than} ${affix}`, // Greater than
-    val_a: mapp.ui.elements.numericFormatter(entry, filter.min),
-    slider_a: Number(filter.min),
+    val_a: mapp.ui.elements.numericFormatter(entry, filter.minmax[0]),
+    slider_a: Number(filter.minmax[0]),
     callback_a: e => {
       layer.filter.current[filter.field].gte = Number(e)
       applyFilter(layer)
     },
     label_b: `${mapp.dictionary.layer_filter_less_than}  ${affix}`, // Less than
-    val_b: mapp.ui.elements.numericFormatter(entry, filter.max),
-    slider_b: Number(filter.max),
+    val_b: mapp.ui.elements.numericFormatter(entry, filter.minmax[1]),
+    slider_b: Number(filter.minmax[1]),
     callback_b: e => {
       layer.filter.current[filter.field].lte = Number(e)
       applyFilter(layer)

--- a/mod/workspace/templates/_queries.js
+++ b/mod/workspace/templates/_queries.js
@@ -24,6 +24,9 @@ module.exports = {
   field_max: {
     template: require('./field_max'),
   },
+  field_minmax: {
+    template: require('./field_minmax'),
+  },
   get_nnearest: {
     render: require('./get_nnearest'),
   },

--- a/mod/workspace/templates/field_minmax.js
+++ b/mod/workspace/templates/field_minmax.js
@@ -1,0 +1,5 @@
+module.exports = `
+  SELECT
+    ARRAY[min(\${field}), max(\${field})] as minmax
+    FROM \${table}
+    WHERE true \${filter};`


### PR DESCRIPTION
# Filter Min Fix

## Description
I have added a new filter_minmax query that returns an array of both min and max values. This removed some of the complexity in the generateMinMax function as you no longer need to pass in a string of "min" or "max".

I have added a new filter.minmax array that gets set to [filter.min, filter.max] initially. The benefit of this is that by extracting the query response from the filter.min and filter.max values, we separate providing a specific min or max in the configuration vs getting them from the database.

I have resolved the issue with clear and reload of the filter, it will now update the filter values using the query.
I have added a new message that displays when the min and max are identical.
![image](https://github.com/GEOLYTIX/xyz/assets/56163132/51f27375-49ca-4016-9ff2-dc96a5c72a7d)

## GitHub Issue

 - [#1301](https://github.com/GEOLYTIX/xyz/issues/1301)

## Type of Change
Please delete options that are not relevant, and select all options that apply. 

- ✅ Bug fix (non-breaking change which fixes an issue)

## How have you tested this? 
Ran this using a field that contained 0 as the minimum field value. 

## Testing Checklist 

- ✅ Existing Tests still pass
- ✅ Ran locally on my machine

## Code Quality Checklist

- ✅ My code follows the guidelines of XYZ
- ✅ My code has been commented
- ✅ Documentation has been updated
- ✅ New and existing unit tests pass locally with my changes
- ✅ Main has been merged into this PR
