### PR TITLE
Check for ACL module being a function.

### DIFF
--- a/mod/user/acl.js
+++ b/mod/user/acl.js
@@ -12,7 +12,8 @@ const { Pool } = require('pg');
 
 const connection = process.env.PRIVATE?.split('|') || process.env.PUBLIC?.split('|')
 
-if(!connection || !connection[1]) return
+// The acl module will export an empty require object instead of a function if no ACL connection has been defined.
+if(!connection || !connection[1]) return;
 
 const acl_table = connection[1].split('.').pop()
 

--- a/mod/user/add.js
+++ b/mod/user/add.js
@@ -40,7 +40,10 @@ Requesting user is admin.
 
 module.exports = async function addUser(req, res) {
 
-  if (!acl) return res.status(500).send('ACL unavailable.')
+  // acl module will export an empty require object without the ACL being configured.
+  if (typeof acl !== 'function') {
+    return res.status(500).send('ACL unavailable.')
+  }
 
   if (!req.params.email) {
 

--- a/mod/user/cookie.js
+++ b/mod/user/cookie.js
@@ -45,7 +45,12 @@ The cookie should be destroyed.
 
 module.exports = async function cookie(req, res) {
 
-  if (!acl) return res.status(500).send('ACL unavailable.')
+  console.log(typeof acl)
+
+  // acl module will export an empty require object without the ACL being configured.
+  if (typeof acl !== 'function') {
+    return res.status(500).send('ACL unavailable.')
+  }
 
   const cookie = req.cookies && req.cookies[process.env.TITLE]
 

--- a/mod/user/delete.js
+++ b/mod/user/delete.js
@@ -37,7 +37,10 @@ Requesting user is admin.
 
 module.exports = async function deleteUser(req, res) {
 
-  if (!acl) return res.status(500).send('ACL unavailable.')
+  // acl module will export an empty require object without the ACL being configured.
+  if (typeof acl !== 'function') {
+    return res.status(500).send('ACL unavailable.')
+  }
 
   if (!req.params.email) {
 

--- a/mod/user/key.js
+++ b/mod/user/key.js
@@ -35,7 +35,10 @@ Requesting user.
 
 module.exports = async function apiKey(req, res) {
 
-  if (!acl) return res.status(500).send('ACL unavailable.')
+  // acl module will export an empty require object without the ACL being configured.
+  if (typeof acl !== 'function') {
+    return res.status(500).send('ACL unavailable.')
+  }
 
   if (!req.params.user) {
 

--- a/mod/user/log.js
+++ b/mod/user/log.js
@@ -34,7 +34,10 @@ Requesting user is admin.
 
 module.exports = async function accessLog(req, res) {
 
-  if (!acl) return res.status(500).send('ACL unavailable.')
+  // acl module will export an empty require object without the ACL being configured.
+  if (typeof acl !== 'function') {
+    return res.status(500).send('ACL unavailable.')
+  }
 
   if (!req.params.email) {
 

--- a/mod/user/register.js
+++ b/mod/user/register.js
@@ -46,7 +46,10 @@ Post body object with user data.
 
 module.exports = async function register(req, res) {
 
-  if (!acl) return res.status(500).send('ACL unavailable.')
+  // acl module will export an empty require object without the ACL being configured.
+  if (typeof acl !== 'function') {
+    return res.status(500).send('ACL unavailable.')
+  }
 
   req.params.host = reqHost(req)
 

--- a/mod/user/saml.js
+++ b/mod/user/saml.js
@@ -190,7 +190,7 @@ User object or Error.
 
 async function acl_lookup(email) {
 
-  if (!acl) {
+  if (typeof acl !== 'function') {
     return new Error('ACL unavailable.')
   }
 

--- a/mod/user/update.js
+++ b/mod/user/update.js
@@ -37,7 +37,10 @@ Requesting user is admin.
 
 module.exports = async function update(req, res) {
 
-  if (!acl) return res.status(500).send('ACL unavailable.')
+  // acl module will export an empty require object without the ACL being configured.
+  if (typeof acl !== 'function') {
+    return res.status(500).send('ACL unavailable.')
+  }
 
   if (!req.params.user) {
 

--- a/mod/user/verify.js
+++ b/mod/user/verify.js
@@ -43,7 +43,10 @@ Request messaging language
 
 module.exports = async (req, res) => {
 
-  if (!acl) return res.status(500).send('ACL unavailable.')
+  // acl module will export an empty require object without the ACL being configured.
+  if (typeof acl !== 'function') {
+    return res.status(500).send('ACL unavailable.')
+  }
 
   // Find user record with matching verificationtoken.
   let rows = await acl(`

--- a/public/views/_default.html
+++ b/public/views/_default.html
@@ -443,7 +443,11 @@
   console.log(`MAPP v${mapp.version}`)
 
   // Refresh cookie and get user with updated credentials.
-  mapp.user = await mapp.utils.xhr(`${mapp.host}/api/user/cookie`);
+  await mapp.utils.xhr(`${mapp.host}/api/user/cookie`).then(user => {
+
+    // The cookie request will Err without an ACL being configured for public access.
+    mapp.user = user instanceof Error? false: user
+  })
 
   // Language as URL parameter will override user language.
   mapp.language = mapp.hooks.current.language


### PR DESCRIPTION
The ACL module will export the require object as an empty object and not resolve as the ACL function default export from the ACL module.

The cookie request must check whether an user object or an error object is returned from query,