### PR TITLE
The layer style cache should be optional.

### DIFF
--- a/lib/layer/featureStyle.mjs
+++ b/lib/layer/featureStyle.mjs
@@ -13,10 +13,13 @@ Exports the featureStyle method to assign style methods to OL vector layer.
 Returns a style function for OL vector layers.
 
 @param {Object} layer The layer object.
+@property {layer-style} layer.style The layer style config.
+@property {Boolean} [style.cache] The feature style should be retrieved from the feature 'Styles' property.
 
 @returns {function} The style function for the layer.
 */
 export default function featureStyle(layer) {
+
   /**
   @function Style
   @description
@@ -31,7 +34,7 @@ export default function featureStyle(layer) {
   return function Style(feature) {
 
     // Style caching must be disabled with a null flag.
-    if (layer.style.cache !== null) {
+    if (layer.style.cache === true) {
 
       // Get and return OL styles object.
       const Styles = feature.get('Styles')

--- a/lib/layer/styleParser.mjs
+++ b/lib/layer/styleParser.mjs
@@ -40,6 +40,7 @@ Overall, the `styleParser` module ensures that the layer style configuration is 
 /**
 @global
 @typedef {Object} layer-style
+@property {Boolean} [cache] The feature style should be retrieved from the feature 'Styles' property.
 @property {object} theme The current theme to be rendered.
 @property {feature-style} [default] The default style for features.
 @property {feature-style} [highlight] The style for highlighted features.


### PR DESCRIPTION
The layer style cache property must be documented and optional.

Instead of applying the cache unless the cache property is set to null the cache should only be applied if the boolean property is set to true.

Complex icons may be flicker if the style isn't cached.

But icon scale changes will not apply if the style is cached [by default].