### PR TITLE
numericChecks method for slider_ab element.

### DIFF
--- a/lib/ui/elements/numericInput.mjs
+++ b/lib/ui/elements/numericInput.mjs
@@ -22,6 +22,7 @@ export default function numericInput(params) {
 
   params.placeholder ??= ''
   params.data_id ??= 'numeric-input'
+  params.numericChecks ??= numericChecks
 
   const numericInput = mapp.utils.html.node`<input
     data-id=${params.data_id}
@@ -56,7 +57,7 @@ function oninput(e, params) {
   // Assign numeric newValue.
   params.newValue = mapp.utils.unformatStringValue(params)
 
-  if (numericChecks(params.newValue, params)) {
+  if (params.numericChecks(params.newValue, params)) {
 
     // The numericCheck passes.
     delete params.invalid

--- a/lib/ui/elements/slider_ab.mjs
+++ b/lib/ui/elements/slider_ab.mjs
@@ -29,7 +29,8 @@ export default function slider_ab(params) {
     data_id: 'a',
     value: params.val_a,
     rangeInput: 'minRangeInput',
-    callback: params.callback_a
+    callback: params.callback_a,
+    numericChecks
   }
 
   // Create numericInput element for formatting and numeric checks.
@@ -40,11 +41,57 @@ export default function slider_ab(params) {
     data_id: 'b',
     value: params.val_b,
     rangeInput: 'maxRangeInput',
-    callback: params.callback_b
+    callback: params.callback_b,
+    numericChecks
   }
 
   // Create numericInput element for formatting and numeric checks.
   const maxNumericInput = mapp.ui.elements.numericInput(maxInputParams)
+
+  /**
+  @function numericChecks
+
+  @description
+  The numericChecks method checks whether a provided numeric value is a number, larger than params.min, and smaller than params.max.
+
+  The slider_ab numericCheck methods returns false if the 'a' slider element value exceeds the 'b' slider element value or vice versa.
+
+  @param {Object} value The numeric value to check.
+  @param {Object} params The config object argument.
+  @property {numeric} params.min Value must be larger than min.
+  @property {numeric} params.max Value must be smaller than max.
+  @property {string} params.data_id The id of the numeric input element.
+
+  @returns {Boolean} true if checks are passed.
+  */
+  function numericChecks(value, params) {
+
+    // Check whether value is a number.
+    if (isNaN(value)) return false;
+   
+    if (params.data_id === 'a' && value > maxInputParams.newValue) {
+  
+      return false
+    }
+  
+    if (params.data_id === 'b' && value < minInputParams.newValue) {
+  
+      return false
+    }
+  
+    if (params.min && value < params.min) {
+  
+      // The value is smaller than min.
+      return false
+    }
+  
+    if (params.max) {
+  
+      return value <= params.max
+    }
+  
+    return true
+  }
 
   const element = mapp.utils.html.node`
     <div


### PR DESCRIPTION
It must be possible to assign a custom numericChecks method to a numericInput element.

The slider_ab element has two numeric input elements `a` & `b`.

The a.newValue must not be more than the b.newValue.

The b.newValue must not be less than the a.newValue.