### PR TITLE
Do not assign window as caller for vector layer reload method

### DIFF
--- a/lib/layer/format/vector.mjs
+++ b/lib/layer/format/vector.mjs
@@ -124,7 +124,7 @@ export default function vector(layer) {
 
       clearTimeout(layer.timeout)
 
-      layer.timeout = setTimeout(layer.reload, 100)
+      layer.timeout = setTimeout(()=>layer.reload(), 100)
     })
   }
 

--- a/tests/workspace.json
+++ b/tests/workspace.json
@@ -1,7 +1,7 @@
 {
     "locale": {
         "plugins": [
-            "${PLUGINS}v4.8.0/coordinates.js"
+            "${PLUGINS}/v4.8.0/coordinates.js"
         ],
         "syncPlugins": [
             "zoomBtn",

--- a/tests/workspace.json
+++ b/tests/workspace.json
@@ -1,7 +1,7 @@
 {
     "locale": {
         "plugins": [
-            "${PLUGINS}/v4.8.0/coordinates.js"
+            "${PLUGINS}v4.8.0/coordinates.js"
         ],
         "syncPlugins": [
             "zoomBtn",


### PR DESCRIPTION
calling a bound method like this from a [window] setTimeout() method assigns the window as this.

```js
setTimeout(layer.reload, 100)
```