### PR TITLE
Assign getLayer template error message; catch and log error in addLayer

### DIFF
--- a/lib/mapview/addLayer.mjs
+++ b/lib/mapview/addLayer.mjs
@@ -16,9 +16,8 @@ export default async function (layers) {
 
     // The layer.err will be assigned from a failure to fetch a layer template.
     if (layer.err) {
-
-      console.error(layer.err)
-      continue;
+      // Error for each of the array items.
+      layer.err.forEach(err => console.error(err))
     }
 
     layer.zIndex ??= i

--- a/lib/mapview/addLayer.mjs
+++ b/lib/mapview/addLayer.mjs
@@ -14,6 +14,13 @@ export default async function (layers) {
 
     const layer = mapp.utils.merge({}, this.locale.layer || {}, layers[i])
 
+    // The layer.err will be assigned from a failure to fetch a layer template.
+    if (layer.err) {
+
+      console.error(layer.err)
+      continue;
+    }
+
     layer.zIndex ??= i
 
     layer.mapview = this;

--- a/mod/workspace/getLayer.js
+++ b/mod/workspace/getLayer.js
@@ -58,7 +58,7 @@ module.exports = async (params) => {
     let template = structuredClone(await getTemplate(workspace.templates[layer.template || layer.key]))
 
     // Assign the error message to the template
-    template.err &&= template.err.message;
+    template.err &&= [template.err.message];
 
     // Merge the workspace template into the layer.
     layer =  merge(template, layer)
@@ -70,7 +70,13 @@ module.exports = async (params) => {
     if (!Object.hasOwn(workspace.templates, key)) continue;
 
     let template =  structuredClone(await getTemplate(workspace.templates[key]))
-     
+     // Assign the error message to the template 
+     if (Array.isArray(template.err)) {
+      template.err = template.err.map(err => err.message)
+     } else {
+      template.err &&= [template.err.message];
+     }
+
     // Merge the workspace template into the layer.
     layer = merge(layer, template)
   }

--- a/mod/workspace/getLayer.js
+++ b/mod/workspace/getLayer.js
@@ -57,6 +57,9 @@ module.exports = async (params) => {
 
     let template = structuredClone(await getTemplate(workspace.templates[layer.template || layer.key]))
 
+    // Assign the error message to the template
+    template.err &&= template.err.message;
+
     // Merge the workspace template into the layer.
     layer =  merge(template, layer)
   }


### PR DESCRIPTION
An error object can not be sent with the layer json.

The Error.message can be assigned to the layer json instead.

The addLayer() method can check for an err message and log this.

![image](https://github.com/user-attachments/assets/496aed13-4bd4-4ebd-90c5-174bd488857d)
