### PR TITLE
Vector layer format error handling

### DIFF
--- a/lib/layer/featureFormats.mjs
+++ b/lib/layer/featureFormats.mjs
@@ -31,13 +31,26 @@ export function geojson(layer, features) {
   })
 }
 
+/**
+@function wkt
+
+@description
+The wkt featureFormat method processes an array of wkt features and returns a Openlayer features to be added to the layer source.
+
+@param {layer} layer A decorated mapp layer object.
+@param {array} features An array of WKT features.
+
+@returns {array} Array of openlayers features.
+*/
 export function wkt(layer, features) {
+
+  if (!Array.isArray(features)) return;
   
   const formatWKT = new ol.format.WKT
 
   mapp.layer.featureFields.reset(layer);
 
-  const Fs = features.map((feature) => {
+  const olFeatures = features.map((feature) => {
 
     const properties = {}
 
@@ -64,9 +77,10 @@ export function wkt(layer, features) {
 
   })
 
+  // Process featureFields for dynamic theming.
   mapp.layer.featureFields.process(layer);
 
-  return Fs
+  return olFeatures
 }
 
 export function wkt_properties(layer, features) {

--- a/lib/layer/format/vector.mjs
+++ b/lib/layer/format/vector.mjs
@@ -142,7 +142,13 @@ export default function vector(layer) {
           filter: layer.filter?.current,
           ...layer.params
         })}`)
-        .then(layer.setSource)
+        .then(features => {
+
+          // An error will be returned if the xhr fails with a bad request 400.
+          if (features instanceof Error) return;
+
+          layer.setSource(features)
+        })
 
     }, 100)
 

--- a/lib/layer/format/vector.mjs
+++ b/lib/layer/format/vector.mjs
@@ -96,63 +96,8 @@ export default function vector(layer) {
   // Assigns changeEnd event/method for zoom restricted layers.
   mapp.layer.changeEnd(layer)
 
-  layer.reload = () => {
-
-    // Do not reload the layer if features have been assigned.
-    if (layer.features) return;
-
-    const table = layer.tableCurrent()
-
-    if (!table) return;
-
-    const geom = layer.geomCurrent()
-
-    if (layer.fade) mapp.layer.fade(layer, true)
-
-    // Create a set of feature properties for styling.
-    layer.params.fields = [...new Set([
-      layer.params.default_fields,
-      Array.isArray(layer.style.theme?.fields) ?
-        layer.style.theme.fields : layer.style.theme?.field,
-      layer.style.theme?.field,
-      layer.style.label?.field,
-      layer.cluster?.label,
-    ].flat().filter(field => !!field))]
-
-    const bounds = layer.mapview.getBounds()
-
-    // Assign current viewport if queryparam is truthy.
-    layer.params.viewport &&= [bounds.west, bounds.south, bounds.east, bounds.north, layer.mapview.srid];
-
-    // Assign current viewport if queryparam is truthy.
-    layer.params.z &&= layer.mapview.Map.getView().getZoom();
-
-    clearTimeout(layer.timeout)
-
-    layer.timeout = setTimeout(() => {
-
-      layer.xhr = mapp.utils.xhr(
-        `${layer.mapview.host}/api/query?${mapp.utils.paramString({
-          template: layer.params.template || layer.format,
-          locale: layer.mapview.locale.key,
-          layer: layer.key,
-          table,
-          geom,
-          srid: layer.srid,
-          filter: layer.filter?.current,
-          ...layer.params
-        })}`)
-        .then(features => {
-
-          // An error will be returned if the xhr fails with a bad request 400.
-          if (features instanceof Error) return;
-
-          layer.setSource(features)
-        })
-
-    }, 100)
-
-  }
+  // Assign reload method to layer.
+  layer.reload = reload;
 
   // Create Openlayer Vector Layer
   layer.L = new ol.layer[layer.vectorImage && 'VectorImage' || 'Vector']({
@@ -226,18 +171,92 @@ export default function vector(layer) {
 }
 
 /**
- * Configures the clustering options for a layer.
- * @function clusterConfig
- * @param {Object} layer - The layer object.
- * @param {Object} layer.cluster - The clustering configuration for the layer.
- * @param {number} [layer.cluster.distance] - The distance threshold for clustering.
- * @param {number} [layer.cluster.resolution] - The resolution threshold for clustering.
- * @param {boolean} [layer.cluster.hexgrid] - Flag indicating whether to use hexgrid clustering.
- * @param {string} layer.key - The key of the layer.
- * @param {string} layer.srid - The spatial reference system identifier (SRID) for the layer.
- * @param {Object} layer.params - Additional parameters for the layer.
- * @returns {void}
- */
+@function reload
+
+@description
+The layer.reload() method determines the table and geometry for the current zoom level. And uses the layer.params{} to create a request for layer features to be added to the layer source.
+
+The xhr request is debounced by 100ms to prevent requests in quick succession on panning, scroll, and touch zooming.
+
+The reload method is bound to the layer object and doesn't require any arguments.
+
+@property {Object} layer.params Parameter for data request.
+@property {Object} layer.timeout Timeout for the xhr request.
+*/
+function reload() {
+
+  const layer = this;
+
+  // Do not reload the layer if features have been assigned.
+  if (layer.features) return;
+
+  const table = layer.tableCurrent()
+
+  if (!table) return;
+
+  const geom = layer.geomCurrent()
+
+  if (layer.fade) mapp.layer.fade(layer, true)
+
+  // Create a set of feature properties for styling.
+  layer.params.fields = [...new Set([
+    layer.params.default_fields,
+    Array.isArray(layer.style.theme?.fields) ?
+      layer.style.theme.fields : layer.style.theme?.field,
+    layer.style.theme?.field,
+    layer.style.label?.field,
+    layer.cluster?.label,
+  ].flat().filter(field => !!field))]
+
+  const bounds = layer.mapview.getBounds()
+
+  // Assign current viewport if queryparam is truthy.
+  layer.params.viewport &&= [bounds.west, bounds.south, bounds.east, bounds.north, layer.mapview.srid];
+
+  // Assign current viewport if queryparam is truthy.
+  layer.params.z &&= layer.mapview.Map.getView().getZoom();
+
+  clearTimeout(layer.timeout)
+
+  layer.timeout = setTimeout(() => {
+
+    layer.xhr = mapp.utils.xhr(
+      `${layer.mapview.host}/api/query?${mapp.utils.paramString({
+        template: layer.params.template || layer.format,
+        locale: layer.mapview.locale.key,
+        layer: layer.key,
+        table,
+        geom,
+        srid: layer.srid,
+        filter: layer.filter?.current,
+        ...layer.params
+      })}`)
+      .then(features => {
+
+        // An error will be returned if the xhr fails with a bad request 400.
+        if (features instanceof Error) return;
+
+        layer.setSource(features)
+      })
+
+  }, 100)
+}
+
+/**
+@function clusterConfig
+
+@description
+Configures the clustering options for a layer.
+
+@param {Object} layer The layer object.
+@property {string} layer.key The key of the layer.
+@property {string} layer.srid The spatial reference system identifier (SRID) for the layer.
+@property {Object} layer.params Parameter for data request.
+@property {Object} layer.cluster The clustering configuration for the layer.
+@property {number} [cluster.distance] The distance threshold for clustering.
+@property {number} [cluster.resolution] The resolution threshold for clustering.
+@property {boolean} [cluster.hexgrid] Flag indicating whether to use hexgrid clustering.
+*/
 function clusterConfig(layer) {
 
   // The clusterConfig can not work without the layer having a cluster config object.


### PR DESCRIPTION
The vector format layer.reload() method has been unnested from the vector method and documented.

The xhr request should not attempt to add an Error instance returned from a failing data request to the source.

The featureFormats WKT method has been documented on testing.

To Test this : 
Set an incorrect dbs connection for the layer on load. 
You should now see just one error message instead of 2 that are seen off this PR.