### PR TITLE
Fix language differences

### DIFF
--- a/lib/ui/elements/contextMenu.mjs
+++ b/lib/ui/elements/contextMenu.mjs
@@ -32,7 +32,7 @@ mapp.utils.merge(mapp.dictionaries, {
     remove_last_vertex: '最後のバーテックスを削除',
     delete_vertex: 'バーテックスを削除',
   },
-  es: {
+  esp: {
     remove_last_vertex: 'Eliminar el último vértice',
     delete_vertex: 'Eliminar vértice',
   },
@@ -53,9 +53,9 @@ mapp.utils.merge(mapp.dictionaries, {
 function modify(e) {
 
   e && e.preventDefault()
-   
+
   const menu = []
-  
+
   // Show save option in contextmenu
   menu.push(mapp.utils.html`
     <li
@@ -65,12 +65,12 @@ function modify(e) {
   // Add cancel option to contextmenu.
   menu.push(mapp.utils.html`
     <li
-      onclick=${()=>this.interaction.finish()}>
+      onclick=${() => this.interaction.finish()}>
       ${mapp.dictionary.cancel}`)
 
   // Set context menu popup on last vertex.
   this.popup({
-    coords: this.interaction.vertices[this.interaction.vertices.length-1],
+    coords: this.interaction.vertices[this.interaction.vertices.length - 1],
     content: mapp.utils.html.node`<ul>${menu}`,
   })
 }
@@ -78,23 +78,23 @@ function modify(e) {
 function draw(e) {
 
   if (this.interaction.vertices.length === 0) return;
-  
+
   const menu = []
-  
+
   menu.push(mapp.utils.html`
   <li
-    onclick=${()=>this.interaction.finish(this.interaction.getFeature())}>
+    onclick=${() => this.interaction.finish(this.interaction.getFeature())}>
       ${mapp.dictionary.save}`)
 
   menu.push(mapp.utils.html`
     <li
-      onclick=${()=>this.interaction.finish()}>
+      onclick=${() => this.interaction.finish()}>
       ${mapp.dictionary.cancel}`)
 
   // Set timeout to for the drawend popup to appear after async onchange event popup.
-  setTimeout(()=>this.popup({
+  setTimeout(() => this.popup({
     coords: this.interaction.vertices[this.interaction.vertices.length - 1],
     content: mapp.utils.html.node`<ul>${menu}`,
     autoPan: true
-  }),100)
+  }), 100)
 }

--- a/lib/ui/elements/drawing.mjs
+++ b/lib/ui/elements/drawing.mjs
@@ -113,7 +113,7 @@ mapp.utils.merge(mapp.dictionaries, {
     draw_line: '線',
     create: '作成',
   },
-  es: {
+  esp: {
     draw_point: 'Punto',
     draw_position: 'Posición actual',
     draw_polygon: 'Polígono',

--- a/lib/ui/layers/listview.mjs
+++ b/lib/ui/layers/listview.mjs
@@ -20,7 +20,7 @@ mapp.utils.merge(mapp.dictionaries, {
   ja: {
     layer_group_hide_layers: 'グループからレイヤーを隠す',
   },
-  es: {
+  esp: {
     layer_group_hide_layers: 'Ocultar todas las capas del grupo',
   },
   tr: {
@@ -34,7 +34,7 @@ mapp.utils.merge(mapp.dictionaries, {
   }
 })
 
-export default function (params){
+export default function (params) {
 
   if (!params.mapview) return
 
@@ -49,7 +49,7 @@ export default function (params){
   Object.values(params.mapview.layers).forEach(layer => add(layer))
 
   // Loop through the layers and add to layers list.
-  function add(layer){
+  function add(layer) {
 
     // Do not create a layer view.
     if (layer.hidden) return;
@@ -82,7 +82,7 @@ export default function (params){
     const group = {
       list: []
     }
-  
+
     // Assign layer group to listview object.
     listview.groups[layer.group] = group
 
@@ -93,14 +93,14 @@ export default function (params){
         title=${mapp.dictionary.layer_group_hide_layers}
         onclick=${e => {
 
-          e.target.style.visibility = 'hidden'
+        e.target.style.visibility = 'hidden'
 
-          group.list
-            .filter(layer => layer.display)
-            .forEach(layer => layer.hide())
+        group.list
+          .filter(layer => layer.display)
+          .forEach(layer => layer.hide())
 
-        }}>`
- 
+      }}>`
+
     group.meta = mapp.utils.html.node`<div class="meta">`
 
     group.drawer = mapp.ui.elements.drawer({
@@ -125,22 +125,22 @@ export default function (params){
     group.addLayer = (layer) => {
 
       layer.group = group
-  
+
       if (layer.groupmeta) {
         const metaContent = group.meta.appendChild(mapp.utils.html.node`<div>`)
         metaContent.innerHTML = layer.groupmeta
       }
-  
+
       group.list.push(layer)
-  
+
       group.drawer.appendChild(layer.view)
 
       group.chkVisibleLayer()
 
-      layer.showCallbacks.push(()=>group.chkVisibleLayer())
+      layer.showCallbacks.push(() => group.chkVisibleLayer())
 
-      layer.hideCallbacks.push(()=>group.chkVisibleLayer())      
+      layer.hideCallbacks.push(() => group.chkVisibleLayer())
     }
-  
+
   }
 }

--- a/lib/ui/layers/panels/dataviews.mjs
+++ b/lib/ui/layers/panels/dataviews.mjs
@@ -30,7 +30,7 @@ mapp.utils.merge(mapp.dictionaries, {
   ja: {
     layer_dataview_header: 'データビュー',
   },
-  es: {
+  esp: {
     layer_dataview_header: 'Ver los datos',
   },
   tr: {
@@ -61,7 +61,7 @@ The dataviews will be decorated with the `mapp.ui.Dataview()` method.
 */
 
 export default function dataviews(layer) {
-  
+
   // Create chkbox controls for each dataview entry.
   const dataviewChkboxes = Object.entries(layer.dataviews).map(entry => {
 
@@ -113,7 +113,7 @@ export default function dataviews(layer) {
       && dataview.display
       && dataview.show()
 
-    layer.showCallbacks.push(()=>{
+    layer.showCallbacks.push(() => {
       dataview.display && dataview.show()
     })
 

--- a/lib/ui/layers/panels/draw.mjs
+++ b/lib/ui/layers/panels/draw.mjs
@@ -20,7 +20,7 @@ mapp.utils.merge(mapp.dictionaries, {
   ja: {
     layer_add_new_location: '新しいロケーションを追加',
   },
-  es: {
+  esp: {
     layer_add_new_location: 'Agregar nuevos sitios',
   },
   tr: {
@@ -40,7 +40,7 @@ export default layer => {
 
   // Do not create the panel.
   if (layer.draw.hidden) return;
- 
+
   const elements = Object.keys(layer.draw)
     .map(key => {
 

--- a/lib/ui/layers/panels/filter.mjs
+++ b/lib/ui/layers/panels/filter.mjs
@@ -55,7 +55,7 @@ mapp.utils.merge(mapp.dictionaries, {
     layer_filter_less_than: '以下',
     layer_filter_set_filter: 'フィルターを設定',
   },
-  es: {
+  esp: {
     layer_filter_header: 'Filtro',
     layer_filter_select: 'Seleccionar filtro de la lista',
     layer_filter_clear_all: 'Anular todos los filtros',
@@ -130,9 +130,9 @@ export default layer => {
     placeholder: mapp.dictionary.layer_filter_select,
     keepPlaceholder: true,
     entries: layer.filter.list,
-    callback: async (e,filter) => {
+    callback: async (e, filter) => {
 
-      
+
       // Return if no interface method for the filter type exists.
       if (!mapp.ui.layers.filters[filter.type]) return;
 
@@ -146,25 +146,25 @@ export default layer => {
       filter.remove = () => {
 
         // Delete filter for empty input.
-        if(layer.filter.current[filter.field]){
-          if(!layer.filter.current[filter.field][filter.type]){
+        if (layer.filter.current[filter.field]) {
+          if (!layer.filter.current[filter.field][filter.type]) {
             delete layer.filter.current[filter.field]
           }
-          else{
+          else {
             delete layer.filter.current[filter.field][filter.type]
           }
           if (layer.filter.current[filter.field] && !Object.keys(layer.filter.current[filter.field]).length) {
             delete layer.filter.current[filter.field]
           }
         }
-        
+
         delete filter.card
         e.target.classList.remove('selected')
 
         if (layer.style.legend) {
           mapp.ui.layers.legends[layer.style.theme.type](layer)
         }
-        
+
         layer.reload();
 
         // The changeEnd event will trigger dataview updates if set.
@@ -172,7 +172,7 @@ export default layer => {
 
         // Only show the clearall filter button when filter cards are displayed as children to the filter view.
         layer.filter.view.querySelector('[data-id=clearall]').style.display = layer.filter.view.children.length === 3 ? 'none' : 'block';
-        
+
       };
 
       // Get interface content for filter card.

--- a/lib/ui/layers/panels/style.mjs
+++ b/lib/ui/layers/panels/style.mjs
@@ -80,7 +80,7 @@ mapp.utils.merge(mapp.dictionaries, {
     layer_grid_legend_ratio: 'サイズに対する色を比率で表示します',
     layer_style_cluster: '多数のロケーション',
   },
-  es: {
+  esp: {
     layer_style_header: 'Estilo',
     layer_style_select_theme: 'Seleccionar estilo temático',
     layer_style_display_labels: 'Mostrar etiquetas',
@@ -185,12 +185,12 @@ export default function stylePanel(layer) {
       content.push(mapp.ui.elements.dropdown({
         placeholder: layer.style.hover.title,
         entries: Object.keys(layer.style.hovers)
-           // Check if that label is set to be hidden. 
-           .filter(key => !layer.style.hovers[key].hidden)
-           .map(key => ({
-          title: layer.style.hovers[key].title || key,
-          option: key
-        })),
+          // Check if that label is set to be hidden. 
+          .filter(key => !layer.style.hovers[key].hidden)
+          .map(key => ({
+            title: layer.style.hovers[key].title || key,
+            option: key
+          })),
         callback: (e, entry) => {
 
           const display = layer.style.hover.display

--- a/lib/ui/layers/view.mjs
+++ b/lib/ui/layers/view.mjs
@@ -9,12 +9,12 @@ mapp.utils.merge(mapp.dictionaries, {
     layer_visibility: 'Umschalten der Ansicht',
     zoom_to: 'Heranzoomen',
   },
-  zn: {
+  zh: {
     layer_zoom_to_extent: '缩放至筛选图层的相应范围',
     layer_visibility: '可见性切换',
     zoom_to: '缩放至',
   },
-  zn_tw: {
+  zh_tw: {
     layer_zoom_to_extent: '縮放至篩選圖層的相應範圍',
     layer_visibility: '可見性切換',
     zoom_to: '縮放至',
@@ -34,7 +34,7 @@ mapp.utils.merge(mapp.dictionaries, {
     layer_visibility: '表示切替',
     zoom_to: 'ズームへ',
   },
-  es: {
+  esp: {
     layer_zoom_to_extent: 'Zoom a capa filtrada',
     layer_visibility: 'Alternar visibilidad',
     zoom_to: 'Acercar a',
@@ -91,22 +91,22 @@ export default (layer) => {
         class="mask-icon fullscreen"
         onclick=${async e => {
 
-          // disable button if no locations were found.
-          e.target.disabled = !await layer.zoomToExtent()
+        // disable button if no locations were found.
+        e.target.disabled = !await layer.zoomToExtent()
 
-          layer.show()
-        }}>`
+        layer.show()
+      }}>`
 
     // Create layer.displayToggle button for header.
     layer.displayToggle = mapp.utils.html.node`
       <button
         data-id=display-toggle
         title=${mapp.dictionary.layer_visibility}
-        class="${`mask-icon toggle ${(layer.zoomDisplay || layer.display)? 'on': ''}`}"
+        class="${`mask-icon toggle ${(layer.zoomDisplay || layer.display) ? 'on' : ''}`}"
         onclick=${e => {
-          const toggle = e.target.classList.toggle('on')
-          toggle? layer.show(): layer.hide()
-        }}>`
+        const toggle = e.target.classList.toggle('on')
+        toggle ? layer.show() : layer.hide()
+      }}>`
 
     // Create a div for the magnifying glass icon
     layer.zoomBtn = layer.tables && mapp.utils.html.node`
@@ -114,20 +114,20 @@ export default (layer) => {
         data-id="zoom-to"
         title=${mapp.dictionary.zoom_to}
         class="mask-icon search"
-        onclick=${()=>{
+        onclick=${() => {
 
-          const minZoom = Object.entries(layer.tables).find(entry => !!entry[1])[0]
+        const minZoom = Object.entries(layer.tables).find(entry => !!entry[1])[0]
 
-          const maxZoom = Object.entries(layer.tables).reverse().find(entry => !!entry[1])[0]
+        const maxZoom = Object.entries(layer.tables).reverse().find(entry => !!entry[1])[0]
 
-          const view = layer.mapview.Map.getView()
+        const view = layer.mapview.Map.getView()
 
-          view.getZoom() < minZoom ?
-            view.setZoom(minZoom) :
-            view.setZoom(maxZoom)
+        view.getZoom() < minZoom ?
+          view.setZoom(minZoom) :
+          view.setZoom(maxZoom)
 
-          layer.show()
-        }}>`        
+        layer.show()
+      }}>`
 
     // Add on callback for toggle button.
     layer.showCallbacks.push(() => {
@@ -167,18 +167,18 @@ export default (layer) => {
   layer.tables && layer.mapview.Map.getTargetElement().addEventListener('changeEnd', () => {
 
     if (!layer.tableCurrent()) {
-      
+
       layer.zoomBtn.style.display = 'block'
 
       // Collapse drawer and disable layer.view.
       layer.view.querySelector('[data-id=layer-drawer]').classList.remove('expanded')
-      
+
       // Disable layer display toggle.
       layer.displayToggle.classList.add('disabled')
 
       // Disable layer.view content.
       content.forEach(el => el.classList.add('disabled'))
-      
+
     } else {
 
       layer.zoomBtn.style.display = 'none'

--- a/lib/ui/locations/entries/cloudinary.mjs
+++ b/lib/ui/locations/entries/cloudinary.mjs
@@ -39,7 +39,7 @@ mapp.utils.merge(mapp.dictionaries, {
     image_upload_failed: '画像のアップロードに失敗しました',
     document_upload_failed: '書類のアップロードに失敗しました',
   },
-  es: {
+  esp: {
     image_upload_failed: 'Error al cargar la imagen.',
     document_upload_failed: 'Error al cargar el documento.',
   },

--- a/lib/ui/locations/entries/geometry.mjs
+++ b/lib/ui/locations/entries/geometry.mjs
@@ -30,7 +30,7 @@ mapp.utils.merge(mapp.dictionaries, {
   ja: {
     delete_geometry: 'ジオメトリーを削除',
   },
-  es: {
+  esp: {
     delete_geometry: 'Eliminar geometría',
   },
   tr: {
@@ -102,7 +102,7 @@ export default function geometry(entry) {
   if (entry.style && Object.keys(entry.style).length) {
     entry.style = { ...entry.location?.style, ...entry.style }
   }
-  
+
   // Create ol style from entry.style if not yet defined.
   entry.Style ??= mapp.utils.style(entry.style)
 
@@ -220,7 +220,7 @@ function edit(entry) {
 
   if (entry.field !== entry.location.layer.geomCurrent())
 
-  entry.elements.push(mapp.utils.html`
+    entry.elements.push(mapp.utils.html`
     <button
       class="flat wide no-colour"
       onclick=${() => {
@@ -230,13 +230,13 @@ function edit(entry) {
         entry.display = false
         entry.value = null
         update(entry)
-    }}>
+      }}>
     ${entry.edit.delete_label || mapp.dictionary.delete_geometry}`)
 
   entry.elements.push(mapp.utils.html.node`
     <button
       class="flat bold wide primary-colour modify-btn"
-      onclick=${(e)=>entry.modify(e)}>
+      onclick=${(e) => entry.modify(e)}>
       ${entry.edit.modify_label || mapp.dictionary.modify_geometry}`)
 }
 
@@ -301,7 +301,7 @@ function modify(e) {
 
         // Assign feature geometry as new value.
         entry.value = feature.geometry
-      
+
         update(entry)
       } else {
 
@@ -339,7 +339,7 @@ function draw(entry) {
     }
   })
 
-  function drawCallback(feature){
+  function drawCallback(feature) {
 
     mapp.ui.elements.helpDialog();
 

--- a/lib/ui/locations/entries/link.mjs
+++ b/lib/ui/locations/entries/link.mjs
@@ -27,7 +27,7 @@ mapp.utils.merge(mapp.dictionaries, {
     report: 'レポート',
     link: 'リンク',
   },
-  es: {
+  esp: {
     report: 'Informe',
     link: 'Enlace',
   },
@@ -76,7 +76,7 @@ export default entry => {
 
   // Set default label and icon_class
   entry.icon_class ??= 'mask-icon open-in-new'
-  entry.label ??=  `${mapp.dictionary.link}`
+  entry.label ??= `${mapp.dictionary.link}`
 
   // Construct href from URL + params.
   const href = entry.url + mapp.utils.paramString(entry.params)

--- a/lib/ui/locations/entries/pin.mjs
+++ b/lib/ui/locations/entries/pin.mjs
@@ -20,7 +20,7 @@ mapp.utils.merge(mapp.dictionaries, {
   'ja': {
     pin: 'ピン',
   },
-  'es': {
+  'esp': {
     pin: 'Marcar',
   },
   'tr': {

--- a/lib/ui/locations/entries/text.mjs
+++ b/lib/ui/locations/entries/text.mjs
@@ -35,7 +35,7 @@ mapp.utils.merge(mapp.dictionaries, {
     loading: '読み込み中',
     no_options_available: '選択肢なし'
   },
-  es: {
+  esp: {
     loading: 'Cargando',
     no_options_available: 'No hay opciones disponibles.'
   },

--- a/lib/ui/locations/listview.mjs
+++ b/lib/ui/locations/listview.mjs
@@ -27,7 +27,7 @@ mapp.utils.merge(mapp.dictionaries, {
     location_clear_all: 'ロケーションをクリア',
     location_listview_full: 'ロケーションのリストビューがいっぱいです',
   },
-  es: {
+  esp: {
     location_clear_all: 'Borrar localizaciones',
     location_listview_full: 'La vista de lista de ubicaciones está llena.',
   },

--- a/lib/ui/locations/view.mjs
+++ b/lib/ui/locations/view.mjs
@@ -53,7 +53,7 @@ mapp.utils.merge(mapp.dictionaries, {
     location_delete: 'ロケーションを削除',
     location_save_changes: 'このロケーションの変更を保存',
   },
-  es: {
+  esp: {
     location_zoom: 'Ampliar los contornos del objeto.',
     location_save: 'Registrar modificaciones',
     location_remove: 'Eliminar de la selección',
@@ -142,7 +142,7 @@ export default function view(location) {
     header.push(mapp.utils.html`<button
       title = ${mapp.dictionary.location_delete}
       class = "mask-icon trash"
-      onclick = ${()=>location.trash()}>`)
+      onclick = ${() => location.trash()}>`)
   }
 
   // Clear selection.
@@ -275,13 +275,13 @@ function toggleLocationViewEdits(location) {
 
         return;
       }
-       
-    // There are no unsaved edits.
+
+      // There are no unsaved edits.
     } else if (e.target.classList.toggle('on')) {
 
       // Button is toggled on.
       location.restoreEdits()
-  
+
     } else {
 
       // Button is toggled off.
@@ -368,7 +368,7 @@ function renderLocationView() {
 
   // Enables the location view node and child elements.
   location.view.classList.remove('disabled')
-  
+
   // Recreate location.viewEntries.
   location.viewEntries = location.view.appendChild(mapp.ui.locations.infoj(location))
 }

--- a/public/tests/_base.test.mjs
+++ b/public/tests/_base.test.mjs
@@ -45,7 +45,7 @@ export async function base() {
                     layers: 'Ebenen',
                     locations: 'Orte',
                 },
-                zn: {
+                zh: {
                     toolbar_zoom_in: '放大',
                     toolbar_zoom_out: '缩小',
                     toolbar_zoom_to_area: '缩放至区域',
@@ -57,7 +57,7 @@ export async function base() {
                     layers: '图层',
                     locations: '地点',
                 },
-                zn_tw: {
+                zh_tw: {
                     toolbar_zoom_in: '放大',
                     toolbar_zoom_out: '縮小',
                     toolbar_zoom_to_area: '縮放至區域',
@@ -105,7 +105,7 @@ export async function base() {
                     layers: 'レイヤー',
                     locations: 'ロケーション',
                 },
-                es: {
+                esp: {
                     toolbar_zoom_in: 'Zoom +',
                     toolbar_zoom_out: 'Zoom -',
                     toolbar_zoom_to_area: 'Zoom al área',

--- a/public/views/_default.html
+++ b/public/views/_default.html
@@ -330,7 +330,7 @@
       layers: 'Ebenen',
       locations: 'Orte',
     },
-    zn: {
+    zh: {
       toolbar_zoom_in: '放大',
       toolbar_zoom_out: '缩小',
       toolbar_zoom_to_area: '缩放至区域',
@@ -342,7 +342,7 @@
       layers: '图层',
       locations: '地点',
     },
-    zn_tw: {
+    zh_tw: {
       toolbar_zoom_in: '放大',
       toolbar_zoom_out: '縮小',
       toolbar_zoom_to_area: '縮放至區域',
@@ -390,7 +390,7 @@
       layers: 'レイヤー',
       locations: 'ロケーション',
     },
-    es: {
+    esp: {
       toolbar_zoom_in: 'Zoom +',
       toolbar_zoom_out: 'Zoom -',
       toolbar_zoom_to_area: 'Zoom al área',


### PR DESCRIPTION
## Description

There was a discrepancy between Spanish, Chinese Simplified and Traditional keys being used in the different dictionary objects being used throughout the application. Please make sure that if you add a language that there are base keys, and if there is already a language defined that you are using the correct key.

e.g of issue
Spanish base key = esp 
In other modules = es

## Type of Change

- ✅ Bug fix (non-breaking change which fixes an issue)


## How have you tested this? 
You can test this by running the local tests and you should see the dictionary tests pass.
