### PR TITLE
Log original error message for load plugin errors.

### DIFF
--- a/lib/utils/loadPlugins.mjs
+++ b/lib/utils/loadPlugins.mjs
@@ -38,7 +38,8 @@ export default function loadPlugins(plugins, endsWith = ['.js','.mjs']) {
                 resolve(mod)
               })
               .catch(err => {
-                console.error(`Failed to load plugin: ${plugin}`);
+                console.warn(`Failed to load plugin: ${plugin}`)
+                console.error(err);
                 reject(err)
               })))
 


### PR DESCRIPTION
The plugin src can be warned though it is also in the original error message. But the error itself must be logged otherwise it will be impossible to find issues where a plugin fails to load because the plugin module script throws an exception.

![image](https://github.com/user-attachments/assets/d5b12ae1-ed29-45e7-b3d9-7bc2ca65777e)
