### PR TITLE
Default view dialog fixes

### DIFF
--- a/lib/ui/elements/dialog.mjs
+++ b/lib/ui/elements/dialog.mjs
@@ -41,18 +41,18 @@ const dialog = mapp.ui.elements.dialog({
 */
 
 export default function dialog(dialog) {
-  
+
   if (!dialog.target) {
 
     // The dialog must be modal if no target is provided.
     dialog.modal = true;
 
-  // Ensure the target is an HTMLElement before proceeding
+    // Ensure the target is an HTMLElement before proceeding
   } else if (!(dialog.target instanceof HTMLElement)) return;
 
   // Close existing modal.
   document.querySelector('dialog.modal')?.close()
-  
+
   dialog.closeBtn ??= dialog.close && mapp.utils.html.node`
     <button
       data-id=close
@@ -63,7 +63,7 @@ export default function dialog(dialog) {
 
   // If headerDrag is true - add the headerDrag class to the dialog header
   dialog.headerDrag && (dialog.header = mapp.utils.html.node`<header class="headerDrag">${dialog.header}</header>`);
-  
+
   let classList = `${dialog.modal ? 'modal' : 'dialog'} ${dialog.class || ''}`
 
   dialog.node = mapp.utils.html.node`
@@ -92,8 +92,8 @@ export default function dialog(dialog) {
       dialog.left = dialog.target.offsetWidth - dialog.node.offsetWidth - parseInt(dialog.right)
     }
 
-    dialog.node.style.top = `${dialog.top || 0}px`
-    dialog.node.style.left = `${dialog.left || 0}px`
+    dialog.node.style.top = `${dialog.top || 0}`
+    dialog.node.style.left = `${dialog.left || 0}`
 
     dialog.node.addEventListener('mousedown', handleStartEvent);
     dialog.node.addEventListener('touchstart', handleStartEvent);

--- a/lib/ui/elements/helpDialog.mjs
+++ b/lib/ui/elements/helpDialog.mjs
@@ -12,8 +12,8 @@ export default (params) => {
     height: 'auto',
     width: '200px',
     css_style: 'padding: 0.5em;',
-    top: 30,
-    left: 60,
+    top: '30px',
+    left: '60px',
     contained: true,
     close: true,
     ...params

--- a/lib/ui/elements/helpDialog.mjs
+++ b/lib/ui/elements/helpDialog.mjs
@@ -10,10 +10,9 @@ export default (params) => {
   helpDialog = {
     target: document.getElementById('Map'),
     height: 'auto',
-    width: '200px',
     css_style: 'padding: 0.5em;',
-    top: '30px',
-    left: '60px',
+    top: '3em',
+    left: '6em',
     contained: true,
     close: true,
     ...params

--- a/public/tests/_base.test.mjs
+++ b/public/tests/_base.test.mjs
@@ -31,6 +31,7 @@ export async function base() {
                     layers: 'Layers',
                     locations: 'Locations',
                     no_locales: 'Your account has been verified and approved, but you do not have access to any locales. This is likely as an administrator has not given you the required roles. Please contact an administrator to resolve this.',
+                    no_layers: 'No accessible layers in locale.',
                 },
                 de: {
                     toolbar_zoom_in: 'Zoom rein',
@@ -365,9 +366,13 @@ export async function base() {
 
         if (locale instanceof Error) {
 
-            document.body.append(mapp.utils.html.node`
-  <dialog open class="modal-map">
-    ${mapp.dictionary.no_locales}`)
+            // Create the helpDialog.node
+            mapp.ui.elements.dialog({
+                css_style: 'padding: 1em; border-color: #000',
+                content: mapp.dictionary.no_locales,
+                top: '50%',
+                left: '10%'
+            });
         }
 
         // Add locale dropdown to layers panel if multiple locales are accessible.
@@ -456,6 +461,19 @@ export async function base() {
             // mapp.Mapview must be awaited.
             loadPlugins: true
         });
+
+
+        if (!locale.layers?.length) {
+
+            mapp.ui.elements.dialog({
+                css_style: 'padding: 1em; border-color: #000;',
+                content: mapp.dictionary.no_layers,
+                target: document.getElementById('Map'),
+                top: '50%',
+                left: '50%'
+            });
+
+        }
 
         // Add layers to mapview.
         await mapview.addLayer(locale.layers);

--- a/public/views/_default.html
+++ b/public/views/_default.html
@@ -446,7 +446,7 @@
   await mapp.utils.xhr(`${mapp.host}/api/user/cookie`).then(user => {
 
     // The cookie request will Err without an ACL being configured for public access.
-    mapp.user = user instanceof Error? false: user
+    mapp.user = user instanceof Error ? false : user
   })
 
   // Language as URL parameter will override user language.
@@ -568,10 +568,14 @@
 
   if (locale instanceof Error) {
 
-    // Create the helpDialog.node
+    // Create the Dialog.node
     mapp.ui.elements.dialog({
       css_style: 'padding: 1em; border-color: #000',
-      content: mapp.dictionary.no_locales
+      content: mapp.dictionary.no_locales,
+      target: document.getElementById('Map'),
+      top: '50%',
+      left: '10%',
+      contained: true
     });
   }
 
@@ -636,11 +640,15 @@
     loadPlugins: true
   });
 
-  if (!locale.layers?.length) {
+  if (!locale.layers?.length && !locale instanceof Error) {
 
     mapp.ui.elements.dialog({
-      css_style: 'padding: 1em; border-color: #000',
-      content: mapp.dictionary.no_layers
+      css_style: 'padding: 1em; border-color: #000;',
+      content: mapp.dictionary.no_layers,
+      target: document.getElementById('Map'),
+      top: '50%',
+      left: '50%',
+      contained: true
     });
   }
 

--- a/public/views/_default.html
+++ b/public/views/_default.html
@@ -640,7 +640,7 @@
     loadPlugins: true
   });
 
-  if (!locale.layers?.length && !locale instanceof Error) {
+  if (!locale.layers?.length && !(locale instanceof Error)) {
 
     mapp.ui.elements.dialog({
       css_style: 'padding: 1em; border-color: #000;',

--- a/public/views/_default.html
+++ b/public/views/_default.html
@@ -570,9 +570,9 @@
 
     // Create the Dialog.node
     mapp.ui.elements.dialog({
-      css_style: 'padding: 1em; border-color: #000',
+      css_style: 'padding: 1em; border-color: #000; z-index:9999;',
       content: mapp.dictionary.no_locales,
-      target: document.getElementById('Map'),
+      target: document.body,
       top: '50%',
       left: '10%',
       contained: true
@@ -643,9 +643,9 @@
   if (!locale.layers?.length && !(locale instanceof Error)) {
 
     mapp.ui.elements.dialog({
-      css_style: 'padding: 1em; border-color: #000;',
+      css_style: 'padding: 1em; border-color: #000; z-index:9999;',
       content: mapp.dictionary.no_layers,
-      target: document.getElementById('Map'),
+      target: document.body,
       top: '50%',
       left: '50%',
       contained: true

--- a/public/views/_default.html
+++ b/public/views/_default.html
@@ -570,11 +570,11 @@
 
     // Create the Dialog.node
     mapp.ui.elements.dialog({
-      css_style: 'padding: 1em; border-color: #000; z-index:9999;',
+      css_style: 'padding: 1em; border-color: #000; z-index:9999; max-width: 50%;',
       content: mapp.dictionary.no_locales,
       target: document.body,
-      top: '50%',
-      left: '10%',
+      top: '40%',
+      left: '25%',
       contained: true
     });
   }
@@ -643,11 +643,11 @@
   if (!locale.layers?.length && !(locale instanceof Error)) {
 
     mapp.ui.elements.dialog({
-      css_style: 'padding: 1em; border-color: #000; z-index:9999;',
+      css_style: 'padding: 1em; border-color: #000; z-index:9999; max-width: 50%;',
       content: mapp.dictionary.no_layers,
       target: document.body,
-      top: '50%',
-      left: '50%',
+      top: '40%',
+      left: '25%',
       contained: true
     });
   }

--- a/tests/workspace.json
+++ b/tests/workspace.json
@@ -7,8 +7,7 @@
         "roles": {
             "A": null,
             "B": null,
-            "C": null,
-            "*": null
+            "C": null
         },
         "plugins": [
             "${PLUGINS}v4.8.0/coordinates.js"


### PR DESCRIPTION
## Description

The no_locales and no_layers dialogs on the default view were displaying as full modals which would prevent the user from accessing any other controls in the mapview. (admin or logout).

Fixes.
1. Gave the two dialogs a target, because if a dialog does not have a target it is a modal.
2. I removed the 'px' suffix because a user may want to set the position with other units other than 'px'.
3. Fixed the 'helpDialog' to use 'px' in the config.
## GitHub Issue
https://github.com/GEOLYTIX/xyz/issues/1421

## Type of Change
- ✅ Bug fix (non-breaking change which fixes an issue)
