### PR TITLE
Remove dev console.log() from cookie module.

### DIFF
--- a/mod/user/cookie.js
+++ b/mod/user/cookie.js
@@ -45,8 +45,6 @@ The cookie should be destroyed.
 
 module.exports = async function cookie(req, res) {
 
-  console.log(typeof acl)
-
   // acl module will export an empty require object without the ACL being configured.
   if (typeof acl !== 'function') {
     return res.status(500).send('ACL unavailable.')


### PR DESCRIPTION
The console.log() should have been removed in recent PR. https://github.com/GEOLYTIX/xyz/pull/1373