### PR TITLE
The style must be assigned before the highlight.

### DIFF
--- a/lib/layer/styleParser.mjs
+++ b/lib/layer/styleParser.mjs
@@ -74,13 +74,13 @@ Parses and validates the style configuration of a layer.
  */
 export default layer => {
 
+  layer.style ??= {}
+
   // Assign a default highlight style and ensure that zIndex is infinity if not implicit.
   layer.style.highlight ??= {}
   layer.style.highlight.zIndex ??= Infinity
   layer.style.highlight.highlightScale = layer.style.highlight.scale
   delete layer.style.highlight.scale
-
-  layer.style ??= {}
 
   warnings(layer)
 


### PR DESCRIPTION
A vector layer without a style object will crash trying to assign the highlight style to undefined.