### PR TITLE
Assign location.style to vector_layer entry

### DIFF
--- a/lib/ui/locations/entries/vector_layer.mjs
+++ b/lib/ui/locations/entries/vector_layer.mjs
@@ -145,7 +145,7 @@ async function show(entry) {
   entry.display = true;
 
   // the show event maybe triggered by an API, draw, or modify interaction.
-  const chkbox = entry.location.view?.querySelector(`[data-id=${entry.key}-chkbox] input`)
+  const chkbox = entry.location.view?.querySelector(`[data-id=chkbox-${entry.key}] input`)
 
   if (chkbox) chkbox.checked = true
 

--- a/lib/ui/locations/entries/vector_layer.mjs
+++ b/lib/ui/locations/entries/vector_layer.mjs
@@ -15,11 +15,25 @@ The vector_layer entry generates a checkbox to control the display of a vector l
 @example
 ```json
 {
-  "title": "This is a title",
-  "type":"title",
-  "tooltip": "This is a tooltip",
-  "css_title": "font-weight: 800"
-}
+      "key": "nearest_to",
+      "label": "Nearest to",
+      "type": "vector_layer",
+      "format": "wkt",
+      "srid": "4326",
+      "zIndex": 94,
+      "query": "nearest_to",
+      "queryparams": {
+        "id": true,
+        "reduce": true
+      },
+      "style": {
+        "default": {
+          "icon": {
+            "type": "triangle"
+          }
+        }
+      }
+    }
 ``` 
 @function vector_layer
 @param {Object} entry
@@ -77,13 +91,13 @@ export default function vector_layer(entry) {
     label: entry.label,
     data_id: `${entry.key}-chkbox`,
     checked: !!entry.display,
-    onchange: (checked) => checked ? entry.show() : hide(entry)
+    onchange: (checked) => checked ? entry.show(entry) : hide(entry)
   })
 
   entry.show ??= show
 
   // Show geometry if entry is set to display.
-  entry.display && entry.show()
+  entry.display && entry.show(entry)
 
   // Create a node consistent of the chkbox and the style drawer.
   entry.panel = mapp.utils.html.node`<div>${entry.chkbox}${entry.elements}`
@@ -112,68 +126,75 @@ The entry object will be updated with the features.
 The entry object will be updated with the layer source.
 The layer will be added to the map.
 
-@param {dataview} entry Dataview object.
+@param {entry} entry entry object.
 @property {string} entry.format The type of layer.
 @property {string} entry.key The unique identifier for the entry.
 @property {string} entry.query The query for the generation of the data to be displayed.
 @property {string} entry.host The host for the entry.
 */
-async function show() {
+async function show(entry) {
 
-  this.display = true;
+  entry.display = true;
 
   // the show event maybe triggered by an API, draw, or modify interaction.
-  const chkbox = this.location.view?.querySelector(`[data-id=${this.key}-chkbox] input`)
+  const chkbox = entry.location.view?.querySelector(`[data-id=${entry.key}-chkbox] input`)
 
   if (chkbox) chkbox.checked = true
 
-  if (this.mapview.Map.getLayers().getArray().includes(this.L)) {
+  if (entry.mapview.Map.getLayers().getArray().includes(entry.L)) {
 
     // The layer has already been added to the map.
     return;
   }
 
   // Create query paramString from the entry object.
-  const paramString = mapp.utils.paramString(mapp.utils.queryParams(this))
+  const paramString = mapp.utils.paramString(mapp.utils.queryParams(entry))
 
   // Get features from query.
-  this.features ??= await mapp.utils.xhr(`${this.host || this.mapview?.host || mapp.host}/api/query?${paramString}`)
+  entry.features ??= await mapp.utils.xhr(`${entry.host || entry.mapview?.host || mapp.host}/api/query?${paramString}`)
 
-  if (this.features instanceof Error) {
+  if (entry.features instanceof Error) {
 
     console.warn('Features query failed.')
     return;
   }
 
-  if (!this.features && this.api instanceof Function) await this.api(this)
+  if (!entry.features && entry.api instanceof Function) await entry.api(entry)
 
-  if (!this.features) {
+  if (!entry.features) {
 
+    // Disable checkbox.
+    entry.panel.querySelector('input').disabled = true
+
+    // Hide style drawer if present.
+    if (entry.style.panel) {
+      entry.style.panel.style.display = 'none'
+    }
     return;
   }
 
   // The layer already exists.
-  if (this.setSource) {
+  if (entry.setSource) {
 
-    this.setSource(this.features)
+    entry.setSource(entry.features)
   } else {
 
-    mapp.layer.formats[this.format](this)
+    mapp.layer.formats[entry.format](entry)
   }
 
   try {
 
-    this.mapview.Map.addLayer(this.L)
+    entry.mapview.Map.addLayer(entry.L)
 
   } catch {
     // Will catch assertation error when layer is already added.
   }
 
-  this.style.panel?.remove()
+  entry.style.panel?.remove()
 
   // Create a style panel as entry.style.panel and append to entry.node.
-  this.style.panel = mapp.ui.layers.panels.style(this)
-  this.style.panel && this.panel.append(this.style.panel)
+  entry.style.panel = mapp.ui.layers.panels.style(entry)
+  entry.style.panel && entry.panel.append(entry.style.panel)
 }
 
 /**
@@ -185,7 +206,6 @@ The `entry.style.panel` element display style will be set to `none`, if it exist
 The geometry layer will be removed from the map.
 
 @param {Object} entry entry object.
-@property {HTMLElement} target Target element in which the dataview is rendered.
 */
 function hide(entry) {
 

--- a/lib/ui/locations/entries/vector_layer.mjs
+++ b/lib/ui/locations/entries/vector_layer.mjs
@@ -71,14 +71,13 @@ export default function vector_layer(entry) {
 
     // If entry.style.default.icon exists, merge the location style with the default style icon.
     if (entry.style.default.icon) {
+
       // Assign the location style to the default style icon if it exists.
       entry.style.default.icon = { ...entry.location?.style, ...entry.style.default.icon }
     }
 
     // Assign the location style to the default style.
     entry.style.default = { ...entry.location?.style, ...entry.style.default }
-
-
   }
 
   // Update entry.style config.
@@ -149,7 +148,9 @@ async function show(entry) {
 
   if (chkbox) chkbox.checked = true
 
-  if (entry.mapview.Map.getLayers().getArray().includes(entry.L)) {
+  const mapLayers = entry.mapview.Map.getLayers().getArray()
+
+  if (mapLayers.includes(entry.L)) {
 
     // The layer has already been added to the map.
     return;
@@ -159,7 +160,7 @@ async function show(entry) {
   const paramString = mapp.utils.paramString(mapp.utils.queryParams(entry))
 
   // Get features from query.
-  entry.features ??= await mapp.utils.xhr(`${entry.host || entry.mapview?.host || mapp.host}/api/query?${paramString}`)
+  entry.features = await mapp.utils.xhr(`${entry.host || entry.mapview?.host || mapp.host}/api/query?${paramString}`)
 
   if (entry.features instanceof Error) {
 

--- a/lib/ui/locations/entries/vector_layer.mjs
+++ b/lib/ui/locations/entries/vector_layer.mjs
@@ -13,12 +13,17 @@ export default entry => {
 
   entry.style ??= {}
 
-  if (entry.style.default) {
+  if (entry.style.default && !entry.style.default.icon) {
+    // Should be default.icon 
+    entry.style.default.icon ??= { 'icon': entry.style.default };
+    console.warn(`${entry.label}: Default style should be default.icon.`)
+  };
 
+  if (entry.style.default.icon) {
     // Assign the location style to the default style.
-    entry.style.default = {...entry.location?.style, ...entry.style.default}
+    entry.style.default.icon = { ...entry.location?.style, ...entry.style.default.icon }
   }
-  
+
   // Update entry.style config.
   mapp.layer.styleParser(entry)
 
@@ -103,7 +108,7 @@ async function show() {
   }
 
   try {
-    
+
     this.mapview.Map.addLayer(this.L)
 
   } catch {

--- a/lib/ui/locations/entries/vector_layer.mjs
+++ b/lib/ui/locations/entries/vector_layer.mjs
@@ -8,35 +8,39 @@ The vector_layer entry module exports a default [location] entry method to proce
 */
 
 /**
+
+@function vector_layer
+
+@description
 mapp.ui.locations.entries.vector_layer(entry)
 
 The method processes a vector_layer entry and returns a panel node to the location view.
 The vector_layer entry generates a checkbox to control the display of a vector layer on the map.
-@example
+
 ```json
 {
-      "key": "nearest_to",
-      "label": "Nearest to",
-      "type": "vector_layer",
-      "format": "wkt",
-      "srid": "4326",
-      "zIndex": 94,
-      "query": "nearest_to",
-      "queryparams": {
-        "id": true,
-        "reduce": true
-      },
-      "style": {
-        "default": {
-          "icon": {
-            "type": "triangle"
-          }
-        }
+  "key": "nearest_to",
+  "label": "Nearest to",
+  "type": "vector_layer",
+  "format": "wkt",
+  "srid": "4326",
+  "zIndex": 94,
+  "query": "nearest_to",
+  "queryparams": {
+    "id": true,
+    "reduce": true
+  },
+  "style": {
+    "default": {
+      "icon": {
+        "type": "triangle"
       }
     }
-``` 
-@function vector_layer
-@param {Object} entry
+  }
+}
+```
+
+@param {infoj-entry} entry
 
 @property {string} entry.query The query for the generation of the data to be displayed.
 @property {string} entry.format The format for the entry.
@@ -63,12 +67,14 @@ export default function vector_layer(entry) {
   entry.style ??= {}
 
   if (entry.style.default && !entry.style.default.icon) {
+
     // Should be default.icon 
     entry.style.default.icon ??= { 'icon': entry.style.default };
     console.warn(`${entry.label}: Default style should be default.icon.`)
   };
 
   if (entry.style.default.icon) {
+    
     // Assign the location style to the default style.
     entry.style.default.icon = { ...entry.location?.style, ...entry.style.default.icon }
   }

--- a/lib/ui/locations/entries/vector_layer.mjs
+++ b/lib/ui/locations/entries/vector_layer.mjs
@@ -1,4 +1,39 @@
-export default entry => {
+
+/**
+## ui/locations/entries/vector_layer
+
+The vector_layer entry module exports a default [location] entry method to process infoj `type:vector_layer` entries.
+
+@module /ui/locations/entries/vector_layer
+*/
+
+/**
+mapp.ui.locations.entries.vector_layer(entry)
+
+The method processes a vector_layer entry and returns a panel node to the location view.
+The vector_layer entry generates a checkbox to control the display of a vector layer on the map.
+@example
+```json
+{
+  "title": "This is a title",
+  "type":"title",
+  "tooltip": "This is a tooltip",
+  "css_title": "font-weight: 800"
+}
+``` 
+@function vector_layer
+@param {Object} entry
+
+@property {string} entry.query The query for the generation of the data to be displayed.
+@property {string} entry.format The format for the entry.
+@property {string} entry.theme The theme for the entry.
+@property {string} [entry.key] The unique identifier for the entry.
+@property {string} [entry.label] The label for the entry.
+@property {string} [entry.host] The host for the entry.
+@property {string} [entry.zIndex] The z-index for the entry.
+@property {string} [entry.display] The display flag for the entry.
+*/
+export default function vector_layer(entry) {
 
   // Assign mapview to entry to provide shortened lookup.
   entry.mapview ??= entry.location.layer.mapview
@@ -64,6 +99,25 @@ export default entry => {
   return entry.panel
 }
 
+/**
+@function show
+
+@description
+`entry.display` flag will be set to true.
+The `entry.style.panel` element display style will be set to `block`, if it exists.
+The geometry layer will be added to the map (if it does not already exist).
+The entry.query will be used to generate a query string and fetch features.
+The features will be set to the entry object.
+The entry object will be updated with the features.
+The entry object will be updated with the layer source.
+The layer will be added to the map.
+
+@param {dataview} entry Dataview object.
+@property {string} entry.format The type of layer.
+@property {string} entry.key The unique identifier for the entry.
+@property {string} entry.query The query for the generation of the data to be displayed.
+@property {string} entry.host The host for the entry.
+*/
 async function show() {
 
   this.display = true;
@@ -122,6 +176,17 @@ async function show() {
   this.style.panel && this.panel.append(this.style.panel)
 }
 
+/**
+@function hide
+
+@description
+`entry.display` flag will be set to false.
+The `entry.style.panel` element display style will be set to `none`, if it exists.
+The geometry layer will be removed from the map.
+
+@param {Object} entry entry object.
+@property {HTMLElement} target Target element in which the dataview is rendered.
+*/
 function hide(entry) {
 
   entry.display = false

--- a/lib/ui/locations/entries/vector_layer.mjs
+++ b/lib/ui/locations/entries/vector_layer.mjs
@@ -66,17 +66,19 @@ export default function vector_layer(entry) {
 
   entry.style ??= {}
 
-  if (entry.style.default && !entry.style.default.icon) {
+  // If entry.style.default (default style) exists, merge the location style with the default style.
+  if (entry.style.default) {
 
-    // Should be default.icon 
-    entry.style.default.icon ??= { 'icon': entry.style.default };
-    console.warn(`${entry.label}: Default style should be default.icon.`)
-  };
+    // If entry.style.default.icon exists, merge the location style with the default style icon.
+    if (entry.style.default.icon) {
+      // Assign the location style to the default style icon if it exists.
+      entry.style.default.icon = { ...entry.location?.style, ...entry.style.default.icon }
+    }
 
-  if (entry.style.default.icon) {
-    
     // Assign the location style to the default style.
-    entry.style.default.icon = { ...entry.location?.style, ...entry.style.default.icon }
+    entry.style.default = { ...entry.location?.style, ...entry.style.default }
+
+
   }
 
   // Update entry.style config.
@@ -95,7 +97,7 @@ export default function vector_layer(entry) {
   // Create checkbox to control geometry display.
   entry.chkbox = mapp.ui.elements.chkbox({
     label: entry.label,
-    data_id: `${entry.key}-chkbox`,
+    data_id: `chkbox-${entry.key}`,
     checked: !!entry.display,
     onchange: (checked) => checked ? entry.show(entry) : hide(entry)
   })


### PR DESCRIPTION
# Pull Request Template

## Description

An `infoj` `entry` of `type: vector_layer` would previously be assigned the `location.style` if not provided. 
However following `styleParser` and the need for `style.default.icon` the if statement in the code was not hit.

The checkbox is now also disabled if no features are returned - letting the user know. 
An entry example of this format will get the `location.style` assigned to it. 
``` json
{
      "key": "XX",
      "label": "Nearest to",
      "type": "vector_layer",
      "format": "wkt",
      "srid": "4326",
      "zIndex": 94,
      "query": "XXX",
      "queryparams": {
        "id": true,
        "reduce": true
      },
      "style": {
        "default": {
          "icon": {
            "type": "triangle"
          }
        }
      }
    }
```
## Type of Change
Please delete options that are not relevant, and select all options that apply. 

- ✅ Bug fix (non-breaking change which fixes an issue)

## How have you tested this? 
Tested locally on my machine.

## Testing Checklist 
Please delete options that are not relevant, and select all options that apply. 

- ✅ Existing Tests still pass
- ✅ New Tests Added
- ✅ Ran locally on my machine

## Code Quality Checklist
Please delete options that are not relevant, and select all options that apply. 

- ✅ My code follows the guidelines of XYZ
- ✅ My code has been commented
- ✅ Documentation has been updated
- ✅ New and existing unit tests pass locally with my changes
- ✅ Main has been merged into this PR

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1207878998875070