### PR TITLE
Ensure that each entry has a key.

### DIFF
--- a/lib/ui/locations/entries/geometry.mjs
+++ b/lib/ui/locations/entries/geometry.mjs
@@ -114,7 +114,7 @@ export default function geometry(entry) {
   // Create checkbox to control geometry display.
   entry.chkbox = mapp.ui.elements.chkbox({
     label: entry.label,
-    data_id: `${entry.field}-chkbox`,
+    data_id: `${entry.key}-chkbox`,
     checked: !!entry.display,
 
     // API entries will not be disabled without a value.
@@ -176,7 +176,7 @@ async function show() {
   this.display = true
 
   // the show event maybe triggered by an API, draw, or modify interaction.
-  const chkbox = this.location.view?.querySelector(`[data-id=${this.field}-chkbox] input`)
+  const chkbox = this.location.view?.querySelector(`[data-id=${this.key}-chkbox] input`)
 
   if (chkbox) chkbox.checked = true
 

--- a/lib/ui/locations/entries/mvt_clone.mjs
+++ b/lib/ui/locations/entries/mvt_clone.mjs
@@ -133,7 +133,7 @@ export default entry => {
   // Create checkbox to control geometry display.
   const chkbox = mapp.ui.elements.chkbox({
     label: entry.label || 'MVT Clone',
-    data_id: `${entry.field}-chkbox`,
+    data_id: `${entry.key}-chkbox`,
     checked: !!entry.display,
     onchange: (checked) => checked ? entry.show() : entry.hide()
   })

--- a/lib/ui/locations/entries/vector_layer.mjs
+++ b/lib/ui/locations/entries/vector_layer.mjs
@@ -35,7 +35,7 @@ export default entry => {
   // Create checkbox to control geometry display.
   entry.chkbox = mapp.ui.elements.chkbox({
     label: entry.label,
-    data_id: `${entry.field}-chkbox`,
+    data_id: `${entry.key}-chkbox`,
     checked: !!entry.display,
     onchange: (checked) => checked ? entry.show() : hide(entry)
   })
@@ -64,7 +64,7 @@ async function show() {
   this.display = true;
 
   // the show event maybe triggered by an API, draw, or modify interaction.
-  const chkbox = this.location.view?.querySelector(`[data-id=${this.field}-chkbox] input`)
+  const chkbox = this.location.view?.querySelector(`[data-id=${this.key}-chkbox] input`)
 
   if (chkbox) chkbox.checked = true
 

--- a/lib/ui/locations/infoj.mjs
+++ b/lib/ui/locations/infoj.mjs
@@ -65,8 +65,13 @@ export default function infoj(location, infoj_order) {
     }).filter(entry => entry !== undefined)
     : location.infoj;
 
+  
+  let keyIdx = 0;
+
   // Iterate through info fields and add to info table.
   for (const entry of infoj) {
+
+    entry.key ??= entry.field || keyIdx++
 
     // The location view entries should not be processed if the view is disabled.
     if (location.view?.classList.contains('disabled')) break;


### PR DESCRIPTION
Each entry should be assigned a key in the infoj iteration if not already assigned.

The key can be an entry.field which is unique. Otherwise a running index can be assigned within the iteration.

The key should be used primarily as a data_id to ensure that similar elements such as checkboxes have a unique data-id within their location.view context.
