### PR TITLE
Assign roles onto update_user object

### DIFF
--- a/mod/user/update.js
+++ b/mod/user/update.js
@@ -65,6 +65,7 @@ module.exports = async function update(req, res) {
 
     // The value string must be split into an array for the roles field params.
     req.params.value = req.params.value?.split(',') || [];
+    update_user[req.params.field] = req.params.value;
 
   } else if (req.params.field) {
 

--- a/mod/user/update.js
+++ b/mod/user/update.js
@@ -65,8 +65,8 @@ module.exports = async function update(req, res) {
 
     // The value string must be split into an array for the roles field params.
     req.params.value = req.params.value?.split(',') || [];
-
   }
+
   // Assign field property from request params.
   update_user[req.params.field] = req.params.value
 

--- a/mod/user/update.js
+++ b/mod/user/update.js
@@ -65,13 +65,10 @@ module.exports = async function update(req, res) {
 
     // The value string must be split into an array for the roles field params.
     req.params.value = req.params.value?.split(',') || [];
-    update_user[req.params.field] = req.params.value;
 
-  } else if (req.params.field) {
-
-    // Assign field property from request params.
-    update_user[req.params.field] = req.params.value
   }
+  // Assign field property from request params.
+  update_user[req.params.field] = req.params.value
 
   // Create ISODate for administrator request log.
   const ISODate = new Date().toISOString().replace(/\..*/, '');


### PR DESCRIPTION
## Description

The Roles were not being assigned to the `update_user` object on the mod/user/update function.

The assign will happen regardless if the field is a Roles or not as we will always want to assign that value.

- ✅ Bug fix (non-breaking change which fixes an issue)
