### PR TITLE
Enable delete from hook / url param

### DIFF
--- a/public/views/_default.html
+++ b/public/views/_default.html
@@ -577,12 +577,18 @@
 
   if (mapp.hooks.current.useridb || locale.useridb) {
 
-    let userLocale = await mapp.utils.userIndexedDB.get('locales', locale.key)
+    if (mapp.hooks.current?.useridb === 'delete') {
 
-    if (!userLocale) {
-      await mapp.utils.userIndexedDB.add('locales', locale)
+      await mapp.utils.userIndexedDB.deleteDB()
     } else {
-      locale = userLocale
+
+      let userLocale = await mapp.utils.userIndexedDB.get('locales', locale.key)
+
+      if (!userLocale) {
+        await mapp.utils.userIndexedDB.add('locales', locale)
+      } else {
+        locale = userLocale
+      }
     }
   }
 


### PR DESCRIPTION
It must be possible to delete the useridb with `?useriidb=delete` url parameter.

Otherwise a different workspace with the same title and useridb flag will stuff the default view script.