### PR TITLE
highlight interaction render and getLocation

### DIFF
--- a/lib/hooks.mjs
+++ b/lib/hooks.mjs
@@ -1,5 +1,5 @@
 /**
-## mapp.hooks{}
+## /hooks
 
 The mapp.hooks{} module parses, updates, and stores URL parameter.
 

--- a/lib/hooks.mjs
+++ b/lib/hooks.mjs
@@ -37,12 +37,11 @@ const hooks = {
 export default hooks;
 
 /**
-## mapp.hooks.parse()
-The method parses key/value pairs of URL searchParams from the document window.location.href.
-
 @function parse
-*/
 
+@description
+The method parses key/value pairs of URL searchParams from the document window.location.href.
+*/
 function parse() {
   
   const url = new URL(window.location.href);
@@ -77,15 +76,13 @@ function parse() {
 }
 
 /**
-## mapp.hooks.set()
+@function set
+ 
+@description
 The set method will assign a URL params object to the hooks.current{} before calling the pushState() method.
 
-@function set
-
-@param {Object} _hooks
-A params object to be assigned to the hooks.current.
+@param {Object} _hooks A params object to be assigned to the hooks.current.
 */
-
 function set(_hooks) {
 
   Object.assign(hooks.current, _hooks)
@@ -93,11 +90,19 @@ function set(_hooks) {
   pushState()
 }
 
-// Remove hook from mapp.hooks.current and URI.
+/**
+@function remove
+ 
+@description
+Remove key from mapp.hooks.current and URI. Array properties will be emptied. Other properties will be deleted.
+
+@param {string} key hooks.current{} property key.
+*/
 function remove(key) {
 
   if (Array.isArray(hooks.current[key])) {
 
+    // Empty array.
     hooks.current[key].length = 0
 
   } else {
@@ -108,7 +113,12 @@ function remove(key) {
   pushState()
 }
 
-// Remove all hooks.
+/**
+@function removeAll
+ 
+@description
+Iterate through all hooks.current property keys and call the remove method with the key argument.
+*/
 function removeAll() {
 
   Object.keys(hooks.current).forEach(key => remove(key))
@@ -116,7 +126,15 @@ function removeAll() {
   pushState()
 }
 
-// Push key into an array hook.
+/**
+@function push
+ 
+@description
+Assigns the val param to the hooks.current[key] property.
+
+@param {string} key hooks.current{} property key.
+@param {*} val hooks.current[key] property val.
+*/
 function push(key, val) {
 
   if (hooks.current[key]) {
@@ -131,15 +149,32 @@ function push(key, val) {
   pushState()
 }
 
-// Filter key from an array hook.
+/**
+@function filter
+ 
+@description
+Filter [remove] a value from an hooks.current array property.
+
+This is requiired to strip a location.hook from the [selected] locations.
+
+@param {string} key hooks.current{} array property key.
+@param {*} val hooks.current[key] array property val.
+*/
 function filter(key, val) {
+
+  if (!Array.isArray(hooks.current[key])) return;
 
   hooks.current[key] = hooks.current[key].filter(el => el !== val)
 
   pushState()
 }
 
-// Pushes changes to the url parameter.
+/**
+@function pushState
+ 
+@description
+Pushes changes in the hooks.current to the window URL.
+*/
 function pushState() {
 
   try {

--- a/lib/location/get.mjs
+++ b/lib/location/get.mjs
@@ -4,6 +4,7 @@
 The module exports the location get and getInfoj methods to request location data from the XYZ host.
 
 @requires /location/decorate
+@requires /hooks
 
 @module /location/get
 */
@@ -22,6 +23,8 @@ The layer.key being unique to the locale, and the id being unique to the layer m
 @param {object} list
 @property {layer} location.layer The layer to which the location belongs.
 @property {string} location.id The ID must be unique for the layer dataset.
+@property {mapview} layer.mapview
+@property {boolean} mapview.hooks Hooks are enabled for the location.layer.mapview.
 @returns {Promise<object>} Decorated location
 */
 export async function get(location, list = location.layer.mapview.locations) {
@@ -38,12 +41,6 @@ export async function get(location, list = location.layer.mapview.locations) {
   // Create location hook.
   location.hook ??= `${location.layer.key}!${location.id}`;
 
-  // Return if hook exists in mapview.interaction.locations set.
-  if (location.layer.mapview.interaction?.locations?.has(location.hook)) return;
-
-  // Add hook to mapview.interaction.locations set.
-  location.layer.mapview.interaction?.locations?.add(location.hook)
-
   // Remove location if already in list.
   if (list[location.hook]) {
     list[location.hook].remove()
@@ -54,7 +51,8 @@ export async function get(location, list = location.layer.mapview.locations) {
     return;
   }
 
-  location.locale = location.layer.mapview.locale.key
+  // Assign locale key to location
+  location.locale ??= location.layer.mapview.locale.key
 
   await getInfoj(location)
 
@@ -63,17 +61,11 @@ export async function get(location, list = location.layer.mapview.locations) {
   // Assign location to mapview.
   list[location.hook] = location
 
-  // Remove hook to mapview.interaction.locations set.
-  location.layer.mapview.interaction?.locations?.delete(location.hook)
-
-  // A location must have a record from a listview.
-  location.record
-
-    // Hooks must be enabled on the mapview.
-    && location.layer.mapview.hooks
-
-    // Push location hook to URL params.
-    && mapp.hooks.push('locations', location.hook)
+  // Hooks are enabled for the mapview
+  if (location.layer.mapview.hooks) {
+    
+    mapp.hooks.push('locations', location.hook)
+  }
 
   return location
 }

--- a/lib/location/get.mjs
+++ b/lib/location/get.mjs
@@ -1,18 +1,28 @@
 /**
-## mapp.location.get()
-@module /location/get
+## /location/get
 
-@param {Object} location
-A location object to be decorated.
+The module exports the location get and getInfoj methods to request location data from the XYZ host.
+
+@requires /location/decorate
+
+@module /location/get
+*/
+
+/**
+@function get
+
+@description
+The get method assigns a unique location.hook composed from the location.layer.key and the location.id.
+
+The layer.key being unique to the locale, and the id being unique to the layer makes the location.hook unique to the mapview.
+
+@param {object} location
+@param {object} list
+@property {layer} location.layer The layer to which the location belongs.
+@property {string} location.id The ID must be unique for the layer dataset.
+@returns {Promise<object>} Decorated location
 */
 export async function get(location, list = location.layer.mapview.locations) {
-
-  // A getLocation function has been set for the current mapview.interaction.
-  if (location.layer.mapview.interaction?.getLocation instanceof Function) {
-
-    location.layer.mapview.interaction?.getLocation(location)
-    return;
-  }
 
   if (!location.layer || !location.id) return;
 

--- a/lib/location/get.mjs
+++ b/lib/location/get.mjs
@@ -48,7 +48,7 @@ export async function get(location, list = location.layer.mapview.locations) {
 
   location.hook ??= `${location.layer.key}!${location.id}`;
 
-  if (Object.hasOwn(list, location.hook)) {
+  if (list[location.hook]) {
 
     // Remove location if already in list.
     list[location.hook].remove()
@@ -56,15 +56,15 @@ export async function get(location, list = location.layer.mapview.locations) {
     return;
   }
 
-  // Assign location to mapview.
-  list[location.hook] = location
-
   // Assign locale key to location
   location.locale ??= mapview.locale.key
 
   await getInfoj(location)
 
   mapp.location.decorate(location)
+
+  // Assign location to mapview.
+  list[location.hook] = location
 
   // Hooks are enabled for the mapview
   if (mapview.hooks) {

--- a/lib/location/get.mjs
+++ b/lib/location/get.mjs
@@ -12,6 +12,8 @@ The module exports the location get and getInfoj methods to request location dat
 @function get
 
 @description
+The method will shortcircuit if a default getLocation method has been assigned to the interaction.
+
 The get method assigns a unique location.hook composed from the location.layer.key and the location.id.
 
 The layer.key being unique to the locale, and the id being unique to the layer makes the location.hook unique to the mapview.
@@ -24,10 +26,17 @@ The layer.key being unique to the locale, and the id being unique to the layer m
 */
 export async function get(location, list = location.layer.mapview.locations) {
 
+  // A getLocation function has been assigned to the current mapview.interaction.
+  if (location.layer.mapview.interaction?.getLocation instanceof Function) {
+
+    location.layer.mapview.interaction?.getLocation(location)
+    return;
+  }
+
   if (!location.layer || !location.id) return;
 
   // Create location hook.
-  location.hook = `${location.layer.key}!${location.id}`;
+  location.hook ??= `${location.layer.key}!${location.id}`;
 
   // Return if hook exists in mapview.interaction.locations set.
   if (location.layer.mapview.interaction?.locations?.has(location.hook)) return;

--- a/lib/location/get.mjs
+++ b/lib/location/get.mjs
@@ -5,6 +5,7 @@ The module exports the location get and getInfoj methods to request location dat
 
 @requires /location/decorate
 @requires /hooks
+@requires /utils/xhr
 
 @module /location/get
 */
@@ -13,56 +14,60 @@ The module exports the location get and getInfoj methods to request location dat
 @function get
 
 @description
-The method will shortcircuit if a default getLocation method has been assigned to the interaction.
+The method will shortcircuit if a default getLocation method has been assigned to the [highlight] interaction.
 
 The get method assigns a unique location.hook composed from the location.layer.key and the location.id.
 
 The layer.key being unique to the locale, and the id being unique to the layer makes the location.hook unique to the mapview.
 
+A location will be removed from the list object param if the location already exists in the list. Otherwise the location will be assigned as a property to the list object.
+
+The getInfoj() method is awaited before the location is decorated.
+
 @param {object} location
-@param {object} list
+@param {object} list Object in which locations are stored as properties.
 @property {layer} location.layer The layer to which the location belongs.
 @property {string} location.id The ID must be unique for the layer dataset.
-@property {mapview} layer.mapview
+@property {mapview} layer.mapview 
+@property {object} mapview.interaction The current [highlight] interaction.
 @property {boolean} mapview.hooks Hooks are enabled for the location.layer.mapview.
 @returns {Promise<object>} Decorated location
 */
 export async function get(location, list = location.layer.mapview.locations) {
 
-  // A getLocation function has been assigned to the current mapview.interaction.
-  if (location.layer.mapview.interaction?.getLocation instanceof Function) {
+  const mapview = location.layer.mapview;
 
-    location.layer.mapview.interaction?.getLocation(location)
+  // A getLocation function has been assigned to the current mapview.interaction.
+  if (mapview.interaction?.getLocation instanceof Function) {
+
+    mapview.interaction?.getLocation(location)
     return;
   }
 
   if (!location.layer || !location.id) return;
 
-  // Create location hook.
   location.hook ??= `${location.layer.key}!${location.id}`;
 
-  // Remove location if already in list.
-  if (list[location.hook]) {
+  if (Object.hasOwn(list, location.hook)) {
+
+    // Remove location if already in list.
     list[location.hook].remove()
     delete list[location.hook]
-
-    // Remove hook to mapview.interaction.locations set.
-    location.layer.mapview.interaction?.locations?.delete(location.hook)
     return;
   }
 
+  // Assign location to mapview.
+  list[location.hook] = location
+
   // Assign locale key to location
-  location.locale ??= location.layer.mapview.locale.key
+  location.locale ??= mapview.locale.key
 
   await getInfoj(location)
 
   mapp.location.decorate(location)
 
-  // Assign location to mapview.
-  list[location.hook] = location
-
   // Hooks are enabled for the mapview
-  if (location.layer.mapview.hooks) {
+  if (mapview.hooks) {
     
     mapp.hooks.push('locations', location.hook)
   }
@@ -70,6 +75,22 @@ export async function get(location, list = location.layer.mapview.locations) {
   return location
 }
 
+/**
+@function getInfoj
+
+@description
+The method sends a parameterised query to the location.getTemplate query template.
+
+The response is expected to be an object, not an array.
+
+The response properties are mapped into clones of the layer.infoj which will be assigned to the location.
+
+@param {object} location
+@property {layer} location.layer The layer to which the location belongs.
+@property {layer} [location.getTemplate='location_get'] The query template for the location data.
+
+@returns {Promise<object>} The populated location.infoj entries array.
+*/
 export async function getInfoj(location) {
 
   if (!location.layer) {
@@ -104,6 +125,7 @@ export async function getInfoj(location) {
     console.warn('No data returned from location_get request using ID:', location.id)
     return
   }
+
   // Check if the response is an array.
   else if (Array.isArray(response)) {
     console.warn(`Location response returned more than one record for Layer: ${location.layer.key}.`)

--- a/lib/location/get.mjs
+++ b/lib/location/get.mjs
@@ -33,6 +33,7 @@ The getInfoj() method is awaited before the location is decorated.
 @property {boolean} mapview.hooks Hooks are enabled for the location.layer.mapview.
 @returns {Promise<object>} Decorated location
 */
+const locations = new Set()
 export async function get(location, list = location.layer.mapview.locations) {
 
   const mapview = location.layer.mapview;
@@ -56,12 +57,19 @@ export async function get(location, list = location.layer.mapview.locations) {
     return;
   }
 
+  // Prevent location from being requested again while not yet decorated.
+  if (locations.has(location.hook)) return;
+  locations.add(location.hook)
+
   // Assign locale key to location
   location.locale ??= mapview.locale.key
 
   await getInfoj(location)
 
   mapp.location.decorate(location)
+
+  // Location will be removed if requested again as decorated.
+  locations.delete(location.hook)
 
   // Assign location to mapview.
   list[location.hook] = location

--- a/lib/location/nnearest.mjs
+++ b/lib/location/nnearest.mjs
@@ -1,20 +1,39 @@
 /**
-## mapp.location.nnearest()
-@module /location/nnearest
+## /location/nnearest
 
-@param {Object} params
+The module exports a utility method for the nnearest query template.
+
+@requires /utils/xhr
+@module /location/nnearest
 */
 
-export default async function (params) {
+/**
+@function nnearest
 
-  let
-    properties = params.feature.getProperties(),
-    geom = params.feature.getGeometry(),
-    _coords = geom.getCoordinates(),
-    coords = ol.proj.transform(
-      _coords,
-      'EPSG:' + params.mapview.srid,
-      'EPSG:' + params.layer.srid)
+@description
+The nnearest method gets coordinates from a feature geometry passed in the params argument.
+
+A parameterised query to the get_nnearest template will be sent. The n for the nearest records query param is implied by the count property value of a cluster feature.
+
+The records returned from the query are presented in a list popup positioned on the feature geometry.
+
+Clicking on a list element allows to get the location associated with the query response record.
+
+@param {object} params Parameter for the nnearest location query.
+@property {mapview} params.mapview The mapview for locations layer.
+@property {layer} params.later The locations layer.
+@property {object} params.feature Query records nnearest to the feature.geometry.
+@property {string} params.table The database table for the query.
+*/
+export default async function nnearest(params) {
+
+  const properties = params.feature.getProperties();
+
+  const fGeom = params.feature.getGeometry();
+  const fCoord = fGeom.getCoordinates();
+  const coords = ol.proj.transform(fCoord,
+    `EPSG:${params.mapview.srid}`,
+    `EPSG:${params.layer.srid}`)
 
   const response = await mapp.utils.xhr(
     `${params.mapview.host}/api/query/get_nnearest?` +
@@ -33,22 +52,22 @@ export default async function (params) {
     })
   );
 
-  const list = mapp.utils.html.node`
-    <div style="max-width: 66vw; max-height: 300px; overflow-x: hidden;">
-      <ul>${response.map(
-        li => mapp.utils.html.node`<li 
-        onclick=${e => {
-          params.mapview.popup(null)
-          mapp.location.get({
-            layer: params.layer,
-            table: params.table,
-            id: li.id,
-            marker: ol.proj.transform(
-              li.coords,
-              'EPSG:' + params.layer.srid,
-              'EPSG:' + params.mapview.srid),
-          })
-        }}>${li.label || '"' + params.layer.cluster?.label + '"'}`)}`;
+  const list = response.map(
+    li => mapp.utils.html.node`<li 
+    onclick=${e => {
+    params.mapview.popup(null)
+    mapp.location.get({
+      layer: params.layer,
+      table: params.table,
+      id: li.id,
+      marker: ol.proj.transform(
+        li.coords,
+        'EPSG:' + params.layer.srid,
+        'EPSG:' + params.mapview.srid),
+      })
+    }}>${li.label || '"' + params.layer.cluster?.label + '"'}`)
+
+  const content = mapp.utils.html.node`<ul class="list">${list}`;
 
   params.mapview.popup({
     coords: ol.proj.transform(
@@ -56,8 +75,7 @@ export default async function (params) {
       'EPSG:' + params.layer.srid,
       'EPSG:' + params.mapview.srid
     ),
-    content: list,
     autoPan: true,
+    content,
   });
-
 }

--- a/lib/location/nnearest.mjs
+++ b/lib/location/nnearest.mjs
@@ -18,39 +18,37 @@ export default async function (params) {
 
   const response = await mapp.utils.xhr(
     `${params.mapview.host}/api/query/get_nnearest?` +
-      mapp.utils.paramString({
-        locale: params.mapview.locale.key,
-        layer: params.layer.key,
-        geom: params.layer.geom,
-        qID: params.layer.qID,
-        label: params.layer.cluster?.label || params.layer.qID,
-        table: params.table,
-        filter: params.layer.filter?.current,
-        n: properties.count > (params.max || 99) ? (params.max || 99) : properties.count,
-        x: coords[0],
-        y: coords[1],
-        coords: coords,
-      })
+    mapp.utils.paramString({
+      locale: params.mapview.locale.key,
+      layer: params.layer.key,
+      geom: params.layer.geom,
+      qID: params.layer.qID,
+      label: params.layer.cluster?.label || params.layer.qID,
+      table: params.table,
+      filter: params.layer.filter?.current,
+      n: properties.count > (params.max || 99) ? (params.max || 99) : properties.count,
+      x: coords[0],
+      y: coords[1],
+      coords: coords,
+    })
   );
 
   const list = mapp.utils.html.node`
     <div style="max-width: 66vw; max-height: 300px; overflow-x: hidden;">
-      <ul>
-      ${response.map(li => mapp.utils.html.node`
-        <li
-          onclick=${e => {
-            params.mapview.popup(null)
-            mapp.location.get({
-              //mapview: params.mapview,
-              layer: params.layer,
-              table: params.table,
-              id: li.id,
-              marker: ol.proj.transform(
-                li.coords,
-                'EPSG:' + params.layer.srid,
-                'EPSG:' + params.mapview.srid),
-            })
-          }}>${li.label || '"' + params.layer.cluster?.label + '"'}`)}`;
+      <ul>${response.map(
+        li => mapp.utils.html.node`<li 
+        onclick=${e => {
+          params.mapview.popup(null)
+          mapp.location.get({
+            layer: params.layer,
+            table: params.table,
+            id: li.id,
+            marker: ol.proj.transform(
+              li.coords,
+              'EPSG:' + params.layer.srid,
+              'EPSG:' + params.mapview.srid),
+          })
+        }}>${li.label || '"' + params.layer.cluster?.label + '"'}`)}`;
 
   params.mapview.popup({
     coords: ol.proj.transform(

--- a/lib/mapview/allFeatures.mjs
+++ b/lib/mapview/allFeatures.mjs
@@ -1,48 +1,63 @@
 /**
-## Mapview.allFeatures()
+## /mapview/allFeatures
+
+The allFeatures method exported from the module is assigned to a mapview in the [mapview decorator]{@link module:/mapview~decorate}
 
 @module /mapview/allFeatures
 */
 
-export default function (e, mapview) {
+/**
+@function allFeatures
 
-    // Remove popup from mapview.
-    mapview.popup(null)
+@description
+The allFeatures method checks for all features at a pixel location with the [highlight] interaction.layerFilter and interaction.hitTolerance as options.
 
-    const features = [];
+A list element is created for each feature with the element click event passing the feature as argument to the interaction getFeature method.
 
-    // Find locations at pixel.
-    mapview.Map.forEachFeatureAtPixel(e.pixel,
-        (F, L) => {
+@param {object} e The click event.
+@param {mapview} mapview The mapview from which the click [Map] event originates.
+@property {Object} e.pixel The pixel object for the click event pointer location.
+*/
+export default function allFeatures(e, mapview) {
 
-            const feature = {
-                F, L,
-                layer: mapview.layers[L.get('key')],
-                id: F.get('id') || F.getId()
-            }
+  // Remove popup from mapview.
+  mapview.popup(null)
 
-            features.push(feature)
-        },
-        {
-            layerFilter: mapview.interaction.layerFilter,
-            hitTolerance: mapview.interaction.hitTolerance,
-        })
+  const features = [];
 
-    // No features at pixel.
-    if (!features.length) return;
+  const callback = (F, L) => {
 
-    const content = mapp.utils.html.node`
-      <div style="max-width: 66vw; max-height: 300px; overflow-x: hidden;">
-        <ul>
-        ${features.map(feature => mapp.utils.html.node`
-          <li onclick=${e => {
-            mapview.interaction.getFeature(feature)
-            mapview.popup(null)
-        }}
-        }}>${feature.L.get('key')} [${feature.id}]`)}`;
+    const feature = {
+      F, L,
+      layer: mapview.layers[L.get('key')],
+      id: F.get('id') || F.getId()
+    }
 
-    mapview.popup({
-        content,
-        autoPan: true,
-    });
+    features.push(feature)
+  }
+
+  const options = {
+    layerFilter: mapview.interaction.layerFilter,
+    hitTolerance: mapview.interaction.hitTolerance,
+  }
+
+  // Find features at pixel.
+  mapview.Map.forEachFeatureAtPixel(e.pixel, callback, options)
+
+  // No features at pixel.
+  if (!features.length) return;
+
+  const list = features.map(feature => mapp.utils.html`
+    <li onclick=${e => {
+      mapview.interaction.getFeature(feature)
+      mapview.popup(null)
+    }}>${feature.L.get('key')} [${feature.id}]`)
+
+  const content = mapp.utils.html.node`<div 
+    style="max-width: 66vw; max-height: 300px; overflow-x: hidden;"><ul>${list}`;
+
+  mapview.popup({
+    content,
+    autoPan: true,
+  });
 }

--- a/lib/mapview/allFeatures.mjs
+++ b/lib/mapview/allFeatures.mjs
@@ -53,8 +53,7 @@ export default function allFeatures(e, mapview) {
       mapview.popup(null)
     }}>${feature.L.get('key')} [${feature.id}]`)
 
-  const content = mapp.utils.html.node`<div 
-    style="max-width: 66vw; max-height: 300px; overflow-x: hidden;"><ul>${list}`;
+  const content = mapp.utils.html.node`<ul class="list">${list}`;
 
   mapview.popup({
     content,

--- a/lib/mapview/interactions/highlight.mjs
+++ b/lib/mapview/interactions/highlight.mjs
@@ -26,6 +26,8 @@ export default function (params) {
 
     getFeature,
 
+    getLocation: mapp.location.get,
+
     hitTolerance: 5,
 
     candidates: {},
@@ -321,12 +323,12 @@ export default function (params) {
           ${featuresList.map(li => mapp.utils.html.node`
             <li
               onclick=${e => {
-            mapview.popup(null)
-            mapp.location.get({
-              layer: feature.layer,
-              table: feature.layer.table || feature.layer.tableCurrent(),
-              id: li.id
-            })
+              mapview.popup(null)
+              mapview.interaction.getLocation({
+                layer: feature.layer,
+                table: feature.layer.table || feature.layer.tableCurrent(),
+                id: li.id
+              })
           }}>${li.label || li.id}`)}`;
 
         // Create popup to select cluster features.
@@ -349,7 +351,7 @@ export default function (params) {
     }
 
     // Select the current highlight feature.
-    mapp.location.get({
+    mapview.interaction.getLocation({
       layer: feature.layer,
       table: feature.layer.table || feature.layer.tableCurrent(),
       id: feature.id

--- a/lib/mapview/interactions/highlight.mjs
+++ b/lib/mapview/interactions/highlight.mjs
@@ -16,9 +16,11 @@ The module exports the highlight interaction method which is bound to a mapview 
 @property {Function} longClickMethod Defaults to [mapview.allFeatures()]{@link module:/mapview/allFeatures}
 @property {Number} longClickTimeout Timeout for the execution of the longClickMethod.
 @property {Integer} longClickMS Milliseconds for longClickTimeout. Defaults to 500ms.
+@property {Boolean} longClick Execute longClick method.
 @property {Number} hitTolerance Pixel distance for detection of features on pixel. Defaults to 5pixel.
 @property {Set} candidateKeys A set of candidate features under the cursor.
 @property {Object} current The current highlighted feature.
+@property {Boolean} clicked The click method was recently called.
 */
 
 /**
@@ -50,10 +52,6 @@ export default function highlight(params) {
     type: 'highlight',
 
     finish,
-
-    clear,
-
-    highlight,
 
     getFeature,
 
@@ -169,11 +167,19 @@ export default function highlight(params) {
 
   The method will shortcircuit if the are no candidates or the highlight stays the same.
 
-  Otherwise a candidate is chosen which is not in the interaction.candidateKeys set.
+  Otherwise a feature is chosen which is not in the interaction.candidateKeys set.
 
-  The method will shortcircuit if the chosen candidate key is the same as the interaction.current [feature] key.
+  The method will shortcircuit if the chosen feature key is the same as the interaction.current [feature] key.
 
-  Otherwise the candidate is passed as feature argument with the event object to the highlight() method.
+  Otherwise the clear method is called and the feature is assigned as the interaction.current thereafter.
+
+  The pointerMove method will be called from a touch click event in order to select features on a touch screen. However there is no cursor and the highlight style should not be applied nor should the hover method be called. The pointerMove method will shortcircuit if called with a touch event.
+
+  Otherwise the cursor will check to a pointer if selection is possible.
+
+  The feature will be passed as argument to a feature.layer.hover method.
+
+  Finally the layerRender() method will be called.
 
   @param {Object} e The pointerMove event.
   @property {Object} e.pixel The pixel object for the current pointer location.
@@ -219,8 +225,8 @@ export default function highlight(params) {
       return;
     }
 
-    // Find candidate from key which is not in candidates set.
-    const candidate = candidates[Object.keys(candidates).find(key => !mapview.interaction.candidateKeys.has(key))]
+    // Find feature from key which is not in candidates set.
+    const feature = candidates[Object.keys(candidates).find(key => !mapview.interaction.candidateKeys.has(key))]
 
       // Or assign candidate from first key
       || mapview.interaction.current?.key && candidates[mapview.interaction.current?.key]
@@ -229,59 +235,77 @@ export default function highlight(params) {
     // Assign new Set of candidate keys to mapview.interaction.
     mapview.interaction.candidateKeys = new Set(Object.keys(candidates))
 
-    // Don't highlight the highlighted candidate.
-    if (mapview.interaction.current?.key === candidate.key) return;
+    // Return if feature is current.
+    if (mapview.interaction.current?.key === feature.key) return;
 
-    // Call highlight method.
-    mapview.interaction.highlight(candidate, e)
-  }
-
-  function highlight(feature, e) {
-
-    // Clear curent highlight before assigning new.
+    // Clear highlight before assigning feature.
     clear()
 
-    // Assign the layer and ID to the candidate object.
-    mapview.interaction.current = Object.assign(feature, {
-      layer: mapview.layers[feature.L.get('key')],
-      id: feature.F.get('id') || feature.F.getId()
-    })
+    // Assign feature.layer from mapview.layer
+    feature.layer = mapview.layers[feature.L.get('key')]
 
-    // Assign the id to the layer highlight key.
-    // Required to determine in the style function whether the current feature should be styled as highlighted.
-    mapview.interaction.current.layer.highlight = feature.id
+    // Assign feature.id from id property or getId method.
+    feature.id = feature.F.get('id') || feature.F.getId()
 
-    // Touch events should not highlight features since there is no cursor.
+    // Required for featureStyle() styling of highlight feature.
+    feature.layer.highlight = feature.id
+
+    // Assign feature as current.
+    mapview.interaction.current = feature
+
     if (e.originalEvent.pointerType !== 'mouse') {
 
-      // Don't get location from touch pan or zoom pinch event.
-      e.type !== 'pointermove' && mapview.interaction.getFeature(mapview.interaction.current)
+      console.log(e.originalEvent)
 
-      // Clear touch highlight.
+      // The pointMove() method maybe called from touch/click event.
+      e.type !== 'pointermove' && mapview.interaction.getFeature(feature)
+
+      // Touch events should not highlight style features or call hover method since there is no cursor.
       clear()
       return;
     }
 
-    // Change cursor if the highlight is selectable.
-    if (mapview.interaction.current.layer.infoj) mapview.Map.getTargetElement().style.cursor = 'pointer'
+    if (feature.layer.infoj) {
 
-    // Execute hover method assigned to the current feature layer.
-    typeof mapview.interaction.current.layer.style?.hover?.method === 'function'
-      && mapview.interaction.current.layer.style.hover.method(feature.F, mapview.interaction.current.layer)
+      // Change cursor if the highlight is selectable.
+      mapview.Map.getTargetElement().style.cursor = 'pointer'
+    }
+
+    if (typeof feature.layer.style?.hover?.method === 'function') {
+
+      // Execute hover method assigned to the current feature layer.
+      feature.layer.style.hover.method(feature.F, feature.layer)
+    }
 
     layerRender()
   }
 
-  // Select the current highlighted feature.
+  /**
+  @function click
+
+  @description
+  The click() method is assigned to the mapview.Map element click event listener.
+
+  The method will reset the cursor and check for execution of the interaction.longClickMethod.
+
+  The method is debounced to 600ms with interaction.clicked flag.
+
+  The pointerMove method will be called with the click event [location] to get a feature without a cursor.
+
+  The interaction.noLocationClick method will be called if no current location is available.
+
+  Otherwise the interaction.current feature is passed to the interaction.getFeature method.
+
+  @param {Object} e The calling event.
+  */
   function click(e) {
 
     // Reset cursor.
     mapview.Map.getTargetElement().style.cursor = 'auto'
 
-    // Clear longClick timeout.
-    mapview.interaction.longClickTimeout && clearTimeout(mapview.interaction.longClickTimeout)
+    clearTimeout(mapview.interaction.longClickTimeout)
 
-    if (mapview.interaction.longClick && typeof mapview.interaction.longClickMethod === 'function') {
+    if (mapview.interaction.longClick) {
 
       mapview.interaction.longClickMethod(e, mapview)
       return;
@@ -306,17 +330,15 @@ export default function highlight(params) {
 
     // Remove any existing popup. e.g. Cluster select dialogue.
     mapview.popup(null)
+    
+    if (!mapview.interaction.current && typeof mapview.interaction.noLocationClick === 'function') {
 
-    // Return if there is no current highlight to select.
-    if (mapview.interaction.current) {
-      mapview.interaction.getFeature(mapview.interaction.current);
+      // Execute the noLocationClick method
+      mapview.interaction.noLocationClick(e)
       return;
     }
 
-    // Execute the noLocationClick method
-    if (typeof mapview.interaction.noLocationClick === 'function') {
-      mapview.interaction.noLocationClick(e)
-    }
+    mapview.interaction.getFeature(mapview.interaction.current);
   }
 
   /**
@@ -350,6 +372,20 @@ export default function highlight(params) {
     delete mapview.interaction.current
   }
 
+  /**
+  @function getFeature
+
+  @description
+  The getFeature method deals with cluster features.
+
+  A dialog to select a cluster feature will be presented.
+
+  The interaction.getFeature method can be overwritten in the params passed to the highlight interaction.
+
+  The nnearest method is called for cluster features which are not created from a vector source.
+
+  @param {Object} feature The feature to get.
+  */
   function getFeature(feature) {
 
     // Get the properties of the current highlight feature.
@@ -438,7 +474,16 @@ export default function highlight(params) {
     }
   }
 
-  // Finished the highlight mapview.interaction.
+  /**
+  @function finish
+
+  @description
+  The [highlight] interaction will be cleared.
+  
+  Any popup will be removed from mapview.
+
+  Event listener will be removed the mapview.Map element.
+  */
   function finish() {
 
     // Clear must be called before interaction is nulled.

--- a/lib/mapview/interactions/highlight.mjs
+++ b/lib/mapview/interactions/highlight.mjs
@@ -4,19 +4,38 @@
 The module exports the highlight interaction method which is bound to a mapview in the [decorator]{@link module:/mapview~decorate} method.
 
 @requires /location/get
+@requires /mapview/allFeatures
 
 @module /mapview/interactions/highlight
+*/
+
+/**
+@typedef {Object} interaction The highlight interaction object.
+@property {Function} getFeature Method to return a feature from the highlight or click event methods.
+@property {Function} longClickMethod Defaults to [mapview.allFeatures()]{@link module:/mapview/allFeatures}
+@property {Number} longClickTimeout Timeout for the execution of the longClickMethod.
+@property {Integer} longClickMS Milliseconds for longClickTimeout. Defaults to 500ms.
+@property {Number} hitTolerance Pixel distance for detection of features on pixel. Defaults to 5pixel.
+@property {Set} candidateKeys A set of candidate features under the cursor.
+@property {Object} current The current highlighted feature.
 */
 
 /**
 @function highlight
 
 @description
-The location decorator method creates mapp-location typedef object from a JSON location.
+The highlight interaction method is bound to a mapview object [this].
+
+The highlight interaction method will call the finish() method of the mapview.interaction before assigning a highlight interaction object as mapview.interaction.
+
+The configuration params are spread into the interaction configuration overriding any of the defaults.
+
+The highlight interaction works by assigning mousedown, touchstart, mouseup, and mouseleave events to the mapview.Map object.
+
+The optional getLocation function property will be executed the [mapp.location.get()]{@link module:/location/get~get} method.
 
 @param {object} params The params object is spread into the interaction defaults.
-@property {Function} [params.getFeature] Overrides getFeature method.
-@property {Function} [params.getLocation = mapp.location.get] Overrides [location.get]{@link module:/location/get~get} method.
+@property {Function} [getLocation] Will be executed after the getFeature method.
 */
 export default function highlight(params) {
 
@@ -36,8 +55,6 @@ export default function highlight(params) {
     highlight,
 
     getFeature,
-
-    getLocation: mapp.location.get,
 
     hitTolerance: 5,
 
@@ -73,6 +90,14 @@ export default function highlight(params) {
 
   mapview.Map.getTargetElement().addEventListener('mouseleave', mouseleave)
 
+  /**
+  @function mouseleave
+
+  @description
+  The mouseleave event method will be triggered when the cursor leaves the mapview.Map element.
+
+  The method will empty the interaction.candidateKeys set and call the clear method.
+  */
   function mouseleave() {
 
     // Reset candidateKeys Set
@@ -80,62 +105,105 @@ export default function highlight(params) {
     clear()
   }
 
-  // Prevent mouseDown event on touch input.
+  /**
+  @function touchStart
+
+  @description
+  The touchStart event prevents the mouseDown event on touch input.
+  */
   function touchStart(e) {
     e.preventDefault()
   }
 
+  /**
+  @function mouseDown
+
+  @description
+  The mouseDown event method enables the longClickMethod.
+
+  The cursor is set to wait after the longClickTimeout event.
+
+  The longClickTimeout is cleared in the pointerMove and click event methods.
+  */
   function mouseDown() {
 
     // Short circuit the mouseDown event method if the longClickMethod is falsy.
     if (!mapview.interaction.longClickMethod) return;
 
-    // Remove longClick flag.
     delete mapview.interaction.longClick
 
-    // Clear longClick timeout.
     mapview.interaction.longClickTimeout && clearTimeout(mapview.interaction.longClickTimeout)
 
-    // Set longClick timeout.
-    mapview.interaction.longClickTimeout = setTimeout(
-
-      // Set longClick flag.
-      () => {
-        mapview.interaction.longClick = true
-        mapview.Map.getTargetElement().style.cursor = 'wait'
-      },
-
-      // 1000ms default timeout for longclick.
-      mapview.interaction.longClickMS)
+    mapview.interaction.longClickTimeout = setTimeout(() => {
+      mapview.interaction.longClick = true
+      mapview.Map.getTargetElement().style.cursor = 'wait'
+    }, mapview.interaction.longClickMS)
   }
 
+  /**
+  @function mouseUp
+
+  @description
+  The mouseUp event method reset the cursor to auto.
+  */
   function mouseUp() {
     mapview.Map.getTargetElement().style.cursor = 'auto'
   }
 
+  /**
+  @function pointerMove
+
+  @description
+  The pointerMove event method will clear the interaction.longClickTimeout number before assigning each feature intersecting with the event [pixel] location.
+
+  Each feature is stored in the candidates object in the forEachFeatureAtPixel callback method.
+
+  The interaction.layerFilter method is assigned as an option to filter feature from relevant feature layer.
+
+  A candidate object consists of a key, the Openlayers layer object L, and the feature object F itself.
+
+  The method checks whether a Set candidates objects keys is different from the interaction.candidateKeys set to determine whether the highlight feature has changed.
+
+  The interaction.candidateKeys set will be cleared and the clear method is called if there are no candidate features.
+
+  The method will shortcircuit if the are no candidates or the highlight stays the same.
+
+  Otherwise a candidate is chosen which is not in the interaction.candidateKeys set.
+
+  The method will shortcircuit if the chosen candidate key is the same as the interaction.current [feature] key.
+
+  Otherwise the candidate is passed as feature argument with the event object to the highlight() method.
+
+  @param {Object} e The pointerMove event.
+  @property {Object} e.pixel The pixel object for the current pointer location.
+  */
   function pointerMove(e) {
 
     // Clear longClick timeout.
     mapview.interaction.longClickTimeout && clearTimeout(mapview.interaction.longClickTimeout)
 
-    let candidates = {};
+    const candidates = {};
 
-    mapview.Map.forEachFeatureAtPixel(e.pixel,
-      (F, L) => {
+    const callback = (F, L) => {
 
-        // Create candidate object.
-        let candidate = {
-          key: `${L.get('key') || ol.util.getUid(L)}!${F.get('id') || F.getId() || ol.util.getUid(F)}`,
-          F, L
-        }
+      // get layerKey from key property or ol object L Uid.
+      const layerKey = L.get('key') || ol.util.getUid(L)
 
-        // Assign to key in candidates object.
-        candidates[candidate.key] = candidate
-      },
-      {
-        layerFilter: mapview.interaction.layerFilter,
-        hitTolerance: mapview.interaction.hitTolerance,
-      })
+      // get featureID from id property, getId method or ol object F Uid.
+      const featureID = F.get('id') || F.getId() || ol.util.getUid(F)
+
+      // Compose candidate key from layerKey and featureID.
+      const key = `${layerKey}!${featureID}`
+
+      candidates[key] = {key, F, L}
+    }
+
+    const options = {
+      layerFilter: mapview.interaction.layerFilter,
+      hitTolerance: mapview.interaction.hitTolerance,
+    }
+
+    mapview.Map.forEachFeatureAtPixel(e.pixel, callback, options)
 
     // Check whether set of candidate keys is equal to mapview.interaction.candidateKeys
     if (mapp.utils.areSetsEqual(mapview.interaction.candidateKeys, new Set(Object.keys(candidates)))) {
@@ -145,11 +213,9 @@ export default function highlight(params) {
 
     } else if (!Object.keys(candidates).length) {
 
-      // Reset candidateKeys Set
       mapview.interaction.candidateKeys = new Set();
       clear()
       return;
-
     }
 
     // Find candidate from key which is not in candidates set.
@@ -202,25 +268,8 @@ export default function highlight(params) {
     typeof mapview.interaction.current.layer.style?.hover?.method === 'function'
       && mapview.interaction.current.layer.style.hover.method(feature.F, mapview.interaction.current.layer)
 
-    // Style the feature itself if possible.
-    if (mapview.interaction.current.layer.format !== 'mvt'
-      && mapview.interaction.current.layer.style.highlight
-      && typeof mapview.interaction.current.F.setStyle === 'function') {
-
-      // Unset cached OL Styles object.
-      feature.F.set('Styles', null, true)
-
-      feature.F.set('highlight', true, true)
-      mapview.interaction.current.F.setStyle()
-
-    } else if (mapview.interaction.current.layer.style.highlight) {
-
-      // Render unto canvas those things that are canvas'
-      mapview.interaction.current.layer.L.changed()
-    }
+    layerRender()
   }
-
-  let clicked;
 
   // Select the current highlighted feature.
   function click(e) {
@@ -238,9 +287,11 @@ export default function highlight(params) {
     }
 
     // Limit click event to 600ms
-    if (clicked) return;
+    if (mapview.interaction.clicked) return;
 
-    clicked = setTimeout(() => { clicked = null }, 600);
+    mapview.interaction.clicked = setTimeout(() => {
+      mapview.interaction.clicked = null
+    }, 600);
 
     // There is no current highlighted feature without pointerMove.
     // Simulate pointermove on the touch click coordinates.
@@ -267,37 +318,34 @@ export default function highlight(params) {
     }
   }
 
+  /**
+  @function clear
+
+  @description
+  The clear method will clear the current feature and shortcircuit if there is no current feature.
+
+  The infotip object [eg. hover] will be removed.
+
+  The cursor will be reset.
+
+  Will call the layerRender method.
+  */
   function clear() {
 
     // Highlight has already been cleared.
     if (!mapview.interaction.current) return;
 
-    // Remove any infotip.
     mapview.infotip(null)
 
-    // Reset cursor.
     mapview.Map.getTargetElement().style.cursor = 'auto'
 
-    // Delete the highlight id from current layer.
+    // Prevent highlight render.
     delete mapview.interaction.current.layer.highlight
 
-    // Style the feature itself if possible.
-    if (mapview.interaction.current.layer.format !== 'mvt'
-      && typeof mapview.interaction.current.F.setStyle === 'function') {
+    layerRender()
 
-      // Unset cached style to allow for highlight style.
-      mapview.interaction.current.F.set('Styles', null, true)
-
-      mapview.interaction.current.F.set('highlight', false, true)
-      mapview.interaction.current.F.setStyle()
-
-    } else if (mapview.interaction.current.layer.style.highlight) {
-
-      // Render unto canvas those things that are canvas'
-      mapview.interaction.current.layer.L.changed()
-    }
-
-    // Delete the current highlight object.
+    // Delete the current highlight feature after render.
+    // The [feature] current.layer object is required for the layerRender.
     delete mapview.interaction.current
   }
 
@@ -333,7 +381,7 @@ export default function highlight(params) {
             <li
               onclick=${e => {
               mapview.popup(null)
-              mapview.interaction.getLocation({
+              mapp.location.get({
                 layer: feature.layer,
                 table: feature.layer.table || feature.layer.tableCurrent(),
                 id: li.id
@@ -360,11 +408,36 @@ export default function highlight(params) {
     }
 
     // Select the current highlight feature.
-    mapview.interaction.getLocation({
+    mapp.location.get({
       layer: feature.layer,
       table: feature.layer.table || feature.layer.tableCurrent(),
       id: feature.id
     })
+  }
+
+  /**
+  @function layerRender
+
+  @description
+  Will trigger the render method of an mvt format layer by calling the layer.L.changed() event. This will render the whole layer.
+
+  Features on vector layer can be individually styled.
+  */
+  function layerRender() {
+
+    if (mapview.interaction.current.layer.format === 'mvt') {
+            
+      // Render unto canvas those things that are canvas'
+      mapview.interaction.current.layer.L.changed()
+
+    } else if (typeof mapview.interaction.current.F.setStyle === 'function') {
+      
+      // Unset cached style to allow for highlight style.
+      mapview.interaction.current.F.set('Styles', null, true)
+      
+      mapview.interaction.current.F.set('highlight', false, true)
+      mapview.interaction.current.F.setStyle()
+    }
   }
 
   // Finished the highlight mapview.interaction.

--- a/lib/mapview/interactions/highlight.mjs
+++ b/lib/mapview/interactions/highlight.mjs
@@ -4,6 +4,7 @@
 The module exports the highlight interaction method which is bound to a mapview in the [decorator]{@link module:/mapview~decorate} method.
 
 @requires /location/get
+@requires /location/nnearest
 @requires /mapview/allFeatures
 
 @module /mapview/interactions/highlight
@@ -351,17 +352,15 @@ export default function highlight(params) {
 
   function getFeature(feature) {
 
-    if (!feature.layer.infoj) return;
-
     // Get the properties of the current highlight feature.
     const properties = feature.F.getProperties();
 
-    // Return with a select dialogue for cluster feature.
+    // The feature is a cluster feature.
     if (properties.count > 1) {
 
-      // Get cluster features
       const features = feature.F.get('features')
 
+      // Features are clustered in source.
       if (Array.isArray(features)) {
 
         // Get list of cluster feature label and id.
@@ -373,31 +372,30 @@ export default function highlight(params) {
           }
         })
 
-        // Create list to get cluster features
-        const list = mapp.utils.html.node`
-        <div style="max-width: 66vw; max-height: 300px; overflow-x: hidden;">
-          <ul>
-          ${featuresList.map(li => mapp.utils.html.node`
-            <li
-              onclick=${e => {
-              mapview.popup(null)
-              mapp.location.get({
-                layer: feature.layer,
-                table: feature.layer.table || feature.layer.tableCurrent(),
-                id: li.id
-              })
-          }}>${li.label || li.id}`)}`;
+        // Create list for cluster features.
+        const list = featuresList.map(
+          li => mapp.utils.html.node`<li
+          onclick=${e => {
+          mapview.popup(null)
+          mapp.location.get({
+            layer: feature.layer,
+            table: feature.layer.table || feature.layer.tableCurrent(),
+            id: li.id
+          })}}>${li.label || li.id}`)
 
-        // Create popup to select cluster features.
+        const content = mapp.utils.html.node`<ul class="list">${list}`;
+
+        // Display the popup to select cluster feature.
         mapview.popup({
           coords: feature.F.getGeometry().getCoordinates(),
-          content: list,
           autoPan: true,
+          content,
         });
 
         return;
       }
 
+      // Features are not clustered in source.
       mapp.location.nnearest({
         mapview,
         layer: feature.layer,
@@ -407,7 +405,7 @@ export default function highlight(params) {
       return;
     }
 
-    // Select the current highlight feature.
+    // Get feature location.
     mapp.location.get({
       layer: feature.layer,
       table: feature.layer.table || feature.layer.tableCurrent(),

--- a/lib/mapview/interactions/highlight.mjs
+++ b/lib/mapview/interactions/highlight.mjs
@@ -66,10 +66,7 @@ export default function highlight(params) {
     longClickMS: 500,
 
     // Filter for layers which have a highlight style.
-    layerFilter: L => Object.values(this.layers)
-
-      // layer L matching the feature layer L must have a qID defined
-      .some(layer => layer.qID && layer.L === L),
+    layerFilter,
 
     // Spread params argument.
     ...params
@@ -88,6 +85,20 @@ export default function highlight(params) {
   mapview.Map.getTargetElement().addEventListener('mouseup', mouseUp)
 
   mapview.Map.getTargetElement().addEventListener('mouseleave', mouseleave)
+
+  /**
+  @function layerFilter
+
+  @description
+  The layerFilter method filters mapview layers with a qID.
+  
+  @param {Object} L Openlayers layer.
+  */
+  function layerFilter(L) {
+
+    return Object.values(mapview.layers)
+      .some(layer => layer.qID && layer.L === L)
+  }
 
   /**
   @function mouseleave
@@ -254,8 +265,6 @@ export default function highlight(params) {
     mapview.interaction.current = feature
 
     if (e.originalEvent.pointerType !== 'mouse') {
-
-      console.log(e.originalEvent)
 
       // The pointMove() method maybe called from touch/click event.
       e.type !== 'pointermove' && mapview.interaction.getFeature(feature)

--- a/lib/mapview/interactions/highlight.mjs
+++ b/lib/mapview/interactions/highlight.mjs
@@ -190,7 +190,7 @@ export default function highlight(params) {
 
   The feature will be passed as argument to a feature.layer.hover method.
 
-  Finally the layerRender() method will be called.
+  Finally the layer.L change event will be called to trigger the featureStyle render.
 
   @param {Object} e The pointerMove event.
   @property {Object} e.pixel The pixel object for the current pointer location.
@@ -223,18 +223,19 @@ export default function highlight(params) {
 
     mapview.Map.forEachFeatureAtPixel(e.pixel, callback, options)
 
-    // Check whether set of candidate keys is equal to mapview.interaction.candidateKeys
+    if (!Object.keys(candidates).length) {
+
+      // There is no candidate to highlight.
+      mapview.interaction.candidateKeys.clear();
+      clear()
+      return;
+    }
+
     if (mapp.utils.areSetsEqual(mapview.interaction.candidateKeys, new Set(Object.keys(candidates)))) {
 
       // The highlight hasn't changed.
       return;
-
-    } else if (!Object.keys(candidates).length) {
-
-      mapview.interaction.candidateKeys = new Set();
-      clear()
-      return;
-    }
+    }   
 
     // Find feature from key which is not in candidates set.
     const feature = candidates[Object.keys(candidates).find(key => !mapview.interaction.candidateKeys.has(key))]
@@ -286,7 +287,7 @@ export default function highlight(params) {
       feature.layer.style.hover.method(feature.F, feature.layer)
     }
 
-    layerRender()
+    mapview.interaction.current.layer.L.changed()
   }
 
   /**
@@ -360,7 +361,7 @@ export default function highlight(params) {
 
   The cursor will be reset.
 
-  Will call the layerRender method.
+  The layer.L change event will be called to trigger the featureStyle render.
   */
   function clear() {
 
@@ -374,10 +375,10 @@ export default function highlight(params) {
     // Prevent highlight render.
     delete mapview.interaction.current.layer.highlight
 
-    layerRender()
+    mapview.interaction.current.layer.L.changed()
 
     // Delete the current highlight feature after render.
-    // The [feature] current.layer object is required for the layerRender.
+    // The [feature] current.layer object is required for the featureStyle render.
     delete mapview.interaction.current
   }
 
@@ -456,31 +457,6 @@ export default function highlight(params) {
       table: feature.layer.table || feature.layer.tableCurrent(),
       id: feature.id
     })
-  }
-
-  /**
-  @function layerRender
-
-  @description
-  Will trigger the render method of an mvt format layer by calling the layer.L.changed() event. This will render the whole layer.
-
-  Features on vector layer can be individually styled.
-  */
-  function layerRender() {
-
-    if (mapview.interaction.current.layer.format === 'mvt') {
-            
-      // Render unto canvas those things that are canvas'
-      mapview.interaction.current.layer.L.changed()
-
-    } else if (typeof mapview.interaction.current.F.setStyle === 'function') {
-      
-      // Unset cached style to allow for highlight style.
-      mapview.interaction.current.F.set('Styles', null, true)
-      
-      mapview.interaction.current.F.set('highlight', false, true)
-      mapview.interaction.current.F.setStyle()
-    }
   }
 
   /**

--- a/lib/mapview/interactions/highlight.mjs
+++ b/lib/mapview/interactions/highlight.mjs
@@ -45,8 +45,6 @@ export default function highlight(params) {
 
     candidateKeys: new Set(),
 
-    locations: new Set(),
-
     longClickMethod: mapview.allFeatures,
 
     longClickMS: 500,

--- a/lib/mapview/interactions/highlight.mjs
+++ b/lib/mapview/interactions/highlight.mjs
@@ -1,13 +1,24 @@
 /**
-## Mapview.interactions.highlight()
+## /mapview/interactions/highlight
+
+The module exports the highlight interaction method which is bound to a mapview in the [decorator]{@link module:/mapview~decorate} method.
+
+@requires /location/get
 
 @module /mapview/interactions/highlight
-
-@param {Object} params
-The params object argument.
 */
 
-export default function (params) {
+/**
+@function highlight
+
+@description
+The location decorator method creates mapp-location typedef object from a JSON location.
+
+@param {object} params The params object is spread into the interaction defaults.
+@property {Function} [params.getFeature] Overrides getFeature method.
+@property {Function} [params.getLocation = mapp.location.get] Overrides [location.get]{@link module:/location/get~get} method.
+*/
+export default function highlight(params) {
 
   const mapview = this;
 

--- a/public/css/_mapp.css
+++ b/public/css/_mapp.css
@@ -136,6 +136,12 @@ body {
     background: var(--color-light-secondary);
     cursor: pointer;
   }
+
+  .list {
+    max-width: 66vw;
+    max-height: 300px;
+    overflow-x: hidden;
+  }
 }
 
 a > img {

--- a/public/css/mapp.css
+++ b/public/css/mapp.css
@@ -132,6 +132,11 @@ body {
     background: var(--color-light-secondary);
     cursor: pointer;
   }
+  .list {
+    max-width: 66vw;
+    max-height: 300px;
+    overflow-x: hidden;
+  }
 }
 a > img {
   height: 100%;


### PR DESCRIPTION
The default getFeature method of the highlight interaction provides a dialog for selecting cluster features. In order to use this dialog with a custom method to use for the feature/location from cluster it is required to override the getLocation method and use this method in the feature selection of the default getFeature method.

This feature is actually already provided by the location.get method but was undocumented.

This PR provides the override to highlight interaction method as well as documents the related location.get and nnearest methods and the dependency hooks module.