### PR TITLE
elements.slider val/value property and layer.style.opacity slider element callback

### DIFF
--- a/lib/ui/elements/slider.mjs
+++ b/lib/ui/elements/slider.mjs
@@ -29,6 +29,9 @@ export default function slider(params) {
   // Range inputs require a step.
   params.step ??= 1
 
+  // Set value to val if value is not defined.
+  params.value ??= params.val;
+
   // Create numericInput element for formatting and numeric checks.
   const numericInput = mapp.ui.elements.numericInput(params)
 

--- a/lib/ui/elements/slider.mjs
+++ b/lib/ui/elements/slider.mjs
@@ -32,6 +32,10 @@ export default function slider(params) {
   // Set value to val if value is not defined.
   params.value ??= params.val;
 
+  params.title ??= ''
+
+  params.style ??= ''
+
   // Create numericInput element for formatting and numeric checks.
   const numericInput = mapp.ui.elements.numericInput(params)
 
@@ -39,14 +43,14 @@ export default function slider(params) {
   params.sliderElement = mapp.utils.html.node`
     <div
       role="group"
-      data-id=${params.data_id || 'slider'}
-      title=${params.title || ''}
+      data-id=${params.data_id}
+      title=${params.title}
       class="input-range single"
       style=${`
         --min: ${params.min};
         --max: ${params.max};
         --a: ${params.value};
-        ${params.style || ''}`}>
+        ${params.style}`}>
       <div class="label-row">
         <label>${params.label}
         ${numericInput}

--- a/lib/ui/layers/panels/style.mjs
+++ b/lib/ui/layers/panels/style.mjs
@@ -18,6 +18,7 @@ mapp.utils.merge(mapp.dictionaries, {
     layer_style_switch_all: 'switch all',
     layer_grid_legend_ratio: 'Display colour as a ratio to the size',
     layer_style_cluster: 'Multiple locations',
+    layer_style_opacity: 'Change layer opacity:'
   },
   de: {
     layer_style_header: 'Stil',
@@ -153,27 +154,12 @@ export default function stylePanel(layer) {
   if (layer.style.opacitySlider) {
 
     content.push(mapp.ui.elements.slider({
-      label: 'Change layer opacity:',
+      label: `${mapp.dictionary.layer_style_opacity}`,
       min: 0,
       max: 100,
       val: parseInt(layer.L.getOpacity() * 100),
       callback: e => {
-        layer.L.setOpacity(parseFloat(e.target.value / 100))
-      }
-    }))
-  }
-
-  if (layer.style.scaleSlider) {
-
-    content.push(mapp.ui.elements.slider({
-      label: 'Change icon scale:',
-      min: layer.style.scaleSlider.min,
-      max: layer.style.scaleSlider.max,
-      step: layer.style.scaleSlider.step,
-      val: layer.style.default.icon.scale,
-      callback: e => {
-        layer.style.default.icon.scale = e.target.value
-        layer.L.changed()
+        layer.L.setOpacity(parseFloat(e / 100))
       }
     }))
   }

--- a/lib/ui/locations/entries/numeric.mjs
+++ b/lib/ui/locations/entries/numeric.mjs
@@ -82,10 +82,14 @@ function edit(entry) {
 
   Object.assign(entry, entry.edit)
 
+  // A new value might be set as entry.default
+  const value = entry.value || entry.newValue
+
+  // Range must be shown when value is 0 and in range.
   if (entry.edit.range
-    && entry.value
-    && entry.value > entry.min
-    && entry.value < entry.max) {
+    && !isNaN(value)
+    && value > entry.min
+    && value < entry.max) {
 
     return mapp.ui.elements.slider(entry);
   }

--- a/tests/browser/local.test.mjs
+++ b/tests/browser/local.test.mjs
@@ -8,6 +8,7 @@ import { setView } from '../utils/view.js';
 import { delayFunction } from '../utils/delay.js';
 import { apiTest } from './_api.test.mjs';
 import { userTest } from '../mod/user/_user.test.js';
+import { ui_elementsTest } from '../lib/ui/elements/_elements.test.mjs';
 // import { booleanTest } from '../lib/ui/locations/entries/boolean.test.mjs';
 
 await userTest.updateTest();
@@ -48,6 +49,8 @@ await layerTest.styleParserTest(mapview);
 // await mapviewTest.infotipTest();
 // await mapviewTest.locateTest();
 // await mapviewTest.popupTest();
+
+await ui_elementsTest.sliderTest();
 // await booleanTest();
 
 await apiTest();

--- a/tests/lib/ui/elements/_elements.test.mjs
+++ b/tests/lib/ui/elements/_elements.test.mjs
@@ -1,0 +1,5 @@
+import { sliderTest } from './slider.test.mjs';
+
+export const ui_elementsTest = {
+    sliderTest
+};

--- a/tests/lib/ui/elements/slider.test.mjs
+++ b/tests/lib/ui/elements/slider.test.mjs
@@ -1,12 +1,25 @@
-
+/**
+ * ## layer.decorateTest()
+ * @module ui/elements/slider
+ */
+/**
+ * This function is used as an entry point for the sliderTest
+ * This test is used to test the creation of the slider ui element.
+ * **Note: I still want to figure out event management for these elements to trigger the oninput function to simulate sliding the element**
+ * @function sliderTest 
+*/
 export async function sliderTest() {
     await codi.describe('UI elements: slider', async () => {
         await codi.it('Should return an slider', async () => {
+            //get the workspace from the local files
             const workspace = await mapp.utils.xhr(`/test/tests/workspace.json`);
-            const layer = workspace.locale.layers['input_slider'];
+            const layer = workspace.locale.layers['input_slider'];//Get the input slider layer that we can get the params for.
+
             const input_slider_params = layer.infoj.filter(entry => entry.field === 'integer_field');
+            //Getting the params for the slider
             const input_slider = mapp.ui.elements.slider(input_slider_params[0]);
 
+            //Getting the creating input slider element and asserting the exected value
             const input_slider_element = input_slider.getElementsByTagName('input')[1];
             const assert_input = `<input data-id="a" name="rangeInput" type="range" min="-100000" max="10000" step="1">`;
             codi.assertEqual(input_slider_element.outerHTML, assert_input, 'We expect to see the input defined in the test');

--- a/tests/lib/ui/elements/slider.test.mjs
+++ b/tests/lib/ui/elements/slider.test.mjs
@@ -1,0 +1,15 @@
+
+export async function sliderTest() {
+    await codi.describe('UI elements: slider', async () => {
+        await codi.it('Should return an slider', async () => {
+            const workspace = await mapp.utils.xhr(`/test/tests/workspace.json`);
+            const layer = workspace.locale.layers['input_slider'];
+            const input_slider_params = layer.infoj.filter(entry => entry.field === 'integer_field');
+            const input_slider = mapp.ui.elements.slider(input_slider_params[0]);
+
+            const input_slider_element = input_slider.getElementsByTagName('input')[1];
+            const assert_input = `<input data-id="a" name="rangeInput" type="range" min="-100000" max="10000" step="1">`;
+            codi.assertEqual(input_slider_element.outerHTML, assert_input, 'We expect to see the input defined in the test');
+        });
+    });
+}

--- a/tests/workspace.json
+++ b/tests/workspace.json
@@ -335,6 +335,63 @@
                         "fieldfx": "ARRAY[ST_X(ST_PointOnSurface(geom_3857)),ST_Y(ST_PointOnSurface(geom_3857))]"
                     }
                 ]
+            },
+            "input_slider": {
+                "display": true,
+                "group": "ui_elements",
+                "format": "wkt",
+                "dbs": "NEON",
+                "table": "test.scratch",
+                "srid": "3857",
+                "geom": "geom_3857",
+                "qID": "id",
+                "toggleLocationViewEdits": true,
+                "style": {
+                    "default": {
+                        "strokeColor": "#333",
+                        "fillColor": "#fff9",
+                        "icon": {
+                            "type": "dot"
+                        }
+                    },
+                    "highlight": {
+                        "scale": 1.3,
+                        "strokeColor": "#090"
+                    }
+                },
+                "deleteLocation": true,
+                "infoj": [
+                    {
+                        "title": "qID",
+                        "field": "id",
+                        "inline": true
+                    },
+                    {
+                        "type": "key"
+                    },
+                    {
+                        "type": "pin",
+                        "label": "ST_PointOnSurface",
+                        "field": "pin",
+                        "fieldfx": "ARRAY[ST_X(ST_PointOnSurface(geom_3857)),ST_Y(ST_PointOnSurface(geom_3857))]"
+                    },
+                    {
+                        "title": "int",
+                        "field": "integer_field",
+                        "type": "integer",
+                        "formatterParams": null,
+                        "default": 0,
+                        "edit": {
+                            "range": true
+                        },
+                        "min": -100000,
+                        "max": 10000,
+                        "prefix": "£",
+                        "filter": {
+                            "type": "integer"
+                        }
+                    }
+                ]
             }
         }
     }


### PR DESCRIPTION
# Slider Tweaks

## Description

1. Assign val to value if not defined (as we changed this recently)
2. Fix opacitySlider
3. Add translation for opacity slider
4. Remove scaleSlider as doesn't work and superseeded by plugin

## Type of Change
Please delete options that are not relevant, and select all options that apply. 

- ✅ Bug fix (non-breaking change which fixes an issue)

## How have you tested this? 
Tested it locally.

## Testing Checklist 
Please delete options that are not relevant, and select all options that apply. 

- ✅ Existing Tests still pass
- ✅ Updated Existing Tests
- ✅ New Tests Added
- ✅ Ran locally on my machine

## Code Quality Checklist
Please delete options that are not relevant, and select all options that apply. 

- ✅ My code follows the guidelines of XYZ
- ✅ My code has been commented
- ✅ Documentation has been updated
- ✅ New and existing unit tests pass locally with my changes
- ✅ Main has been merged into this PR