### PR TITLE
entry without node in valChangeMethod on a new location.

### DIFF
--- a/lib/ui/locations/view.mjs
+++ b/lib/ui/locations/view.mjs
@@ -329,13 +329,13 @@ function valChange(e) {
   if (entry.value != entry.newValue) {
 
     // newValue is different from value.
-    entry.node.classList.add('val-changed')
+    entry.node?.classList.add('val-changed')
 
   } else {
 
     // newValue is the same as value.
     delete entry.newValue
-    entry.node.classList.remove('val-changed')
+    entry.node?.classList.remove('val-changed')
   }
 
   if (location.infoj.some(entry => entry.invalid)) {


### PR DESCRIPTION
A new location is immediately editable.

The valChange method called to check values in a new location will fail because the entry.node is undefined.