### PR TITLE
maplibre and style.zIndex

### DIFF
--- a/lib/layer/format/googleMapTiles.mjs
+++ b/lib/layer/format/googleMapTiles.mjs
@@ -4,18 +4,17 @@ export default async (layer) => {
 
   layer.style.mapType ??= 'roadmap'
 
-  layer.zIndex ??= 0
-
   layer.L = new ol.layer.WebGLTile({
+    key: layer.key,
+    className: `mapp-layer-${layer.key}`,
+    zIndex: layer.zIndex,
     source: new ol.source.Google({
       key: layer.apiKey,
       scale: 'scaleFactor2x',
       highDpi: true,
       mapType: layer.style.mapType,
       layerTypes: layer.style.layerTypes
-    }),
-    layer: layer,
-    zIndex: layer.zIndex
+    })
   })
 
 }

--- a/lib/layer/format/maplibre.mjs
+++ b/lib/layer/format/maplibre.mjs
@@ -46,8 +46,10 @@ async function MaplibreGL() {
 
 export default async layer => {
 
+  const className = `mapp-layer-${layer.key} maplibre`
+
   layer.container = mapp.utils.html.node`<div 
-    class="maplibre" 
+    class=${className}
     style="visibility: hidden; position: absolute; width: 100%; height: 100%;">`
 
   layer.mapview.Map.getTargetElement().prepend(layer.container)
@@ -66,7 +68,7 @@ export default async layer => {
     pitchWithRotate: false,
     scrollZoom: false,
     touchZoomRotate: false,
-    preserveDrawingBuffer: true,
+    preserveDrawingBuffer: layer.preserveDrawingBuffer,
     transformRequest: (url, resourceType) => {
 
       if (url.indexOf('mapbox:') === 0) {
@@ -88,10 +90,8 @@ export default async layer => {
     console.warn(`Layer: ${layer.key}, layer.style.zIndex has been deprecated. Use layer.zIndex instead.`);
   }
 
-  //layer.zIndex ??= 0
-
   layer.L = new ol.layer.Layer({
-    className: `mapp-layer-${layer.key}`,
+    key: layer.key,
     zIndex: layer.zIndex,
     render: frameState => {
 

--- a/lib/layer/format/maplibre.mjs
+++ b/lib/layer/format/maplibre.mjs
@@ -83,11 +83,16 @@ export default async layer => {
   // The Maplibre Map control must resize with mapview Map targetElement.
   layer.mapview.Map.getTargetElement().addEventListener('resize', () => layer.Map.resize())
 
+  // Handle layer.style.zIndex deprecation.
+  if (layer.style.zIndex) {
+    console.warn(`Layer: ${layer.key}, layer.style.zIndex has been deprecated. Use layer.zIndex instead.`);
+  }
+
+  //layer.zIndex ??= 0
 
   layer.L = new ol.layer.Layer({
-    // zIndex is commented out as it does not work correctly
-    // When a layer.zIndex is specified, it appears on top of all other layers and cannot be changed
-    //zIndex: layer.zIndex,
+    className: `mapp-layer-${layer.key}`,
+    zIndex: layer.zIndex,
     render: frameState => {
 
       if (!layer.display) return

--- a/lib/layer/format/maplibre.mjs
+++ b/lib/layer/format/maplibre.mjs
@@ -14,20 +14,20 @@ async function MaplibreGL() {
   // Create promise to load maplibre from esm.sh
   if (!promise) promise = new Promise(async resolve => {
 
-    try{
+    try {
 
       const mod = await import('https://esm.sh/maplibre-gl@4.0.2')
 
       maplibregl = mod.default
-  
+
       // Avoid loading RTL Text Plugin twice, else it will error
-      if (!["deferred", "loaded"].includes(maplibregl.getRTLTextPluginStatus())) {
+      if (!['deferred', 'loaded'].includes(maplibregl.getRTLTextPluginStatus())) {
         maplibregl.setRTLTextPlugin(
           'https://unpkg.com/@mapbox/mapbox-gl-rtl-text@0.2.3/mapbox-gl-rtl-text.min.js',
           true // Lazy load the plugin
         );
       }
-  
+
       resolve()
 
     } catch {
@@ -49,7 +49,7 @@ export default async layer => {
   layer.container = mapp.utils.html.node`<div 
     class="maplibre" 
     style="visibility: hidden; position: absolute; width: 100%; height: 100%;">`
-  
+
   layer.mapview.Map.getTargetElement().prepend(layer.container)
 
   layer.Map = await MaplibreGL({
@@ -72,27 +72,28 @@ export default async layer => {
       if (url.indexOf('mapbox:') === 0) {
         return transformMapboxUrl(url, resourceType, layer.accessToken)
       }
-      
+
       // Do any other transforms you want
-      return {url}
+      return { url }
     }
   });
 
   if (!layer.Map) return;
 
   // The Maplibre Map control must resize with mapview Map targetElement.
-  layer.mapview.Map.getTargetElement().addEventListener('resize', ()=>layer.Map.resize())
-  
-  layer.zIndex ??= 0
+  layer.mapview.Map.getTargetElement().addEventListener('resize', () => layer.Map.resize())
 
-  layer.L =  new ol.layer.Layer({
-    zIndex: layer.zIndex,
+
+  layer.L = new ol.layer.Layer({
+    // zIndex is commented out as it does not work correctly
+    // When a layer.zIndex is specified, it appears on top of all other layers and cannot be changed
+    //zIndex: layer.zIndex,
     render: frameState => {
 
       if (!layer.display) return
 
       layer.container.style.visibility = 'visible';
-      
+
       // adjust view parameters in mapbox
       layer.Map.jumpTo({
         center: ol.proj.toLonLat(frameState.viewState.center),
@@ -104,13 +105,12 @@ export default async layer => {
       return layer.container;
     }
   })
-
 }
 
 // transformMapboxUrl and supporting functions are taken from https://github.com/rowanwins/maplibregl-mapbox-request-transformer
 
 function transformMapboxUrl(url, resourceType, accessToken) {
-  
+
   if (url.indexOf('/styles/') > -1 && url.indexOf('/sprite') === -1) {
     return {
       url: normalizeStyleURL(url, accessToken)

--- a/lib/layer/format/mbtiles.mjs
+++ b/lib/layer/format/mbtiles.mjs
@@ -38,8 +38,10 @@ async function MaplibreGL() {
 
 export default async layer => {
 
+  const className = `mapp-layer-${layer.key} mbtiles`
+
   layer.container = mapp.utils.html.node`<div 
-    class="mbtiles" 
+    class=${className}
     style="visibility: hidden; position: absolute; width: 100%; height: 100%;">`
   
   layer.mapview.Map.getTargetElement().prepend(layer.container)
@@ -61,9 +63,9 @@ export default async layer => {
     preserveDrawingBuffer: layer.preserveDrawingBuffer
   });
 
-  layer.zIndex ??= 0
-
   layer.L =  new ol.layer.Layer({
+    key: layer.key,
+    className: `mapp-layer-${layer.key}`,
     zIndex: layer.zIndex,
     render: frameState => {
 

--- a/lib/layer/format/mvt.mjs
+++ b/lib/layer/format/mvt.mjs
@@ -94,12 +94,12 @@ export default layer => {
   }
 
   layer.L = new ol.layer.VectorTile({
-    className: `mapp-layer-${layer.key}`,
     key: layer.key,
+    className: `mapp-layer-${layer.key}`,
+    zIndex: layer.zIndex,
     source: layer.source,
     renderBuffer: 200,
     //renderMode: 'vector',
-    zIndex: layer.style?.zIndex || 1,
     style: mapp.layer.featureStyle(layer)
   })
 }

--- a/lib/layer/format/mvt.mjs
+++ b/lib/layer/format/mvt.mjs
@@ -94,6 +94,7 @@ export default layer => {
   }
 
   layer.L = new ol.layer.VectorTile({
+    className: `mapp-layer-${layer.key}`,
     key: layer.key,
     source: layer.source,
     renderBuffer: 200,

--- a/lib/layer/format/tiles.mjs
+++ b/lib/layer/format/tiles.mjs
@@ -33,16 +33,15 @@ export default layer => {
 
   layer.paramString ??= mapp.utils.paramString(layer.params)
 
-  layer.zIndex ??= 0
-
   layer.L = new ol.layer.Tile({
+    key: layer.key,
+    className: `mapp-layer-${layer.key}`,
+    zIndex: layer.zIndex,
     source: new ol.source[layer.source]({
       projection: layer.projection,
       url: layer.URI+layer.paramString,
       transition: 0
-    }),
-    layer: layer,
-    zIndex: layer.zIndex
+    })
   })
 
   if (layer.style?.contextFilter) {

--- a/lib/layer/format/vector.mjs
+++ b/lib/layer/format/vector.mjs
@@ -153,12 +153,10 @@ export default layer => {
 
   }
 
-  layer.zIndex ??= 1
-
   // Create Openlayer Vector Layer
   layer.L = new ol.layer[layer.vectorImage && 'VectorImage' || 'Vector']({
-    className: `mapp-layer-${layer.key}`,
     key: layer.key,
+    className: `mapp-layer-${layer.key}`,
     zIndex: layer.zIndex,
     style: layer.styleFunction || mapp.layer.featureStyle(layer)
   })

--- a/lib/layer/format/vector.mjs
+++ b/lib/layer/format/vector.mjs
@@ -157,6 +157,7 @@ export default layer => {
 
   // Create Openlayer Vector Layer
   layer.L = new ol.layer[layer.vectorImage && 'VectorImage' || 'Vector']({
+    className: `mapp-layer-${layer.key}`,
     key: layer.key,
     zIndex: layer.zIndex,
     style: layer.styleFunction || mapp.layer.featureStyle(layer)

--- a/lib/layer/styleParser.mjs
+++ b/lib/layer/styleParser.mjs
@@ -176,6 +176,11 @@ export default layer => {
       console.warn(`Layer: ${layer.key}, cannot use both layer.style.label and layer.style.labels. Layer.style.label has been deleted.`);
       delete layer.style.label;
     }
+
+    // Handle layer.style.zIndex deprecation.
+    if (layer.style.zIndex) {
+      console.warn(`Layer: ${layer.key}, layer.style.zIndex has been deprecated. Use layer.zIndex instead.`);
+    }
   }
 
   function clusterChecks(layer) {


### PR DESCRIPTION
# Pull Request Template

## Description

1. Added a warning on `layer.style.zIndex` deprecation and to use `layer.zIndex` instead in `styleParser`.
2. In PR https://github.com/GEOLYTIX/xyz/pull/1326 the `maplibre` `layer.zIndex` was uncommented. This was a mistake as it doesn't work correctly. I re-commented but added information about why it is commented out. 

## Type of Change
Please delete options that are not relevant, and select all options that apply. 

- ✅ Bug fix (non-breaking change which fixes an issue)

## How have you tested this? 
Tested locally.

## Testing Checklist 
Please delete options that are not relevant, and select all options that apply. 

- ✅ Existing Tests still pass
- ✅ Updated Existing Tests
- ✅ New Tests Added
- ✅ Ran locally on my machine

## Code Quality Checklist
Please delete options that are not relevant, and select all options that apply. 

- ✅ My code follows the guidelines of XYZ
- ✅ My code has been commented
- ✅ Documentation has been updated
- ✅ New and existing unit tests pass locally with my changes
- ✅ Main has been merged into this PR