### PR TITLE
Boolean entry  - unnecessary label after symbol

### DIFF
--- a/lib/ui/locations/entries/boolean.mjs
+++ b/lib/ui/locations/entries/boolean.mjs
@@ -33,22 +33,22 @@ export default function boolean(entry) {
 
     return mapp.ui.elements.chkbox({
       label: entry.label || entry.title,
-      checked: entry.newValue !== undefined ? entry.newValue: entry.value,
+      checked: entry.newValue !== undefined ? entry.newValue : entry.value,
       disabled: !entry.edit,
       onchange: (checked) => {
-  
+
         entry.newValue = checked
         entry.location.view?.dispatchEvent(
           new CustomEvent('valChange', {
             detail: entry
           }))
-    
+
       }
     })
 
   }
 
-  const icon = `mask-icon ${entry.value? 'done': 'close'}`
+  const icon = `mask-icon ${entry.value ? 'done' : 'close'}`
 
   return mapp.utils.html.node`
   <div class="link-with-img">

--- a/lib/ui/locations/entries/boolean.mjs
+++ b/lib/ui/locations/entries/boolean.mjs
@@ -24,5 +24,5 @@ export default entry => {
   return mapp.utils.html.node`
   <div class="link-with-img">
     <div class=${icon}></div>
-    <span>${entry.label || entry.field}`
+    <span>`
 }

--- a/lib/ui/locations/entries/boolean.mjs
+++ b/lib/ui/locations/entries/boolean.mjs
@@ -1,4 +1,33 @@
-export default entry => {
+/**
+mapp.ui.locations.entries.boolean(entry)
+
+Exports the boolean entry method.
+
+@module boolean
+*/
+
+/**
+@function boolean
+
+@description
+Returns a HTML element, the value of which is a boolean and will display either a tick or a cross.
+
+@example
+```json
+{
+  "title": "Flag",
+  "field": "flag",
+  "type": "boolean",
+  "inline": true
+}
+``` 
+
+@param {Object} entry
+@param {string} [entry.title] The entry title.
+@param {Object} entry.field The entry field.
+@param {boolean} [entry.inline] Whether the entry should be displayed inline.
+*/
+export default function boolean(entry) {
 
   if (entry.edit) {
 

--- a/public/tests/_default.test.mjs
+++ b/public/tests/_default.test.mjs
@@ -1,6 +1,6 @@
 import { describe, it, assertEqual, assertNotEqual, assertTrue, assertFalse, assertThrows } from 'https://esm.sh/codi-test-framework@0.0.26';
 import { layerTest } from './layer.test.mjs';
-
+import { uiElementsTest } from './lib/ui/_ui.test.mjs';
 await describe('Mapview test', async () => {
 
     console.log(`MAPP v${mapp.version}`)
@@ -605,5 +605,6 @@ await describe('Mapview test', async () => {
     });
 
     await layerTest(mapview);
+    await uiElementsTest(mapview);
 
 });

--- a/public/tests/layer.test.mjs
+++ b/public/tests/layer.test.mjs
@@ -8,7 +8,7 @@ export async function layerTest(mapview) {
         });
     }
 
-    const default_zoom = mapview.view.z;
+    const default_zoom = mapview.view?.z || 0;
 
     await describe(`${mapview.host} : Layer Test`, async () => {
         for (const key in mapview.layers) {
@@ -21,7 +21,9 @@ export async function layerTest(mapview) {
                         mapview.Map.getView().setZoom(layerZoom);
                     }
                     else {
-                        mapview.Map.getView().setZoom(default_zoom);
+                        if (default_zoom !== 0) {
+                            mapview.Map.getView().setZoom(default_zoom);
+                        }
                     }
 
                     if (layer.dataviews) {

--- a/public/tests/lib/ui/_ui.test.mjs
+++ b/public/tests/lib/ui/_ui.test.mjs
@@ -1,0 +1,8 @@
+import { booleanTest } from './locations/entries/boolean.test.mjs'
+import { describe } from 'https://esm.sh/codi-test-framework@0.0.26';
+
+export async function uiElementsTest(mapview) {
+    await describe('UI elements test', async () => {
+        await booleanTest();
+    })
+}

--- a/public/tests/lib/ui/locations/entries/boolean.test.mjs
+++ b/public/tests/lib/ui/locations/entries/boolean.test.mjs
@@ -1,0 +1,10 @@
+import { it, assertEqual } from 'https://esm.sh/codi-test-framework@0.0.26';
+export async function booleanTest() {
+    it('Should return a checkbox', () => {
+        const entry = { title: 'title', field: 'booleanField', inline: true, value: false };
+        const checkboxElement = mapp.ui.locations.entries.boolean(entry);
+
+        assertEqual(checkboxElement.className, 'link-with-img', 'The Checkbox element should have a class of link-with-img');
+        assertEqual(checkboxElement.children[0].className, 'mask-icon close', 'The checbox should have a first child with a close class');
+    });
+}


### PR DESCRIPTION
## Description

The boolean entry has an extra label defined that is not required. As the checkbox is created with a label or title. 
This adds an ugly field or label to the end of the checkbox that is only removed by passing a  `entry.label = " "`.
![image](https://github.com/GEOLYTIX/xyz/assets/56163132/0bbb7e74-f31d-4e3a-9874-f8624cd39042)

This PR simply removes this from the end of the boolean entry. So that `entry.title` is used instead of appending this to the end. 

![image](https://github.com/GEOLYTIX/xyz/assets/56163132/2661bc74-b524-4843-bee5-ea489cd989d5)


## Type of Change
Please delete options that are not relevant, and select all options that apply. 

- ✅ Bug fix (non-breaking change which fixes an issue)

## How have you tested this? 
Tested locally with an entry of this configuration 

``` json 
  {
      "title": "Flag",
      "field": "flag",
      "type": "boolean",
      "inline": true
    }
```
## Testing Checklist 
Please delete options that are not relevant, and select all options that apply. 

- ✅ Existing Tests still pass
- ✅ Updated Existing Tests
- ✅ New Tests Added
- ✅ Ran locally on my machine

## Code Quality Checklist
Please delete options that are not relevant, and select all options that apply. 

- ✅ My code follows the guidelines of XYZ
- ✅ My code has been commented
- ✅ Documentation has been updated
- ✅ New and existing unit tests pass locally with my changes
- ✅ Main has been merged into this PR