### PR TITLE
Only update dataview with activateUpdate or no data.

### DIFF
--- a/lib/ui/Tabview.mjs
+++ b/lib/ui/Tabview.mjs
@@ -84,13 +84,12 @@ function addTab(entry) {
 
     if (entry.update instanceof Function) {
 
-      if (entry.data && entry.keepDataOnActivate) {
+      
+      if (!entry.data || entry.activateUpdate) {
 
-        // Do not update dataview entry with data.
-        return;
+        // Call dataview update method if data is falsy or activateUpdate flag is set.
+        entry.update()
       }
-
-      entry.update()
     }
   }
 

--- a/lib/ui/Tabview.mjs
+++ b/lib/ui/Tabview.mjs
@@ -83,6 +83,13 @@ function addTab(entry) {
     }
 
     if (entry.update instanceof Function) {
+
+      if (entry.data && entry.keepDataOnActivate) {
+
+        // Do not update dataview entry with data.
+        return;
+      }
+
       entry.update()
     }
   }


### PR DESCRIPTION
By default the dataview update method is triggered from the tab activate method.

With the `keepDataOnActivate` flag the update method will be shortcircuited in the tabview tab.activate() method.

The dataview can persist with this flag.