### PR TITLE
User update req.body check for Vercel deployments ▲

### DIFF
--- a/mod/user/update.js
+++ b/mod/user/update.js
@@ -104,7 +104,8 @@ module.exports = async function update(req, res) {
     return res.status(400).send('Invalid key in user object for SQL update.')
   }
 
-  if (!update_user.email) { return res.status(500).send('Email address required.') }
+  //If the client has provided a request with a body/param that does not have an email we will return a 400
+  if (!update_user.email) { return res.status(400).send('Email address required.') }
 
   const properties = []
   const substitutes = [update_user.email]

--- a/mod/user/update.js
+++ b/mod/user/update.js
@@ -61,6 +61,9 @@ module.exports = async function update(req, res) {
     ? { email: req.params.email }
     : req.body;
 
+  //If the client has provided a request with a body/params that does not have an email we will return a 400
+  if (!update_user.email) { return res.status(400).send('Email address required.') }
+
   if (req.params.field) {
     if (req.params.field === 'roles') {
 
@@ -104,8 +107,6 @@ module.exports = async function update(req, res) {
     return res.status(400).send('Invalid key in user object for SQL update.')
   }
 
-  //If the client has provided a request with a body/param that does not have an email we will return a 400
-  if (!update_user.email) { return res.status(400).send('Email address required.') }
 
   const properties = []
   const substitutes = [update_user.email]

--- a/mod/user/update.js
+++ b/mod/user/update.js
@@ -118,7 +118,6 @@ module.exports = async function update(req, res) {
       properties.push(`${key} = $${substitutes.length}`)
     })
 
-
   const update_query = `
     UPDATE acl_schema.acl_table
     SET 

--- a/mod/user/update.js
+++ b/mod/user/update.js
@@ -104,6 +104,8 @@ module.exports = async function update(req, res) {
     return res.status(400).send('Invalid key in user object for SQL update.')
   }
 
+  if (!update_user.email) { return res.status(500).send('Email address required.') }
+
   const properties = []
   const substitutes = [update_user.email]
 
@@ -115,7 +117,6 @@ module.exports = async function update(req, res) {
       properties.push(`${key} = $${substitutes.length}`)
     })
 
-  if (!update_user.email) { return res.status(500).send('Email address required.') }
 
   const update_query = `
     UPDATE acl_schema.acl_table

--- a/mod/user/update.js
+++ b/mod/user/update.js
@@ -107,7 +107,6 @@ module.exports = async function update(req, res) {
     return res.status(400).send('Invalid key in user object for SQL update.')
   }
 
-
   const properties = []
   const substitutes = [update_user.email]
 

--- a/mod/user/update.js
+++ b/mod/user/update.js
@@ -57,9 +57,9 @@ module.exports = async function update(req, res) {
   }
 
   // Create update_user from request body or create Object with email from params.
-  const update_user = req.body || {
-    email: req.params.email
-  }
+  const update_user = (Object.keys(req.body || {}).length === 0 || req.body === undefined)
+    ? { email: req.params.email }
+    : req.body;
 
   if (req.params.field) {
     if (req.params.field === 'roles') {

--- a/mod/user/update.js
+++ b/mod/user/update.js
@@ -115,6 +115,8 @@ module.exports = async function update(req, res) {
       properties.push(`${key} = $${substitutes.length}`)
     })
 
+  if (!update_user.email) { return res.status(500).send('Email address required.') }
+
   const update_query = `
     UPDATE acl_schema.acl_table
     SET 

--- a/public/views/_user.html
+++ b/public/views/_user.html
@@ -489,7 +489,9 @@
 
       const cellValue = !cell.getValue();
 
-      const apiValue = field === 'api' ? (cellValue === false ? null : cellValue) : cellValue;
+      const cellFalsy = cellValue === false ? null : cellValue;
+
+      const apiValue = field === 'api' ? cellFalsy : cellValue;
 
       // Re-verification cannot be undone.
       if (field === 're_verification' && cell.getValue()) return;

--- a/public/views/_user.html
+++ b/public/views/_user.html
@@ -490,7 +490,8 @@
       // Re-verification cannot be undone.
       if (field === 're_verification' && cell.getValue()) return;
 
-      const response = await xhrPromise(`${document.head.dataset.dir}/api/user/update?email=${user.email}&field=${field === 're_verification' ? 'verified' : field}&value=${!cell.getValue()}`);
+      //The value of the field will be set to null if the field is an api and the new value from the cell is false.
+      const response = await xhrPromise(`${document.head.dataset.dir}/api/user/update?email=${user.email}&field=${field === 're_verification' ? 'verified' : field}&value=${field === 'api' ? (!cell.getValue() === false ? null : !cell.getValue()) : !cell.getValue()}`);
 
       if (response.err) return console.error(response.err);
 

--- a/public/views/_user.html
+++ b/public/views/_user.html
@@ -487,15 +487,19 @@
 
       const field = col.getField();
 
+      const cellValue = !cell.getValue();
+
+      const apiValue = field === 'api' ? (cellValue === false ? null : cellValue) : cellValue;
+
       // Re-verification cannot be undone.
       if (field === 're_verification' && cell.getValue()) return;
 
       //The value of the field will be set to null if the field is an api and the new value from the cell is false.
-      const response = await xhrPromise(`${document.head.dataset.dir}/api/user/update?email=${user.email}&field=${field === 're_verification' ? 'verified' : field}&value=${field === 'api' ? (!cell.getValue() === false ? null : !cell.getValue()) : !cell.getValue()}`);
+      const response = await xhrPromise(`${document.head.dataset.dir}/api/user/update?email=${user.email}&field=${field === 're_verification' ? 'verified' : field}&value=${apiValue}`);
 
       if (response.err) return console.error(response.err);
 
-      cell.setValue(!cell.getValue());
+      cell.setValue(cellValue);
 
       const row = cell.getRow();
 

--- a/public/views/_user.html
+++ b/public/views/_user.html
@@ -489,14 +489,13 @@
 
       const cellValue = !cell.getValue();
 
+      //The value of the field will be set to null if the field is an api and the new value from the cell is false.
       const cellFalsy = cellValue === false ? null : cellValue;
-
       const apiValue = field === 'api' ? cellFalsy : cellValue;
 
       // Re-verification cannot be undone.
       if (field === 're_verification' && cell.getValue()) return;
 
-      //The value of the field will be set to null if the field is an api and the new value from the cell is false.
       const response = await xhrPromise(`${document.head.dataset.dir}/api/user/update?email=${user.email}&field=${field === 're_verification' ? 'verified' : field}&value=${apiValue}`);
 
       if (response.err) return console.error(response.err);


### PR DESCRIPTION
## Description

On deployed instances the req.body always defaults to '{}'. Therefore the check that was applied on the user_update assign for the req.body would not resolve correctly because it would be truthy and then provide an undefined email address to the update query.

```js
const update_user = (Object.keys(req.body || {}).length === 0 || req.body === undefined)
    ? { email: req.params.email }
    : req.body;
```

This is solved by adding in a check on if there are no keys in the object then it would resolve to falsy assigning the email from the params.

We also check if there is an email property on the update_user before executing the query. As if you provide a body with keys it will pass the initial check but still fail the query.


- 🐛 Bug fix (non-breaking change which fixes an issue)

**Note**
You can also test this locally with the rewrites of a deployed instance by running `vercel dev`. It will ask you some setup questions but just point them to the instance. 
