### PR TITLE
infoj_skip in layer decorator

### DIFF
--- a/lib/layer/decorate.mjs
+++ b/lib/layer/decorate.mjs
@@ -134,6 +134,24 @@ export default async function decorate(layer) {
   // Set layer opacity from style.
   layer.L.setOpacity(layer.style?.opacity || 1);
 
+  // Check which infoj entries should be skipped.
+  if (Array.isArray(layer.infoj_skip)) {
+
+    layer.infoj
+      .filter(entry => [
+        entry.key,
+        entry.field,
+        entry.query,
+        entry.type,
+        entry.group]
+
+        // Some object property value is included in infoj_skip array.
+        .some(val => layer.infoj_skip.includes(val)))
+
+      // Set skipEntry flag if some entry property is included in infoj_skip array.
+      .forEach(entry = entry.skipEntry = true)
+  }  
+
   // Call layer and/or plugin methods.
   Object.keys(layer).forEach((key) => {
     typeof mapp.layer[key] === 'function' && mapp.layer[key]?.(layer);

--- a/lib/layer/decorate.mjs
+++ b/lib/layer/decorate.mjs
@@ -149,7 +149,7 @@ export default async function decorate(layer) {
         .some(val => layer.infoj_skip.includes(val)))
 
       // Set skipEntry flag if some entry property is included in infoj_skip array.
-      .forEach(entry = entry.skipEntry = true)
+      .forEach(entry => entry.skipEntry = true)
   }  
 
   // Call layer and/or plugin methods.

--- a/lib/ui/layers/panels/filter.mjs
+++ b/lib/ui/layers/panels/filter.mjs
@@ -101,7 +101,7 @@ export default layer => {
     .filter(entry => entry.filter !== undefined)
     .filter(entry => entry.field !== undefined)
     .filter(entry => !layer.filter?.exclude?.includes(entry.field))
-    .filter(entry => ![entry.key, entry.field, entry.query, entry.type, entry.group].some(val => new Set(layer.infoj_skip || []).has(val)))
+    .filter(entry => !entry.skipEntry)
     .map(entry => {
 
       // The filter is defined as a string e.g. "like"

--- a/lib/ui/locations/infoj.mjs
+++ b/lib/ui/locations/infoj.mjs
@@ -215,14 +215,6 @@ function entrySkip(entry) {
   // Skip entry, no matter what.
   if (entry.skipEntry) return true;
 
-  // Skip entries from infoj_skip array;
-  if (Array.isArray(entry.location?.layer?.infoj_skip)) {
-
-    // Check whether some val from this array is in infoj_skip set.
-    if ([entry.key, entry.field, entry.query, entry.type, entry.group]
-      .some(val => new Set(entry.location?.layer?.infoj_skip).has(val))) return true;
-  }
-
   // Skip entries which are falsy if flagged.
   if (entry.skipFalsyValue
     && !entry.value?.length


### PR DESCRIPTION
The infoj_skip array should only processed once when the layer is decorated.

Creating a new Set on each iteration of multiple entry object properties on each iteration of every entry in the infoj is incredibly resource wasteful.

The uncommented negated array check in the filters panel lookup is hard to understand test or maintain.

It is much easier to set a flag in the infoj_array based on inclusion in the infoj_array which must a be an array and therefore supports the [array.includes](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/includes) method.