### PR TITLE
Queryselector fails with data-id beginning with zero

### DIFF
--- a/lib/ui/locations/entries/geometry.mjs
+++ b/lib/ui/locations/entries/geometry.mjs
@@ -118,7 +118,7 @@ export default function geometry(entry) {
   // Create checkbox to control geometry display.
   entry.chkbox = mapp.ui.elements.chkbox({
     label: entry.label,
-    data_id: `${entry.key}-chkbox`,
+    data_id: `chkbox-${entry.key}`,
     checked: !!entry.display,
 
     // API entries will not be disabled without a value.
@@ -180,7 +180,7 @@ async function show() {
   this.display = true
 
   // the show event maybe triggered by an API, draw, or modify interaction.
-  const chkbox = this.location.view?.querySelector(`[data-id=${this.key}-chkbox] input`)
+  const chkbox = this.location.view?.querySelector(`[data-id=chkbox-${this.key}] input`)
 
   if (chkbox) chkbox.checked = true
 


### PR DESCRIPTION
A valid construction is to create a geometry type entry to request geometries from an API.

Without a key and a field 0 may be assigned as key.

A data-id queryselect fails beginning with 0.

```
{
  "type": "isoline_mapbox",
  "params": {
    "access_token": "***"
  }
},
```
