### PR TITLE
typedef documentation

### DIFF
--- a/DOCUMENTATION.md
+++ b/DOCUMENTATION.md
@@ -56,7 +56,11 @@ Comments for functions begin with the `@function` tag. Functions should not be a
 
 Each function comment should include an `@description` tag. It is recommended to use a new line for multiline descriptions.
 
-The `@param` tag list should incluide nested params only if these are required or optional in the commented function itself. An optional [param] is marked in square brackets.
+The `@param` tag list should include only params used as function arguments.
+
+Parameter properties should be included if used in the method. Any optional [property] are marked in square brackets.
+
+A global typedef should be created for common Mapp objects.
 
 The `@return` comment tag should state whether a promise is returned which may return an Error object, eg. `@returns {Promise<Object|Error>}`
 
@@ -70,14 +74,34 @@ Creates a request object for the getUser(request) method argument.
 The request.email and request.password are taken from the req.body or authorization header.
 
 @param {Object} req The request object.
-@param {string} [req.body.email] The email address of the user.
-@param {string} [req.body.password] The password of the user.
-@param {string} [req.params.language] The language for the user.
-@param {Object} req.headers The request headers.
-@param {string} [req.headers.authorization] The authorization header containing the email and password.
+@property {string} [req.body.email] The email address of the user.
+@property {string} [req.body.password] The password of the user.
+@property {string} [req.params.language] The language for the user.
+@property {Object} req.headers The request headers.
+@property {string} [req.headers.authorization] The authorization header containing the email and password.
 
 @returns {Promise<Object|Error>}
 Validated user object or an Error if authentication fails.
+*/
+```
+#### Decorator methods
+
+Decorator methods should always return a typedef.
+
+### @typedef [GLOBAL]
+
+Mapp type object should be defined as global typedefs.
+
+Typedef properties should be defined as typedef using a dash naming convention. eg. The style object property of a `layer` typedef will be defined as `layer-style`, the theme object of a layer-style typedef will be type defined as `layer-style-theme`.
+
+```js
+/**
+@global
+@typedef {Object} layer
+A mapp-layer object is a decorated JSON layer object which has been added to a mapview.
+@property {boolean} display Whether the layer should be displayed.
+@property {layer-style} style The mapp-layer style configuration.
+@property {layer-cluster} [cluster] Point layer cluster configuration.
 */
 ```
 

--- a/DOCUMENTATION.md
+++ b/DOCUMENTATION.md
@@ -105,6 +105,10 @@ A mapp-layer object is a decorated JSON layer object which has been added to a m
 */
 ```
 
+### @example 
+
+An @example does not require a code block [\`\`\`JS] definition. At examples should be reserved for codepen examples which can be run. Code blocks should be used for code syntax highlighting in the rendered markdown.
+
 ### /docs express route
 
 The /docs express route can be used to preview the built pages on `http://localhost:3000/docs/`

--- a/DOCUMENTATION.md
+++ b/DOCUMENTATION.md
@@ -88,6 +88,29 @@ Validated user object or an Error if authentication fails.
 
 Decorator methods should always return a typedef.
 
+#### @deprecated methods.
+
+Functions no longer in use but kept with a warning for legacy configurations should be marked as `@deprecated`.
+
+```js
+/**
+@function Style
+@deprecated
+
+@description
+The deprectaed mapp.layer.Style() method will warn if use and return the featureStyle() method which supersedes the Style() method.
+
+@param {Object} layer 
+
+@return {Function} featureStyle
+*/
+
+function Style(layer) {
+  console.warn(`The mapp.layer.Style() method has been superseeded by the mapp.layer.featureStyle() method.`)
+  return featureStyle(layer)
+}
+```
+
 ### @typedef [GLOBAL]
 
 Mapp type object should be defined as global typedefs.

--- a/api/README.md
+++ b/api/README.md
@@ -1,0 +1,27 @@
+## XYZ API
+
+The XYZ API are a collection of javascript modules for Node.js web application frameworks.
+
+An example Express application script is provided in the project root.
+
+XYZ API modules should be run with a Node.js runtime v18 or higher.
+
+The [XYZ API](/docs/module-_api.html) module is located in the api folder as a requirement for using the offical Node.js runtime in Vercel's Edge Network.
+
+All other XYZ API modules are located in the /mod directory.
+
+JSDoc is used to documented any XYZ API module, function, and their parameter.
+
+The [clean-jsdoc-theme](https://www.npmjs.com/package/clean-jsdoc-theme) is used to build the XYZ and MAPP API reference pages which can be built and hosted local with the provided Express application script.
+
+The XYZ API modules are:
+
+### [Workspace](/docs/module-_workspace)
+
+### [View](/docs/module-_view)
+
+### [Query](/docs/module-_query)
+
+### [User](/docs/module-_user)
+
+### [Sign](/docs/module-_sign)

--- a/api/api.js
+++ b/api/api.js
@@ -1,3 +1,25 @@
+/**
+## XYZ API
+
+The XYX API module exports the api function which serves as the entry point for all XYZ API requests.
+
+A node.js express app will require the api module and reference the exported api method for all request routes.
+
+```js
+const app = express()
+const api = require('./api/api')
+app.get(`/`, api)
+```
+
+@requires /view
+@requires /query
+@requires /fetch
+@requires /sign
+@requires /user/auth
+
+@module /api
+*/
+
 const logger = require('../mod/utils/logger')
 
 const login = require('../mod/user/login')
@@ -23,6 +45,34 @@ process.env.COOKIE_TTL ??= 36000
 process.env.TITLE ??= 'GEOLYTIX | XYZ'
 
 process.env.DIR ??= ''
+
+/**
+@global
+@typedef {Object} req
+The req object represents the HTTP request and has properties for the request query string, parameters, body, HTTP headers, and so on.
+@property {Object} params HTTP request parameter.
+*/
+
+/**
+@global
+@typedef {Object} res
+The res object represents the HTTP response that an [Express] app sends when it gets an HTTP request.
+*/
+
+/**
+@function api
+@async
+
+@description
+The XYZ api method will validate request parameter.
+
+The API module method requires the user/auth module to authenticate private API requests.
+
+Requests are passed to individual API modules from the api() method.
+
+@param {req} req HTTP request.
+@param {res} res HTTP response.
+*/
 
 module.exports = async function api(req, res) {
 

--- a/express.js
+++ b/express.js
@@ -6,7 +6,9 @@ const cookieParser = require('cookie-parser')
 
 const app = express()
 
-app.use('/docs', express.static('docs'))
+app.use('/docs', express.static('docs', {
+    extensions: ['html']
+}))
 
 app.use(`${process.env.DIR||''}/public`, express.static('public'))
 

--- a/jsdoc_mapp.json
+++ b/jsdoc_mapp.json
@@ -25,6 +25,11 @@
             "title": "Github",
             "id": "github",
             "link": "https://github.com/GEOLYTIX/xyz"
+        },
+        {
+          "title": "XYZ",
+          "id": "xyz",
+          "link": "/docs"
         }
       ]
     }

--- a/jsdoc_xyz.json
+++ b/jsdoc_xyz.json
@@ -1,36 +1,43 @@
 {
-    "source": {
-      "include": [
-        "mod"
-      ],
-      "includePattern": ".js$"
-    },
-    "plugins": [
-      "plugins/markdown"
+  "source": {
+    "include": [
+      "api", "mod"
     ],
-    "opts": {
-      "encoding": "utf8",
-      "readme": "./mod/README.md",
-      "destination": "docs/",
-      "recurse": true,
-      "verbose": true,
-      "template": "./node_modules/clean-jsdoc-theme",
-      "theme_opts": {
-        "title": "XYZ",
-        "homepageTitle": "XYZ",
-        "static_dir": ["./public/icons"],
-        "favicon": "./public/icons/favicon.ico",
-        "menu": [
-          {
-              "title": "Github",
-              "id": "github",
-              "link": "https://github.com/GEOLYTIX/xyz"
-          }
-        ]
-      }
-    },
-    "markdown": {
-      "hardwrap": false,
-      "idInHeadings": true
+    "includePattern": ".js$"
+  },
+  "plugins": [
+    "plugins/markdown"
+  ],
+  "opts": {
+    "encoding": "utf8",
+    "readme": "./api/README.md",
+    "destination": "docs/",
+    "recurse": true,
+    "verbose": true,
+    "template": "./node_modules/clean-jsdoc-theme",
+    "theme_opts": {
+      "title": "XYZ",
+      "homepageTitle": "XYZ",
+      "static_dir": [
+        "./public/icons"
+      ],
+      "favicon": "./public/icons/favicon.ico",
+      "menu": [
+        {
+          "title": "Github",
+          "id": "github",
+          "link": "https://github.com/GEOLYTIX/xyz"
+        },
+        {
+          "title": "Mapp",
+          "id": "mapp",
+          "link": "/docs/mapp"
+        }
+      ]
     }
+  },
+  "markdown": {
+    "hardwrap": false,
+    "idInHeadings": true
   }
+}

--- a/lib/README.md
+++ b/lib/README.md
@@ -1,5 +1,9 @@
-## MAPP
+## MAPP API
 
-**Application control and presentation layers** are provided as ES6 javscript libraries. **MAPP** utilizes the Openlayers map engine for mapviews and provides an interface to the XYZ API. The library abstracts away the complexities of handling spatial data objects such as layers and locations.
+The MAPP API is a collection of javascript modules to interface with the [XYZ API](/docs).
 
-**MAPP.UI** contains utilities to build engaging user interfaces around mapviews. The application views can be dashboards made up of multiple data views such as maps, tables, lists, or graphs.
+The [mapp.mjs](/docs/mapp/module-mapp) module imports any modules required to create an interactive Openlayers mapview in a web document.
+
+### MAPP/UI
+
+A collection of modules for the creation of user interfaces to support the interaction with MAPP elements like the mapview, layer, and locations can be accessed through the [ui.mjs](/docs/mapp/module-ui).

--- a/lib/hooks.mjs
+++ b/lib/hooks.mjs
@@ -18,7 +18,7 @@ The mapp.hooks{} module parses, updates, and stores URL parameter.
 }
 ```
 
-@module hooks
+@module /hooks
 */
 
 const hooks = {
@@ -41,8 +41,8 @@ export default hooks;
 The method parses key/value pairs of URL searchParams from the document window.location.href.
 
 @function parse
-@memberof module:hooks
 */
+
 function parse() {
   
   const url = new URL(window.location.href);
@@ -81,10 +81,11 @@ function parse() {
 The set method will assign a URL params object to the hooks.current{} before calling the pushState() method.
 
 @function set
-@memberof module:hooks
+
 @param {Object} _hooks
 A params object to be assigned to the hooks.current.
 */
+
 function set(_hooks) {
 
   Object.assign(hooks.current, _hooks)

--- a/lib/layer/_layer.mjs
+++ b/lib/layer/_layer.mjs
@@ -9,9 +9,7 @@ The individual mapp layer modules are exported as mapp.layer{} object to the map
 /**
 @global
 @typedef {Object} layer
-@description
 A mapp-layer object is a decorated JSON layer object which has been added to a mapview.
-
 @property {boolean} display Whether the layer should be displayed.
 @property {layer-style} style The mapp-layer style configuration.
 @property {layer-cluster} [cluster] Point layer cluster configuration.

--- a/lib/layer/_layer.mjs
+++ b/lib/layer/_layer.mjs
@@ -1,8 +1,21 @@
 /**
 ## mapp.layer{}
-This module exports methods to decorate layer objects.
+
+The individual mapp layer modules are exported as mapp.layer{} object to the mapp library module.
+
 @module /layer
- */
+*/
+
+/**
+@global
+@typedef {Object} layer
+@description
+A mapp-layer object is a decorated JSON layer object which has been added to a mapview.
+
+@property {boolean} display Whether the layer should be displayed.
+@property {layer-style} style The mapp-layer style configuration.
+@property {layer-cluster} [cluster] Point layer cluster configuration.
+*/
 
 import decorate from './decorate.mjs';
 import formats from './format/_format.mjs';
@@ -14,32 +27,11 @@ import * as featureFormats from './featureFormats.mjs';
 import * as featureFields from './featureFields.mjs';
 import featureStyle from './featureStyle.mjs';
 import styleParser from './styleParser.mjs';
-const Style = layer => {
-  console.warn(`The mapp.layer.Style() method has been superseeded by the mapp.layer.featureStyle() method.`)
-  return featureStyle(layer)
-}
 import basic from './themes/basic.mjs';
 import categorized from './themes/categorized.mjs';
 import distributed from './themes/distributed.mjs';
 import graduated from './themes/graduated.mjs';
 
-/**
-@function layer
-@property {function} decorate - A function to decorate layer objects.
-@property {function} changeEnd - A function to add the changeEnd event.
-@property {Object} formats - An object containing layer format modules.
-@property {Object} featureFormats - An object containing feature format modules.
-@property {Object} featureFields - An object containing feature field modules.
-@property {function} featureHover - A function to handle feature hover interactions.
-@property {function} featureFilter - A function to filter features.
-@property {function} featureStyle - A function to style features.
-@property {function} fade - A function to apply fade effects to layers.
-@property {function} styleParser - A function to parse layer styles.
-@property {Object} themes - An object containing theme modules.
-@property {function} themes.categorized - A function to apply a categorized theme to features.
-@property {function} themes.distributed - A function to apply a distributed theme to features.
-@property {function} themes.graduated - A function to apply a graduated theme to features.
- */
 export default {
   decorate,
   changeEnd,
@@ -59,3 +51,20 @@ export default {
     graduated
   }
 };
+
+/**
+@function Style
+@deprecated
+
+@description
+The deprectaed mapp.layer.Style() method will warn if use and return the featureStyle() method which supersedes the Style() method.
+
+@param {Object} layer 
+
+@return {Function} featureStyle
+*/
+
+function Style(layer) {
+  console.warn(`The mapp.layer.Style() method has been superseeded by the mapp.layer.featureStyle() method.`)
+  return featureStyle(layer)
+}

--- a/lib/layer/decorate.mjs
+++ b/lib/layer/decorate.mjs
@@ -27,6 +27,8 @@ The layer object is returned from the decorator.
 The layer decorator method create mapp-layer typedef object from a json-layer.
 
 @param {object} layer JSON layer.
+
+@returns {layer} Decorated Mapp Layer.
 */
 
 export default async function decorate(layer) {

--- a/lib/layer/decorate.mjs
+++ b/lib/layer/decorate.mjs
@@ -17,9 +17,16 @@ Any plugins matching layer keys will be executed with the layer being passed as 
 The layer object is returned from the decorator.
 
 @module /layer/decorate
+*/
 
-@param {Object} layer
-The layer object to be decorated.
+/**
+@function decorator
+@async
+
+@description
+The layer decorator method create mapp-layer typedef object from a json-layer.
+
+@param {object} layer JSON layer.
 */
 
 export default async function decorate(layer) {

--- a/lib/layer/format/vector.mjs
+++ b/lib/layer/format/vector.mjs
@@ -1,13 +1,18 @@
 /**
 ### mapp.layer.formats.vector()
+
 This module defines the vector format for map layers.
+
 @module /layer/formats/vector
 */
 
 /**
-Configures the vector format for a map layer.
 @function vector
-@param {Object} layer - The layer object.
+
+@description
+Configures the vector format for a map layer.
+
+@param {layer} layer - The layer object.
 @param {string} [layer.srid] - The spatial reference system identifier (SRID) for the layer.
 @param {Object} [layer.properties] - Deprecated. The properties of the layer.
 @param {Object} [layer.params={}] - Additional parameters for the layer.
@@ -17,11 +22,7 @@ Configures the vector format for a map layer.
 @param {ol.layer.Vector|ol.layer.VectorImage} layer.L - The OpenLayers vector or vector image layer.
 @param {Array} [layer.features] - An array of features for the layer.
 @param {boolean} [layer.fade] - Flag indicating whether to apply a fade effect to the layer.
-@param {Object} [layer.cluster] - The clustering configuration for the layer.
-@param {number} [layer.cluster.distance] - The distance threshold for clustering.
-@param {string} [layer.cluster.label] - The field used for labeling the clusters.
-@param {number} [layer.cluster.resolution] - The resolution threshold for clustering.
-@param {boolean} [layer.cluster.hexgrid] - Flag indicating whether to use hexgrid clustering.
+@property {layer-cluster} [layer.cluster] Point layer cluster configuration.
 @param {ol.source.Vector} [layer.source] - The OpenLayers vector source for the layer.
 @param {Object} [layer.xhr] - The XMLHttpRequest object used for loading data.
 @param {string} [layer.format] - The format of the layer data.
@@ -40,9 +41,19 @@ Configures the vector format for a map layer.
 @param {Object} [layer.filter] - The filter object for the layer.
 @param {function} [layer.filter.current] - The current filter function for the layer.
 @param {boolean} [layer.vectorImage] - Flag indicating whether to use vector image rendering.
-@returns {void}
- */
-export default layer => {
+*/
+
+/**
+@global
+@typedef {Object} layer-cluster
+Point layer cluster configuration.
+@property {number} [distance] The distance threshold [pixel] for OL source clustering.
+@property {string} [label] The field used for labeling the clusters.
+@property {number} [resolution] The resolution parameter for PostGIS database cluster queries.
+@property {boolean} [hexgrid] Use hexgrid clustering query for PostGIS.
+*/
+
+export default function vector(layer) {
 
   if (!layer.srid) {
 

--- a/lib/layer/styleParser.mjs
+++ b/lib/layer/styleParser.mjs
@@ -35,7 +35,21 @@ The main tasks performed by the `styleParser` module include:
 Overall, the `styleParser` module ensures that the layer style configuration is properly structured, applies default styles where necessary, handles multiple themes, hovers, and labels, and processes individual style objects and icon styles. It helps to maintain a consistent and valid style configuration for the layer in the mapping application.
 
 @module /layer/styleParser
- */
+*/
+
+/**
+@global
+@typedef {Object} layer-style
+@property {object} theme The current theme to be rendered.
+@property {Object} [default] The default style for features.
+@property {Object} [highlight] The style for highlighted features.
+@property {Object} [theme] The theme style configuration.
+@property {Object} [themes] Multiple theme style configurations.
+@property {Object} [hover] The hover style configuration.
+@property {Object} [hovers] Multiple hover style configurations.
+@property {Object} [label] The label style configuration.
+@property {Object} [labels] Multiple label style configurations.
+*/
 
 const iconKeys = new Set([
   'anchor',
@@ -57,22 +71,17 @@ const styleKeys = new Set([
   'highlightScale', ...iconKeys])
 
 /**
-Parses and validates the style configuration of a layer.
 @function styleParser
-@param {Object} layer - The layer object.
-@param {Object} layer.style - The style configuration of the layer.
-@param {Object} [layer.style.default] - The default style for features.
-@param {Object} [layer.style.highlight] - The style for highlighted features.
-@param {Object} [layer.style.theme] - The theme style configuration.
-@param {Object} [layer.style.themes] - Multiple theme style configurations.
-@param {Object} [layer.style.hover] - The hover style configuration.
-@param {Object} [layer.style.hovers] - Multiple hover style configurations.
-@param {Object} [layer.style.label] - The label style configuration.
-@param {Object} [layer.style.labels] - Multiple label style configurations.
-@param {Object} [layer.cluster] - The cluster configuration of the layer.
-@returns {void}
- */
-export default layer => {
+
+@description
+The styleParser method parses and validates the mapp.style object and its properties.
+
+@param {layer} layer A json layer object.
+@property {layer-style} layer.style The mapp-layer style configuration.
+@property {Object} [layer.cluster] Cluster configuration for a point layer.
+*/
+
+export default function styleParser(layer) {
 
   layer.style ??= {}
 
@@ -100,6 +109,7 @@ export default layer => {
       layer.style.themes[key].title ??= key;
       if (layer.style.themes[key].skip) delete layer.style.themes[key];
     });
+
     layer.style.theme = typeof layer.style.theme === 'object'
       ? layer.style.theme
       : layer.style.themes[layer.style.theme || Object.keys(layer.style.themes)[0]];
@@ -120,12 +130,6 @@ export default layer => {
     layer.style.label = typeof layer.style.label === 'object' ? layer.style.label : layer.style.labels[layer.style.label || Object.keys(layer.style.labels)[0]];
   }
 
-  /**
-  Handles warnings and deprecation notices for the layer style configuration.
-  @function warnings
-  @param {Object} layer - The layer object.
-  @returns {void}
-   */
   function warnings(layer) {
 
     if (!layer.style.default) {
@@ -227,13 +231,6 @@ export default layer => {
     }
   }
 
-  /**
-   Parses a theme style configuration.
-   @function parseTheme
-   @param {Object} theme - The theme style configuration.
-   @param {Object} layer - The layer object.
-   @returns {void}
-   */
   function parseTheme(theme, layer) {
 
     if (typeof theme.style === 'object') {
@@ -267,7 +264,7 @@ export default layer => {
     // Check if graduated breaks is not defined, or is not less_than or greater_than.
     if (theme.type === 'graduated') {
 
-      if (!['less_than','greater_than'].includes(theme.graduated_breaks)) {
+      if (!['less_than', 'greater_than'].includes(theme.graduated_breaks)) {
 
         console.warn(`You must provide a graduated_breaks value of either greater_than or less_than for graduated theme on layer: ${layer.key}; field: ${theme.field}. less_than is assumed.`);
 
@@ -319,13 +316,6 @@ export default layer => {
     }
   }
 
-  /**
-   Processes a style object and merges it with the default style.
-   @function styleObject
-   @param {Object} cat - The category style object.
-   @param {Object} defaultStyle - The default style object.
-   @returns {void}
-  */
   function styleObject(cat, defaultStyle) {
 
     cat.style ??= {}
@@ -349,7 +339,7 @@ export default layer => {
       if (cat.style.icon.type) return;
 
       // Do not merge default style into svg [type] icons.
-      if (cat.style.icon.svg) return;      
+      if (cat.style.icon.svg) return;
 
       if (defaultStyle.icon && !Array.isArray(defaultStyle.icon)) {
 
@@ -392,12 +382,6 @@ export default layer => {
     }
   }
 
-  /**
-  Processes an icon style object.
-  @function iconObject
-  @param {Object} style - The style object.
-  @returns {void}
-  */
   function iconObject(style) {
 
     // The style object already has an icon object.

--- a/lib/layer/themes/basic.mjs
+++ b/lib/layer/themes/basic.mjs
@@ -1,17 +1,25 @@
 /**
-### mapp.layer.themes.basic()
-This module exports a function that assigns the theme.style as feature.style
-@module /layer/themes/categorized
+## layer/themes/basic
+This basic theme module exports a function to support a `type:basic` theme.
 
-@function categorized
-@param {Object} theme - The theme configuration object.
+@module /layer/themes/basic
+*/
+
+/**
+@function basic
+
+@description
+The basic [theme] method spreads the theme.style object into the feature.style.
+
+@param {Object} theme The layer.style.theme object.
 @param {Object} feature - The feature object.
 */
-export default function (theme, feature) {
 
-    // Spread theme style to retain scale property
-    feature.style = {
-      ...feature.style,
-      ...theme.style
-    }
+export default function basic(theme, feature) {
+
+  // Spread theme style to retain scale property
+  feature.style = {
+    ...feature.style,
+    ...theme.style
+  }
 }

--- a/lib/layer/themes/categorized.mjs
+++ b/lib/layer/themes/categorized.mjs
@@ -24,6 +24,7 @@ A theme can have a fields array to apply an icon style array for the individual 
 @param {Object} feature.properties
 @param {Array} [feature.properties.features] A cluster feature will have a features array property.
 */
+
 export default function categorized(theme, feature) {
 
   // The categorized theme requires feature.properties.

--- a/lib/mapp.mjs
+++ b/lib/mapp.mjs
@@ -1,15 +1,16 @@
-/*
-A location object is created by decorating a location JSON.
+/**
+## MAPP
+
+The primary module for the MAPP API will import other MAPP modules and assign itself as the `window.mapp{}` object.
+
+The `mapp.mjs` module is used as entry point for the esbuild process to bundle the MAPP API.
+
+@requires /mapview
+@requires /layer
+@requires /layer
+@requires /utils
+
 @module mapp
-
-@property {string} version
-The mapp library release version.
-
-@property {object} dictionaries
-Dictionaries for supported language values.
-
-@property {method} Mapview(mapview)
-Method to decorate a mapview object.
 */
 
 import utils from './utils/_utils.mjs'

--- a/lib/ui.mjs
+++ b/lib/ui.mjs
@@ -1,3 +1,20 @@
+/**
+## MAPP/UI
+
+The primary module for the MAPP/UI API will import other MAPP/UI modules and assign itself to the `window.ui{}` object.
+
+The `ui{}` object will be assigned to the global `mapp{}` object if loaded prior to the execution of the ui module script.
+
+The `ui.mjs` module is used as entry point for the esbuild process to bundle the MAPP/UI API.
+
+@requires /ui/elements
+@requires /ui/locations
+@requires /ui/layers
+@requires /ui/utils
+
+@module ui
+*/
+
 import layers from './ui/layers/_layers.mjs'
 
 import locations from './ui/locations/_locations.mjs'

--- a/lib/ui/elements/_elements.mjs
+++ b/lib/ui/elements/_elements.mjs
@@ -1,7 +1,6 @@
 /**
-### mapp.ui.elements{}
+## mapp/ui/elements
 
-Module to export all the ui element functions used in mapp.
 @module /ui/elements
 */
 

--- a/lib/ui/layers/_layers.mjs
+++ b/lib/ui/layers/_layers.mjs
@@ -1,3 +1,9 @@
+/**
+## /ui/layers
+
+@module /ui/layers
+*/
+
 import view from './view.mjs'
 
 import listview from './listview.mjs'

--- a/lib/ui/locations/entries/_entries.mjs
+++ b/lib/ui/locations/entries/_entries.mjs
@@ -33,6 +33,21 @@ Exports a collection of entry methods for location views.
 @module /ui/locations/entries
 */
 
+/**
+@global
+@typedef {Object} infoj-entry
+A infoj-entry describes a location property. Locations are configured as an array of JSON Object entries layer.infoj[].
+@property {string} key A unique identifier for the entry. Will be assigned from iteration index in infoj location method if not implicit.
+@property {*} [value] The enrty value.
+@property {string} [field] The database field in layer table which holds the entry data.
+@property {string} [fieldfx] A SQL statement to query the entry value in the location get request.
+@property {string} [entry.title] The title to be displayed with the entry.value.
+@property {boolean} [entry.inline] Flag whether the value should be displayed inline with the title.
+@property {object} [entry.edit] Edit configuration for the entry.
+@property {string} [entry.query] Query template.
+@property {Object} [entry.queryparams] Parameter for query in template.
+*/
+
 import boolean from './boolean.mjs'
 
 import cloudinary from './cloudinary.mjs'

--- a/lib/ui/locations/entries/_entries.mjs
+++ b/lib/ui/locations/entries/_entries.mjs
@@ -38,7 +38,7 @@ Exports a collection of entry methods for location views.
 @typedef {Object} infoj-entry
 A infoj-entry describes a location property. Locations are configured as an array of JSON Object entries layer.infoj[].
 @property {string} key A unique identifier for the entry. Will be assigned from iteration index in infoj location method if not implicit.
-@property {*} [value] The enrty value.
+@property {*} [value] The entry value.
 @property {string} [field] The database field in layer table which holds the entry data.
 @property {string} [fieldfx] A SQL statement to query the entry value in the location get request.
 @property {string} [entry.title] The title to be displayed with the entry.value.

--- a/lib/ui/locations/entries/boolean.mjs
+++ b/lib/ui/locations/entries/boolean.mjs
@@ -1,31 +1,30 @@
 /**
-mapp.ui.locations.entries.boolean(entry)
+The boolean [location] entries module exports the boolean function as default.
 
-Exports the boolean entry method.
-
-@module boolean
+@module /ui/locations/entries/boolean
 */
 
 /**
 @function boolean
 
 @description
-Returns a HTML element, the value of which is a boolean and will display either a tick or a cross.
+## mapp.ui.locations.entries.boolean(entry)
+Returns a HTML element as visual representation of the boolean value. A checkbox element will be returned if the entry is editable.
 
-@example
-```json
+```js
 {
   "title": "Flag",
+  "label": "Checkbox",
+  "edit": true,
   "field": "flag",
   "type": "boolean",
   "inline": true
 }
-``` 
+```
 
-@param {Object} entry
-@param {string} [entry.title] The entry title.
-@param {Object} entry.field The entry field.
-@param {boolean} [entry.inline] Whether the entry should be displayed inline.
+@param {infoj-entry} entry type:boolean infoj entry.
+
+@returns {HTMLElement} Location view entry node.
 */
 export default function boolean(entry) {
 
@@ -45,13 +44,12 @@ export default function boolean(entry) {
 
       }
     })
-
   }
 
   const icon = `mask-icon ${entry.value ? 'done' : 'close'}`
 
   return mapp.utils.html.node`
-  <div class="link-with-img">
-    <div class=${icon}></div>
-    <span>`
+    <div class="link-with-img">
+      <div class=${icon}></div>
+      <span>`
 }

--- a/lib/ui/locations/entries/key.mjs
+++ b/lib/ui/locations/entries/key.mjs
@@ -1,4 +1,12 @@
 /**
+## ui/locations/entries/key
+
+The key entry module exports a default [location] entry method to process infoj `type:key` entries.
+
+@module /ui/locations/entries/key
+*/
+
+/**
 @function key
 
 @description

--- a/lib/ui/locations/entries/query_button.mjs
+++ b/lib/ui/locations/entries/query_button.mjs
@@ -1,19 +1,17 @@
 /**
-mapp.ui.locations.entries.query_button(entry)
+The query_button [location] entries module exports the query_button method as default.
 
-Exports the query_button entry method.
-
-@module query_button
+@module /ui/locations/entries/query_button
 */
 
 /**
 @function query_button
 
 @description
+## mapp.ui.locations.entries.query_button(entry)
 Returns a button element. The `query(entry)` method will be called by the button onclick event.
 
-@example
-```json
+```js
 {
   "label": "Snap to Postal Sector",
   "type": "query_button",
@@ -29,15 +27,14 @@ Returns a button element. The `query(entry)` method will be called by the button
     "area"
   ]
 }
-``` 
+```
 
-@param {Object} entry
-@param {string} entry.query The query template.
-@param {Object} entry.queryparams Parameter object.
-@param {string} [entry.label] The button label.
-@returns {HTMLElement} The query button element.
+@param {infoj-entry} entry type:query_button infoj entry.
+
+@returns {HTMLElement} Location view entry node.
 */
-export default function query_button(entry) {
+
+export default function _query_button(entry) {
 
   if (!entry.query) {
     console.warn('You must provide a query to use "type": "query_button".');
@@ -56,6 +53,7 @@ export default function query_button(entry) {
 
 /**
 @function query
+@async
 
 @description
 Will be called by the onclick event of the query_button element.
@@ -74,13 +72,13 @@ The `entry.alert` message will be displayed after the query has been resolved.
 
 The `entry.location.view` will be enabled by calling the `updateInfo` element event.
 
-@param {Object} entry infoj entry.
-@param {string} entry.query query template.
-@param {Object} entry.queryparams parameter object for query.
-@param {string} [entry.host] The host for the query.
-@param {string} [entry.alert] Alert message after the query has responded.
-@param {boolean} [entry.reload] Reload location.layer if true.
-@param {Array} [entry.dependents] Reload dependent entry.field values.
+@param {infoj-entry} entry type:query_button infoj entry.
+@property {string} entry.query Query template.
+@property {Object} [entry.queryparams] Parameter for query in template.
+@property {string} [entry.host] The host for the query.
+@property {string} [entry.alert] Alert message after the query has responded.
+@property {boolean} [entry.reload] Reload location.layer if true.
+@property {Array} [entry.dependents] Reload dependent entry.field values.
 */
 
 async function query(entry) {

--- a/lib/ui/locations/entries/title.mjs
+++ b/lib/ui/locations/entries/title.mjs
@@ -1,4 +1,12 @@
 /**
+## ui/locations/entries/title
+
+The key entry module exports a default [location] entry method to process infoj `type:title` entries.
+
+@module /ui/locations/entries/title
+*/
+
+/**
 mapp.ui.locations.entries.title(entry)
 
 The method returns just the title of the entry.

--- a/lib/ui/utils/_utils.mjs
+++ b/lib/ui/utils/_utils.mjs
@@ -1,3 +1,9 @@
+/**
+## mapp/ui/utils
+
+@module /ui/utils
+*/
+
 import chart from './Chart.mjs'
 
 import tabulator from './tabulator.mjs'

--- a/lib/utils/_utils.mjs
+++ b/lib/utils/_utils.mjs
@@ -29,13 +29,6 @@ const compose = (...fns) => {
   }, arg)
 }
 
-/**
-## mapp.utils.olScript()
-Import ol script through scrit tag in promise.
-@function olScript
-@memberof module:/utils
-*/
-
 import convert from './convert.mjs'
 
 import {copyToClipboard} from './copyToClipboard.mjs'

--- a/mod/README.md
+++ b/mod/README.md
@@ -1,3 +1,0 @@
-## XYZ
-
-The pattern for the Node.js **domain and service layer** are that of a RESTful API which provides secure gateways for spatial data sources and 3rd party service providers. The domain layer handles API routing, rewrites, and ressource caching. The service layer manages authentication and transaction script. URL parameter (and payloads) from the application control layer are assigned to query templates and passed to the data source layer. The response being parsed and returned to the presentation layer. The Node.js application layers may be served by an Express web server or deployed as cloud native serverless functions.

--- a/mod/fetch.js
+++ b/mod/fetch.js
@@ -1,5 +1,5 @@
 /**
-@module fetch
+@module /fetch
 */
 
 module.exports = async (req, res) => {

--- a/mod/query.js
+++ b/mod/query.js
@@ -49,7 +49,7 @@ The response of a query will typically result in a text/json response.
 ```
 
 > All status codes are defined by [RFC 9110](https://httpwg.org/specs/rfc9110.html#overview.of.status.codes)
-@module query
+@module /query
 */
 
 const dbs_connections = require('./utils/dbs')

--- a/mod/view.js
+++ b/mod/view.js
@@ -1,7 +1,7 @@
 /**
 The view module retrieves a view template, and substitutes parameter before sending the view to the client. 
 
-@module view
+@module /view
 */
 
 const logger = require('./utils/logger')


### PR DESCRIPTION
### Modules

JSDoc comments for modules must include the module path as title and any `@requires` linking the page to other pages in the docs directory.

A small description should be provided to outline the module's purpose.

```js
/**
## /user/auth

The auth module is required by the XYZ API for request authorization.

A user_sessions{} object is declared in the module to store user sessions.

@requires module:/user/acl
@requires module:/user/fromACL
@requires jsonwebtoken

@module /user/auth
*/
```

### Functions

Comments for functions begin with the `@function` tag. Functions should not be anonymous. `@async` functions should be commented as such.

Each function comment should include an `@description` tag. It is recommended to use a new line for multiline descriptions.

The `@param` tag list should include only params used as function arguments.

Parameter properties should be included if used in the method. Any optional [property] are marked in square brackets.

A global typedef should be created for common Mapp objects.

The `@return` comment tag should state whether a promise is returned which may return an Error object, eg. `@returns {Promise<Object|Error>}`

```js
/**
@function fromACL
@async

@description
Creates a request object for the getUser(request) method argument.
The request.email and request.password are taken from the req.body or authorization header.

@param {Object} req The request object.
@property {string} [req.body.email] The email address of the user.
@property {string} [req.body.password] The password of the user.
@property {string} [req.params.language] The language for the user.
@property {Object} req.headers The request headers.
@property {string} [req.headers.authorization] The authorization header containing the email and password.

@returns {Promise<Object|Error>}
Validated user object or an Error if authentication fails.
*/
```
#### Decorator methods

Decorator methods should always return a typedef.

#### @deprecated methods.

Functions no longer in use but kept with a warning for legacy configurations should be marked as `@deprecated`.

```js
/**
@function Style
@deprecated

@description
The deprectaed mapp.layer.Style() method will warn if use and return the featureStyle() method which supersedes the Style() method.

@param {Object} layer 

@return {Function} featureStyle
*/

function Style(layer) {
  console.warn(`The mapp.layer.Style() method has been superseeded by the mapp.layer.featureStyle() method.`)
  return featureStyle(layer)
}
```

### @typedef [GLOBAL]

Mapp type object should be defined as global typedefs.

Typedef properties should be defined as typedef using a dash naming convention. eg. The style object property of a `layer` typedef will be defined as `layer-style`, the theme object of a layer-style typedef will be type defined as `layer-style-theme`.

```js
/**
@global
@typedef {Object} layer
A mapp-layer object is a decorated JSON layer object which has been added to a mapview.
@property {boolean} display Whether the layer should be displayed.
@property {layer-style} style The mapp-layer style configuration.
@property {layer-cluster} [cluster] Point layer cluster configuration.
*/
```

### @example 

An @example does not require a code block [\`\`\`JS] definition. At examples should be reserved for codepen examples which can be run. Code blocks should be used for code syntax highlighting in the rendered markdown.
