### PR TITLE
mapp.ui.elements.confirm

### DIFF
--- a/lib/dictionaries/en.mjs
+++ b/lib/dictionaries/en.mjs
@@ -1,6 +1,7 @@
 export default {
   save: 'Save',
   cancel: 'Cancel',
+  ok: 'OK',
   confirm_delete: 'Are you sure you want to delete this feature? This cannot be undone.',
   invalid_geometry: 'Invalid geometry',
   no_results: 'No results for this search',

--- a/lib/location/decorate.mjs
+++ b/lib/location/decorate.mjs
@@ -236,7 +236,9 @@ function flyTo(maxZoom) {
 
 async function trash() {
 
-  if (!confirm(mapp.dictionary.confirm_delete)) return;
+  const confirm = await mapp.ui.elements.confirm({text: mapp.dictionary.confirm_delete})
+
+  if (!confirm) return;
 
   await mapp.utils.xhr(`${this.layer.mapview.host}/api/query?` +
     mapp.utils.paramString({

--- a/lib/ui/elements/_elements.mjs
+++ b/lib/ui/elements/_elements.mjs
@@ -14,6 +14,7 @@ import dropdown_multi from './dropdown_multi.mjs';
 import btnPanel from './btnPanel.mjs';
 import legendIcon from './legendIcon.mjs';
 import dialog from './dialog.mjs';
+import confirm from './confirm.mjs';
 import helpDialog from './helpDialog.mjs';
 import searchbox from './searchbox.mjs';
 import slider from './slider.mjs';
@@ -35,6 +36,7 @@ UI elements object containing various UI components.
 @property {Function} dropdown_multi - Multi-select dropdown component.
 @property {Function} legendIcon - Legend icon component.
 @property {Function} dialog - Dialog component.
+@property {Function} confirm - Confirm component.
 @property {Function} helpDialog - Help Dialog component.
 @property {Function} searchbox - Searchbox component.
 @property {Function} slider - Slider component.
@@ -57,6 +59,7 @@ export default {
   layerStyle,
   legendIcon,
   dialog,
+  confirm,
   pills,
   helpDialog,
   searchbox,

--- a/lib/ui/elements/confirm.mjs
+++ b/lib/ui/elements/confirm.mjs
@@ -34,64 +34,12 @@ if(confirm) {
 export default function confirm(params) {
 
     params.title ??= 'Confirm';
-
-    const css = `
-    dialog.alert {
-      margin: auto;
-      box-shadow: rgba(0, 0, 0, 0.15) 1.95px 1.95px 2.6px;
-      border: none !important;
-      border-radius: 2px;
-      min-width: 350px;
-      max-width: 70%;
-      max-height: 70%;
-      z-index: 1001;
-      user-select: none;
-    }
-
-    dialog.alert::-webkit-scrollbar {
-      display: none;
-    }
-
-    dialog.alert h4 {
-      padding: 0.5em 1em;
-      position: sticky;
-      top: 0;
-      left: 0;
-      z-index: 10001;
-      background-color: var(--color-primary);
-      border-bottom: solid 2px var(--color-primary-light);
-      color: var(--color-light)
-    }
-
-    dialog.alert div {
-      padding: 1em;
-    }
-
-    dialog.alert p {
-      white-space: pre;
-      text-align: center;
-      padding: 1em;
-    }
-
-    dialog.alert button {
-      float: right;
-      font-size: 0.9em;
-      color: var(--color-primary);
-      z-index: 1005;
-    }
-
-    dialog.alert:focus {
-      outline: none;
-    }
-    `;
-
-    document.head.prepend(mapp.utils.html.node`<style>${css}`)
     
     const btn_true = mapp.utils.html.node`<button class="raised primary-colour del bold">${mapp.dictionary.ok}`;
     
     const btn_false = mapp.utils.html.node`<button class="raised primary-colour bold">${mapp.dictionary.cancel}`
     
-    const confirm = mapp.utils.html.node`<dialog class="alert" 
+    const confirm = mapp.utils.html.node`<dialog class="mapp-says" 
     onclose=${() => {
         confirm.remove();
     }}

--- a/lib/ui/elements/confirm.mjs
+++ b/lib/ui/elements/confirm.mjs
@@ -35,40 +35,38 @@ export default function confirm(params) {
 
     params.title ??= 'Confirm';
     
-    const btn_true = mapp.utils.html.node`<button class="raised primary-colour del bold">${mapp.dictionary.ok}`;
+    const btn_true = mapp.utils.html.node`<button class="raised primary-colour bold">${mapp.dictionary.ok}`;
     
     const btn_false = mapp.utils.html.node`<button class="raised primary-colour bold">${mapp.dictionary.cancel}`
-    
-    const confirm = mapp.utils.html.node`<dialog class="mapp-says" 
-    onclose=${() => {
-        confirm.remove();
-    }}
-    onclick=${e => {
-        e.preventDefault();
-        confirm.close();
-    }}>
-    <h4>${params.title}</h4>
-    <p>${params.text}</p>
-    <div style="display: grid; grid-template-columns: repeat(2, 1fr); grid-gap: 0.2em">
-    ${btn_false}
-    ${btn_true}`;
-    
-    document.body.append(confirm);
 
-    confirm.showModal();
+    mapp.ui.elements.dialog({
+        data_id: 'confirm',
+        class: 'mapp-says',
+        closeOnClick: true,
+        onClose: (e) => {
+            e.target.remove()
+        },
+        header: mapp.utils.html.node`<h4>${params.title}`,
+        content: mapp.utils.html.node`<p>${params.text}</p>
+        <div style="display: grid; grid-template-columns: repeat(2, 1fr); grid-gap: 0.2em">
+        ${btn_false}
+        ${btn_true}`
+    })
+
     
     return new Promise((resolve, reject) => {
         
         btn_true.addEventListener("click", (e) => {
             e.stopPropagation();
-            confirm.close();
+            document.querySelector('dialog.mapp-says[data-id="confirm"]').close();
             resolve(true);
         });
         
         btn_false.addEventListener("click", (e) => {
             e.stopPropagation();
-            confirm.close();
+            document.querySelector('dialog.mapp-says[data-id="confirm"]').close();
             resolve(false);
         });
     });
 }
+

--- a/lib/ui/elements/confirm.mjs
+++ b/lib/ui/elements/confirm.mjs
@@ -1,0 +1,126 @@
+/**
+### mapp.ui.elements.confirm()
+
+Exports the confirm dialog method as mapp.ui.elements.confirm()
+
+@module /ui/elements/confirm
+*/
+
+/**
+@function confirm
+
+@description
+This is a confirm element to display information to the user and resolving to yes/no response.
+It is a framework alternative way to using window.confirm() browser function.
+
+```js
+const confirm = await mapp.ui.elements.confirm({
+   text: "Please confim changes."
+})
+if(confirm) {
+// proceed
+} else {
+// prevent
+}
+```
+
+@param {Object} confirm The confirm configuration object.
+@property {string} [confirm.data_id='alert'] The data-id attribute value for the dialog.
+@property {string} [confirm.title] Text to display in the confirm header. Defaults to 'Confirm'.
+@property {string} [confirm.text] Text to display in the confirm content. 
+@returns {HTMLElement} confirm The confirm element.
+*/
+
+export default function confirm(params) {
+
+    params.title ??= 'Confirm';
+
+    const css = `
+    dialog.alert {
+      margin: auto;
+      box-shadow: rgba(0, 0, 0, 0.15) 1.95px 1.95px 2.6px;
+      border: none !important;
+      border-radius: 2px;
+      min-width: 350px;
+      max-width: 70%;
+      max-height: 70%;
+      z-index: 1001;
+      user-select: none;
+    }
+
+    dialog.alert::-webkit-scrollbar {
+      display: none;
+    }
+
+    dialog.alert h4 {
+      padding: 0.5em 1em;
+      position: sticky;
+      top: 0;
+      left: 0;
+      z-index: 10001;
+      background-color: var(--color-primary);
+      border-bottom: solid 2px var(--color-primary-light);
+      color: var(--color-light)
+    }
+
+    dialog.alert div {
+      padding: 1em;
+    }
+
+    dialog.alert p {
+      white-space: pre;
+      text-align: center;
+      padding: 1em;
+    }
+
+    dialog.alert button {
+      float: right;
+      font-size: 0.9em;
+      color: var(--color-primary);
+      z-index: 1005;
+    }
+
+    dialog.alert:focus {
+      outline: none;
+    }
+    `;
+
+    document.head.prepend(mapp.utils.html.node`<style>${css}`)
+    
+    const btn_true = mapp.utils.html.node`<button class="raised primary-colour del bold">${mapp.dictionary.ok}`;
+    
+    const btn_false = mapp.utils.html.node`<button class="raised primary-colour bold">${mapp.dictionary.cancel}`
+    
+    const confirm = mapp.utils.html.node`<dialog class="alert" 
+    onclose=${() => {
+        confirm.remove();
+    }}
+    onclick=${e => {
+        e.preventDefault();
+        confirm.close();
+    }}>
+    <h4>${params.title}</h4>
+    <p>${params.text}</p>
+    <div style="display: grid; grid-template-columns: repeat(2, 1fr); grid-gap: 0.2em">
+    ${btn_false}
+    ${btn_true}`;
+    
+    document.body.append(confirm);
+
+    confirm.showModal();
+    
+    return new Promise((resolve, reject) => {
+        
+        btn_true.addEventListener("click", (e) => {
+            e.stopPropagation();
+            confirm.close();
+            resolve(true);
+        });
+        
+        btn_false.addEventListener("click", (e) => {
+            e.stopPropagation();
+            confirm.close();
+            resolve(false);
+        });
+    });
+}

--- a/lib/ui/locations/entries/cloudinary.mjs
+++ b/lib/ui/locations/entries/cloudinary.mjs
@@ -275,7 +275,9 @@ async function docLoad(e, entry) {
 
 async function trash(e, entry) {
 
-  if (!confirm('Remove item?')) return;
+  const confirm = await mapp.ui.elements.confirm({text: 'Remove item?'});
+
+  if (!confirm) return;
 
   // Send request to cloudinary to destroy resource.
   await mapp.utils.xhr(`${entry.location.layer.mapview.host}/api/provider/cloudinary?${mapp.utils.paramString({

--- a/lib/ui/locations/view.mjs
+++ b/lib/ui/locations/view.mjs
@@ -149,11 +149,13 @@ export default function view(location) {
   header.push(mapp.utils.html`<button
     title = ${mapp.dictionary.location_remove}
     class = "mask-icon close no"
-    onclick = ${() => {
+    onclick = ${async () => {
 
       if (location.infoj.some(entry => typeof entry.newValue !== 'undefined')) {
 
-        if (!confirm(`${mapp.dictionary.location_close_without_save}`)) return;
+        const confirm = await mapp.ui.elements({text: mapp.dictionary.location_close_without_save})
+
+        if (!confirm) return;
       }
 
       location.remove()


### PR DESCRIPTION
2/2 of planned additions

mapp.ui.elements.confirm method added to elements.

This is a confirm element to display information to the user and resolve to yes/no response.
It is a framework alternative way to using window.confirm() browser function.

At the moment css is included in the element to test it separately.
Once we're happy with it it can be moved to ui.css and unified with its sibling .alert()