### PR TITLE
Allow for array updates with text entry arraySeparator

### DIFF
--- a/lib/ui/locations/entries/text.mjs
+++ b/lib/ui/locations/entries/text.mjs
@@ -1,3 +1,11 @@
+/**
+## ui/locations/entries/text
+
+The locations entries text module exports the default text entry as mapp.ui.locations.entries.text(entry)
+
+@module /ui/locations/entries/text
+*/
+
 mapp.utils.merge(mapp.dictionaries, {
   en: {
     loading: 'Loading',
@@ -45,13 +53,28 @@ mapp.utils.merge(mapp.dictionaries, {
   },
 })
 
-export default entry => {
+/**
+@function text
+
+@description
+The text method will return the textedit function for editable entries or an HTML node with the formated field value.
+
+Non editable entries without a value will return void.
+
+@param {infoj-entry} entry type:geometry entry.
+@property {Object} entry.value geometry as JSON value.
+@property {Object} [entry.edit] configuration object for editing the value.
+
+@return {HTMLElement} elements for the location view.
+*/
+
+export default function text(entry) {
 
   // Short circuit if not editable without a value.
   if (!entry.edit && !entry.value) return;
 
   // Return inputs for editing.
-  if (entry.edit) return edit(entry)
+  if (entry.edit) return textedit(entry)
 
   // Return value as text, including prefix and suffix.
   return mapp.utils.html.node`
@@ -61,8 +84,28 @@ export default entry => {
       ${entry.prefix}${entry.value}${entry.suffix}`
 }
 
-// Edit function
-function edit(entry) {
+/**
+@function textedit
+
+@description
+The textedit method will return input elements for editable type:text entries.
+
+The container populated by the textoptions method will be returned if an options array has been defined in the edit object.
+
+The options array will be populated with distinct values from the data at rest if the length of the options array is naught.
+
+A text input is returned if no options are configured.
+
+The oninput method for the text input will split the value as an array if an arraySeparator has been defined in the entry.edit{} property.
+
+@param {infoj-entry} entry type:geometry entry.
+@property {Object} entry.value geometry as JSON value.
+@property {Object} [entry.edit] configuration object for editing the value.
+
+@return {HTMLElement} elements for the location view.
+*/
+
+function textedit(entry) {
 
   // If edit options are defined.
   if (entry.edit.options) {
@@ -74,15 +117,14 @@ function edit(entry) {
     if (entry.edit.options.length) {
 
       // Create dropdown from options.
-      options(entry)
+      textoptions(entry)
 
     }
     // If options is empty array, we need to query the table to populate it.
     else {
 
       // We can query a particular template or Query distinct field values from the layer table.
-      mapp.utils.xhr(
-        `${entry.location.layer.mapview.host}/api/query?` +
+      mapp.utils.xhr(`${entry.location.layer.mapview.host}/api/query?` +
         mapp.utils.paramString({
           template: entry.edit.query || (entry.jsonb_field || entry.json_field ? 'distinct_values_json' : 'distinct_values'),
           dbs: entry.location.layer.dbs,
@@ -107,7 +149,7 @@ function edit(entry) {
           })
 
           // Create dropdown from options.
-          options(entry)
+          textoptions(entry)
         })
     }
 
@@ -122,15 +164,33 @@ function edit(entry) {
       maxlength=${entry.edit.maxlength}
       value="${entry.newValue || entry.value || ''}"
       placeholder="${entry.edit.placeholder || ''}"
-      onkeyup=${e => {
-      entry.newValue = e.target.value
-      entry.location.view?.dispatchEvent(
-        new CustomEvent('valChange', { detail: entry }))
-    }}>`
+      onkeyup=${onInput}>`
+
+  function onInput(e) {
+
+    // Split target value as array if an arraySeparator has been provided.
+    entry.newValue = entry.edit.arraySeparator
+      ? e.target.value.split(entry.edit.arraySeparator)
+      : e.target.value;
+
+    entry.location.view?.dispatchEvent(
+      new CustomEvent('valChange', { detail: entry }))
+
+  }
 }
 
-// Options function
-function options(entry) {
+/**
+@function textoptions
+
+@description
+The textoptions method will render a dropdown control for the edit.options[] array values into the entry.container.
+
+@param {infoj-entry} entry type:geometry entry.
+@property {Object} entry.value geometry as JSON value.
+@property {Object} [entry.edit] configuration object for editing the value.
+*/
+
+function textoptions(entry) {
 
   // Create array of objects for optionEntries.
   const optionEntries = entry.edit.options.map(option => ({
@@ -176,5 +236,4 @@ function options(entry) {
       );
     }
   }))
-
 }


### PR DESCRIPTION
In order to set and update an array type database field the arraySeparator edit property is introduced in this PR.

```js
"edit": {
  "arraySeparator": ","
}
```

The `onInput` method of the text input element will use the arraySeparator character to split a provided target element string value into an array provided as newValue property value to the entry.

[Screencast from 18-07-24 09:00:39.webm](https://github.com/user-attachments/assets/539543de-94a6-40a2-8351-218e33da7bf1)
