### PR TITLE
check on falsy values; not length

### DIFF
--- a/lib/ui/locations/infoj.mjs
+++ b/lib/ui/locations/infoj.mjs
@@ -219,7 +219,7 @@ function entrySkip(entry) {
 
   // Skip entries which are falsy if flagged.
   if (entry.skipFalsyValue
-    && !entry.value?.length
+    && !entry.value
     && !entry.edit) return true;
 
   // Skip entries which are undefined if flagged.


### PR DESCRIPTION
A numeric [integer] value should not be skipped due missing length.

Only falsy values should be skipped as the flag implies.
skipFalsy with an integer value, like 1 prior to PR would incorrectly skip - this is resolved.
skipFalsy with an integer value of 0 will be skipped as its falsy.