### PR TITLE
Only check highlight style if typeof object

### DIFF
--- a/lib/layer/styleParser.mjs
+++ b/lib/layer/styleParser.mjs
@@ -85,11 +85,13 @@ export default function styleParser(layer) {
 
   layer.style ??= {}
 
-  // Assign a default highlight style and ensure that zIndex is infinity if not implicit.
-  layer.style.highlight ??= {}
-  layer.style.highlight.zIndex ??= Infinity
-  layer.style.highlight.highlightScale = layer.style.highlight.scale
-  delete layer.style.highlight.scale
+  if (typeof layer.style.highlight === 'object') {
+
+    // Assign a default highlight style and ensure that zIndex is infinity if not implicit.
+    layer.style.highlight.zIndex ??= Infinity
+    layer.style.highlight.highlightScale = layer.style.highlight.scale
+    delete layer.style.highlight.scale
+  }
 
   warnings(layer)
 

--- a/tests/lib/layer/styleParser.test.mjs
+++ b/tests/lib/layer/styleParser.test.mjs
@@ -2,19 +2,6 @@ import { describe, it, assertEqual, assertNotEqual, assertTrue, assertFalse } fr
 import styleParser from '../../../lib/layer/styleParser.mjs';
 
 describe('styleParser', () => {
-  it('should assign default highlight style and zIndex', () => {
-    const layer = {
-      key: 'test-layer',
-      style: {
-        default: {}
-      },
-    };
-
-    styleParser(layer);
-
-    assertTrue(layer.style.highlight !== undefined, 'highlight style should be assigned');
-    assertEqual(layer.style.highlight.zIndex, Infinity, 'zIndex should be set to Infinity');
-  });
 
   it('should parse theme styles', () => {
     const layer = {


### PR DESCRIPTION
![Screenshot from 2024-07-16 15-37-48](https://github.com/user-attachments/assets/82f48aa5-0fe7-4a05-befa-f8d39f3ab6c6)

The styleParser must not assign an empty highlight style.

Otherwise the highlight interaction will re-style an mvt layer, even if there is nothing to re-style.