### PR TITLE
getfeature call from highlight click

### DIFF
--- a/lib/mapview/interactions/highlight.mjs
+++ b/lib/mapview/interactions/highlight.mjs
@@ -348,7 +348,10 @@ export default function highlight(params) {
       return;
     }
 
-    mapview.interaction.getFeature(mapview.interaction.current);
+    if (mapview.interaction.current) {
+
+      mapview.interaction.getFeature(mapview.interaction.current);
+    }
   }
 
   /**


### PR DESCRIPTION
The getFeature method must only be called from the click event method if there is a current feature.

Clicking into the mapview without a current feature should not throw an error exception.