### PR TITLE
Query Button PR

### DIFF
--- a/lib/ui/locations/entries/_entries.mjs
+++ b/lib/ui/locations/entries/_entries.mjs
@@ -28,6 +28,7 @@ Exports a collection of entry methods for location views.
 - time
 - title
 - vector_layer
+- query_button
 
 @module /ui/locations/entries
 */
@@ -66,6 +67,8 @@ import time from './time.mjs'
 
 import vector_layer from './vector_layer.mjs'
 
+import query_button from './query_button.mjs'
+
 export default {
   boolean,
   dataview,
@@ -91,7 +94,8 @@ export default {
   textarea,
   time,
   title,
-  vector_layer
+  vector_layer,
+  query_button
 }
 
 function key(entry) {

--- a/lib/ui/locations/entries/query_button.mjs
+++ b/lib/ui/locations/entries/query_button.mjs
@@ -1,0 +1,131 @@
+/**
+mapp.ui.locations.entries.query_button(entry)
+
+The method returns a button element which will execute a parameterised query.
+"reload" is used to reload the location.layer after the query has been executed (e.g. when the location geometry has been updated).
+"dependents" is used to reload the dependent fields after the query has been executed.
+"alert" is used to display a message after the query has been executed.
+@example
+```json
+{
+  "label": "Snap to Postal Sector",
+  "type": "query_button",
+  "query": "catchment_statistics_snap_to_postal_sector",
+  "queryparams": {
+    "id": true
+  },
+  "alert": "Query has executed!",
+  "reload": true,
+  "dependents": [
+    "geom_3857",
+    "perimeter",
+    "area"
+  ]
+}
+``` 
+@module query_button
+*/
+
+
+/**
+### mapp.ui.locations.entries.query_button(entry)
+
+Returns a button to execute a parameterised query.
+
+@function query_button
+@param {Object} [entry]
+@param {string} [entry.query] The query template.
+@param {string} entry.label The button label.
+@param {Object} entry.queryparams Parameter object.
+@returns {HTMLElement} The query button element.
+*/
+export default function query_button(entry) {
+
+    if (!entry.query) {
+      console.warn('You must provide a query to use "type": "query_button".');
+      return;
+    };
+  
+    // If a label is provided, use it, otherwise use the default
+    entry.label ??= 'Update Entry With Query';
+  
+    // Return button to update the entry.
+    return mapp.utils.html.node`
+      <button 
+        class="flat wide bold primary-colour"
+        onclick=${() => query(entry)}>${entry.label}`;
+  };
+  
+  /**
+     ### query(entry)
+     Executes a parameterised query.
+     The paramString is created from the queryParams utility response.
+     The `entry.host` defaults to the mapview.host concatenated with the `/api/query` path.
+     @function query
+     @param {Object} [entry]
+     @param {string} [entry.query] The query template.
+     @param {Object} entry.queryparams Parameter object.
+     @param {string} entry.host The host for the query.
+     @param {string} entry.alert Alert message (optionaL) - displays after the query has executed.
+     @param {boolean} entry.reload Reload location.layer (optional) - useful when the location geometry has been updated to refresh the layer.
+     @param {Array} entry.dependents Reload dependent fields (optional) - when the query has executed, the dependent fields will be reloaded.
+     @returns {HTMLElement} The query button element.
+     */
+  async function query(entry) {
+  
+    // Disable location view.
+    entry.location.view.classList.add('disabled');
+  
+    entry.queryparams ??= {}
+  
+    entry.queryparams.template = entry.query
+  
+    // Stringify paramString from object.
+    const paramString = mapp.utils.paramString(mapp.utils.queryParams(entry))
+  
+    // 
+    entry.host ??= entry.location.layer.mapview.host + '/api/query'
+  
+    // Run query to get data to update the entry on the db.
+    const response = await mapp.utils.xhr(`${entry.host}?${paramString}`);
+  
+    if (response instanceof Error) {
+  
+      alert('Query failed.')
+  
+      // Enable location view.
+      entry.location.view.classList.remove('disabled');
+  
+      return;
+    }
+  
+    entry.value = response
+  
+    entry.alert && alert(entry.alert)
+  
+    entry.reload && entry.location.layer.reload()
+  
+    // Warning for legacy config.
+    if (entry.updated_fields) {
+  
+      console.warn('entry.updated_fields is deprecated, please use entry.dependents instead.');
+  
+      // If entry.updated_fields, set to entry.dependents and warn
+      entry.dependents ??= entry.updated_fields;
+    }
+  
+    if (entry.dependents) {
+  
+      // Reload the dependent fields
+      await entry.location.syncFields(entry.dependents)
+  
+    }
+  
+    // Updating the view will enable the view itself.
+    // No need to enable the button and view themselves.
+    entry.location.view.dispatchEvent(new Event('updateInfo'))
+  
+    // Enable location view.
+    entry.location.view.classList.remove('disabled');
+  }
+  

--- a/lib/ui/locations/entries/query_button.mjs
+++ b/lib/ui/locations/entries/query_button.mjs
@@ -1,10 +1,17 @@
 /**
 mapp.ui.locations.entries.query_button(entry)
 
-The method returns a button element which will execute a parameterised query.
-"reload" is used to reload the location.layer after the query has been executed (e.g. when the location geometry has been updated).
-"dependents" is used to reload the dependent fields after the query has been executed.
-"alert" is used to display a message after the query has been executed.
+Exports the query_button entry method.
+
+@module query_button
+*/
+
+/**
+@function query_button
+
+@description
+Returns a button element. The `query(entry)` method will be called by the button onclick event.
+
 @example
 ```json
 {
@@ -23,109 +30,112 @@ The method returns a button element which will execute a parameterised query.
   ]
 }
 ``` 
-@module query_button
-*/
 
-
-/**
-### mapp.ui.locations.entries.query_button(entry)
-
-Returns a button to execute a parameterised query.
-
-@function query_button
-@param {Object} [entry]
-@param {string} [entry.query] The query template.
-@param {string} entry.label The button label.
+@param {Object} entry
+@param {string} entry.query The query template.
 @param {Object} entry.queryparams Parameter object.
+@param {string} [entry.label] The button label.
 @returns {HTMLElement} The query button element.
 */
 export default function query_button(entry) {
 
-    if (!entry.query) {
-      console.warn('You must provide a query to use "type": "query_button".');
-      return;
-    };
-  
-    // If a label is provided, use it, otherwise use the default
-    entry.label ??= 'Update Entry With Query';
-  
-    // Return button to update the entry.
-    return mapp.utils.html.node`
-      <button 
-        class="flat wide bold primary-colour"
-        onclick=${() => query(entry)}>${entry.label}`;
+  if (!entry.query) {
+    console.warn('You must provide a query to use "type": "query_button".');
+    return;
   };
-  
-  /**
-     ### query(entry)
-     Executes a parameterised query.
-     The paramString is created from the queryParams utility response.
-     The `entry.host` defaults to the mapview.host concatenated with the `/api/query` path.
-     @function query
-     @param {Object} [entry]
-     @param {string} [entry.query] The query template.
-     @param {Object} entry.queryparams Parameter object.
-     @param {string} entry.host The host for the query.
-     @param {string} entry.alert Alert message (optionaL) - displays after the query has executed.
-     @param {boolean} entry.reload Reload location.layer (optional) - useful when the location geometry has been updated to refresh the layer.
-     @param {Array} entry.dependents Reload dependent fields (optional) - when the query has executed, the dependent fields will be reloaded.
-     @returns {HTMLElement} The query button element.
-     */
-  async function query(entry) {
-  
-    // Disable location view.
-    entry.location.view.classList.add('disabled');
-  
-    entry.queryparams ??= {}
-  
-    entry.queryparams.template = entry.query
-  
-    // Stringify paramString from object.
-    const paramString = mapp.utils.paramString(mapp.utils.queryParams(entry))
-  
-    // 
-    entry.host ??= entry.location.layer.mapview.host + '/api/query'
-  
-    // Run query to get data to update the entry on the db.
-    const response = await mapp.utils.xhr(`${entry.host}?${paramString}`);
-  
-    if (response instanceof Error) {
-  
-      alert('Query failed.')
-  
-      // Enable location view.
-      entry.location.view.classList.remove('disabled');
-  
-      return;
-    }
-  
-    entry.value = response
-  
-    entry.alert && alert(entry.alert)
-  
-    entry.reload && entry.location.layer.reload()
-  
-    // Warning for legacy config.
-    if (entry.updated_fields) {
-  
-      console.warn('entry.updated_fields is deprecated, please use entry.dependents instead.');
-  
-      // If entry.updated_fields, set to entry.dependents and warn
-      entry.dependents ??= entry.updated_fields;
-    }
-  
-    if (entry.dependents) {
-  
-      // Reload the dependent fields
-      await entry.location.syncFields(entry.dependents)
-  
-    }
-  
-    // Updating the view will enable the view itself.
-    // No need to enable the button and view themselves.
-    entry.location.view.dispatchEvent(new Event('updateInfo'))
-  
+
+  // If a label is provided, use it, otherwise use the default
+  entry.label ??= `Run query:${entry.query}`;
+
+  // Return button to update the entry.
+  return mapp.utils.html.node`
+    <button 
+      class="flat wide bold primary-colour"
+      onclick=${() => query(entry)}>${entry.label}`;
+};
+
+/**
+@function query
+
+@description
+Will be called by the onclick event of the query_button element.
+
+The `entry.location.view` will be disabled.
+
+Runs the `entry.query` template with the provided `entry.queryparams`.
+
+The `entry.host` defaults to the entry.mapview.host concatenated with the `/api/query` path.
+
+The location.layer will reload after the query response with the `entry.reload` flag.
+
+The entry values of fields in the `entry.dependents` array will be synched after the query has been resolved.
+
+The `entry.alert` message will be displayed after the query has been resolved.
+
+The `entry.location.view` will be enabled by calling the `updateInfo` element event.
+
+@param {Object} entry infoj entry.
+@param {string} entry.query query template.
+@param {Object} entry.queryparams parameter object for query.
+@param {string} [entry.host] The host for the query.
+@param {string} [entry.alert] Alert message after the query has responded.
+@param {boolean} [entry.reload] Reload location.layer if true.
+@param {Array} [entry.dependents] Reload dependent entry.field values.
+*/
+
+async function query(entry) {
+
+  // Warning for legacy config.
+  if (entry.updated_fields) {
+
+    console.warn('entry.updated_fields is deprecated, please use entry.dependents instead.');
+
+    // If entry.updated_fields, set to entry.dependents and warn
+    entry.dependents ??= entry.updated_fields;
+  }
+
+  // Disable location view.
+  entry.location.view.classList.add('disabled');
+
+  entry.queryparams ??= {}
+
+  entry.queryparams.template = entry.query
+
+  // Stringify paramString from object.
+  const paramString = mapp.utils.paramString(mapp.utils.queryParams(entry))
+
+  entry.host ??= entry.location.layer.mapview.host + '/api/query'
+
+  // Run query to get data to update the entry on the db.
+  const response = await mapp.utils.xhr(`${entry.host}?${paramString}`);
+
+  if (response instanceof Error) {
+
+    alert('Query failed.')
+
     // Enable location view.
     entry.location.view.classList.remove('disabled');
+
+    return;
   }
-  
+
+  entry.value = response
+
+  entry.alert && alert(entry.alert)
+
+  entry.reload && entry.location.layer.reload()
+
+  if (entry.dependents) {
+
+    // Reload the dependent fields
+    await entry.location.syncFields(entry.dependents)
+
+  }
+
+  // Updating the view will enable the view itself.
+  // No need to enable the button and view themselves.
+  entry.location.view.dispatchEvent(new Event('updateInfo'))
+
+  // Enable location view.
+  entry.location.view.classList.remove('disabled');
+}


### PR DESCRIPTION
This PR moves the query_button plugin into the core. 
The method returns a button element which will execute a parameterised query.
"reload" is used to reload the location.layer after the query has been executed (e.g. when the location geometry has been updated).
"dependents" is used to reload the dependent fields after the query has been executed.
"alert" is used to display a message after the query has been executed.

```json
{
  "label": "Snap to Postal Sector",
  "type": "query_button",
  "query": "catchment_statistics_snap_to_postal_sector",
  "queryparams": {
    "id": true
  },
  "alert": "Query has executed!",
  "reload": true,
  "dependents": [
    "geom_3857",
    "perimeter",
    "area"
  ]
}