### PR TITLE
Allow for custom min max query template.

### DIFF
--- a/lib/ui/layers/filters.mjs
+++ b/lib/ui/layers/filters.mjs
@@ -156,11 +156,12 @@ Query the min and max values for a numeric filter field.
 @property {string} filter.field Field to filter.
 @property {numeric} [filter.min] Min bounds.
 @property {numeric} [filter.max] Max bounds.
+@property {string} [filter.minmax_query] Query template for min max values.
 */
 async function generateMinMax(layer, filter) {
 
   const response = await mapp.utils.xhr(`${layer.mapview.host}/api/query?${mapp.utils.paramString({
-    template: `field_minmax`,
+    template: filter.minmax_query || `field_minmax`,
     locale: layer.mapview.locale.key,
     layer: layer.key,
     table: layer.tableCurrent(),

--- a/lib/ui/layers/filters.mjs
+++ b/lib/ui/layers/filters.mjs
@@ -158,7 +158,7 @@ Query the min and max values for a numeric filter field.
 @property {numeric} [filter.max] Max bounds.
 @property {string} [filter.minmax_query] Query template for min max values.
 */
-async function generateMinMax(layer, filter) {
+export async function generateMinMax(layer, filter) {
 
   const response = await mapp.utils.xhr(`${layer.mapview.host}/api/query?${mapp.utils.paramString({
     template: filter.minmax_query || `field_minmax`,
@@ -169,13 +169,13 @@ async function generateMinMax(layer, filter) {
   })}`);
 
   // Assign min, max from response if not a number.
-  const min = isNaN(filter.min) ? response.minmax[0]: filter.min
-  const max = isNaN(filter.max) ? response.minmax[1]: filter.max
+  const min = isNaN(filter.min) ? response.minmax[0] : filter.min
+  const max = isNaN(filter.max) ? response.minmax[1] : filter.max
 
   // Parse min, max as interger or float depending on type.
   // Round integer to be correct up or down.
-  filter.min = filter.type === 'integer'? Math.round(min) : parseFloat(min)
-  filter.max = filter.type === 'integer'? Math.round(max) : parseFloat(max)
+  filter.min = filter.type === 'integer' ? Math.round(min) : parseFloat(min)
+  filter.max = filter.type === 'integer' ? Math.round(max) : parseFloat(max)
 }
 
 /**
@@ -228,7 +228,7 @@ async function filter_numeric(layer, filter) {
     // Return text to indicate that the field contains only one distinct value.
     return mapp.utils.html.node`<div>${mapp.dictionary.identical_values_filter}</div>`
   };
-  
+
   // Only if filter.min and filter.max are not numeric values, return a message.
   if (isNaN(filter.min) || isNaN(filter.max)) {
 
@@ -364,7 +364,7 @@ async function filter_in(layer, filter) {
     return mapp.utils.html.node`<div class="filter">${dropdown}`
   }
 
-  if(filter.searchbox) {
+  if (filter.searchbox) {
 
     const searchbox_filter = mapp.utils.html.node`<div class="filter">`
 
@@ -380,7 +380,7 @@ async function filter_in(layer, filter) {
       },
       removeCallback: (val, pills) => {
 
-        if(pills.size === 0) {
+        if (pills.size === 0) {
           searchbox.input.value = null;
 
           //if nothing left selected delete the entire filter
@@ -395,7 +395,8 @@ async function filter_in(layer, filter) {
         }
 
         applyFilter(layer);
-      }});
+      }
+    });
 
     const searchbox = mapp.ui.elements.searchbox({
       target: searchbox_filter,
@@ -404,7 +405,7 @@ async function filter_in(layer, filter) {
 
         searchbox.list.innerHTML = '';
 
-        if(!e.target.value) return; // nothing to match
+        if (!e.target.value) return; // nothing to match
 
         const pattern = e.target.value;
 

--- a/lib/ui/layers/filters.mjs
+++ b/lib/ui/layers/filters.mjs
@@ -27,8 +27,7 @@ export default {
   date: filter_date,
   datetime: filter_date,
   boolean: filter_boolean,
-  null: filter_null,
-  generateMinMax
+  null: filter_null
 }
 
 mapp.utils.merge(mapp.dictionaries, {
@@ -178,7 +177,6 @@ async function generateMinMax(layer, filter) {
   filter.min = filter.type === 'integer' ? Math.round(min) : parseFloat(min)
   filter.max = filter.type === 'integer' ? Math.round(max) : parseFloat(max)
 
-  return filter;
 }
 
 /**

--- a/lib/ui/layers/filters.mjs
+++ b/lib/ui/layers/filters.mjs
@@ -177,6 +177,8 @@ async function generateMinMax(layer, filter) {
   // Round integer to be correct up or down.
   filter.min = filter.type === 'integer' ? Math.round(min) : parseFloat(min)
   filter.max = filter.type === 'integer' ? Math.round(max) : parseFloat(max)
+
+  return filter;
 }
 
 /**

--- a/lib/ui/layers/filters.mjs
+++ b/lib/ui/layers/filters.mjs
@@ -28,6 +28,7 @@ export default {
   datetime: filter_date,
   boolean: filter_boolean,
   null: filter_null,
+  generateMinMax
 }
 
 mapp.utils.merge(mapp.dictionaries, {
@@ -158,7 +159,7 @@ Query the min and max values for a numeric filter field.
 @property {numeric} [filter.max] Max bounds.
 @property {string} [filter.minmax_query] Query template for min max values.
 */
-export async function generateMinMax(layer, filter) {
+async function generateMinMax(layer, filter) {
 
   const response = await mapp.utils.xhr(`${layer.mapview.host}/api/query?${mapp.utils.paramString({
     template: filter.minmax_query || `field_minmax`,

--- a/tests/assets/queries/minmax_mock.sql
+++ b/tests/assets/queries/minmax_mock.sql
@@ -1,0 +1,4 @@
+
+select array[
+    100, 500 
+] as minmax;

--- a/tests/browser/local.test.mjs
+++ b/tests/browser/local.test.mjs
@@ -5,16 +5,13 @@ import { locationTest } from '../lib/location/_location.test.mjs';
 import { mapviewTest } from '../lib/mapview/_mapview.test.mjs';
 import { pluginsTest } from '../plugins/_plugins.test.mjs';
 import { setView } from '../utils/view.js';
-import { delayFunction } from '../utils/delay.js';
 import { workspaceTest } from '../mod/workspace/_workspace.test.mjs'
 import { queryTest } from '../mod/query.test.mjs';
-import { apiTest } from './_api.test.mjs';
 import { userTest } from '../mod/user/_user.test.js';
 import { ui_elementsTest } from '../lib/ui/elements/_elements.test.mjs';
 
 import { ui_layers } from '../lib/ui/layers/_layers.test.mjs';
 import { entriesTest } from '../lib/ui/locations/entries/_entires.test.mjs';
-// import { booleanTest } from '../lib/ui/locations/entries/boolean.test.mjs';
 
 //API Tests
 await workspaceTest();
@@ -29,40 +26,27 @@ await dictionaryTest.unknownLanguageTest(mapview);
 await dictionaryTest.keyValueDictionaryTest(mapview);
 
 await pluginsTest.linkButtonTest();
+
 setView(mapview, 2, 'default');
 await layerTest.changeEndTest(mapview);
-
 setView(mapview, 2, 'default');
 await layerTest.decorateTest(mapview);
-
 setView(mapview, 2, 'default');
 await layerTest.fadeTest(mapview);
 await layerTest.featureFieldsTest();
-// await layerTest.featureFilterTest();
 await layerTest.featureFormatsTest();
-// await layerTest.featureHoverTest();
-//await layerTest.featureStyleTest(mapview);
 await layerTest.styleParserTest(mapview);
 
-// await locationTest.createTest();
 await locationTest.getTest(mapview);
-// await locationTest.decorateTest();
-// await locationTest.nnearestTest();
 
 await mapviewTest.addLayerTest(mapview);
 await mapviewTest.olControlsTest(mapview);
-// await mapviewTest.addLayerTest();
-// await mapviewTest.allfeaturesTest();
-// await mapviewTest.attributionTest();
-// await mapviewTest.fitViewTest();
-// await mapviewTest.geoJSONTest();
-// await mapviewTest.getBoundsTest();
-// await mapviewTest.infotipTest();
-// await mapviewTest.locateTest();
-// await mapviewTest.popupTest();
+
 await ui_elementsTest.sliderTest();
 await ui_elementsTest.layerStyleTest(mapview);
+
 await entriesTest.pinTest(mapview);
 await entriesTest.geometryTest(mapview);
+
 await ui_elementsTest.pillsTest();
 await ui_layers.filtersTest(mapview);

--- a/tests/browser/local.test.mjs
+++ b/tests/browser/local.test.mjs
@@ -65,4 +65,4 @@ await ui_elementsTest.layerStyleTest(mapview);
 await entriesTest.pinTest(mapview);
 await ui_elementsTest.pillsTest();
 
-// await ui_layers.filtersTest(mapview);
+await ui_layers.filtersTest(mapview);

--- a/tests/browser/local.test.mjs
+++ b/tests/browser/local.test.mjs
@@ -11,6 +11,8 @@ import { queryTest } from '../mod/query.test.mjs';
 import { apiTest } from './_api.test.mjs';
 import { userTest } from '../mod/user/_user.test.js';
 import { ui_elementsTest } from '../lib/ui/elements/_elements.test.mjs';
+
+import { ui_layers } from '../lib/ui/layers/_layers.test.mjs';
 import { entriesTest } from '../lib/ui/locations/entries/_entires.test.mjs';
 // import { booleanTest } from '../lib/ui/locations/entries/boolean.test.mjs';
 
@@ -62,3 +64,5 @@ await ui_elementsTest.sliderTest();
 await ui_elementsTest.layerStyleTest(mapview);
 await entriesTest.pinTest(mapview);
 await ui_elementsTest.pillsTest();
+
+await ui_layers.filtersTest();

--- a/tests/browser/local.test.mjs
+++ b/tests/browser/local.test.mjs
@@ -56,7 +56,6 @@ await mapviewTest.olControlsTest(mapview);
 // await mapviewTest.attributionTest();
 // await mapviewTest.fitViewTest();
 // await mapviewTest.geoJSONTest();
-// await mapviewTest.geometryTest();
 // await mapviewTest.getBoundsTest();
 // await mapviewTest.infotipTest();
 // await mapviewTest.locateTest();

--- a/tests/browser/local.test.mjs
+++ b/tests/browser/local.test.mjs
@@ -65,4 +65,4 @@ await ui_elementsTest.layerStyleTest(mapview);
 await entriesTest.pinTest(mapview);
 await ui_elementsTest.pillsTest();
 
-await ui_layers.filtersTest(mapview);
+// await ui_layers.filtersTest(mapview);

--- a/tests/browser/local.test.mjs
+++ b/tests/browser/local.test.mjs
@@ -65,4 +65,4 @@ await ui_elementsTest.layerStyleTest(mapview);
 await entriesTest.pinTest(mapview);
 await ui_elementsTest.pillsTest();
 
-await ui_layers.filtersTest();
+await ui_layers.filtersTest(mapview);

--- a/tests/lib/ui/layers/_layers.test.mjs
+++ b/tests/lib/ui/layers/_layers.test.mjs
@@ -1,0 +1,5 @@
+import { filtersTest } from './filters.test.mjs';
+
+export const ui_layers = {
+    filtersTest
+}

--- a/tests/lib/ui/layers/filters.test.mjs
+++ b/tests/lib/ui/layers/filters.test.mjs
@@ -1,17 +1,18 @@
 export async function filtersTest(mapview) {
-    codi.describe('UI Layers: Filters test', async () => {
-        codi.it('Should generate correct min/max values', async () => {
+    await codi.describe('UI Layers: Filters test', async () => {
+        await codi.it('Should generate correct min/max values', async () => {
 
             const filter = {
-                field: 'field'
+                field: 'field',
+                minmax_query: 'minmax_query_mock'
             };
 
             const layer = mapview.layers['location_get_test'];
 
-            console.log(layer);
+            const minMax = await mapp.ui.layers.filters.generateMinMax(layer, filter);
 
-            const minMax = mapp.ui.layers.filters.generateMinMax(layer, filter);
-            console.log(minMax)
+            codi.assertEqual(minMax.min, 100, 'The min should return 100');
+            codi.assertEqual(minMax.max, 500, 'The max should return 500');
         });
     });
 }

--- a/tests/lib/ui/layers/filters.test.mjs
+++ b/tests/lib/ui/layers/filters.test.mjs
@@ -9,10 +9,10 @@ export async function filtersTest(mapview) {
 
             const layer = mapview.layers['location_get_test'];
 
-            const minMax = await mapp.ui.layers.filters.generateMinMax(layer, filter);
+            // const minMax = await mapp.ui.layers.filters.generateMinMax(layer, filter);
 
-            codi.assertEqual(minMax.min, 100, 'The min should return 100');
-            codi.assertEqual(minMax.max, 500, 'The max should return 500');
+            // codi.assertEqual(minMax.min, 100, 'The min should return 100');
+            // codi.assertEqual(minMax.max, 500, 'The max should return 500');
         });
     });
 }

--- a/tests/lib/ui/layers/filters.test.mjs
+++ b/tests/lib/ui/layers/filters.test.mjs
@@ -1,0 +1,9 @@
+export async function filtersTest() {
+    codi.desribe('UI Layers: Filters test', async () => {
+        codi.it('Should generate correct min/max values', async () => {
+
+            const minMax = mapp.ui.layers.filters.generateMinMax();
+            console.log(minMax)
+        });
+    });
+}

--- a/tests/lib/ui/layers/filters.test.mjs
+++ b/tests/lib/ui/layers/filters.test.mjs
@@ -1,18 +1,71 @@
+/**
+ * This is the entry point function for the ui/layers/filters test
+ * @function filtersTest 
+ * @param {object} mapview 
+ */
 export async function filtersTest(mapview) {
     await codi.describe('UI Layers: Filters test', async () => {
-        await codi.it('Should generate correct min/max values', async () => {
 
-            const filter = {
-                field: 'field',
-                minmax_query: 'minmax_query_mock'
-            };
+        //Creating the filter to be used in other tests
+        let filter = {
+            field: 'id',
+            minmax_query: 'minmax_query_mock'
+        };
 
-            const layer = mapview.layers['location_get_test'];
+        //Getting a layer
+        const layer = mapview.layers['location_get_test'];
 
-            // const minMax = await mapp.ui.layers.filters.generateMinMax(layer, filter);
+        /**
+        * This function is used to test a custom minmax query
+        * This query is by design returning 100 & 500 as min max
+        * @function it
+        */
+        await codi.it('Numeric Filter: minmax_query test', async () => {
 
-            // codi.assertEqual(minMax.min, 100, 'The min should return 100');
-            // codi.assertEqual(minMax.max, 500, 'The max should return 500');
+            const numericFilter = await mapp.ui.layers.filters.numeric(layer, filter);
+            const minInput = numericFilter.querySelector('div > input[type=range]:nth-child(3)');
+            const maxInput = numericFilter.querySelector('div > input[type=range]:nth-child(4)');
+
+            codi.assertEqual(minInput.value, '100', 'The min should return 100.');
+            codi.assertEqual(maxInput.value, '500', 'The max should return 500');
+        });
+
+        /**
+         * Testing providing an explicit min value on the filter.
+         * @function it
+         */
+        await codi.it('Numeric Filter: min value specified', async () => {
+
+            filter['min'] = 200;
+
+            const numericFilter = await mapp.ui.layers.filters.numeric(layer, filter);
+            const minInput = numericFilter.querySelector('div > input[type=range]:nth-child(3)');
+            const maxInput = numericFilter.querySelector('div > input[type=range]:nth-child(4)');
+
+            codi.assertEqual(minInput.value, '200', 'The min should return 200.');
+            codi.assertEqual(maxInput.value, '500', 'The max should return 500');
+
+            //Delete the min value from the filter
+            delete filter.min;
+
+            //Delte the lte value of the current filter otherwise it will not be changed in the next test
+            delete layer.filter.current[filter.field].lte;
+        });
+
+        /**
+         * Testing providing an explicit max value on the filter.
+         * @function it
+         */
+        await codi.it('Numeric Filter: max value specified', async () => {
+
+            filter['max'] = 1000;
+
+            const numericFilter = await mapp.ui.layers.filters.numeric(layer, filter);
+            const minInput = numericFilter.querySelector('div > input[type=range]:nth-child(3)');
+            const maxInput = numericFilter.querySelector('div > input[type=range]:nth-child(4)');
+
+            codi.assertEqual(minInput.value, '100', 'The min should return 100.');
+            codi.assertEqual(maxInput.value, '1000', 'The max should return 1000');
         });
     });
 }

--- a/tests/lib/ui/layers/filters.test.mjs
+++ b/tests/lib/ui/layers/filters.test.mjs
@@ -1,8 +1,16 @@
-export async function filtersTest() {
-    codi.desribe('UI Layers: Filters test', async () => {
+export async function filtersTest(mapview) {
+    codi.describe('UI Layers: Filters test', async () => {
         codi.it('Should generate correct min/max values', async () => {
 
-            const minMax = mapp.ui.layers.filters.generateMinMax();
+            const filter = {
+                field: 'field'
+            };
+
+            const layer = mapview.layers['location_get_test'];
+
+            console.log(layer);
+
+            const minMax = mapp.ui.layers.filters.generateMinMax(layer, filter);
             console.log(minMax)
         });
     });

--- a/tests/lib/ui/locations/entries/geometry.test.mjs
+++ b/tests/lib/ui/locations/entries/geometry.test.mjs
@@ -1,18 +1,19 @@
 export async function geometryTest(mapview) {
     await codi.describe('UI Entries: Geometry', async () => {
+        await codi.it('Should return geometry checkbox', async () => {
+            const entry = {
+                mapview: mapview,
+                key: 'geometry-test',
+                value: {
+                    type: 'Point',
+                    coordinates: '0101000020110F000065D98262C7490CC10DF78253F7B75D41',
+                },
+                srid: 3856,
+                display: false
+            }
 
-        const entry = {
-            mapview: mapview,
-            key: 'geometry-test',
-            value: {
-                type: 'Point',
-                coordinates: '0101000020110F000065D98262C7490CC10DF78253F7B75D41',
-            },
-            srid: 3856,
-            display: false
-        }
-
-        const geometryCheckBox = mapp.ui.locations.entries.geometry(entry);
-        codi.assertTrue(!!geometryCheckBox, 'A checkbox needs to be returned');
+            const geometryCheckBox = mapp.ui.locations.entries.geometry(entry);
+            codi.assertTrue(!!geometryCheckBox, 'A checkbox needs to be returned');
+        });
     })
 }

--- a/tests/workspace.json
+++ b/tests/workspace.json
@@ -28,6 +28,9 @@
         },
         "get_location_mock": {
             "src": "file:/tests/assets/queries/get_location_mock.sql"
+        },
+        "minmax_query_mock": {
+            "src": "file:/tests/assets/queries/minmax_mock.sql"
         }
     },
     "locale": {


### PR DESCRIPTION
By default the `field_minmax` query module is used to determine the bounds for a filter if not explicit in the filter config.

```js
module.exports = `
  SELECT
    ARRAY[min(\${field}), max(\${field})] as minmax
    FROM \${table}
    WHERE true \${filter};`
```

This PR adds a condition to the `generateMinMax` method which allows to define a custom query template in the workspace and the filter entry.