### PR TITLE
Ensure that the style.zIndex is only used in the olStyle module

### DIFF
--- a/lib/layer/format/googleMapTiles.mjs
+++ b/lib/layer/format/googleMapTiles.mjs
@@ -4,6 +4,8 @@ export default async (layer) => {
 
   layer.style.mapType ??= 'roadmap'
 
+  layer.zIndex ??= 0
+
   layer.L = new ol.layer.WebGLTile({
     source: new ol.source.Google({
       key: layer.apiKey,
@@ -13,7 +15,7 @@ export default async (layer) => {
       layerTypes: layer.style.layerTypes
     }),
     layer: layer,
-    zIndex: layer.style.zIndex || 0
+    zIndex: layer.zIndex
   })
 
 }

--- a/lib/layer/format/maplibre.mjs
+++ b/lib/layer/format/maplibre.mjs
@@ -82,9 +82,11 @@ export default async layer => {
 
   // The Maplibre Map control must resize with mapview Map targetElement.
   layer.mapview.Map.getTargetElement().addEventListener('resize', ()=>layer.Map.resize())
+  
+  layer.zIndex ??= 0
 
   layer.L =  new ol.layer.Layer({
-    //zIndex: layer.zIndex || 0,
+    zIndex: layer.zIndex,
     render: frameState => {
 
       if (!layer.display) return

--- a/lib/layer/format/mbtiles.mjs
+++ b/lib/layer/format/mbtiles.mjs
@@ -61,8 +61,10 @@ export default async layer => {
     preserveDrawingBuffer: layer.preserveDrawingBuffer
   });
 
+  layer.zIndex ??= 0
+
   layer.L =  new ol.layer.Layer({
-    zIndex: layer.zIndex || 0,
+    zIndex: layer.zIndex,
     render: frameState => {
 
       if (!layer.display) return

--- a/lib/layer/format/tiles.mjs
+++ b/lib/layer/format/tiles.mjs
@@ -13,7 +13,7 @@ The function takes a layer object as input and performs the following steps:
 3. It creates a new `ol.layer.Tile` object and assigns it to `layer.L`. The tile layer is configured with the following properties:
    - `source`: A new instance of the tile source based on layer.source. The source is created using `ol.source[layer.source]` and is configured with the projection, url, and transition properties.
    - `layer`: The layer object itself, allowing access to layer properties within the tile layer.
-   - `zIndex`: The z-index of the layer, obtained from `layer.style.zIndex` or defaulting to 0.
+   - `zIndex`: The z-index of the layer.
 @function tiles
 @param {Object} layer - The layer object.
 @param {string} [layer.source='OSM'] - The source of the tile layer (e.g., 'OSM', 'XYZ').
@@ -22,7 +22,7 @@ The function takes a layer object as input and performs the following steps:
 @param {Object} [layer.params] - Additional parameters for the tile layer.
 @param {string} layer.URI - The base URI for the tile layer.
 @param {Object} [layer.style] - The style configuration for the layer.
-@param {number} [layer.style.zIndex=0] - The z-index of the layer.
+@param {number} [layer.zIndex=0] - The z-index of the layer.
 @param {ol.layer.Tile} layer.L - The OpenLayers tile layer object.
 */
 export default layer => {
@@ -33,6 +33,8 @@ export default layer => {
 
   layer.paramString ??= mapp.utils.paramString(layer.params)
 
+  layer.zIndex ??= 0
+
   layer.L = new ol.layer.Tile({
     source: new ol.source[layer.source]({
       projection: layer.projection,
@@ -40,7 +42,7 @@ export default layer => {
       transition: 0
     }),
     layer: layer,
-    zIndex: layer.style?.zIndex || 0
+    zIndex: layer.zIndex
   })
 
   if (layer.style?.contextFilter) {

--- a/lib/layer/format/vector.mjs
+++ b/lib/layer/format/vector.mjs
@@ -153,10 +153,12 @@ export default layer => {
 
   }
 
+  layer.zIndex ??= 1
+
   // Create Openlayer Vector Layer
   layer.L = new ol.layer[layer.vectorImage && 'VectorImage' || 'Vector']({
     key: layer.key,
-    zIndex: layer.zIndex || 1,
+    zIndex: layer.zIndex,
     style: layer.styleFunction || mapp.layer.featureStyle(layer)
   })
 


### PR DESCRIPTION
The style.zIndex must not be confused with the layer.zIndex.

The style.zIndex defines the render order within a layer.canvas

The layer.index defines the order of layer canvases within the Openlayers mapview.