### PR TITLE
addlayer to allow for single layer to be added.

### DIFF
--- a/lib/mapview/addLayer.mjs
+++ b/lib/mapview/addLayer.mjs
@@ -10,7 +10,7 @@ The module exports the addLayer method which is bound to the mapview.
 @function addLayer
 
 @description
-The addLayer method will iterate over an array of JSON layer to be added to the mapview.
+A single or an array of JSON layer can be added to the mapview with the addLayer method.
 
 A default zIndex is assigned to layer without an implicit zIndex.
 
@@ -24,14 +24,18 @@ Layer with a display flag will shown in the mapview.
 
 A renderComplete event will be assigned to the Openlayers mapview.Map{}. This promise will resolve once after all layer to be shown in the addLayer method have completed their render.
 
-@param {array} layers Array of JSON layer to be added to the mapview.
+@param {object} layers A single JSON layer or an array of JSON layer to be added to the mapview.
 
 @returns {array} The array of decorated layers is returned.
 */
-
 export default async function addLayer(layers) {
 
-  if (!Array.isArray(layers)) return;
+  // A single JSON layer is provided.
+  if (layers instanceof Object && !Array.isArray(layers)) {
+
+    // Create array of layers with single JSON layer.
+    layers = [layers]
+  }
 
   // A set of the layers is required in order to control the display based on URL params [hooks]
   const layersSet = this.hooks && new Set(mapp.hooks.current.layers);
@@ -41,9 +45,12 @@ export default async function addLayer(layers) {
     // The JSON layer is merged into the locale.layer
     const layer = mapp.utils.merge({}, this.locale.layer || {}, layers[i])
 
+    // Replace layer object in layers array with layer clone from merge.
+    layers[i] = layer
+
     // The layer.err is an array of errors from failing to retrieve templates asscoiated with a layer.
     layer.err && console.error(layer.err)
-    
+   
     // A default zIndex is assigned from the loop index to ensure layers are drawn in the order without an implicit zIndex.
     layer.zIndex ??= i
 
@@ -57,6 +64,9 @@ export default async function addLayer(layers) {
 
     // Layer without format should not be decorated.
     if (!layer.format) continue;
+
+    // Assign default key if not explicit in layer JSON.
+    layer.key ??= `${layer.format}-${i}`
 
     // Check the layer format.
     if (!mapp.layer.formats[layer.format]) {

--- a/tests/browser/local.test.mjs
+++ b/tests/browser/local.test.mjs
@@ -47,7 +47,7 @@ await locationTest.getTest(mapview);
 // await locationTest.decorateTest();
 // await locationTest.nnearestTest();
 
-// await mapviewTest.addLayerTest();
+await mapviewTest.addLayerTest(mapview);
 // await mapviewTest.allfeaturesTest();
 // await mapviewTest.attributionTest();
 // await mapviewTest.fitViewTest();

--- a/tests/lib/mapview/addLayer.test.mjs
+++ b/tests/lib/mapview/addLayer.test.mjs
@@ -1,7 +1,31 @@
-export async function addLayerTest() {
-    codi.describe('TODO: Mapview: addLayerTest', () => {
-        codi.it('Should should test for something', () => {
-            //TODO
-        });
+export async function addLayerTest(mapview) {
+  await codi.describe('Mapview: addLayerTest', async () => {
+    await codi.it('Add single layer to mapview.', async () => {
+
+      const layer = {
+        "format": "tiles",
+        "URI": "https://{a-c}.tile.openstreetmap.org/{z}/{x}/{y}.png"
+      }
+
+      const layers = await mapview.addLayer(layer)
+
+      codi.assertEqual(layers.length, 1, 'We expect to see 1 layer being returned from getLayers method.');
+      codi.assertTrue(layers[0].show instanceof Function, 'The decorated layer has a show method.');
+      codi.assertTrue(Object.hasOwn(mapview.layers, layers[0].key), 'The layer has been added to the mapview.');
     });
+
+    await codi.it('Add multiple layer to mapview.', async () => {
+
+      const layer = {
+        "format": "tiles",
+        "URI": "https://{a-c}.tile.openstreetmap.org/{z}/{x}/{y}.png"
+      }
+
+      const layers = await mapview.addLayer([layer, layer])
+
+      codi.assertEqual(layers.length, 2, 'We expect to see 2 layer being returned from getLayers method.');
+      codi.assertTrue(layers[0].show instanceof Function, 'The first decorated layer has a show method.');
+      codi.assertTrue(Object.hasOwn(mapview.layers, layers[0].key), 'The first layer has been added to the mapview.');
+    });
+  });
 }

--- a/tests/lib/mapview/addLayer.test.mjs
+++ b/tests/lib/mapview/addLayer.test.mjs
@@ -1,10 +1,26 @@
+
+/**
+* This is the add layer test module for the mapview. 
+ * @module lib/mapview/addLayer
+*/
+
+/**
+ * The entry point test that is used to test the add layer module for a mapview. 
+ * @param {Object} mapview 
+ * @function addLayerTest
+ */
 export async function addLayerTest(mapview) {
   await codi.describe('Mapview: addLayerTest', async () => {
+
+    /**
+     * This test is used to check if we can add a single layer to the mapview.
+     * @function it
+     */
     await codi.it('Add single layer to mapview.', async () => {
 
       const layer = {
-        "format": "tiles",
-        "URI": "https://{a-c}.tile.openstreetmap.org/{z}/{x}/{y}.png"
+        'format': 'tiles',
+        'URI': 'https://{a-c}.tile.openstreetmap.org/{z}/{x}/{y}.png'
       }
 
       const layers = await mapview.addLayer(layer)
@@ -14,11 +30,15 @@ export async function addLayerTest(mapview) {
       codi.assertTrue(Object.hasOwn(mapview.layers, layers[0].key), 'The layer has been added to the mapview.');
     });
 
+    /**
+   * This test is used to check if we can add multiple layers to the mapview.
+   * @function it
+   */
     await codi.it('Add multiple layer to mapview.', async () => {
 
       const layer = {
-        "format": "tiles",
-        "URI": "https://{a-c}.tile.openstreetmap.org/{z}/{x}/{y}.png"
+        'format': 'tiles',
+        'URI': 'https://{a-c}.tile.openstreetmap.org/{z}/{x}/{y}.png'
       }
 
       const layers = await mapview.addLayer([layer, layer])


### PR DESCRIPTION
The addLayer method now allows for a single layer to be added or an array of JSON layer.

A default key consisting of the format + index will be assigned to layer with a valid format.

The layer will be replaced in the layers array in order to return an array of decorated layer.

The addLLayer test has been updated to test the method.

![image](https://github.com/user-attachments/assets/4d867993-54d8-4459-b9da-bfb72f314413)
