### PR TITLE
styleParser default style merge issue

### DIFF
--- a/lib/layer/styleParser.mjs
+++ b/lib/layer/styleParser.mjs
@@ -318,7 +318,10 @@ export default layer => {
 
       if (defaultStyle.icon && !Array.isArray(defaultStyle.icon)) {
 
-        Object.assign(cat.style.icon, defaultStyle.icon)
+        cat.style.icon = {
+          ...defaultStyle.icon,
+          ...cat.style.icon
+        }
       }
       return;
 


### PR DESCRIPTION
# Pull Request Template

## Description

StyleParser Fix 

## Type of Change
Please delete options that are not relevant, and select all options that apply. 

- ✅ Bug fix (non-breaking change which fixes an issue)

## How have you tested this? 
The `object.assign` for a default style icon to a cat style icon was incorrect, it was merging the wrong way. 
Updated to use spread assignment where the defaultstyle is first to resolve this. 

## Testing Checklist 
Please delete options that are not relevant, and select all options that apply. 

- ✅ Existing Tests still pass
- ✅ Ran locally on my machine

## Code Quality Checklist
Please delete options that are not relevant, and select all options that apply. 

- ✅ My code follows the guidelines of XYZ
- ✅ My code has been commented
- ✅ Documentation has been updated
- ✅ New and existing unit tests pass locally with my changes
- ✅ Main has been merged into this PR