### PR TITLE
Update user - only add `field` if present in params

### DIFF
--- a/mod/user/update.js
+++ b/mod/user/update.js
@@ -61,14 +61,16 @@ module.exports = async function update(req, res) {
     email: req.params.email
   }
 
-  if (req.params.field === 'roles') {
+  if (req.params.field) {
+    if (req.params.field === 'roles') {
 
-    // The value string must be split into an array for the roles field params.
-    req.params.value = req.params.value?.split(',') || [];
+      // The value string must be split into an array for the roles field params.
+      req.params.value = req.params.value?.split(',') || [];
+    }
+
+    // Assign field property from request params.
+    update_user[req.params.field] = req.params.value
   }
-
-  // Assign field property from request params.
-  update_user[req.params.field] = req.params.value
 
   // Create ISODate for administrator request log.
   const ISODate = new Date().toISOString().replace(/\..*/, '');


### PR DESCRIPTION
## Description

The params.field only needs to be added to the user_update object if its present in the params. On a request with just a body, it will not have this param.

- ✅ Bug fix (non-breaking change which fixes an issue)


## How to test this? 
Please run the local tests with the tests settings. (please note that we will need to turn the PUBLIC key to PRIVATE for this to work.) You will also need to be signed in as an admin user
