### PR TITLE
Disable location view for blocking api request from geometry entry me…

### DIFF
--- a/lib/ui/locations/entries/geometry.mjs
+++ b/lib/ui/locations/entries/geometry.mjs
@@ -115,6 +115,9 @@ export default function geometry(entry) {
 
   entry.label ??= 'Geometry'
 
+  // Show geometry if entry is set to display.
+  entry.display && entry.show()
+
   // Create checkbox to control geometry display.
   entry.chkbox = mapp.ui.elements.chkbox({
     label: entry.label,
@@ -133,9 +136,6 @@ export default function geometry(entry) {
       entry.L && entry.location.layer.mapview.Map.removeLayer(entry.L)
     }
   })
-
-  // Show geometry if entry is set to display.
-  entry.display && entry.show()
 
   entry.elements = entry.api_elements || []
 
@@ -185,6 +185,9 @@ async function show() {
   if (chkbox) chkbox.checked = true
 
   if (!this.value && this.api) {
+
+    // Disable location view while awaiting API response.
+    this.blocking && this.location.view?.classList.add('disabled')
 
     await this.api(this)
   }


### PR DESCRIPTION
The api call for a geometry entry maybe defined as blocking.

In this case the location.view must disabled before the api method is called from the show method.

Iteration of the infoj entries array will `break` while the view is disabled.

The location view must be re-rendered once the API call has been resolved. This will enable the view and re-start the infoj entries iteration.

The display condition call to show the geometry should be prior to the creation of the checkbox.

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1207704292668498