### PR TITLE
Circle Configuration Fixes; Min Max Based on Units

### DIFF
--- a/lib/ui/elements/drawing.mjs
+++ b/lib/ui/elements/drawing.mjs
@@ -495,6 +495,11 @@ function circle(layer) {
 
   createSlider();
 
+/**
+@function createSlider
+@description Creates a slider for the circle radius, renders this slider into the rangeSlider div, and assigns a callback function to update the radius value.
+*/
+
   function createSlider() {
     mapp.utils.render(rangeSlider, mapp.ui.elements.slider({
       min: layer.draw.circle.radiusMin,

--- a/lib/ui/elements/drawing.mjs
+++ b/lib/ui/elements/drawing.mjs
@@ -223,6 +223,12 @@ function drawOnclick(e, layer, interaction) {
   btn.classList.add('active')
 }
 
+/**
+@function point
+@description Creates a button for drawing a point on the map.
+@param {layer} layer Decorated MAPP Layer.
+@return {HTMLElement} The button element.
+*/
 function point(layer) {
 
   const helpDialog = {
@@ -250,6 +256,12 @@ function point(layer) {
   return layer.draw.point.btn
 }
 
+/**
+@function line
+@description Creates a button for drawing a line on the map.
+@param {layer} layer Decorated MAPP Layer.
+@return {HTMLElement} The button element.
+*/
 function line(layer) {
 
   const helpDialog = {
@@ -278,6 +290,12 @@ function line(layer) {
   return layer.draw.line.btn
 }
 
+/**
+@function polygon
+@description Creates a button for drawing a polygon on the map.
+@param {layer} layer Decorated MAPP Layer.
+@return {HTMLElement} The button element.
+*/
 function polygon(layer) {
 
   const helpDialog = {
@@ -307,6 +325,12 @@ function polygon(layer) {
   return layer.draw.polygon.btn
 }
 
+/**
+@function rectangle
+@description Creates a button for rectangle a line on the map.
+@param {layer} layer Decorated MAPP Layer.
+@return {HTMLElement} The button element.
+*/
 function rectangle(layer) {
 
   const helpDialog = {
@@ -335,6 +359,12 @@ function rectangle(layer) {
   return layer.draw.rectangle.btn
 }
 
+/**
+@function circle_2pt
+@description Creates a button for circle_2pt a line on the map.
+@param {layer} layer Decorated MAPP Layer.
+@return {HTMLElement} The button element.
+*/
 function circle_2pt(layer) {
 
   const helpDialog = {
@@ -363,6 +393,12 @@ function circle_2pt(layer) {
   return layer.draw.circle_2pt.btn
 }
 
+/**
+@function circle
+@description Creates a button for circle a line on the map.
+@param {layer} layer Decorated MAPP Layer.
+@return {HTMLElement} The button element.
+*/
 function circle(layer) {
 
   const helpDialog = {
@@ -403,48 +439,73 @@ function circle(layer) {
     ...layer.draw.circle
   }
 
+  // Build an array for the unit, label, min and max values.
+  const units = [
+    {
+      option: 'meter',
+      title: 'Meter',
+      min: 1,
+      max: 1000
+    },
+    {
+      option: 'km',
+      title: 'KM',
+      min: 1,
+      max: 10
+    },
+    {
+      option: 'miles',
+      title: 'Miles',
+      min: 1,
+      max: 10
+    },
+    {
+      option: 'meter2',
+      title: 'Meter²',
+      min: 1,
+      max: 1000
+    },
+    {
+      option: 'km2',
+      title: 'KM²',
+      min: 1,
+      max: 10
+    }
+  ];
+
   const unitsDropDown = mapp.utils.html.node`
     <div style="display: grid; grid-template-columns: 100px 1fr; align-items: center;">
       <div style="grid-column: 1;">${mapp.dictionary.units}</div>
       <div style="grid-column: 2;">
         ${mapp.ui.elements.dropdown({
-    placeholder: layer.draw.circle.units,
-    entries: [
-      {
-        title: 'Meter',
-        option: 'meter',
-      },
-      {
-        title: 'KM',
-        option: 'km',
-      },
-      {
-        title: 'Miles',
-        option: 'miles',
-      },
-      {
-        title: 'Meter²',
-        option: 'meter2',
-      },
-      {
-        title: 'KM²',
-        option: 'km2',
-      },
-    ],
+    placeholder: units.find(entry => entry.option === layer.draw.circle.units).title,
+    entries: units,
     callback: (e, entry) => {
+
       layer.draw.circle.units = entry.option;
+      layer.draw.circle.radiusMin = entry.min;
+      layer.draw.circle.radiusMax = entry.max;
+
+      // Update the value of the slider to ensure it is within the new min and max values.
+      layer.draw.circle.radius = layer.draw.circle.radius > layer.draw.circle.radiusMax ? layer.draw.circle.radiusMax : layer.draw.circle.radius;
     }
   })}`
 
-  const rangeSlider = mapp.ui.elements.slider({
-    label: mapp.dictionary.radius,
-    min: layer.draw.circle.radiusMin,
-    max: layer.draw.circle.radiusMax,
-    val: layer.draw.circle.radius,
-    callback: e => {
-      layer.draw.circle.radius = parseFloat(e.target.value)
-    }
-  })
+  const rangeSlider = mapp.utils.html.node`<div>`;
+
+  createSlider();
+
+  function createSlider() {
+    mapp.utils.render(rangeSlider, mapp.ui.elements.slider({
+      min: layer.draw.circle.radiusMin,
+      max: layer.draw.circle.radiusMax,
+      val: layer.draw.circle.radius,
+      callback: e => {
+        layer.draw.circle.radius = parseFloat(e)
+      }
+    })
+    )
+  }
 
   layer.draw.circle.panel = mapp.utils.html.node`
     <div class="panel flex-col">
@@ -470,6 +531,12 @@ function circle(layer) {
   })}${layer.draw.circle.btn}`
 }
 
+/**
+@function locator
+@description Creates a button for drawing a point at your current location.
+@param {layer} layer Decorated MAPP Layer.
+@return {HTMLElement} The button element.
+*/
 function locator(layer) {
 
   layer.draw.locator = {

--- a/lib/ui/elements/drawing.mjs
+++ b/lib/ui/elements/drawing.mjs
@@ -488,6 +488,9 @@ function circle(layer) {
 
       // Update the value of the slider to ensure it is within the new min and max values.
       layer.draw.circle.radius = layer.draw.circle.radius > layer.draw.circle.radiusMax ? layer.draw.circle.radiusMax : layer.draw.circle.radius;
+    
+      // Render the slider after changes
+      createSlider();
     }
   })}`
 


### PR DESCRIPTION

## Description

The existing `rangeSlider` used when drawing a circle and setting the radius is broken. 
This is as it is still looking for `e.target.value` when it is now just `e`. 
``` js
const rangeSlider = mapp.ui.elements.slider({
    label: mapp.dictionary.radius,
    min: layer.draw.circle.radiusMin,
    max: layer.draw.circle.radiusMax,
    val: layer.draw.circle.radius,
    callback: e => {
      layer.draw.circle.radius = parseFloat(e.target.value)
    }
  })
```

I also noticed that when you swap units, the min and max of the sliders do not update. So even on KM you had the option to draw a 1000KM circle which may well crash the process. 

As such, this PR has fixed the above issue, and has also set min and maxes for the different options accordingly. When you swap the unit, the slider and value will now update to the new min and max. 

![image](https://github.com/user-attachments/assets/35185032-eaf7-480d-86dc-a7622f45bc2f)

![image](https://github.com/user-attachments/assets/e3526654-8256-4d02-bb20-471888a0ab82)

## Type of Change
Please delete options that are not relevant, and select all options that apply. 

- ✅ Bug fix (non-breaking change which fixes an issue)

## Testing Checklist 
Please delete options that are not relevant, and select all options that apply. 

- ✅ Existing Tests still pass
- ✅ Ran locally on my machine

## Code Quality Checklist
Please delete options that are not relevant, and select all options that apply. 

- ✅ My code follows the guidelines of XYZ
- ✅ My code has been commented
- ✅ Documentation has been updated
- ✅ New and existing unit tests pass locally with my changes
- ✅ Main has been merged into this PR