### PR TITLE
Loadplugins error

### DIFF
--- a/lib/utils/loadPlugins.mjs
+++ b/lib/utils/loadPlugins.mjs
@@ -1,10 +1,28 @@
 /**
-## mapp.utils.loadPlugins()
+Exports the default loadPlugins utility method as mapp.utils.loadPlugins().
 
 @module /utils/loadPlugins
 */
 
-export default (plugins, endsWith = ['.js','.mjs']) => {
+/**
+@function loadPlugins
+
+@description
+The loadPlugins utility method receives an array argument of src string locations.
+
+The method creates an array of promises to load each plugin from the provided source.
+
+All import promises must be resolved for the loadPlugins method to resolve.
+
+The endsWith argument can be used to provide an array of string conditions on which the plugin src string must end to be loaded.
+
+@param {Array} plugins Array of plugin src location strings.
+@param  {Array} endsWith Array of strings to limit which plugins should be loaded. Defaults to ['.js','.mjs']
+
+@returns {Promise} The promise returned from the method will resolve once all [plugin] import promises are settled.
+*/
+
+export default function loadPlugins(plugins, endsWith = ['.js','.mjs']) {
 
   if (!Array.isArray(plugins)) return;
 

--- a/lib/utils/loadPlugins.mjs
+++ b/lib/utils/loadPlugins.mjs
@@ -38,7 +38,8 @@ export default function loadPlugins(plugins, endsWith = ['.js','.mjs']) {
                 resolve(mod)
               })
               .catch(err => {
-                console.error(err)
+                console.error(`Failed to load plugin: ${plugin}`);
+                console.error(err);
                 reject(err)
               })))
 

--- a/lib/utils/loadPlugins.mjs
+++ b/lib/utils/loadPlugins.mjs
@@ -19,8 +19,9 @@ export default (plugins, endsWith = ['.js','.mjs']) => {
               .then(mod => {
                 resolve(mod)
               })
-              .catch(() => {
-                reject()
+              .catch(err => {
+                console.error(err)
+                reject(err)
               })))
 
     Promise

--- a/lib/utils/loadPlugins.mjs
+++ b/lib/utils/loadPlugins.mjs
@@ -39,7 +39,6 @@ export default function loadPlugins(plugins, endsWith = ['.js','.mjs']) {
               })
               .catch(err => {
                 console.error(`Failed to load plugin: ${plugin}`);
-                console.error(err);
                 reject(err)
               })))
 


### PR DESCRIPTION
The loadPlugins utility method should console err when an import error is caught.

![Screenshot from 2024-07-16 18-08-30](https://github.com/user-attachments/assets/93eaade8-5e8a-498e-ab20-4375c53df415)
