### PR TITLE
Dataview entry exception for show method.

### DIFF
--- a/lib/ui/Dataview.mjs
+++ b/lib/ui/Dataview.mjs
@@ -82,6 +82,7 @@ export default async function Dataview(_this) {
   // Dataviews must be rendered into a target element.
   if (!(_this.target instanceof HTMLElement)) {
     console.warn('Dataviews require a HTMLHtmlElement target');
+    console.log(_this);
     return;
   }
 

--- a/lib/ui/Dataview.mjs
+++ b/lib/ui/Dataview.mjs
@@ -82,7 +82,6 @@ export default async function Dataview(_this) {
   // Dataviews must be rendered into a target element.
   if (!(_this.target instanceof HTMLElement)) {
     console.warn('Dataviews require a HTMLHtmlElement target');
-    console.log(_this);
     return;
   }
 

--- a/lib/ui/locations/entries/dataview.mjs
+++ b/lib/ui/locations/entries/dataview.mjs
@@ -134,7 +134,7 @@ export default function dataview(entry) {
   }
 
   // Decorate the dataview entry.
-  mapp.ui.Dataview(entry)
+  if (mapp.ui.Dataview(entry) instanceof Error) return;
 
   // Dataview should be displayed.
   entry.display && entry.show?.()

--- a/lib/ui/locations/entries/dataview.mjs
+++ b/lib/ui/locations/entries/dataview.mjs
@@ -97,7 +97,7 @@ export default function dataview(entry) {
   // Dataview has already been created. e.g. after the location (view) is updated.
   if (entry.update) {
 
-    if (entry.display) entry.show()
+    if (entry.display) entry.show?.()
 
     // Return elements to location view.
     return mapp.utils.html.node`
@@ -133,10 +133,11 @@ export default function dataview(entry) {
     entry.target = entry.locationViewTarget
   }
 
-  if (mapp.ui.Dataview(entry) instanceof Error) return;
+  // Decorate the dataview entry.
+  mapp.ui.Dataview(entry)
 
   // Dataview should be displayed.
-  entry.display && entry.show()
+  entry.display && entry.show?.()
 
   // Return elements to location view.
   return mapp.utils.html.node`


### PR DESCRIPTION
The dataview decorator is async for legacy reasons.

However this means that the dataviiew decorator returns a promise which will not be caught as instance of error by the dataview entry method.

The dataview entry method may attempt to show the dataview and crash out if the dataview check has failed.

The dataview entry method should check whether the entry.show method exists on execution.

An error should be logged in the console.

It must be possible to select locations with a caught error exception.