### PR TITLE
Cluster style parser and spread.

### DIFF
--- a/lib/layer/featureStyle.mjs
+++ b/lib/layer/featureStyle.mjs
@@ -159,16 +159,17 @@ export default layer => {
 
     let clusterScale = parseFloat(layer.style.cluster.clusterScale)
 
-    // Set style.cluster as feature.style
+    // Spread cluster style into feature.style.
     feature.style = {
-      icon: layer.style.cluster.icon
+      ...feature.style,
+      ...layer.style.cluster
     }
 
     // Cluster icons will NOT scale different to single locations if the clusterScale is not set in the cluster style.
     if (clusterScale) {
 
       // The clusterScale will be added to the icon scale.
-      feature.style.clusterScale = layer.style.logScale ?
+      feature.style.clusterScale = layer.style.cluster.logScale ?
 
         // A natural log will be applied to the cluster scaling.
         Math.log(clusterScale) / Math.log(layer.max_size) * Math.log(feature.properties.size || feature.properties.count) :
@@ -186,7 +187,7 @@ export default layer => {
     // Setting a zoomOutScale will DECREASE the scale of icons on higher zoom levels.
     if (layer.style.cluster.zoomOutScale) {
 
-      feature.style.zoomOutScale = layer.style.cluster.zoomInScale / layer.mapview.Map.getView().getZoom()
+      feature.style.zoomOutScale = layer.style.cluster.zoomOutScale / layer.mapview.Map.getView().getZoom()
     }
   }
 

--- a/lib/layer/styleParser.mjs
+++ b/lib/layer/styleParser.mjs
@@ -203,11 +203,12 @@ export default layer => {
     }
 
     // Define default style cluster icon
-    layer.style.cluster ??= {
+    layer.style.cluster = {
       clusterScale: 1,
       icon: {
         type: 'dot'
-      }
+      },
+      ...layer.style.cluster
     }
 
     if (!layer.style.cluster.icon) {

--- a/lib/layer/styleParser.mjs
+++ b/lib/layer/styleParser.mjs
@@ -198,6 +198,7 @@ export default layer => {
       console.warn(`Cluster Layer: ${layer.key} has no default icon. 'Dot' will be assigned.`)
     }
 
+    // Cluster layer must not have stroke or fill styles.
     Object.keys(layer.style.default)
       .filter(key => !['icon', 'scale'].includes(key))
       .forEach(key => {

--- a/lib/layer/styleParser.mjs
+++ b/lib/layer/styleParser.mjs
@@ -193,14 +193,14 @@ export default layer => {
       console.warn(`Cluster Layer: ${layer.key} has no default icon. 'Dot' will be assigned.`)
     }
 
-    if (Object.keys(layer.style.default).some(key => key !== 'icon')) {
+    Object.keys(layer.style.default)
+      .filter(key => !['icon', 'scale'].includes(key))
+      .forEach(key => {
 
-      console.warn(`Cluster Layer: ${layer.key}; None icon keys will be removed from default style.`)
+        console.warn(`Cluster Layer: ${layer.key}; ${key} key removed from default style.`)
 
-      Object.keys(layer.style.default)
-        .filter(key => key !== 'icon')
-        .forEach(key => delete layer.style.default[key])
-    }
+        delete layer.style.default[key]
+      })
 
     // Define default style cluster icon
     layer.style.cluster = {

--- a/lib/layer/themes/basic.mjs
+++ b/lib/layer/themes/basic.mjs
@@ -9,5 +9,9 @@ This module exports a function that assigns the theme.style as feature.style
 */
 export default function (theme, feature) {
 
-  feature.style = theme.style
+    // Spread theme style to retain scale property
+    feature.style = {
+      ...feature.style,
+      ...theme.style
+    }
 }

--- a/lib/layer/themes/categorized.mjs
+++ b/lib/layer/themes/categorized.mjs
@@ -69,5 +69,9 @@ export default function categorized(theme, feature) {
 
   if (!cat) return;
 
-  feature.style = cat.style
+  // Spread cat style to retain scale property
+  feature.style = {
+    ...feature.style,
+    ...cat.style
+  }
 }

--- a/lib/layer/themes/graduated.mjs
+++ b/lib/layer/themes/graduated.mjs
@@ -15,7 +15,7 @@ This module exports a function that applies a graduated theme to a feature based
 @param {Array} [feature.properties.features] - An array of sub-features.
 @returns {void}
  */
-export default function(theme, feature) {
+export default function (theme, feature) {
 
   // The graduated theme requires feature.properties.
   if (!feature.properties) return;
@@ -31,8 +31,8 @@ export default function(theme, feature) {
   if (!isNaN(catValue) && catValue !== null) {
 
     const graduated_breaks = {
-      "less_than": val => cat => val <= cat.value,
-      "greater_than": val => cat => val >= cat.value
+      'less_than': val => cat => val <= cat.value,
+      'greater_than': val => cat => val >= cat.value
     }
 
     let index = theme.categories.findIndex(graduated_breaks[theme.graduated_breaks](catValue))

--- a/lib/layer/themes/graduated.mjs
+++ b/lib/layer/themes/graduated.mjs
@@ -39,6 +39,10 @@ export default function(theme, feature) {
 
     let cat = theme.categories.at(index)
 
-    feature.style = cat.style
+    // Spread cat style to retain scale property
+    feature.style = {
+      ...feature.style,
+      ...cat.style
+    }
   }
 }

--- a/lib/utils/olStyle.mjs
+++ b/lib/utils/olStyle.mjs
@@ -32,7 +32,8 @@ export default (style, feature) => {
       function iconStyle(style, icon) {
 
         // Calculate scale for icon render.
-        let scale = icon.scale || style.scale || 1
+        let scale = icon.scale || 1
+        scale *= style.scale || 1
         scale *= style.clusterScale || 1
         scale *= style.zoomInScale || 1
         scale *= style.zoomOutScale || 1

--- a/tests/lib/layer/styleParser.test.mjs
+++ b/tests/lib/layer/styleParser.test.mjs
@@ -119,9 +119,9 @@ describe('styleParser', () => {
     };
 
     const expected_categories = [
-      { value: 10, style: { fillColor: "red" }, label: 10 }, 
-      { value: 20, style: { fillColor: "green" }, label: 20 },
-      { value: 30, style: { fillColor: "blue" }, label: 30 }
+      { value: 10, style: { fillColor: 'red' }, label: 10 },
+      { value: 20, style: { fillColor: 'green' }, label: 20 },
+      { value: 30, style: { fillColor: 'blue' }, label: 30 }
     ];
 
     styleParser(layer);
@@ -168,6 +168,123 @@ describe('styleParser', () => {
 
     assertEqual(layer.style.hover.method, 'customHoverMethod', 'hover configuration should be moved to layer.style.hover');
     assertFalse(layer.hasOwnProperty('hover'), 'layer.hover should be deleted');
+  });
+
+  it('should handle layer.style.hover and layers.style.hovers', () => {
+    const layer = {
+      key: 'test-layer',
+      style: {
+        hover: {
+          method: 'customHoverMethod',
+        },
+        hovers: {
+          hover1: {
+            method: 'customHoverMethod1',
+          },
+          hover2: {
+            method: 'customHoverMethod2',
+          },
+        }
+      }
+    };
+
+    styleParser(layer);
+
+    const expected = {
+      'hovers': {
+        'hover1': {
+          'method': 'customHoverMethod1'
+        },
+        'hover2': {
+          'method': 'customHoverMethod2'
+        }
+      },
+      'highlight': { 'zIndex': null },
+      'default': { 'strokeColor': '#333', 'fillColor': '#fff9' },
+      'hover': { 'method': 'customHoverMethod1' }
+    }
+
+    assertTrue('hover' in layer.style);
+    assertTrue('hovers' in layer.style);
+    assertEqual(layer.style.hover.method, expected.hover.method);
+  });
+
+  it('should handle layer.style.label and layers.style.labels', () => {
+    const layer = {
+      key: 'test-layer',
+      style: {
+        label: {
+          field: 'labelField',
+        },
+        labels: {
+          label1: {
+            field: 'label1Field',
+          },
+          label2: {
+            field: 'label2Field',
+          },
+        }
+      }
+    };
+
+    styleParser(layer);
+
+    const expected = {
+      style: {
+        labels: {
+          label1: {
+            field: 'label1Field',
+          },
+          label2: {
+            field: 'label2Field',
+          },
+        },
+        'highlight': { 'zIndex': null },
+        'default': { 'strokeColor': '#333', 'fillColor': '#fff9' },
+        'label': {
+          field: 'label1Field'
+        }
+      }
+    }
+    assertTrue('label' in layer.style);
+    assertTrue('labels' in layer.style);
+    assertEqual(layer.style.label.field, expected.style.label.field)
+  });
+
+  it('should remove keys that are not in the default icon object', () => {
+    const layer = {
+      format: 'wkt',
+      key: 'test-layer',
+      style: {
+        default: {
+          testkey: 'test',
+          icon: {
+            type: 'target',
+            fillColor: '#000000',
+          }
+        }
+      }
+    };
+
+    styleParser(layer);
+
+    const expected = {
+      format: 'wkt',
+      key: 'test-layer',
+      style: {
+        default: {
+          icon: {
+            type: 'target',
+            fillColor: '#000000',
+          }
+        },
+        'highlight': { 'zIndex': null }
+
+      }
+    }
+
+    // Non-icon key should be removed 
+    assertFalse('testkey' in layer.style.default, 'There should be no other keys other than icon and scale in the default style');
   });
 
 });

--- a/tests/lib/layer/styleParser.test.mjs
+++ b/tests/lib/layer/styleParser.test.mjs
@@ -257,7 +257,7 @@ describe('styleParser', () => {
       key: 'test-layer',
       style: {
         default: {
-          testkey: 'test',
+          key_to_be_removed: 'remove me',
           icon: {
             type: 'target',
             fillColor: '#000000',
@@ -284,7 +284,7 @@ describe('styleParser', () => {
     }
 
     // Non-icon key should be removed 
-    assertFalse('testkey' in layer.style.default, 'There should be no other keys other than icon and scale in the default style');
+    assertFalse('key_to_be_removed' in layer.style.default, 'There should be no other keys other than icon and scale in the default style');
   });
 
 });

--- a/tests/lib/layer/styleParser.test.mjs
+++ b/tests/lib/layer/styleParser.test.mjs
@@ -255,11 +255,13 @@ describe('styleParser', () => {
     const layer = {
       format: 'wkt',
       key: 'test-layer',
+      cluster: {},
       style: {
         default: {
+          scale: 2,
           key_to_be_removed: 'remove me',
           icon: {
-            type: 'target',
+            type: 'dot',
             fillColor: '#000000',
           }
         }
@@ -267,21 +269,6 @@ describe('styleParser', () => {
     };
 
     styleParser(layer);
-
-    const expected = {
-      format: 'wkt',
-      key: 'test-layer',
-      style: {
-        default: {
-          icon: {
-            type: 'target',
-            fillColor: '#000000',
-          }
-        },
-        'highlight': { 'zIndex': null }
-
-      }
-    }
 
     // Non-icon key should be removed 
     assertFalse('key_to_be_removed' in layer.style.default, 'There should be no other keys other than icon and scale in the default style');


### PR DESCRIPTION
Working on the cluster and icon scaling plugin we noticed a couple of small issues in regards to the cluster style assignment.

The style.cluster must be spread into the feature.style object to preserve cluster scaling properties.

The logScale is a cluster property not a layer.style property.

The zoomOutScale must be used for the zoomOutScale, not the zoomInScale.

The scale key must not be removed outside the icon in the style.default.

A warning should be issued for the keys which are removed.

```js
    Object.keys(layer.style.default)
      .filter(key => !['icon', 'scale'].includes(key))
      .forEach(key => {

        console.warn(`Cluster Layer: ${layer.key}; ${key} key removed from default style.`)

        delete layer.style.default[key]
      })
```

The a scale maybe inside and outside an icon. These are all valid.

```
{
  scale: 2,
  icon: {
    type: 'dot'
  }
},
{
  icon: {
    scale: 3,
    type: 'dot'
  }
},
{
  scale: 0.5,
  icon: {
    scale: 2,
    type: 'dot'
  }
},
{
  scale: 0.5,
  icon: [{
    scale: 1,
    type: 'dot',
    color: 'red'
  },{
    scale: 2,
    type: 'dot',
    color: 'blue'
  }]
},
```