### PR TITLE
Fix issue where dataview is disconnected from layer object.

### DIFF
--- a/lib/ui/layers/panels/dataviews.mjs
+++ b/lib/ui/layers/panels/dataviews.mjs
@@ -68,13 +68,13 @@ export default function dataviews(layer) {
     // The layer.dataviews{} object may include a hide flag.
     if (typeof entry[1] !== 'object') return;
 
-    // Spread dataview properties.
-    const dataview = {
-      key: entry[0],
-      host: layer.mapview.host,
-      ...entry[1],
-      layer,
-    }
+    // Assign key, host, and layer to dataview object.
+    const dataview = Object.assign(entry[1],
+      {
+        key: entry[0],
+        host: layer.mapview.host,
+        layer,
+      })
 
     // Find tabview element from data-id attribute.
     dataview.tabview = document.querySelector(`[data-id=${dataview.target}]`)


### PR DESCRIPTION
Dataviews are not associated with the layer object if referenced from the entry.location.layer, for example in an update statement. The reason for this being the entry[1] being spread into the dataview object in the dataview decorator.

![image](https://github.com/user-attachments/assets/4b03f5fe-3a93-4f12-8819-d85f76342c16)

The effect of this being that the dataview cannot be referenced through the location.layer in the location update method.

![image](https://github.com/user-attachments/assets/6c5a807f-2cf3-478b-8371-54bb3114c1e1)
