### PR TITLE
location.create() method as replacement for draw interaction callback with defaults/default_fields location updates.

### DIFF
--- a/lib/layer/decorate.mjs
+++ b/lib/layer/decorate.mjs
@@ -65,66 +65,6 @@ export default async function decorate(layer) {
     console.warn(`Layer: ${layer.key}, please move draw.delete to use layer.deleteLocation:true.`);
   }
 
-  // Callback which creates and stores a location from a feature returned by the drawing interaction.
-  layer.draw.callback = async (feature, params) => {
-    // If the feature is null, return.
-    if (!feature) return;
-
-    // Get the current table and set new to true.
-    const location = {
-      layer,
-      table: layer.tableCurrent(),
-      new: true
-    };
-
-    // Store location in database.
-    // The id must be returned from a serial ID field.
-    location.id = await mapp.utils.xhr({
-      method: 'POST',
-      url: `${layer.mapview.host}/api/query?` +
-        mapp.utils.paramString({
-          template: 'location_new',
-          locale: layer.mapview.locale.key,
-          layer: layer.key,
-          table: location.table
-        }),
-      body: JSON.stringify({
-        [layer.geom]: feature.geometry,
-
-        // Spread in defaults.
-        ...params?.defaults,
-        ...layer.draw?.defaults
-      })
-    });
-
-    // Check whether feature is loaded on MVT update.
-    if (layer.format === 'mvt') {
-      layer.features = [];
-      layer.source.on('tileloadend', concatFeatures);
-
-      function concatFeatures(e) {
-        layer.features = layer.features.concat(e.tile.getFeatures());
-      }
-
-      setTimeout(checkFeature, 1000);
-
-      function checkFeature() {
-        let found = layer.features?.find(F => F.properties?.id === location.id);
-        if (found) {
-          layer.source.un('tileloadend', concatFeatures);
-        } else {
-          layer.reload();
-        }
-      }
-    }
-
-    // Layer must be reloaded to reflect geometry changes.
-    layer.reload();
-
-    // Get the newly created location.
-    mapp.location.get(location);
-  };
-
   // Set layer filter.
   layer.filter = {
     current: {},

--- a/lib/location/_location.mjs
+++ b/lib/location/_location.mjs
@@ -1,9 +1,10 @@
 /**
-## mapp.location{}
-The mapp.location module provides methods to get and decorate location objects.
+## /location
 
 @module /location
 */
+
+import create from './create.mjs'
 
 import decorate from './decorate.mjs'
 
@@ -12,6 +13,7 @@ import {get, getInfoj} from './get.mjs'
 import nnearest from './nnearest.mjs'
 
 export default {
+  create,
   decorate,
   get,
   getInfoj,

--- a/lib/location/create.mjs
+++ b/lib/location/create.mjs
@@ -21,6 +21,8 @@ The method will attempt to get the location from the layer data at rest.
 @param {layer} layer Decorated Mapp Layer.
 
 @property {Object} feature.geometry GeoJSON geometry for new location.
+@property {Object} [interaction.defaults] defaults{} object properties are stored as field columns in the location record.
+@property {Object} [interaction.default_fields] default_fields{} object keys are assigned as interaction.defaults properties with the values used to lookup interaction object properties values.
 */
 
 export default async function createLocation(feature, interaction, layer) {
@@ -34,6 +36,17 @@ export default async function createLocation(feature, interaction, layer) {
     table: layer.tableCurrent(),
     new: true
   };
+
+  // Assign defaults from interaction[default_fields]
+  if (interaction.default_fields) {
+
+    interaction.defaults ??= {}
+
+    Object.entries(interaction.default_fields).forEach(entry => {
+
+      interaction.defaults[entry[0]] = interaction[entry[1]]
+    })
+  }
 
   // Store location in database.
   // The id must be returned from a serial ID field.

--- a/lib/location/create.mjs
+++ b/lib/location/create.mjs
@@ -1,0 +1,84 @@
+/**
+### /location/create
+
+@module /location/create
+*/
+
+/**
+@function createLocation
+
+@description
+The createLocation method creates a location from a JSON feature and stores the new Location in the layer data at rest.
+
+The layer will be reloaded to show the new location in the mapview.
+
+Dynamic tile generation for MVT layer may lag and not represent recently inserted rows. The feature will be checked for inclusion and the tile generation will be attempted at a 1 second interval until the feature is included in the generated tiles.
+
+The method will attempt to get the location from the layer data at rest.
+
+@param {Object} feature JSON feature. 
+@param {Object} interaction Mapview drawing interaction.
+@param {layer} layer Decorated Mapp Layer.
+
+@property {Object} feature.geometry GeoJSON geometry for new location.
+*/
+
+export default async function createLocation(feature, interaction, layer) {
+
+  // If the feature is null, return.
+  if (!feature) return;
+
+  // Get the current table and set new to true.
+  const location = {
+    layer,
+    table: layer.tableCurrent(),
+    new: true
+  };
+
+  // Store location in database.
+  // The id must be returned from a serial ID field.
+  location.id = await mapp.utils.xhr({
+    method: 'POST',
+    url: `${layer.mapview.host}/api/query?` +
+      mapp.utils.paramString({
+        template: 'location_new',
+        locale: layer.mapview.locale.key,
+        layer: layer.key,
+        table: location.table
+      }),
+    body: JSON.stringify({
+      [layer.geom]: feature.geometry,
+
+      // Spread in defaults.
+      ...interaction?.defaults,
+      ...layer.draw?.defaults
+    })
+  });
+
+  // Check whether feature is loaded on MVT update.
+  if (layer.format === 'mvt') {
+    layer.features = [];
+    layer.source.on('tileloadend', concatFeatures);
+
+    function concatFeatures(e) {
+      layer.features = layer.features.concat(e.tile.getFeatures());
+    }
+
+    setTimeout(checkFeature, 1000);
+
+    function checkFeature() {
+      let found = layer.features?.find(F => F.properties?.id === location.id);
+      if (found) {
+        layer.source.un('tileloadend', concatFeatures);
+      } else {
+        layer.reload();
+      }
+    }
+  }
+
+  // Layer must be reloaded to reflect geometry changes.
+  layer.reload();
+
+  // Get the newly created location.
+  mapp.location.get(location);
+}

--- a/lib/location/decorate.mjs
+++ b/lib/location/decorate.mjs
@@ -1,11 +1,21 @@
 /**
-## mapp.location.decorate()
-@module /location/decorate
+### /location/decorate
 
-@param {Object} location
-The location object to be decorated.
+@module /location/decorate
 */
-export default location => {
+
+/**
+@function decorate
+
+@description
+The location decorator method creates mapp-location typedef object from a JSON location.
+
+@param {object} location JSON location.
+
+@returns {location} Decorated Mapp Location.
+*/
+
+export default function decorate(location) {
 
   Object.assign(location, {
     flyTo,

--- a/lib/mapview/_mapview.mjs
+++ b/lib/mapview/_mapview.mjs
@@ -1,14 +1,14 @@
 /**
-## mapp.Mapview()
-The decorated mapview object is returned from the decorator.
+### /mapview
 
-### Testing 🧪 
-To test the mapview module in a Browser environment you can execute a test view with a test script that follows similar logic to the default view.
-You can execute these tests by navigating to `http://localhost:3000/{dir}?template=test_view`
 @module /mapview
+*/
 
-@param {Object} mapview
-The mapview object to be decorated.
+/**
+@global
+@typedef {Object} interaction
+A mapview interaction is an object assigned to the mapview as mapview.interaction. A mapview can have only one current interaction. The method to assign an interaction to the mapview should finish the current interaction.
+@property {function} finish Method called when the current interaction finishes.
 */
 
 import attribution from './attribution.mjs'

--- a/lib/mapview/interactions/draw.mjs
+++ b/lib/mapview/interactions/draw.mjs
@@ -28,7 +28,9 @@ export default function(params){
     source: new ol.source.Vector(),
   
     // The Layer is required for generated features such as isolines.
-    Layer: new ol.layer.Vector(),
+    Layer: new ol.layer.Vector({
+      zIndex: params.layer?.zIndex || 99
+    }),
 
     // Bind context menu from mapp ui elements.
     drawend: mapp.ui?.elements.contextMenu.draw.bind(this),

--- a/lib/ui/elements/drawing.mjs
+++ b/lib/ui/elements/drawing.mjs
@@ -1,3 +1,9 @@
+/**
+### /ui/elements/drawing
+
+@module /ui/elements/drawing
+*/
+
 export default {
   point,
   line,
@@ -161,6 +167,23 @@ mapp.utils.merge(mapp.dictionaries, {
   }
 })
 
+/**
+@function drawOnclick
+
+@description
+The drawOnClick method is triggered by clicking on a drawing element button.
+
+The 'active' class is toggled on the button element. The drawing interaction is finished if the 'active' class is toggled off.
+
+A callback method is assigned to the interaction before the interaction object is passed as argument to call the mapview's draw interaction.
+
+@param {Object} e The click event. 
+@param {layer} layer Decorated Mapp Layer.
+@param {Object} interaction Mapview drawing interaction.
+
+@property {Object} e.target The click event target [button].
+*/
+
 function drawOnclick(e, layer, interaction) {
 
   const btn = e.target
@@ -175,7 +198,7 @@ function drawOnclick(e, layer, interaction) {
 
   interaction.callback = feature => {
 
-    layer.draw.callback(feature, interaction)
+    mapp.location.create(feature, interaction, layer)
 
     btn.classList.remove('active')
 


### PR DESCRIPTION
The `layer.draw.callback()` method has been removed from the layer.decorator method.

The replacement method is `mapp.location.create()` which is defined in the mapp/location create module.

The location.create method will be called from the drawing elements drawOnclick methods interaction callback.

The location.create method will assign defaults properties from interaction properties with interaction.default_fields as lookup.

This is required to assign defaults from api geometry methods, eg. drawing isolines.

The location/decorate module documentation has been updated. Modules do not have params.

The location.decorate method should be named decorate.

The mapview module documentation has been updated. Modules do not have params.