### PR TITLE
Pills - minor fix;

### DIFF
--- a/lib/ui/elements/dropdown.mjs
+++ b/lib/ui/elements/dropdown.mjs
@@ -92,7 +92,7 @@ export default (params) => {
       params.selectedOptions.add(entry.option)
 
       // create pill
-      params.pills && pills.add(entry.title)
+      params.pills && params.pills.add(entry.title)
     }
 
     return li
@@ -158,7 +158,7 @@ export default (params) => {
       data-id=${params.data_id || 'dropdown'}
       class="dropdown">
         <div class="head" onclick=${params.headerOnClick}>
-          <span data-id=header-span>${headerSpan}</span>
+          <span data-id=header-span>${params.pills ? params.placeholder : headerSpan}</span>
           <div class="icon"></div>
         </div>
         <ul>${ul}`;


### PR DESCRIPTION
`pills` not assigned to parent params. Would error when layer was initially filtered on the same field. Second fix - when using pills keep placeholder in the dropdown.

## Description

Layer with a filter initially set in the workspace. When filtering on the same field by pills dropdown 
access to current `in` filter would fail: 

was: params.pills && pills.add(entry.title)
should be: params.pills && params.pills.add(entry.title)

Additional change: when using pills keep the dropdown placeholder. Join values only when pills not in use.

## GitHub Issue

Provide the link to the relevant GitHub issue it addresses. 

## Type of Change

- ✅ Bug fix (non-breaking change which fixes an issue)


## How have you tested this? 
Please describe how to test this change and how you verified it worked. 

## Testing Checklist 
Please delete options that are not relevant, and select all options that apply. 

- ✅ Existing Tests still pass
- ✅ Updated Existing Tests
- ✅ New Tests Added
- ✅ Ran locally on my machine

## Code Quality Checklist
Please delete options that are not relevant, and select all options that apply. 

- ✅ My code follows the guidelines of XYZ
- ✅ My code has been commented
- ✅ Documentation has been updated
- ✅ New and existing unit tests pass locally with my changes
- ✅ Main has been merged into this PR