### PR TITLE
Don't spread style when style object is empty

### DIFF
--- a/lib/ui/locations/entries/geometry.mjs
+++ b/lib/ui/locations/entries/geometry.mjs
@@ -100,8 +100,10 @@ export default function geometry(entry) {
   // Return if entry has no geometry value and cannot be drawn in to.
   if (!entry.value && !entry.draw && !entry.api) return;
 
-  // Assign entry.style to location.style
-  entry.style = { ...entry.location?.style, ...entry.style }
+  // Assign entry.style to location.style if entry.style is not an empty object.
+  if (Object.keys(entry.style).length) {
+    entry.style = { ...entry.location?.style, ...entry.style }
+  }
   
   // Create ol style from entry.style if not yet defined.
   entry.Style ??= mapp.utils.style(entry.style)

--- a/lib/ui/locations/entries/geometry.mjs
+++ b/lib/ui/locations/entries/geometry.mjs
@@ -101,7 +101,7 @@ export default function geometry(entry) {
   if (!entry.value && !entry.draw && !entry.api) return;
 
   // Assign entry.style to location.style if entry.style is not an empty object.
-  if (Object.keys(entry.style).length) {
+  if (entry.style && Object.keys(entry.style).length) {
     entry.style = { ...entry.location?.style, ...entry.style }
   }
   


### PR DESCRIPTION
# Pull Request Template

## Description

Assigning `entry.style` using spread assignment means that it is not possible to have an empty style object. This is valid as we often use an empty style object to generate third-party isolines for example, but not draw them on the map. 
For example, an entry configuration of this which used to not draw, will currently draw to the map which is incorrect.
``` json
{
      "field": "x",
      "fieldfx": "ST_AsGeoJSON(x)",
      "type": "third_party_plugin",
      "display": true,
      "style": {},
      "class": "display-none"
}
```

By checking on the length of `entry.style` this means that if the object is empty, we won't merge in the `entry.location.style` thus keeping the entry with no styling, so it won't be drawn to the map. 
``` js 
// Assign entry.style to location.style if entry.style is not an empty object.
  if (Object.keys(entry.style).length) {
    entry.style = { ...entry.location?.style, ...entry.style }
  }
```

## Type of Change
Please delete options that are not relevant, and select all options that apply. 

- ✅ Bug fix (non-breaking change which fixes an issue)

## How have you tested this? 
Tested locally on my machine.

## Testing Checklist 
Please delete options that are not relevant, and select all options that apply. 

- ✅ Existing Tests still pass
- ✅ Updated Existing Tests
- ✅ New Tests Added
- ✅ Ran locally on my machine

## Code Quality Checklist
Please delete options that are not relevant, and select all options that apply. 

- ✅ My code follows the guidelines of XYZ
- ✅ My code has been commented
- ✅ Documentation has been updated
- ✅ New and existing unit tests pass locally with my changes
- ✅ Main has been merged into this PR