### PR TITLE
Log error instead of warning for missing entry.type in infoj check ; log error instead of warning for invalid format.

### DIFF
--- a/lib/mapview/addLayer.mjs
+++ b/lib/mapview/addLayer.mjs
@@ -24,6 +24,9 @@ export default async function (layers) {
       layer.display = layersSet.has(layer.key);
     }
 
+    // Layer without format should not be decorated.
+    if (!layer.format) continue;
+
     // Check the layer format.
     if (!mapp.layer.formats[layer.format]) {
       console.error(`Layer: ${layer.key}, format is unknown or undefined. This is likely due to an incorrect file path.`)

--- a/lib/mapview/addLayer.mjs
+++ b/lib/mapview/addLayer.mjs
@@ -29,7 +29,7 @@ export default async function (layers) {
 
     // Check the layer format.
     if (!mapp.layer.formats[layer.format]) {
-      console.error(`Layer: ${layer.key}, format is unknown or undefined. This is likely due to an incorrect file path.`)
+      console.error(`Layer: ${layer.key}; Format: ${layer.format} is unknown.`)
       continue;
     }
 

--- a/lib/mapview/addLayer.mjs
+++ b/lib/mapview/addLayer.mjs
@@ -26,7 +26,7 @@ export default async function (layers) {
 
     // Check the layer format.
     if (!mapp.layer.formats[layer.format]) {
-      console.warn(`Layer: ${layer.key}, format is unknown or undefined. This is likely due to an incorrect file path.`)
+      console.error(`Layer: ${layer.key}, format is unknown or undefined. This is likely due to an incorrect file path.`)
       continue;
     }
 

--- a/lib/ui/locations/infoj.mjs
+++ b/lib/ui/locations/infoj.mjs
@@ -80,7 +80,7 @@ export default function infoj(location, infoj_order) {
     entry.listview = listview
 
     // The default entry type is text.
-    entry.type = entry.type || 'text'
+    entry.type ??= 'text'
 
     entryJSONB(entry)
 
@@ -103,7 +103,7 @@ export default function infoj(location, infoj_order) {
 
     // Check whether a method exists for the entry type.
     if (!Object.hasOwn(mapp.ui.locations.entries, entry.type)) {
-      console.warn(`entry.type:${entry.type} method not found.`)
+      console.error(`entry.type:${entry.type} method not found.`)
       continue;
     }
 

--- a/lib/ui/locations/infoj.mjs
+++ b/lib/ui/locations/infoj.mjs
@@ -3,6 +3,8 @@
 
 The infoj module exports a default method to process the infoj entries of a location.
 
+@requires /ui/locations/entries
+
 @module /ui/locations/infoj
 */
 


### PR DESCRIPTION
Instead of a warning the the infoj method should console an error when the `entry.type` is not an own property of the `mapp.ui.location.entries{}` method.

![image](https://github.com/user-attachments/assets/1338c22b-1fec-432a-bc35-b7706485e820)


Add requires for entries module.

![image](https://github.com/user-attachments/assets/c9e7eb31-3c49-404d-a8bc-c34c16885f5d)
