### PR TITLE
Missing HelpDialog for Editing a Geometry Editing

### DIFF
--- a/lib/ui/locations/entries/geometry.mjs
+++ b/lib/ui/locations/entries/geometry.mjs
@@ -11,6 +11,10 @@ mapp.utils.merge(mapp.dictionaries, {
     delete_geometry: 'Delete Geometry',
     modify_geometry: 'Modify Geometry',
     edit_dialog_title: 'Editing Instructions',
+    edit_dialog_cancel_drawing: 'Cancel Drawing - Click on the cancel button to cancel the drawing.',
+    edit_dialog_remove_vertex: 'Remove Vertex - Click on a vertex to remove it.',
+    edit_dialog_modify_shape: 'Edit Shape- Drag a vertex to modify the shape, or add a new vertex on the polygon.',
+    edit_dialog_save: 'Save - Click on the save button to save your changes.',
   },
   de: {
     delete_geometry: 'Geometrie entfernen',
@@ -263,9 +267,10 @@ function modify(e) {
   const helpDialog = {
     header: mapp.utils.html`<h3>${mapp.dictionary.edit_dialog_title}</h3>`,
     content: mapp.utils.html.node`<li>
-      <ul>${mapp.dictionary.draw_dialog_cancel_drawing}
-      <ul>${mapp.dictionary.draw_dialog_remove_vertex}</ul>
-      <ul>${mapp.dictionary.draw_dialog_save}</ul>`
+      <ul>${mapp.dictionary.edit_dialog_cancel_drawing}
+      <ul>${mapp.dictionary.edit_dialog_remove_vertex}</ul>
+      <ul>${mapp.dictionary.edit_dialog_modify_shape}</ul>
+      <ul>${mapp.dictionary.edit_dialog_save}</ul>`
   }
 
   // Call the helpDialog

--- a/lib/ui/locations/entries/geometry.mjs
+++ b/lib/ui/locations/entries/geometry.mjs
@@ -10,6 +10,7 @@ mapp.utils.merge(mapp.dictionaries, {
   en: {
     delete_geometry: 'Delete Geometry',
     modify_geometry: 'Modify Geometry',
+    edit_dialog_title: 'Editing Instructions',
   },
   de: {
     delete_geometry: 'Geometrie entfernen',
@@ -258,6 +259,18 @@ function modify(e) {
 
   // the modify event maybe triggered by an API.
   const btn = e.target
+
+  const helpDialog = {
+    header: mapp.utils.html`<h3>${mapp.dictionary.edit_dialog_title}</h3>`,
+    content: mapp.utils.html.node`<li>
+      <ul>${mapp.dictionary.draw_dialog_cancel_drawing}
+      <ul>${mapp.dictionary.draw_dialog_remove_vertex}</ul>
+      <ul>${mapp.dictionary.draw_dialog_save}</ul>`
+  }
+
+  // Call the helpDialog
+  mapp.ui.elements.helpDialog(helpDialog);
+
 
   // Check whether to cancel interaction.
   if (btn.classList.contains('active')) {


### PR DESCRIPTION
It was noticed that when you are editing an `infoj` `geometry` `entry` - you are not provided with a `helpDialog` , when you do get this for drawing. 

This PR simply adds a `helpDialog` for this. 


## Type of Change
Please delete options that are not relevant, and select all options that apply. 

- ✅ Bug fix (non-breaking change which fixes an issue)
- ✅ New feature (non-breaking change which adds functionality)

## Testing Checklist 

- ✅ Existing Tests still pass
- ✅ Ran locally on my machine

## Code Quality Checklist
Please delete options that are not relevant, and select all options that apply. 

- ✅ My code follows the guidelines of XYZ
- ✅ My code has been commented
- ✅ Documentation has been updated
- ✅ New and existing unit tests pass locally with my changes
- ✅ Main has been merged into this PR