### PR TITLE
Update JSDocs definition in infoj module; Location typedef

### DIFF
--- a/DOCUMENTATION.md
+++ b/DOCUMENTATION.md
@@ -128,6 +128,11 @@ A mapp-layer object is a decorated JSON layer object which has been added to a m
 */
 ```
 
+### @link
+The link tag creates an inline link element which can be used to create a link inline the description.
+
+The link can reference a module and it's inline members like methods. `{@link module:/location/decorate~flyTo}`
+
 ### @example 
 
 An @example does not require a code block [\`\`\`JS] definition. At examples should be reserved for codepen examples which can be run. Code blocks should be used for code syntax highlighting in the rendered markdown.

--- a/lib/location/decorate.mjs
+++ b/lib/location/decorate.mjs
@@ -5,6 +5,18 @@
 */
 
 /**
+@global
+@typedef {Object} location
+A decorated mapp location.
+
+@property {layer} layer The layer from which the location data was queried.
+@property {Array} Layers Array of Openlayer Layers (with Source) to store geometries associated with the location.
+@property {Array} infoj Array of infoj-entry objects with their values populated by the location get() method.
+@property {function} flyTo {@link module:/location/decorate~flyTo}
+@property {HTMLElement} view The location view displayed in the location listview in the default Mapp application view.
+*/
+
+/**
 @function decorate
 
 @description
@@ -14,7 +26,6 @@ The location decorator method creates mapp-location typedef object from a JSON l
 
 @returns {location} Decorated Mapp Location.
 */
-
 export default function decorate(location) {
 
   Object.assign(location, {
@@ -62,7 +73,6 @@ function remove() {
 Update a location from host
 @function update
 */
-
 async function update() {
 
   if (this.infoj.some(entry => entry.invalid)) {
@@ -183,6 +193,9 @@ async function syncFields(fields) {
     })
 }
 
+/**
+@function flyTo
+*/
 function flyTo(maxZoom) {
   const sourceVector = new ol.source.Vector();
 

--- a/lib/ui/locations/infoj.mjs
+++ b/lib/ui/locations/infoj.mjs
@@ -4,13 +4,15 @@
 The infoj module exports a default method to process the infoj entries of a location.
 
 @requires /ui/locations/entries
+@requires /utils/paramString
 
 @module /ui/locations/infoj
 */
 
 /**
-### mapp.ui.infoj(location, infoj_order)
+@function infoj
 
+@description
 The infoj methods iterates through the location's infoj [entries] array.
 
 mapp.ui.locations.entries{} methods matching the entry type keyvalue are called with the entry as argument.
@@ -21,16 +23,16 @@ The infoj_order array argument provides an option to extend the location infoj_a
 
 The infoj_order array may contain string entries which allow to order entries before processing. Ordered infoj_order string values are used to map infoj entries with matching key, field, or query values. Infoj entries which are not matched by infoj_order string values will be excluded from being processed for the creation of the location view.
 
-@function infoj
 @param {Object} location A decorated location object.
-@param {Object} location.layer A decorated layer object to which the location belongs.
-@param {Object} location.view Location view HTMLElement.
 @param {array} infoj_order Optional array to order and expand the infoj array.
+@property {Object} location.layer A decorated layer object to which the location belongs.
+@property {Array} location.infoj Array of infoj-entry objects with values.
+@property {HTMLElement} location.view Location view HTMLElement.
+
 @return {HTMLElement} listview grid element with entry elements.
 */
 
 let groups
-
 export default function infoj(location, infoj_order) {
 
   if (!location.infoj) return
@@ -120,17 +122,20 @@ export default function infoj(location, infoj_order) {
 }
 
 /**
+@function entryJSONB
+
+@description
 The entryJSONB(entry) method assign an entry.value from a jsonb object contained in the entry.value assigned by the location.get method.
 
 The entry must have an JSON object value which is not null.
 
 The entry.jsonb_field and entry.jsonb_key must be configured and found in the entry.value object.
 
-@param {Object} entry 
-@param {string} entry.jsonb_field Lookup of field in jsonb value object.
-@param {string} entry.jsonb_key Lookup of key value in jsonb.field valye object.
-*/
+@param {infoj-entry} entry 
 
+@property {string} entry.jsonb_field Lookup of field in jsonb value object.
+@property {string} entry.jsonb_key Lookup of key value in jsonb.field valye object.
+*/
 function entryJSONB(entry) {
   if (!entry.jsonb_field) return;
   if (!entry.jsonb_key) return;
@@ -142,18 +147,20 @@ function entryJSONB(entry) {
 }
 
 /**
+@function entryObject
+
+@description
 The entryObject(entry) method can be used to lookup another entry and assign or merge the found entry object value.
 
 A entry.json_key in combination with entry.json_field can be configured to assign a specific JSON key value to the entry.
 
-@function entryObject
-@param {Object} entry
-@param {string} entry.objectAssignFromField - Lookup for json value entry for object assign.
-@param {string} entry.objectMergeFromField Lookup for json value entry for object merge.
-@param {string} entry.json_field Lookup for json value entry.
-@param {string} entry.json_key Required for json_field assignment.
-*/
+@param {infoj-entry} entry
 
+@property {string} entry.objectAssignFromField Lookup for json value entry for object assign.
+@property {string} entry.objectMergeFromField Lookup for json value entry for object merge.
+@property {string} entry.json_field Lookup for json value entry.
+@property {string} entry.json_key Required for json_field assignment.
+*/
 function entryObject(entry) {
 
   const field = entry.objectAssignFromField || entry.objectMergeFromField || entry.json_field
@@ -195,6 +202,9 @@ function entryObject(entry) {
 }
 
 /**
+@function entrySkip
+
+@description
 The entrySkip(entry) methods checks whether a entry should be skipped from being processed in the iteration of infoj entries.
 
 Skipping may be conditional on the entry.value.
@@ -203,15 +213,14 @@ Entries with falsy, null, or undefined values may be skipped if the entry is not
 
 A layer.infoj_skip[] array can be configured to define which infoj entries should be skipped.
 
-@function entrySkip
-@param {Object} entry 
-@param {Object} entry.value
-@param {Object} entry.skipEntry Entry will always be skipped.
-@param {Object} entry.skipFalsyValue Entry with falsy value will be skipped.
-@param {Object} entry.skipUndefinedValue Entry with undefined value will be skipped.
-@param {Object} entry.skipNullValue - Entry with null value will be skipped.
-*/
+@param {infoj-entry} entry
 
+@property {Object} entry.value
+@property {Object} entry.skipEntry Entry will always be skipped.
+@property {Object} entry.skipFalsyValue Entry with falsy value will be skipped.
+@property {Object} entry.skipUndefinedValue Entry with undefined value will be skipped.
+@property {Object} entry.skipNullValue - Entry with null value will be skipped.
+*/
 function entrySkip(entry) {
 
   // Skip entry, no matter what.
@@ -237,11 +246,13 @@ function entrySkip(entry) {
 @function entryNullValue
 
 @description
-The entryNullValue method will assign the nullValue property value as entry.value for non editable entries only.
+The entryNullValue method will assigns the nullValue property value as entry.value for non editable entries only.
 
-@param {infoj-entry} entry An infoj-entry typedef object.
+@param {infoj-entry} entry
+@property {any} entry.nullValue Any JSON value; Must not be undefined.
+@property {Object} entry.edit Must be falsy.
+@property {any} entry.value
 */
-
 function entryNullValue(entry) {
 
   // Assign a default nullValue
@@ -261,8 +272,10 @@ function entryNullValue(entry) {
 The entryDefault method will assign the entry.default property value as entry.newValue on editable entries.
 
 @param {infoj-entry} entry An infoj-entry typedef object.
-*/
 
+@property {Object} [entry.edit] The info-entry must have an edit config.
+@property {any} entry.default Any JSON value to be assigned as default newValue.
+*/
 function entryDefault(entry) {
 
   // The entry.default must be defined.
@@ -271,6 +284,7 @@ function entryDefault(entry) {
   if (!entry.edit) return;
 
   entry.newValue = entry.default
+
   entry.location.view?.dispatchEvent(
     new CustomEvent('valChange', {
       detail: entry
@@ -278,18 +292,22 @@ function entryDefault(entry) {
 }
 
 /**
+@function entryGroup
+
+@description
 The entryGroup(entry) method will create a new group for each unique entry.group string.
 
 Entry elements in the same group will be added to a group element drawer added to the entry[location].listview.
 
-@function entryGroup
-@param {Object} entry
-@param {string} entry.group The group key.
-@param {string} entry.groupClassList Group element classlist.
-@param {boolean} entry.expanded The 'expanded' class will be concatenated with group element classlist.
-@param {HTMLDivElement} entry.listview The entry [location] listview.
-*/
+The group layout will be expanded by adding the expanded class to the group elements classList if the entry.expanded property is true.
 
+@param {infoj-entry} entry
+
+@property {string} entry.group The group key.
+@property {string} [entry.groupClassList] Group element classlist.
+@property {boolean} [entry.expanded] The 'expanded' class will be concatenated with group element classList.
+@property {HTMLElement} entry.listview The listview element will be returned from the infoj method and appended to the location.view.
+*/
 function entryGroup(entry) {
   
   if (!entry.group) return;
@@ -315,17 +333,22 @@ function entryGroup(entry) {
 }
 
 /**
-The entryNode(entry) method creates the entry.node div element with a concatenated classlist.
-
-The entry.node element is appended to the entry[location].listview.
-
 @function entryNode
-@param {Object} entry
-@param {string} entry.type Concatenate with entry.node classlist. 
-@param {string} entry.class Concatenate with entry.node classlist.
-@param {boolean} entry.inline Add 'inline' to entry.node classlist.
-*/
 
+@description
+The method assigns a <div> element with no children as entry.node and appends the HTMLElement to the entry.listview.
+
+This allows entry methods to render into the entry.node after the infoj iteration has completed.
+
+A classList is assigned to the <div> element to represnt custom classes and layout (eg. inline).
+
+@param {infoj-entry} entry
+
+@property {string} entry.type Concatenate with entry.node classList. 
+@property {string} [entry.class] Concatenate with entry.node classList.
+@property {boolean} [entry.inline] Add 'inline' to entry.node classList.
+@property {HTMLElement} entry.listview The listview element will be returned from the infoj method and appended to the location.view.
+*/
 function entryNode(entry) {
 
   const classString = `contents ${entry.type} ${entry.class || ''} ${entry.inline && 'inline' || ''}`
@@ -337,13 +360,16 @@ function entryNode(entry) {
 }
 
 /**
-The entryTitle methods checks whether a title element should be appended to the entry.node before any entry.type elements.
-
 @function entryTitle
-@param {Object} entry
-@param {Object} entry.title The title value.
-*/
 
+@description
+The entryTitle methods will append a title element returned from mapp.ui.locations.entries.title(entry) to the entry.node if the entry.title is not falsy.
+
+@param {infoj-entry} entry
+
+@property {Object} entry.title The title value.
+@property {HTMLElement} entry.node The entry HTMLElement to be appended to the location.view element grid.
+*/
 function entryTitle(entry) {
 
   if (!entry.title) return;
@@ -353,9 +379,12 @@ function entryTitle(entry) {
 }
 
 /**
-The entryQuery(entry) method checks whether a query should be executed to populate the entry.value.
+@function entryQuery
 
-mapp.utils.paramString(mapp.utils.queryParams(entry)) will be used to create a parameter string for the query request from the entry.queryparams.
+@description
+The entryQuery() method checks whether a query should be executed to populate the entry.value.
+
+mapp.utils.paramString() will be used to create a parameter string for the query request from the entry.queryparams.
 
 A query flagged with entry.run or entry.queryCheck will be executed immediately.
 
@@ -365,15 +394,15 @@ The entry can be skipped depending on the response value.
 
 The entry method will be called with the response value once the xhr utility promise has been resolved.
 
-@function entryQuery
-@param {Object} entry
-@param {string} entry.query The query template.
-@param {string} entry.queryparams Parameter for the query.
-@param {boolean} entry.queryCheck Query should be immediate.
-@param {boolean} entry.run Query should be immediate.
-@param {boolean} entry.hasRan Flag whether query has been executed.
-*/
+@param {infoj-entry} entry
 
+@property {string} entry.query The query template.
+@property {string} entry.queryparams Parameter for the query.
+@property {boolean} entry.queryCheck Query should be immediate.
+@property {boolean} entry.run Query should be immediate.
+@property {boolean} entry.hasRan Flag whether query has been executed.
+@property {string} entry.host The host for the XHR request.
+*/
 function entryQuery(entry) {
 
   if (!entry.query) return;

--- a/lib/ui/locations/infoj.mjs
+++ b/lib/ui/locations/infoj.mjs
@@ -272,10 +272,14 @@ function entryNullValue(entry) {
 @description
 The entryDefault method will assign the entry.default property value as entry.newValue on editable entries.
 
+The valChange event of the entry.location.view HTMLElement will be called to indicate that the default value must be updated on the location.
+
 @param {infoj-entry} entry An infoj-entry typedef object.
 
 @property {Object} [entry.edit] The info-entry must have an edit config.
 @property {any} entry.default Any JSON value to be assigned as default newValue.
+@property {location} entry.location The location to which the entry belongs.
+@property {HTMLElement} location.view The location view to which the entry.listview / entry.node will be appended.
 */
 function entryDefault(entry) {
 

--- a/lib/ui/locations/infoj.mjs
+++ b/lib/ui/locations/infoj.mjs
@@ -5,6 +5,8 @@ The infoj module exports a default method to process the infoj entries of a loca
 
 @requires /ui/locations/entries
 @requires /utils/paramString
+@requires /utils/xhr
+@requires /utils/merge
 
 @module /ui/locations/infoj
 */
@@ -68,7 +70,6 @@ export default function infoj(location, infoj_order) {
       }
     }).filter(entry => entry !== undefined)
     : location.infoj;
-
   
   let keyIdx = 0;
 

--- a/lib/utils/merge.mjs
+++ b/lib/utils/merge.mjs
@@ -1,14 +1,15 @@
 /**
-## merge.mjs
+## /utils/merge
 
-Imported by _utils.mjs to assign the exported default method mergeDeep as mapp.utils.merge().
+Export the default mergeDeep method to mapp.utils{}.
 
 @module /utils/merge
 */
 
 /**
-### mapp.utils.merge()
+@function mergeDeep
 
+@description
 The mergeDeep utility method will set the source object's own enumerable string-keyed property values on a target object.
 
 mergeDeep will call itself recursively allowing to merge nested objects.
@@ -19,11 +20,9 @@ Instances of HTMLElement objects will be ignored by the merge method.
 
 Arrays will not be merged. The source array will overwrite a target array.
 
-@function mergeDeep
-@param {*} target 
-@param  {...any} sources 
+@param {Object} target 
+@param  {Spread} sources The sources param is spread into an array.
 */
-
 export default function mergeDeep(target, ...sources) {
 
   // No sources to merge.
@@ -70,6 +69,16 @@ export default function mergeDeep(target, ...sources) {
   return mergeDeep(target, ...sources);
 }
 
+/**
+@function isObject
+
+@description
+The method checks whether item param is an object, excluding true, false, null, Array objects.
+
+@param {Any} item 
+
+@return {Boolean} Return boolean whether item param is an object.
+*/
 function isObject(item) {
 
   if (item === true) return false;

--- a/lib/utils/paramString.mjs
+++ b/lib/utils/paramString.mjs
@@ -1,29 +1,34 @@
 /**
-## mapp.utils.paramString()
+## /utils/paramString
 This module creates a parameter string for an XHR request.
 
 @module /utils/paramString
 */
 
 /**
+@function paramString
+
+@description
 Creates a parameter string for an XHR request based on the provided parameters object.
 
-The function takes an object params as input and performs the following steps:
-1. It returns an empty string if params is falsy.
-2. It applies a series of filters to the entries of params:
-    - It filters out entries where the value is not 0 or truthy.
-    - It filters out entries where the value is an empty functional bracket string ('{}').
-    - It filters out entries where the value is an object with zero length or an object with empty object values.
-3. It maps the remaining entries to a string representation:
-    - If the value is a non-array object, it stringifies the value and encodes it as a URI component.
-    - Otherwise, it encodes the key-value pair as a URI string.
-4. It joins the mapped entries with '&' to create the parameter string.
-5. It returns the resulting parameter string.
-@function paramString
-@param {Object} params - The object containing the parameters.
+The function takes a params object and returns a URL parameter string for for requests.
+
+Following properties are filtered out:
+
+- Value is falsy and not 0
+- Value is '{}' string.
+- Value is not typeof 'object', empty array, or object with some property value that is an object with keys.
+
+The URL parameter value of objects which are not arrays will be stringified and URI component encoded.
+
+Other property values will be URI encoded.
+
+The URL parameter array is joined with an ampersand (&) to be returned as URL parameter string.
+
+@param {Object} params The object containing the parameters.
+
 @returns {string} The parameter string.
- */
-// Create param string for XHR request.
+*/
 export default params => {
 
   if (!params) return ''

--- a/lib/utils/xhr.mjs
+++ b/lib/utils/xhr.mjs
@@ -1,12 +1,15 @@
 /**
-## mapp.utils.xhr(params)
+## /utils/xhr
 
-The default method of the xhr module returns a promise which resolves with an response from a XMLHttpRequest.
+Export the default xhr method to mapp.utils{}.
 
 @module /utils/xhr
+*/
 
-*/ /**
+/**
+@function xhr
 
+@description
 The params object/string for the xhr utility method is required.
 
 The params are assumed to the request URL if provided as a string argument.
@@ -15,18 +18,17 @@ The request params and response are stored in a Map() if the cache flag is set i
 
 The method is assumed to be 'POST' if a params.body is provided.
 
-@function default
 @param {Object} params The object containing the parameters.
-@param {string} params.url The request URL.
-@param {string} [params.method=GET] The request method.
-@param {string} [params.responseType=json] The XHR responseType.
-@param {Object} [params.requestHeader={'Content-Type': 'application/json'}] The XHR requestHeader.
-@param {string} [params.body] A stringified request body for a 'POST' request.
-@param {boolean} [params.resolveTarget] Whether the target instead of target.response should be resolved.
-@param {boolean} [params.cache] Whether the response should be cached in a Map().
+@property {string} params.url The request URL.
+@property {string} [params.method=GET] The request method.
+@property {string} [params.responseType=json] The XHR responseType.
+@property {Object} [params.requestHeader={'Content-Type': 'application/json'}] The XHR requestHeader.
+@property {string} [params.body] A stringified request body for a 'POST' request.
+@property {boolean} [params.resolveTarget] Whether the target instead of target.response should be resolved.
+@property {boolean} [params.cache] Whether the response should be cached in a Map().
+
 @returns {Promise} A promise that resolves with the XHR.
 */
-
 const requestMap = new Map()
 
 export function xhr(params) {


### PR DESCRIPTION
Update `utils/paramString` module/method documentation and added as `@requires` to info module.

Update `utils/xhr` module/method documentation and added as `@requires` to info module.

Update `utils/merge` module/method documentation and added as `@requires` to info module.

Updated `infoj-entry` typedef as entry param for infoj module methods.

Changed `@param` to `@property` for infoj module method param which are properties.

Reviewed and added missing property defintions, updated property types.

Checked whether properties are optional.

Added missing function tag.

Moved function descriptions into `@description` tag.

Added `location` typedef.

This typedef is a stump which includes a function property with a `@link` inline link tag to a innerMember of a module.

```
{@link module:/location/decorate~flyTo}
```

![image](https://github.com/user-attachments/assets/d4d3dfcc-88bd-4572-bea2-abdbcff11c60)
