### PR TITLE
Reverse theme style assignment; Check for useridb flag in locale.

### DIFF
--- a/lib/layer/styleParser.mjs
+++ b/lib/layer/styleParser.mjs
@@ -239,7 +239,10 @@ export default layer => {
     if (typeof theme.style === 'object') {
 
       // Assign the default style to the theme.style
-      Object.assign(theme.style, structuredClone(layer.style.default))
+      theme.style = {
+        ...structuredClone(layer.style.default),
+        ...theme.style 
+      }
     }
 
     if (typeof theme.cat === 'object') {

--- a/public/views/_default.html
+++ b/public/views/_default.html
@@ -568,7 +568,7 @@
         ${mapp.dictionary.no_locales}`)
   }
 
-  if (mapp.hooks.current.useridb) {
+  if (mapp.hooks.current.useridb || locale.useridb) {
 
     let userLocale = await mapp.utils.userIndexedDB.get('locales', locale.key)
 


### PR DESCRIPTION
The theme style assignment in the styleParser was the wrong way. The theme style should be spread into a structured clone of the default style before being assigned as theme style.

The default view script should check for a useridb flag in the locale in addition to the url parameter [hook] check.

If the theme style fillColor is blue, and the default fillColor is red, then blue must be assigned as the fillColor if the theme is current.

Storing styles will not work otherwise because no matter which property you change the default property would always be assigned on top of the theme style, not the other way around.

```js
{
  style: {
    default: {
      fillColor: 'red'
    },
    theme: 
      style: {
        fillColor: 'blue'
      }
    }
  }
}
```