### PR TITLE
Enable mapviewControls in locale

### DIFF
--- a/lib/mapview/_mapview.mjs
+++ b/lib/mapview/_mapview.mjs
@@ -119,6 +119,11 @@ export default function decorate(mapview) {
     mapview.extent = ol.proj.transformExtent([-180, -90, 180, 90], 'EPSG:4326', `EPSG:${mapview.srid}`);
   }
 
+  // Assign ol controls for mapview from locale.
+  mapview.controls ??= mapview.locale.mapviewControls
+    ?.filter(control => Object.hasOwn(ol.control, control))
+    .map(control => new ol.control[control]) || []
+
   // Map
   mapview.Map = new ol.Map({
     target: mapview.target,
@@ -132,7 +137,7 @@ export default function decorate(mapview) {
       } || false
     }),
     moveTolerance: 5,
-    controls: mapview.controls || [], //[new ol.control.Zoom()]
+    controls: mapview.controls, //[new ol.control.Zoom()]
     view: new ol.View({
       projection: `EPSG:${mapview.srid}`,
       zoom: initialZoom,


### PR DESCRIPTION
Openlayers controls must be created from the ol.controls library.

This prevents controls being defined as string in the workspace.

In addition of providing an array of control objects in the mapview creation eg `controls:[new ol.control.Zoom()]` it should be possible to define an array of string values for the controls in the locale as mapviewControls.

This will allow to move remove the zoom control plugins from the default `syncPlugins` and add the OL zoom control to the mapview.Map.

```js
    "mapviewControls": ["Foo", "Zoom"],
    "syncPlugins": ["admin", "login"],
```

Control methods which are not a property of the ol.controls object are ignored.
