### PR TITLE
Check whether user exists before language

### DIFF
--- a/public/views/_default.html
+++ b/public/views/_default.html
@@ -454,7 +454,7 @@
 
     mapp.language = mapp.hooks.current.language
 
-  } else if (mapp.user.language) {
+  } else if (mapp.user?.language) {
 
     if (!Object.hasOwn(mapp.dictionaries, mapp.user.language)) {
 


### PR DESCRIPTION
The check for the user language must check whether the user exists as otherwise the view script will break on a public instance.