### PR TITLE
Remove reference for mapButton used for user admin only.

### DIFF
--- a/public/views/_default.html
+++ b/public/views/_default.html
@@ -570,8 +570,6 @@
     },
   });
 
-  const btnColumn = document.getElementById('mapButton');
-
   // Get list of accessible locales from Workspace API.
   const locales = await mapp.utils.xhr(`${mapp.host}/api/workspace/locales`);
 
@@ -718,7 +716,7 @@
     });
 
   // Append spacer for tableview
-  btnColumn.appendChild(mapp.utils.html.node`
+  document.getElementById('mapButton').append(mapp.utils.html.node`
     <div class="mobile-display-none" style="height: 60px;">`);
 
 </script>


### PR DESCRIPTION
The mapButton shouldn't be stored in a const at the beginning to be used only once at the very end of the script.

At best this is hard to read. At worst this makes re-working the mapButton element impossible.