### PR TITLE
Infoj: Group expanding on load

### DIFF
--- a/lib/ui/locations/infoj.mjs
+++ b/lib/ui/locations/infoj.mjs
@@ -296,18 +296,17 @@ function entryGroup(entry) {
 
     groups[entry.group] = entry.listview.appendChild(
       mapp.ui.elements.drawer({
-        class: `group ${entry.groupClassList || ''}`,
+        class: `group`,
         header: mapp.utils.html`
           <h3>${entry.group}</h3>
           <div class="mask-icon expander"></div>`,
       }))
   }
 
-  if (entry.groupClassList?.includes('expanded') && !Array.from(groups[entry.group].classList).includes('expanded')) {
-
-    // Add to the string as this can have other classes.
-    groups[entry.group].classList.add('expanded')
+  if (typeof entry.groupClassList === 'string') {
+    groups[entry.group].classList.add(...entry.groupClassList.split(' '))
   }
+
   // The group will replace the entry listview to which elements will be appended.
   entry.listview = groups[entry.group]
 }

--- a/lib/ui/locations/infoj.mjs
+++ b/lib/ui/locations/infoj.mjs
@@ -288,27 +288,26 @@ Entry elements in the same group will be added to a group element drawer added t
 */
 
 function entryGroup(entry) {
-
+  
   if (!entry.group) return;
 
   // Create new group
   if (!groups[entry.group]) {
 
-    if (entry.expanded) {
-
-      // Add to the string as this can have other classes.
-      entry.groupClassList += ' expanded'
-    }
-
     groups[entry.group] = entry.listview.appendChild(
       mapp.ui.elements.drawer({
-        class: `group ${entry.groupClassList && 'expanded' || ''}`,
+        class: `group ${entry.groupClassList || ''}`,
         header: mapp.utils.html`
           <h3>${entry.group}</h3>
           <div class="mask-icon expander"></div>`,
       }))
   }
 
+  if (entry.groupClassList?.includes('expanded') && !Array.from(groups[entry.group].classList).includes('expanded')) {
+
+    // Add to the string as this can have other classes.
+    groups[entry.group].classList.add('expanded')
+  }
   // The group will replace the entry listview to which elements will be appended.
   entry.listview = groups[entry.group]
 }


### PR DESCRIPTION
# Pull Request Template

## Description

Allows `groupClassList: "expanded"' to be added to any member of the group and have the group expanded on load.

## GitHub Issue

This PR addresses [#1327](https://github.com/GEOLYTIX/xyz/issues/1327)

## Type of Change

- ✅ Bug fix (non-breaking change which fixes an issue)

## How have you tested this? 
Test in `bugs_testing/infoj_order/workspace.json` Added `groupClassList: "expanded"` to the second member of a group and saw that the group was expanded as it should be.

## Testing Checklist 

- ✅ Existing Tests still pass
- ✅ Ran locally on my machine

## Code Quality Checklist

- ✅ My code follows the guidelines of XYZ
- ✅ My code has been commented
- ✅ Documentation has been updated
- ✅ New and existing unit tests pass locally with my changes
- ✅ Main has been merged into this PR