### PR TITLE
Set icon_scaling defaults; warn for plugin config; numcheck callback.

### DIFF
--- a/lib/layer/styleParser.mjs
+++ b/lib/layer/styleParser.mjs
@@ -187,6 +187,13 @@ export default function styleParser(layer) {
     if (layer.style.zIndex) {
       console.warn(`Layer: ${layer.key}, layer.style.zIndex has been deprecated. Use layer.zIndex instead.`);
     }
+
+    if (layer.icon_scaling) {
+
+      console.warn(`Layer: ${layer.key}, layer.icon_scaling has been assigned to layer.style.icon_scaling`)
+
+      layer.style.icon_scaling ??= layer.icon_scaling
+    }
   }
 
   function parseTheme(theme, layer) {

--- a/lib/ui/elements/layerStyle.mjs
+++ b/lib/ui/elements/layerStyle.mjs
@@ -386,11 +386,11 @@ function themes(layer) {
   const dropdown = mapp.utils.html`<div>
     ${mapp.dictionary.layer_style_select_theme}
     ${mapp.ui.elements.dropdown({
-      data_id: 'themesDropdown',
-      placeholder: layer.style.theme.title,
-      entries,
-      callback
-    })}`
+    data_id: 'themesDropdown',
+    placeholder: layer.style.theme.title,
+    entries,
+    callback
+  })}`
 
   return dropdown
 }
@@ -463,6 +463,9 @@ function icon_scaling(layer) {
       val: layer.style.default.scale,
       callback: val => {
 
+        // If the val is outside of the min and max range or NaN, return.
+        if (val < layer.style.icon_scaling.minScale || val > layer.style.icon_scaling.maxScale || isNaN(val)) return;
+
         layer.style.default.scale = parseFloat(val)
         clearTimeout(layer.style.timeout)
         layer.style.timeout = setTimeout(() => layer.L.changed(), 400)
@@ -482,6 +485,9 @@ function icon_scaling(layer) {
       step: layer.style.cluster.clusterScale / 10,
       val: layer.style.cluster.clusterScale,
       callback: val => {
+
+        // If the val is outside of the min and max range or NaN, return.
+        if (val < layer.style.icon_scaling.minScale || val > layer.style.icon_scaling.maxScale || isNaN(val)) return;
 
         layer.style.cluster.clusterScale = parseFloat(val)
         clearTimeout(layer.style.timeout)
@@ -505,6 +511,9 @@ function icon_scaling(layer) {
       val: layer.style.zoomInScale,
       callback: val => {
 
+        // If the val is outside of the min and max range or NaN, return.
+        if (val < layer.style.icon_scaling.minScale || val > layer.style.icon_scaling.maxScale || isNaN(val)) return;
+        
         layer.style.zoomInScale = parseFloat(val)
         clearTimeout(layer.style.timeout)
         layer.style.timeout = setTimeout(() => layer.L.changed(), 400)
@@ -526,6 +535,9 @@ function icon_scaling(layer) {
       step: layer.style.zoomOutScale / 10,
       val: layer.style.zoomOutScale,
       callback: val => {
+
+        // If the val is outside of the min and max range or NaN, return.
+        if (val < layer.style.icon_scaling.minScale || val > layer.style.icon_scaling.maxScale || isNaN(val)) return;
 
         layer.style.zoomOutScale = parseFloat(val)
         clearTimeout(layer.style.timeout)

--- a/lib/ui/elements/layerStyle.mjs
+++ b/lib/ui/elements/layerStyle.mjs
@@ -446,12 +446,16 @@ function icon_scaling(layer) {
 
   if (layer.style.icon_scaling.icon) {
 
+    layer.icon_scaling.maxScale ??= layer.style.default.scale * 3
+
+    layer.icon_scaling.minScale ??= 0.1
+
     layer.style.icon_scaling.icon_scaling_label ??= mapp.dictionary.icon_scaling_label
 
     content.push(mapp.ui.elements.slider({
       data_id: 'iconScalingSlider',
-      min: 0.1,
-      max: layer.style.default.scale * 3,
+      min: layer.icon_scaling.minScale,
+      max: layer.icon_scaling.maxScale,
       step: layer.style.default.scale / 10,
       label: layer.style.icon_scaling.icon_scaling_label,
       val: layer.style.default.scale,

--- a/lib/ui/elements/layerStyle.mjs
+++ b/lib/ui/elements/layerStyle.mjs
@@ -463,7 +463,6 @@ function icon_scaling(layer) {
       val: layer.style.default.scale,
       callback: val => {
 
-        layer.style.cache = null
         layer.style.default.scale = parseFloat(val)
         clearTimeout(layer.style.timeout)
         layer.style.timeout = setTimeout(() => layer.L.changed(), 400)

--- a/lib/ui/elements/layerStyle.mjs
+++ b/lib/ui/elements/layerStyle.mjs
@@ -462,10 +462,6 @@ function icon_scaling(layer) {
       label: layer.style.icon_scaling.icon_scaling_label,
       val: layer.style.default.scale,
       callback: val => {
-
-        // If the val is outside of the min and max range or NaN, return.
-        if (val < layer.style.icon_scaling.minScale || val > layer.style.icon_scaling.maxScale || isNaN(val)) return;
-
         layer.style.default.scale = parseFloat(val)
         clearTimeout(layer.style.timeout)
         layer.style.timeout = setTimeout(() => layer.L.changed(), 400)
@@ -485,10 +481,6 @@ function icon_scaling(layer) {
       step: layer.style.cluster.clusterScale / 10,
       val: layer.style.cluster.clusterScale,
       callback: val => {
-
-        // If the val is outside of the min and max range or NaN, return.
-        if (val < layer.style.icon_scaling.minScale || val > layer.style.icon_scaling.maxScale || isNaN(val)) return;
-
         layer.style.cluster.clusterScale = parseFloat(val)
         clearTimeout(layer.style.timeout)
         layer.style.timeout = setTimeout(() => layer.L.changed(), 400)
@@ -509,11 +501,7 @@ function icon_scaling(layer) {
       max: layer.style.zoomInScale * 3,
       step: layer.style.zoomInScale / 10,
       val: layer.style.zoomInScale,
-      callback: val => {
-
-        // If the val is outside of the min and max range or NaN, return.
-        if (val < layer.style.icon_scaling.minScale || val > layer.style.icon_scaling.maxScale || isNaN(val)) return;
-        
+      callback: val => {       
         layer.style.zoomInScale = parseFloat(val)
         clearTimeout(layer.style.timeout)
         layer.style.timeout = setTimeout(() => layer.L.changed(), 400)
@@ -535,10 +523,6 @@ function icon_scaling(layer) {
       step: layer.style.zoomOutScale / 10,
       val: layer.style.zoomOutScale,
       callback: val => {
-
-        // If the val is outside of the min and max range or NaN, return.
-        if (val < layer.style.icon_scaling.minScale || val > layer.style.icon_scaling.maxScale || isNaN(val)) return;
-
         layer.style.zoomOutScale = parseFloat(val)
         clearTimeout(layer.style.timeout)
         layer.style.timeout = setTimeout(() => layer.L.changed(), 400)

--- a/lib/ui/elements/layerStyle.mjs
+++ b/lib/ui/elements/layerStyle.mjs
@@ -446,16 +446,18 @@ function icon_scaling(layer) {
 
   if (layer.style.icon_scaling.icon) {
 
-    layer.icon_scaling.maxScale ??= layer.style.default.scale * 3
+    layer.style.default.scale ??= 1;
 
-    layer.icon_scaling.minScale ??= 0.1
+    layer.style.icon_scaling.maxScale ??= layer.style.default.scale * 3
+
+    layer.style.icon_scaling.minScale ??= 0.1
 
     layer.style.icon_scaling.icon_scaling_label ??= mapp.dictionary.icon_scaling_label
 
     content.push(mapp.ui.elements.slider({
       data_id: 'iconScalingSlider',
-      min: layer.icon_scaling.minScale,
-      max: layer.icon_scaling.maxScale,
+      min: layer.style.icon_scaling.minScale,
+      max: layer.style.icon_scaling.maxScale,
       step: layer.style.default.scale / 10,
       label: layer.style.icon_scaling.icon_scaling_label,
       val: layer.style.default.scale,

--- a/lib/ui/elements/layerStyle.mjs
+++ b/lib/ui/elements/layerStyle.mjs
@@ -463,6 +463,7 @@ function icon_scaling(layer) {
       val: layer.style.default.scale,
       callback: val => {
 
+        layer.style.cache = null
         layer.style.default.scale = parseFloat(val)
         clearTimeout(layer.style.timeout)
         layer.style.timeout = setTimeout(() => layer.L.changed(), 400)

--- a/lib/ui/elements/numericInput.mjs
+++ b/lib/ui/elements/numericInput.mjs
@@ -80,11 +80,11 @@ function oninput(e, params) {
     e.target.classList.add('invalid');
   }
 
+  // The invalid input should not be formatted.
+  if (params.invalid) return;  
+
   // Pass valid newValue to callback method.
   params.callback(params.newValue)
-
-  // The invalid input should not be formatted.
-  if (params.invalid) return;
 
   // Re-format the params numeric value (newValue || value) and set as input string value.
   e.target.value = mapp.utils.formatNumericValue(params)

--- a/tests/assets/layers/scratch/layer.json
+++ b/tests/assets/layers/scratch/layer.json
@@ -7,5 +7,9 @@
     "geom": "geom_3857",
     "qID": "id",
     "toggleLocationViewEdits": true,
-    "deleteLocation": true
+    "deleteLocation": true,
+    "icon_scaling": {
+        "icon": {},
+        "clusterScale": {}
+    }
 }

--- a/tests/assets/layers/scratch/style.json
+++ b/tests/assets/layers/scratch/style.json
@@ -7,6 +7,9 @@
                 "type": "dot"
             }
         },
+        "cluster": {
+            "clusterScale": 1
+        },
         "highlight": {
             "scale": 1.3,
             "strokeColor": "#090"


### PR DESCRIPTION
The icon_scaling plugin will be deprecated.

The styleParser method will warn and assign layer.icon_scaling as layer.style.icon_scaling.

The minScale and maxScale defaults will only be assigned if not explicit in config.