### PR TITLE
Add template typedef review usage test

### DIFF
--- a/mod/workspace/_workspace.js
+++ b/mod/workspace/_workspace.js
@@ -333,10 +333,10 @@ async function test(req, res) {
 
       if (layer.err) test.errArr.push(`${layerKey}: ${layer.err}`)
     }
-  }
 
-  // Test locale and all of its layers as nested object.
-  templateUse(workspace.locales, test);
+    // Test locale and all of its layers as nested object.
+    templateUse(locale, test);
+  }
 
   // From here on its 🐢 Templates all the way down.
   for (const key of Object.keys(workspace.templates)) {

--- a/mod/workspace/_workspace.js
+++ b/mod/workspace/_workspace.js
@@ -359,9 +359,9 @@ async function test(req, res) {
   // Reduce the test.used_templates array to count the occurance of each template.
   test.results.usage = Object.fromEntries(test.used_templates
     // sort by usage
-    .sort((a,b) => {
-      if (a>b) return 1
-      if (a<b) return -1
+    .sort((a, b) => {
+      if (a > b) return 1
+      if (a < b) return -1
       return 0
     })
     .reduce((acc, e) => acc.set(e, (acc.get(e) || 0) + 1), new Map()));

--- a/mod/workspace/_workspace.js
+++ b/mod/workspace/_workspace.js
@@ -356,14 +356,10 @@ async function test(req, res) {
 
   test.results.overwritten_templates = Array.from(test.overwritten_templates);
 
+  test.used_templates.sort()
+
   // Reduce the test.used_templates array to count the occurance of each template.
   test.results.usage = Object.fromEntries(test.used_templates
-    // sort by usage
-    .sort((a, b) => {
-      if (a > b) return 1
-      if (a < b) return -1
-      return 0
-    })
     .reduce((acc, e) => acc.set(e, (acc.get(e) || 0) + 1), new Map()));
 
   res.setHeader('content-type', 'application/json');

--- a/mod/workspace/_workspace.js
+++ b/mod/workspace/_workspace.js
@@ -329,11 +329,11 @@ async function test(req, res) {
       const layer = await getLayer({ locale: localeKey, layer: layerKey, user: req.params.user })
 
       if (layer.template) {
-        checkTemplate(layer.template, custom_templates, templateUsage);
+        update_templateUsage(layer.template, custom_templates, templateUsage);
       }
 
       layer.templates?.forEach(template => {
-        checkTemplate(template, custom_templates, templateUsage);
+        update_templateUsage(template, custom_templates, templateUsage);
       });
 
       if (layer.err) errArr.push(`${layerKey}: ${layer.err}`)
@@ -363,28 +363,36 @@ async function test(req, res) {
   res.send(JSON.stringify(testResults));
 }
 
-//Helper function to update the template usage
-function updateTemplateUsage(templateKey, templateUsage) {
-  if (!templateKey) return;
+/**
+@function update_templateUsage
 
-  //if we find a templatekey in the usage object then incremenet the count by 1.
-  // else we will add a new entry to the object with a count of 1. 
-  if (templateUsage[templateKey]) {
-    templateUsage[templateKey].count++;
-  } else {
-    templateUsage[templateKey] = { count: 1 };
-  }
-}
+@description
+Checks how many times a custom_template is used by layers.
 
-//Helper function used to check against a template coming from either a layer.template or a layer.templates entries.
-function checkTemplate(template, custom_templates, templateUsage) {
-  //We set a template_key based on if the template is a string or an object.
+@param {string||object} template The template maybe a string or an object.
+@param {Object} custom_templates An object of _type='workspace_template' templates.
+@param {Object} templateUsage Also an object of _type='workspace_template' templates with an added count property.
+*/
+function update_templateUsage(template, custom_templates, templateUsage) {
+
+  // We set a template_key based on if the template is a string or an object.
   const template_key = typeof template === 'string' ? template : template.key;
-  //Get the template from the workspace.templates
+
+  // Get the template from the workspace.templates
   const workspace_template = custom_templates[template_key];
 
-  //If we get the template and have a key, then we will increase the usage counter.
+  // If we get the template and have a key, then we will increase the usage counter.
   if (template_key && workspace_template) {
-    updateTemplateUsage(template_key, templateUsage);
+
+    if (templateUsage[templateKey]) {
+
+      // Increase counter for existing templateKey in templateUsage.
+      templateUsage[templateKey].count++;
+
+    } else {
+
+      // Create templateKey in templateUsage with count 1.
+      templateUsage[templateKey] = { count: 1 };
+    }
   }
 }

--- a/mod/workspace/_workspace.js
+++ b/mod/workspace/_workspace.js
@@ -329,7 +329,7 @@ async function test(req, res) {
       // Will get layer and assignTemplates to workspace.
       const layer = await getLayer({ locale: localeKey, layer: layerKey, user: req.params.user })
 
-      locale.layers[layerKey] = layer; 
+      locale.layers[layerKey] = layer;
 
       if (layer.err) test.errArr.push(`${layerKey}: ${layer.err}`)
     }
@@ -385,12 +385,6 @@ function templateUse(obj, test) {
     // entry key === ['template', 'templates', 'query']
     if (test.properties.has(entry[0])) {
 
-      if (typeof entry[1] === 'string') {
-
-        test.unused_templates.delete(entry[1])
-        test.used_templates.push(entry[1])
-      }
-
       if (Array.isArray(entry[1])) {
 
         entry[1]
@@ -399,6 +393,18 @@ function templateUse(obj, test) {
             test.unused_templates.delete(item)
             test.used_templates.push(item)
           })
+      }
+
+      if (typeof entry[1] === 'object' && Object.hasOwn(entry[1], 'key')) {
+        test.unused_templates.delete(entry[1].key)
+        test.used_templates.push(entry[1].key)
+        return
+      }
+
+      if (typeof entry[1] === 'string') {
+
+        test.unused_templates.delete(entry[1])
+        test.used_templates.push(entry[1])
       }
     }
 

--- a/mod/workspace/_workspace.js
+++ b/mod/workspace/_workspace.js
@@ -370,7 +370,7 @@ Add template keys to test.used_templates Array.
 @param {Object} test The test config object.
 @property {Set} test.properties Set of properties to test ['template', 'templates', 'query']
 @property {Set} test.unused_templates Set of templates not (yet) used.
-@property {Arry} test.used_templates Array of template keys for each usage.
+@property {Array} test.used_templates Array of template keys for each usage.
 */
 function templateUse(obj, test) {
 

--- a/mod/workspace/_workspace.js
+++ b/mod/workspace/_workspace.js
@@ -317,6 +317,7 @@ async function test(req, res) {
     // Will get layer and assignTemplates to workspace.
     const locale = await getLocale({ locale: localeKey, user: req.params.user })
 
+    //We get the initial custom templates from the workspace.templates as we want to see usage of templates before we merge templates from layers.
     custom_templates = {
       ...Object.fromEntries(
         Object.entries(workspace.templates).filter(([key, value]) => value._type === 'workspace_template')
@@ -384,15 +385,15 @@ function update_templateUsage(template, custom_templates, templateUsage) {
   // If we get the template and have a key, then we will increase the usage counter.
   if (template_key && workspace_template) {
 
-    if (templateUsage[templateKey]) {
+    if (templateUsage[template_key]) {
 
       // Increase counter for existing templateKey in templateUsage.
-      templateUsage[templateKey].count++;
+      templateUsage[template_key].count++;
 
     } else {
 
       // Create templateKey in templateUsage with count 1.
-      templateUsage[templateKey] = { count: 1 };
+      templateUsage[template_key] = { count: 1 };
     }
   }
 }

--- a/mod/workspace/_workspace.js
+++ b/mod/workspace/_workspace.js
@@ -359,7 +359,11 @@ async function test(req, res) {
   // Reduce the test.used_templates array to count the occurance of each template.
   test.results.usage = Object.fromEntries(test.used_templates
     // sort by usage
-    .sort((a,b) => a>b ? 1: a<b ? -1 : 0)
+    .sort((a,b) => {
+      if (a>b) return 1
+      if (a<b) return -1
+      return 0
+    })
     .reduce((acc, e) => acc.set(e, (acc.get(e) || 0) + 1), new Map()));
 
   res.setHeader('content-type', 'application/json');

--- a/mod/workspace/_workspace.js
+++ b/mod/workspace/_workspace.js
@@ -358,6 +358,8 @@ async function test(req, res) {
 
   // Reduce the test.used_templates array to count the occurance of each template.
   test.results.usage = Object.fromEntries(test.used_templates
+    // sort by usage
+    .sort((a,b) => a>b ? 1: a<b ? -1 : 0)
     .reduce((acc, e) => acc.set(e, (acc.get(e) || 0) + 1), new Map()));
 
   res.setHeader('content-type', 'application/json');
@@ -385,7 +387,7 @@ Add template keys to test.used_templates Array.
 function templateUse(obj, test) {
 
   if (typeof obj !== 'object') return;
-  
+
   Object.entries(obj).forEach(entry => {
 
     // entry key === ['template', 'templates', 'query']
@@ -401,12 +403,14 @@ function templateUse(obj, test) {
           })
       }
 
-      if (typeof entry[1] === 'object' 
+      if (typeof entry[1] === 'object'
         && Object.hasOwn(entry[1], 'key')
-        && test.workspace_templates.has(entry[1].key)
+
       ) {
-        
-        test.overwritten_templates.add(entry[1].key)
+        if (test.workspace_templates.has(entry[1].key)) {
+          test.overwritten_templates.add(entry[1].key)
+        }
+        return;
       }
 
       if (typeof entry[1] === 'string') {
@@ -420,7 +424,7 @@ function templateUse(obj, test) {
 
       entry[1].forEach(entry => templateUse(entry, test))
 
-    // Iterate through nested objects eg. layers      
+      // Iterate through nested objects eg. layers      
     } else if (entry[1] instanceof Object) {
 
       templateUse(entry[1], test)

--- a/mod/workspace/_workspace.js
+++ b/mod/workspace/_workspace.js
@@ -333,10 +333,10 @@ async function test(req, res) {
 
       if (layer.err) test.errArr.push(`${layerKey}: ${layer.err}`)
     }
-
-    // Test locale and all of its layers as nested object.
-    templateUse(locale, test);
   }
+
+  // Test locale and all of its layers as nested object.
+  templateUse(workspace.locales, test);
 
   // From here on its 🐢 Templates all the way down.
   for (const key of Object.keys(workspace.templates)) {
@@ -376,10 +376,8 @@ Add template keys to test.used_templates Array.
 */
 function templateUse(obj, test) {
 
-  if (obj === null) return;
-
-  if (obj instanceof Object && !Object.keys(obj)) return;
-
+  if (typeof obj !== 'object') return;
+  
   Object.entries(obj).forEach(entry => {
 
     // entry key === ['template', 'templates', 'query']
@@ -398,11 +396,10 @@ function templateUse(obj, test) {
       if (typeof entry[1] === 'object' && Object.hasOwn(entry[1], 'key')) {
         test.unused_templates.delete(entry[1].key)
         test.used_templates.push(entry[1].key)
-        return
+        return;
       }
 
       if (typeof entry[1] === 'string') {
-
         test.unused_templates.delete(entry[1])
         test.used_templates.push(entry[1])
       }
@@ -412,14 +409,11 @@ function templateUse(obj, test) {
     if (Array.isArray(entry[1])) {
 
       entry[1].forEach(entry => templateUse(entry, test))
-      return;
+
+    // Iterate through nested objects eg. layers      
+    } else if (entry[1] instanceof Object) {
+
+      templateUse(entry[1], test)
     }
-
-    // Iterate through nested objects eg. layers
-    if (entry[1] instanceof Object) {
-
-      Object.values(entry[1])?.forEach(value => templateUse(value, test))
-    }
-
   })
 }

--- a/mod/workspace/_workspace.js
+++ b/mod/workspace/_workspace.js
@@ -377,7 +377,9 @@ Add template keys to test.used_templates Array.
 @param {Object} obj The object to test.
 @param {Object} test The test config object.
 @property {Set} test.properties Set of properties to test ['template', 'templates', 'query']
+@property {Set} test.workspace_templates Set of templates _type=workspace templates.
 @property {Set} test.unused_templates Set of templates not (yet) used.
+@property {Set} test.overwritten_templates Set of _type=workspace templates which have been overwritten.
 @property {Array} test.used_templates Array of template keys for each usage.
 */
 function templateUse(obj, test) {

--- a/mod/workspace/_workspace.js
+++ b/mod/workspace/_workspace.js
@@ -356,7 +356,12 @@ async function test(req, res) {
 
   test.results.overwritten_templates = Array.from(test.overwritten_templates);
 
-  test.used_templates.sort()
+  // Sort the array.
+  test.used_templates.sort((a, b) => {
+    if (a > b) return 1
+    if (a < b) return -1
+    return 0
+  })
 
   // Reduce the test.used_templates array to count the occurance of each template.
   test.results.usage = Object.fromEntries(test.used_templates

--- a/mod/workspace/_workspace.js
+++ b/mod/workspace/_workspace.js
@@ -329,6 +329,8 @@ async function test(req, res) {
       // Will get layer and assignTemplates to workspace.
       const layer = await getLayer({ locale: localeKey, layer: layerKey, user: req.params.user })
 
+      locale.layers[layerKey] = layer; 
+
       if (layer.err) test.errArr.push(`${layerKey}: ${layer.err}`)
     }
 

--- a/mod/workspace/cache.js
+++ b/mod/workspace/cache.js
@@ -107,7 +107,6 @@ async function cacheWorkspace() {
   */
   function mark_template(templates_object, type) {
 
-    // custom_templates may be undefined.
     if (!templates_object) return;
 
     return Object.fromEntries(
@@ -124,10 +123,10 @@ async function cacheWorkspace() {
     ...mark_template(msg_templates, 'core'),
     ...mark_template(query_templates, 'core'),
 
-    ...mark_template(custom_templates, 'custom_templates'),
+    ...mark_template(custom_templates, 'custom'),
 
     // Default templates can be overridden by assigning a template with the same key.
-    ...mark_template(workspace.templates, 'workspace_template')
+    ...mark_template(workspace.templates, 'workspace')
   }
 
   // A workspace must have a default locale [template]

--- a/mod/workspace/cache.js
+++ b/mod/workspace/cache.js
@@ -64,13 +64,6 @@ const query_templates = require('./templates/_queries')
 const workspace_src = process.env.WORKSPACE?.split(':')[0]
 
 /**
-@global
-@typedef {string} _type
-The _type property on a template used to distinguish templates that get added to the workspace.templates object for further testing.
-Expected values for this are 'core', 'custom_template',  'workspace_template'
-*/
-
-/**
 @function cacheWorkspace
 
 @description

--- a/mod/workspace/getTemplate.js
+++ b/mod/workspace/getTemplate.js
@@ -20,7 +20,7 @@ const envReplace = require('../utils/envReplace')
 /**
 @global
 @typedef {Object} template A template is an object property of the workspace.templates
-@property {Object} _type The _type property distinguish the origin of a template. 'core' templates are added from the /mod/workspace/templates directory. A 'custom_template' is added from a custom_template JSON file defined in the process.env. A 'workspace_template' is added from the workspace itself.
+@property {Object} _type The _type property distinguish the origin of a template. 'core' templates are added from the /mod/workspace/templates directory. A 'custom' is added from a custom_template JSON file defined in the process.env. A 'workspace' is added from the workspace itself. A _type='template' object is assigned in the [assignWorkspaceTemplates]{@link module:/workspace/mergeTemplates~assignWorkspaceTemplates} method.
 @property {String} src The source is a location from which a template object is loaded when required. Once loaded the template will be cached.
 @property {Object} cached The cached template.
 @property {String} template The string representation of a template, eg. html, sql.

--- a/mod/workspace/getTemplate.js
+++ b/mod/workspace/getTemplate.js
@@ -18,6 +18,17 @@ const workspaceCache = require('./cache')
 const envReplace = require('../utils/envReplace')
 
 /**
+@global
+@typedef {Object} template A template is an object property of the workspace.templates
+@property {Object} _type The _type property distinguish the origin of a template. 'core' templates are added from the /mod/workspace/templates directory. A 'custom_template' is added from a custom_template JSON file defined in the process.env. A 'workspace_template' is added from the workspace itself.
+@property {String} src The source is a location from which a template object is loaded when required. Once loaded the template will be cached.
+@property {Object} cached The cached template.
+@property {String} template The string representation of a template, eg. html, sql.
+@property {Function} render A method which resolves in a template string.
+@property {Boolean} module The template is a module.
+*/
+
+/**
 @function getTemplate
 @async
 

--- a/mod/workspace/mergeTemplates.js
+++ b/mod/workspace/mergeTemplates.js
@@ -97,8 +97,10 @@ module.exports = async function mergeTemplates(obj) {
 
       //The object key must not be overwritten by a template key.
       delete template.key;
+
       //The object template must not be overwritten by a templates template.
       delete template.template;
+      
       // Merge template --> obj
       obj = merge(obj, template)
     }

--- a/mod/workspace/mergeTemplates.js
+++ b/mod/workspace/mergeTemplates.js
@@ -119,7 +119,7 @@ module.exports = async function mergeTemplates(obj) {
 @description
 The method parses an object for a template object property. The template property value will be assigned to the workspace.templates{} object matching the template key value.
 
-The template._type property will be set to 'workspace_template' indicating that the templates origin is in the workspace. It is possible to overassign _type:'core' templates which are loaded from the /mod/workspace/templates directory.
+The template._type property will be set to 'template' indicating that the templates origin is in the workspace. It is possible to overassign _type:'core' templates which are loaded from the /mod/workspace/templates directory.
 
 The method will call itself for nested objects.
 
@@ -135,7 +135,7 @@ function assignWorkspaceTemplates(obj) {
 
     if (entry[0] === 'template' && entry[1].key) {
 
-      entry[1]._type = 'workspace_template';
+      entry[1]._type = 'template';
       workspace.templates[entry[1].key] = Object.assign(workspace.templates[entry[1].key] || {}, entry[1])
 
       return;

--- a/mod/workspace/mergeTemplates.js
+++ b/mod/workspace/mergeTemplates.js
@@ -119,6 +119,8 @@ module.exports = async function mergeTemplates(obj) {
 @description
 The method parses an object for a template object property. The template property value will be assigned to the workspace.templates{} object matching the template key value.
 
+The template._type property will be set to 'workspace_template' indicating that the templates origin is in the workspace. It is possible to overassign _type:'core' templates which are loaded from the /mod/workspace/templates directory.
+
 The method will call itself for nested objects.
 
 @param {Object} obj 

--- a/tests/workspace.json
+++ b/tests/workspace.json
@@ -31,6 +31,9 @@
         },
         "minmax_query_mock": {
             "src": "file:/tests/assets/queries/minmax_mock.sql"
+        },
+        "data_array": {
+            "src": "file:/tests/assets/queries/data_array.sql"
         }
     },
     "locale": {


### PR DESCRIPTION
_type is a property of the template typedef addded in this PR.

I merged updateTemplateUsage and checkTemplate to become the documented update_templateUsage method.

The undocumented updateTemplateUsage method was only called by the undocumented checkTemplate method which in turn updated the templateUsage param.

There are still a few things I want to check.

Having a custom_templates object and templateUsage object which are essentially the same but the latter has a counter feels odd.

The templates object can just be cloned with the count being added once.

It doesn't feel right to iterate through layers in locales to update_templateUsage on each iteration within an iteration.

The update usage should be done once after all locales and layers have been parsed.

I am worried that templates used in an entry, or dataview in a layer do not count to the usage if we only check the layer.templates and layer.template.

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1208407306090517