### PR TITLE
Only check obj key template if not implicit

### DIFF
--- a/DOCUMENTATION.md
+++ b/DOCUMENTATION.md
@@ -24,9 +24,9 @@ The documentation pages are generated in the local `/docs` directory. The docs d
 
 The built documentation pages can be accessed via the repositories github pages.
 
-https://geolytix.github.io/xyz/
+<https://geolytix.github.io/xyz/>
 
-MAPP library modules are accessed through https://geolytix.github.io/xyz/mapp/
+MAPP library modules are accessed through <https://geolytix.github.io/xyz/mapp/>
 
 ### Modules
 
@@ -84,11 +84,12 @@ The request.email and request.password are taken from the req.body or authorizat
 Validated user object or an Error if authentication fails.
 */
 ```
+
 #### Decorator methods
 
 Decorator methods should always return a typedef.
 
-#### @deprecated methods.
+#### @deprecated methods
 
 Functions no longer in use but kept with a warning for legacy configurations should be marked as `@deprecated`.
 
@@ -129,11 +130,12 @@ A mapp-layer object is a decorated JSON layer object which has been added to a m
 ```
 
 ### @link
+
 The link tag creates an inline link element which can be used to create a link inline the description.
 
 The link can reference a module and it's inline members like methods. `{@link module:/location/decorate~flyTo}`
 
-### @example 
+### @example
 
 An @example does not require a code block [\`\`\`JS] definition. At examples should be reserved for codepen examples which can be run. Code blocks should be used for code syntax highlighting in the rendered markdown.
 
@@ -142,5 +144,6 @@ An @example does not require a code block [\`\`\`JS] definition. At examples sho
 The /docs express route can be used to preview the built pages on `http://localhost:3000/docs/`
 
 ### docs in vscode
+
 - Docs can also be previewed right in vsdocs by right clicking on any .html page in the docs directory. This will provide a live working preview of the docs in the editor.
 - You will need an extension written by microsoft called [Live Preview](https://marketplace.visualstudio.com/items?itemName=ms-vscode.live-server)

--- a/mod/workspace/getLocale.js
+++ b/mod/workspace/getLocale.js
@@ -50,10 +50,10 @@ module.exports = async function getLocale(params) {
     return new Error('Unable to validate locale param.')
   }
 
-  // The workspace.locale is assigned as locale if params.locale is undefined.
-  let locale = !params.locale
-    ? workspace.locale
-    : workspace.locales[params.locale]
+  // The workspace.locale is assigned as locale if params.locale is not a property of workspace.locales
+  let locale = Object.hasOwn(workspace.locales, params.locale)
+    ? workspace.locales[params.locale]
+    : workspace.locale
 
   locale = await mergeTemplates(locale)
 

--- a/mod/workspace/getLocale.js
+++ b/mod/workspace/getLocale.js
@@ -40,10 +40,6 @@ Role objects in the locale and nested layers are merged with their respective pa
 */
 module.exports = async function getLocale(params) {
 
-  if (Object.keys(params).find(key => key === '__proto__' || key === 'prototype')) {
-    return new Error('Prototype Polution')
-  }
-
   const workspace = await workspaceCache()
 
   if (workspace instanceof Error) {
@@ -68,5 +64,4 @@ module.exports = async function getLocale(params) {
   locale = Roles.objMerge(locale, params.user?.roles)
 
   return locale
-  caches
 }

--- a/mod/workspace/getLocale.js
+++ b/mod/workspace/getLocale.js
@@ -40,6 +40,10 @@ Role objects in the locale and nested layers are merged with their respective pa
 */
 module.exports = async function getLocale(params) {
 
+  if (Object.keys(params).find(key => key === '__proto__' || key === 'prototype')) {
+    return new Error('Prototype Polution')
+  }
+
   const workspace = await workspaceCache()
 
   if (workspace instanceof Error) {
@@ -64,4 +68,5 @@ module.exports = async function getLocale(params) {
   locale = Roles.objMerge(locale, params.user?.roles)
 
   return locale
+  caches
 }

--- a/mod/workspace/mergeTemplates.js
+++ b/mod/workspace/mergeTemplates.js
@@ -47,12 +47,6 @@ module.exports = async function mergeTemplates(obj) {
   // Cache workspace in module scope for template assignment.
   workspace = await workspaceCache()
 
-  if (Object.hasOwn(workspace.templates, obj.key)) {
-
-    obj.err ??= []
-    obj.err.push(`Template matching ${obj.key} exists in workspace.`)
-  }
-
   // The object has an implicit template to merge into.
   if (obj.template) {
 
@@ -76,6 +70,12 @@ module.exports = async function mergeTemplates(obj) {
       // Template must be cloned to prevent cross polination and array aggregation.
       obj = merge(structuredClone(template), obj)
     }
+
+  // Check whether the object key exist as template if no implicit template has been defined.
+  } else if (Object.hasOwn(workspace.templates, obj.key)) {
+
+    obj.err ??= []
+    obj.err.push(`Template matching ${obj.key} exists in workspace.`)
   }
 
   for (const template_key of obj.templates || []) {


### PR DESCRIPTION
The workspace should not be checked for a template matching the object key if there is an implicit template property on the object.

This is to prevent a false flag exception.