### PR TITLE
Prevent this being the location.view element

### DIFF
--- a/lib/ui/locations/view.mjs
+++ b/lib/ui/locations/view.mjs
@@ -174,7 +174,7 @@ export default function view(location) {
 
   location.renderLocationView = renderLocationView
 
-  location.view.addEventListener('render', location.renderLocationView)
+  location.view.addEventListener('render', () => location.renderLocationView())
 
   location.view.addEventListener('updateInfo', () => {
 


### PR DESCRIPTION
Calling render event of the location.view element fails.

```js
location.view.dispatchEvent(new Event('render'))
```

`this` inside the renderLocationView() method will be location.view element in this case and not the location to which the method was bound.