### PR TITLE
Remove redundant featureFormats.cluster method

### DIFF
--- a/lib/layer/featureFormats.mjs
+++ b/lib/layer/featureFormats.mjs
@@ -109,32 +109,3 @@ export function wkt_properties(layer, features) {
 
   mapp.layer.featureFields.process(layer);
 }
-
-export function cluster(layer, features) {
-
-  layer.max_size = 1
-
-  return features.map((vals, i) => {
-
-    const geometry = new ol.geom.Point(vals.shift())
-
-    const count = vals.shift()
-
-    layer.max_size = layer.max_size > count ? layer.max_size : count;
-
-    const id = vals.shift()
-
-    const properties = { count }
-
-    layer.params.fields.forEach((field, i) => {
-      properties[field] = vals[i]
-    })
-
-    return new ol.Feature({
-      id,
-      geometry,
-      ...properties
-    })
-
-  })
-}


### PR DESCRIPTION
The undocumented featureFormats.cluster() method has been removed. The method is not referenced in the mapp library, nor any plugin script.

The origin or legacy use of the method are not known.