### PR TITLE
Location mock

### DIFF
--- a/lib/location/get.mjs
+++ b/lib/location/get.mjs
@@ -72,13 +72,15 @@ export async function getInfoj(location) {
     location.layer = await mapp.utils.xhr(`${mapp.host}/api/workspace/layer?locale=${location.locale}&layer=${location.layer}`)
   }
 
+  location.getTemplate ??= 'location_get'
+
   // Get table from layer if not provided.
   location.table ??= location.layer.table
     || Object.values(location.layer.tables).find(table => !!table)
 
   // Request the location fields from layer json & id.
   const response = await mapp.utils.xhr(`${mapp.host}/api/query?` + mapp.utils.paramString({
-    template: 'location_get',
+    template: location.getTemplate,
     locale: location.locale,
     layer: location.layer.key,
     table: location.table,

--- a/tests/assets/layers/location_mock/infoj.json
+++ b/tests/assets/layers/location_mock/infoj.json
@@ -1,0 +1,18 @@
+{
+    "infoj": [
+        {
+            "title": "qID",
+            "field": "_id",
+            "inline": true
+        },
+        {
+            "type": "key"
+        },
+        {
+            "type": "pin",
+            "label": "ST_PointOnSurface",
+            "field": "pin",
+            "fieldfx": "ARRAY[ST_X(ST_PointOnSurface(geom_3857)),ST_Y(ST_PointOnSurface(geom_3857))]"
+        }
+    ]
+}

--- a/tests/assets/layers/location_mock/layer.json
+++ b/tests/assets/layers/location_mock/layer.json
@@ -1,0 +1,9 @@
+{
+    "display": false,
+    "group": "layer",
+    "format": "wkt",
+    "table": "foo.bar",
+    "srid": "3857",
+    "geom": "geom_3857",
+    "qID": "_id"
+}

--- a/tests/assets/queries/get_location_mock.sql
+++ b/tests/assets/queries/get_location_mock.sql
@@ -1,0 +1,7 @@
+select
+  7 as "id",
+  null as "icon_scale",
+  ARRAY[-15322.318564101091, 6710796.777772117] as "pin",
+  'asdasd' as "textarea",
+  null as "char_field",
+  4 as "integer_field";

--- a/tests/browser/local.test.mjs
+++ b/tests/browser/local.test.mjs
@@ -42,7 +42,7 @@ await layerTest.featureFormatsTest();
 await layerTest.styleParserTest(mapview);
 
 // await locationTest.createTest();
-// await locationTest.getTest();
+await locationTest.getTest(mapview);
 // await locationTest.decorateTest();
 // await locationTest.nnearestTest();
 

--- a/tests/lib/location/get.test.mjs
+++ b/tests/lib/location/get.test.mjs
@@ -4,7 +4,7 @@
  * @param {object} mapview 
  */
 export async function getTest(mapview) {
-    await codi.describe('TODO: Location: getTest', async () => {
+    await codi.describe('Location: getTest', async () => {
 
         /**
          * This tests the functionality to mock a location by passing in a template that returns values from the query

--- a/tests/lib/location/get.test.mjs
+++ b/tests/lib/location/get.test.mjs
@@ -1,8 +1,27 @@
-export async function getTest() {
-    codi.describe('TODO: Location: getTest', () => {
-        codi.it('Should should test for something', () => {
-            //TODO
+/**
+ * This test is used to test the mapp.location.get function
+ * @function getTest 
+ * @param {object} mapview 
+ */
+export async function getTest(mapview) {
+    await codi.describe('TODO: Location: getTest', async () => {
+
+        /**
+         * This tests the functionality to mock a location by passing in a template that returns values from the query
+         * @function it
+         */
+        await codi.it('We should be able to mock a location get.', async () => {
+            const locationLayer = mapview.layers['location_get_test'];
+            //Get the location with the id returned from the query above
+            const location = await mapp.location.get({
+                layer: locationLayer,
+                getTemplate: 'get_location_mock',
+                id: 7,
+            });
+
+            codi.assertEqual(location.infoj.length, 3, 'We expect to see three infoj entries');
+            codi.assertTrue(!!location.record, 'The location needs a record object');
+            codi.assertTrue(!!location.remove, 'The location needs a remove function');
         });
     });
 }
-

--- a/tests/lib/location/get.test.mjs
+++ b/tests/lib/location/get.test.mjs
@@ -22,6 +22,7 @@ export async function getTest(mapview) {
             codi.assertEqual(location.infoj.length, 3, 'We expect to see three infoj entries');
             codi.assertTrue(!!location.record, 'The location needs a record object');
             codi.assertTrue(!!location.remove, 'The location needs a remove function');
+            codi.assertTrue(!!location.layer && typeof(location.layer) === 'object', 'The location needs a layer object');
         });
     });
 }

--- a/tests/workspace.json
+++ b/tests/workspace.json
@@ -21,6 +21,9 @@
         },
         "icon_scaling_scratch": {
             "src": "file:/tests/assets/queries/icon_scaling_scratch.sql"
+        },
+        "get_location_mock": {
+            "src": "file:/tests/assets/queries/get_location_mock.sql"
         }
     },
     "locale": {
@@ -261,6 +264,17 @@
                 "templates": [
                     "template_1",
                     "template_2"
+                ]
+            },
+            "location_get_test": {
+                "hidden": true,
+                "templates": [
+                    {
+                        "src": "file:/tests/assets/layers/location_mock/layer.json"
+                    },
+                    {
+                        "src": "file:/tests/assets/layers/location_mock/infoj.json"
+                    }
                 ]
             }
         }


### PR DESCRIPTION
## Description

We need the ability to pass in a custom template to the location.get() function. This can be used in different use cases. The main one at the moment is used to mock locations in the testing environment. 

## Type of Change
Please delete options that are not relevant, and select all options that apply. 

- ✅ New feature (non-breaking change which adds functionality)
- ✅ Testing

## How have you tested this? 
Run the local tests and Look for the location: getTest.

## Testing Checklist 
Note that the user tests will fail with a public instance. This is something that still needs to be resolved by spoofing a user.

- ✅ New Tests Added