### PR TITLE
Check on entry.Layer needs to happen before assigning entry.Layer.zIndex

### DIFF
--- a/lib/ui/locations/entries/mvt_clone.mjs
+++ b/lib/ui/locations/entries/mvt_clone.mjs
@@ -16,12 +16,12 @@ export default entry => {
   // Assign the mvt layer to be cloned from mapview layers.
   entry.Layer = entry.mapview.layers[entry.layer]
 
-  entry.zIndex ??= entry.Layer.zIndex
-
   if (!entry.Layer) {
     console.warn('mvt_clone Layer not found in mapview.layers object.')
     return;
   }
+
+  entry.zIndex ??= entry.Layer.zIndex
 
   // The entry must have a style object.
   entry.style ??= entry.Layer.style


### PR DESCRIPTION
# MVT Clone Fix

## Description

Bug fix here. 
If entry.Layer is undefined - ie the layer to clone is not accessible, and the entry has no zIndex. The code attempts to set the `entry.zIndex` to `entry.Layer.zIndex`. But as `entry.Layer` does not exist, it crashes. 
``` js 
  // Assign the mvt layer to be cloned from mapview layers.
  entry.Layer = entry.mapview.layers[entry.layer]

  entry.zIndex ??= entry.Layer.zIndex

  if (!entry.Layer) {
    console.warn('mvt_clone Layer not found in mapview.layers object.')
    return;
  }
```

To fix this I simply swapped the code around. This way - if the entry.Layer does not exist then the return happens and no crash occurs.

``` js 
  // Assign the mvt layer to be cloned from mapview layers.
  entry.Layer = entry.mapview.layers[entry.layer]

  if (!entry.Layer) {
    console.warn('mvt_clone Layer not found in mapview.layers object.')
    return;
  }

  entry.zIndex ??= entry.Layer.zIndex

```

## Type of Change
Please delete options that are not relevant, and select all options that apply. 

- ✅ Bug fix (non-breaking change which fixes an issue)

## How have you tested this? 
Tested locally.

## Testing Checklist 
Please delete options that are not relevant, and select all options that apply. 

- ✅ Existing Tests still pass
- ✅ Updated Existing Tests
- ✅ New Tests Added
- ✅ Ran locally on my machine

## Code Quality Checklist
Please delete options that are not relevant, and select all options that apply. 

- ✅ My code follows the guidelines of XYZ
- ✅ My code has been commented
- ✅ Documentation has been updated
- ✅ New and existing unit tests pass locally with my changes
- ✅ Main has been merged into this PR