### PR TITLE
Remove geometry Layers[] from array

### DIFF
--- a/lib/ui/locations/entries/geometry.mjs
+++ b/lib/ui/locations/entries/geometry.mjs
@@ -199,6 +199,9 @@ async function show() {
 
     // Remove existing layer to prevent assertion error.
     this.location.layer.mapview.Map.removeLayer(this.L)
+
+    this.location.Layers = this.location.Layers.filter(L => L.ol_uid !== this.L.ol_uid)
+
     delete this.L
   }
 

--- a/lib/ui/locations/entries/pin.mjs
+++ b/lib/ui/locations/entries/pin.mjs
@@ -1,3 +1,11 @@
+/**
+## ui/locations/entries/pin
+
+The pin entry module exports the pin method as mapp.ui.locations.entries.pin()
+
+@module /ui/locations/entries/pin
+*/
+
 mapp.utils.merge(mapp.dictionaries, {
   'en': {
     pin: 'Pin',
@@ -35,19 +43,9 @@ mapp.utils.merge(mapp.dictionaries, {
 })
 
 /**
-## ui/locations/entries/pin
-
-The pin entry module exports the pin method as mapp.ui.locations.entries.pin()
-
-@module /ui/locations/entries/pin
-*/
-
-/**
 @function pin
 
 @description
-### mapp.ui.locations.entries.pin()
-
 Places a pin on the selected location on the map. A checkbox is supplied to turn the pin on and off.
 
 @param {infoj-entry} entry type:pin entry.
@@ -58,10 +56,9 @@ Places a pin on the selected location on the map. A checkbox is supplied to turn
 @property {string} [entry.srid] The srid of the pin.
 @property {integer} [entry.zIndex] The html layer on which the pin should display.
 @property {object} [entry.style] Style properties of the pin which may include a scale.
+
 @return {HTMLElement} Location pin and display checkbox.
 */
-
-
 export default function pin(entry) {
 
   if (!Array.isArray(entry.value)) {
@@ -92,9 +89,21 @@ export default function pin(entry) {
 
   entry.Style ??= entry.style ? mapp.utils.style(entry.style) : entry.location.pinStyle
 
+  entry.srid ??= entry.location.layer.srid
+
   entry.geometry = {
     type: 'Point',
     coordinates: entry.value,
+  }
+
+  if (entry.L) {
+
+    // Remove existing layer to prevent assertion error.
+    entry.location.layer.mapview.Map.removeLayer(entry.L)
+
+    entry.location.Layers = entry.location.Layers.filter(L => L.ol_uid !== entry.L.ol_uid)
+
+    delete entry.L
   }
 
   entry.L = entry.location.layer.mapview.geoJSON(entry)

--- a/tests/browser/local.test.mjs
+++ b/tests/browser/local.test.mjs
@@ -61,4 +61,5 @@ await mapviewTest.olControlsTest(mapview);
 await ui_elementsTest.sliderTest();
 await ui_elementsTest.layerStyleTest(mapview);
 await entriesTest.pinTest(mapview);
+await entriesTest.geometryTest(mapview);
 await ui_elementsTest.pillsTest();

--- a/tests/lib/ui/locations/entries/_entires.test.mjs
+++ b/tests/lib/ui/locations/entries/_entires.test.mjs
@@ -1,5 +1,7 @@
 import { pinTest } from './pin.test.mjs';
+import { geometryTest } from './geometry.test.mjs';
 
 export const entriesTest = {
-    pinTest
+    pinTest,
+    geometryTest
 }

--- a/tests/lib/ui/locations/entries/geometry.test.mjs
+++ b/tests/lib/ui/locations/entries/geometry.test.mjs
@@ -1,0 +1,18 @@
+export async function geometryTest(mapview) {
+    await codi.describe('UI Entries: Geometry', async () => {
+
+        const entry = {
+            mapview: mapview,
+            key: 'geometry-test',
+            value: {
+                type: 'Point',
+                coordinates: '0101000020110F000065D98262C7490CC10DF78253F7B75D41',
+            },
+            srid: 3856,
+            display: false
+        }
+
+        const geometryCheckBox = mapp.ui.locations.entries.geometry(entry);
+        codi.assertTrue(!!geometryCheckBox, 'A checkbox needs to be returned');
+    })
+}


### PR DESCRIPTION
I wrongly assumed that an object property deleted will automatically be removed from an array. This is not the case.

Even though the `.L` Openlayers layer properties are deleted in the pin and geometry entry method they still remain in the location.Layers[] array.

Using the ol_uid the array is not filtered before the layer object is deleted.