### PR TITLE
No obj.key template lookup and clone merge.

### DIFF
--- a/mod/workspace/mergeTemplates.js
+++ b/mod/workspace/mergeTemplates.js
@@ -47,28 +47,29 @@ module.exports = async function mergeTemplates(obj) {
   // Cache workspace in module scope for template assignment.
   workspace = await workspaceCache()
 
-  const template = await getTemplate(obj.template || obj.key)
+  // The object has an implicit template to merge into.
+  if (obj.template) {
 
-  // Failed to get template matching obj.template from template.src!
-  if (template.err instanceof Error) {
+    const template = await getTemplate(obj.template)
 
-    obj.err ??= []
-    obj.err.push(template.err.message)
-
+    // Failed to get template matching obj.template from template.src!
+    if (template.err instanceof Error) {
+  
+      obj.err ??= []
+      obj.err.push(template.err.message)
+  
     // The template is not in the workspace.templates{}
-  } else if (template instanceof Error) {
-
-    // Only log error if obj.template is implicit.
-    // It is not presumed that a obj.key has a matching template.
-    if (obj.template) {
+    } else if (template instanceof Error) {
+  
       obj.err ??= []
       obj.err.push(template.message)
+  
+    } else {
+  
+      // Merge obj --> template
+      // Template must be cloned to prevent cross polination and array aggregation.
+      obj = merge(structuredClone(template), obj)
     }
-
-  } else {
-
-    // Merge obj --> template
-    obj = merge(template, obj)
   }
 
   for (const template_key of obj.templates || []) {


### PR DESCRIPTION
Merging an object into a template will cause an array aggregation of objects if the template is not cloned for the merge.

This may also cause cross pollination as objects merged from the template will be added to objects merged into the same template from another object.

[Screencast from 03-09-24 10:05:50.webm](https://github.com/user-attachments/assets/e8185704-8623-4f79-97e4-13074a6395ed)

Template lookup for object key is fraught with danger. There is no control to prevent a wrong template being looked up, and the warning if a template is not found cannot be stored because many object keys may not have a matching template.