### PR TITLE
Fix workspace test to include user for roles check

### DIFF
--- a/mod/workspace/_workspace.js
+++ b/mod/workspace/_workspace.js
@@ -312,12 +312,12 @@ async function test(req, res) {
   for (const localeKey of Object.keys(workspace.locales)) {
 
     // Will get layer and assignTemplates to workspace.
-    const locale = await getLocale({locale: localeKey})
+    const locale = await getLocale({ locale: localeKey, user: req.params.user })
 
     for (const layerKey of Object.keys(locale.layers)) {
 
       // Will get layer and assignTemplates to workspace.
-      const layer = await getLayer({locale: localeKey, layer: layerKey})
+      const layer = await getLayer({ locale: localeKey, layer: layerKey })
 
       if (layer.err) errArr.push(`${layerKey}: ${layer.err}`)
     }

--- a/mod/workspace/_workspace.js
+++ b/mod/workspace/_workspace.js
@@ -317,7 +317,7 @@ async function test(req, res) {
     for (const layerKey of Object.keys(locale.layers)) {
 
       // Will get layer and assignTemplates to workspace.
-      const layer = await getLayer({ locale: localeKey, layer: layerKey })
+      const layer = await getLayer({ locale: localeKey, layer: layerKey, user: req.params.user })
 
       if (layer.err) errArr.push(`${layerKey}: ${layer.err}`)
     }


### PR DESCRIPTION
## Description

The `getLocale()` function on the workspace `test()` was missing the user so it would fail on workspaces that had roles.

## Type of Change
- ✅ Bug fix (non-breaking change which fixes an issue)