### PR TITLE
Pass filter to minmax

### DIFF
--- a/lib/ui/layers/filters.mjs
+++ b/lib/ui/layers/filters.mjs
@@ -166,6 +166,7 @@ async function generateMinMax(layer, filter) {
     layer: layer.key,
     table: layer.tableCurrent(),
     field: filter.field,
+    filter: layer.filter?.current
   })}`);
 
   // Assign min, max from response if not a number.

--- a/tests/lib/ui/layers/filters.test.mjs
+++ b/tests/lib/ui/layers/filters.test.mjs
@@ -48,7 +48,7 @@ export async function filtersTest(mapview) {
             //Delete the min value from the filter
             delete filter.min;
 
-            //Delte the lte value of the current filter otherwise it will not be changed in the next test
+            //Delete the lte value of the current filter otherwise it will not be changed in the next test
             delete layer.filter.current[filter.field].lte;
         });
 
@@ -67,5 +67,22 @@ export async function filtersTest(mapview) {
             codi.assertEqual(minInput.value, '100', 'The min should return 100.');
             codi.assertEqual(maxInput.value, '1000', 'The max should return 1000');
         });
+
+        await codi.it('Numeric Filter: layer.current specified as `lte: 200` and `gte: 800`', async () => {
+
+            layer.filter.current[filter.field].lte = 800
+            layer.filter.current[filter.field].gte = 200
+
+            const numericFilter = await mapp.ui.layers.filters.numeric(layer, filter);
+            const minInput = numericFilter.querySelector('div > input[type=range]:nth-child(3)');
+            const maxInput = numericFilter.querySelector('div > input[type=range]:nth-child(4)');
+
+            codi.assertEqual(minInput.value, '200', 'The min should return 200.');
+            codi.assertEqual(maxInput.value, '800', 'The max should return 800');
+
+            //Delete the lte/gte value of the current filter otherwise it will not be changed in the next test
+            delete layer.filter.current[filter.field].lte;
+            delete layer.filter.current[filter.field].gte;
+        })
     });
 }


### PR DESCRIPTION
# Pass Filter to minmax

## Description

I noticed that the default `field_minmax` query contains `WHERE TRUE ${filter}`, however we never pass the `filter` as a parameter into the query. 
So the layer filter is never being used in this query. 
This is a bug as we need to ensure the filtering occurs only on the data used on the layer itself, not on all data on the table on the database.

I have resolved this by simply adding it to the list of parameters passed to the query. 

## Type of Change
Please delete options that are not relevant, and select all options that apply. 

- ✅ Bug fix (non-breaking change which fixes an issue)

## Testing Checklist 
Please delete options that are not relevant, and select all options that apply. 

- ✅ Existing Tests still pass
- ✅ Ran locally on my machine

## Code Quality Checklist
Please delete options that are not relevant, and select all options that apply. 

- ✅ My code follows the guidelines of XYZ
- ✅ My code has been commented
- ✅ Documentation has been updated
- ✅ New and existing unit tests pass locally with my changes
- ✅ Main has been merged into this PR