### PR TITLE
numericFormatter locale issue

### DIFF
--- a/lib/ui/elements/numericInput.mjs
+++ b/lib/ui/elements/numericInput.mjs
@@ -108,7 +108,7 @@ The numericChecks method checks whether a provided numeric value is a number, la
 function numericChecks(value, params) {
 
   // Check whether value is a null.
-  if (value === null) return false;
+  if (params.onRangeInput && value === null) return false;
   // Check whether value is a number.
   if (isNaN(value)) return false;
 

--- a/lib/ui/elements/numericInput.mjs
+++ b/lib/ui/elements/numericInput.mjs
@@ -107,6 +107,8 @@ The numericChecks method checks whether a provided numeric value is a number, la
 */
 function numericChecks(value, params) {
 
+  // Check whether value is a null.
+  if (value === null) return false;
   // Check whether value is a number.
   if (isNaN(value)) return false;
 

--- a/lib/ui/elements/numericInput.mjs
+++ b/lib/ui/elements/numericInput.mjs
@@ -55,7 +55,7 @@ function oninput(e, params) {
   params.stringValue = e.target.value
 
   // Assign numeric newValue.
-  params.newValue = mapp.utils.unformatStringValue(params)
+  params.newValue = params.onRangeInput ? params.stringValue : mapp.utils.unformatStringValue(params);
 
   if (params.numericChecks(params.newValue, params)) {
 
@@ -81,13 +81,15 @@ function oninput(e, params) {
   }
 
   // The invalid input should not be formatted.
-  if (params.invalid) return;  
+  if (params.invalid) return;
 
   // Pass valid newValue to callback method.
   params.callback(params.newValue)
 
   // Re-format the params numeric value (newValue || value) and set as input string value.
   e.target.value = mapp.utils.formatNumericValue(params)
+  //Mark the onRangeInput to false is the origin of the input call could come from either a slider or input
+  params.onRangeInput = false;
 }
 
 /**

--- a/lib/ui/elements/slider.mjs
+++ b/lib/ui/elements/slider.mjs
@@ -66,7 +66,7 @@ export default function slider(params) {
         max=${params.max}
         step=${params.step}
         value=${params.value}
-        oninput=${onRangeInput}>`
+        oninput=${e => onRangeInput(e, params)}>`
 
   return params.sliderElement
 
@@ -80,10 +80,12 @@ export default function slider(params) {
 
   @param {Object} e oninput event from range type input.
   */
-  function onRangeInput(e) {
+  function onRangeInput(e, params) {
 
     // Range type input return a string target.value.
     const val = Number(e.target.value)
+
+    params.onRangeInput = true;
 
     numericInput.value = val
 

--- a/lib/ui/elements/slider.mjs
+++ b/lib/ui/elements/slider.mjs
@@ -79,12 +79,14 @@ export default function slider(params) {
   Formatting and numeric checks will be handled by the numericInput element.
 
   @param {Object} e oninput event from range type input.
+  @param {Object} params params object used to pass additional params to the numericInput input function.
   */
   function onRangeInput(e, params) {
 
     // Range type input return a string target.value.
     const val = Number(e.target.value)
 
+    //Needed to indicate that the change is coming from a slider element
     params.onRangeInput = true;
 
     numericInput.value = val

--- a/lib/ui/elements/slider_ab.mjs
+++ b/lib/ui/elements/slider_ab.mjs
@@ -141,11 +141,14 @@ export default function slider_ab(params) {
   Formatting and numeric checks will be handled by the numericInput element.
 
   @param {Object} e oninput event from range type input.
+  @param {Object} params params object used to pass additional params to the numericInput input function.
   */
   function onRangeInput(e, params) {
 
     // Range type input return a string target.value.
     const val = Number(e.target.value)
+
+    //Needed to indicate that the change is coming from a slider element
     params.onRangeInput = true;
 
     // Check whether input event is from minRangeInput.

--- a/lib/ui/elements/slider_ab.mjs
+++ b/lib/ui/elements/slider_ab.mjs
@@ -27,6 +27,7 @@ export default function slider_ab(params) {
   params.step ??= 1
 
   const minInputParams = {
+    ...params,
     data_id: 'a',
     value: params.val_a,
     rangeInput: 'minRangeInput',
@@ -34,12 +35,11 @@ export default function slider_ab(params) {
     numericChecks
   }
 
-  params = Object.assign(params, minInputParams)
-
   // Create numericInput element for formatting and numeric checks.
-  const minNumericInput = mapp.ui.elements.numericInput(params)
+  const minNumericInput = mapp.ui.elements.numericInput(minInputParams)
 
   const maxInputParams = {
+    ...params,
     data_id: 'b',
     value: params.val_b,
     rangeInput: 'maxRangeInput',
@@ -47,10 +47,8 @@ export default function slider_ab(params) {
     numericChecks
   }
 
-  params = Object.assign(params, maxInputParams)
-
   // Create numericInput element for formatting and numeric checks.
-  const maxNumericInput = mapp.ui.elements.numericInput(params)
+  const maxNumericInput = mapp.ui.elements.numericInput(maxInputParams)
 
   /**
   @function numericChecks
@@ -70,28 +68,32 @@ export default function slider_ab(params) {
   */
   function numericChecks(value, params) {
 
+    // Check whether value is a null.
+    if (value === null) return false;
     // Check whether value is a number.
     if (isNaN(value)) return false;
 
-    if (params.data_id === 'a' && value > maxInputParams.newValue) {
+    //Value should be cast to number
+    value = Number(value);
+
+    if (params.data_id === 'a' && value > Number(maxInputParams.newValue ?? maxInputParams.value)) {
 
       return false
     }
 
-    if (params.data_id === 'b' && value < minInputParams.newValue) {
+    if (params.data_id === 'b' && value < Number(minInputParams.newValue ?? minInputParams.value)) {
 
       return false
     }
 
-    if (params.min && value < params.min) {
-
+    if (value < params.min) {
       // The value is smaller than min.
       return false
     }
 
-    if (params.max) {
+    if (value > params.max) {
 
-      return value <= params.max
+      return false
     }
 
     return true
@@ -150,12 +152,11 @@ export default function slider_ab(params) {
     // Range type input return a string target.value.
     const val = Number(e.target.value)
 
-    //Needed to indicate that the change is coming from a slider element
-    params.onRangeInput = true;
-
     // Check whether input event is from minRangeInput.
     if (e.target.dataset.id === 'a') {
 
+      //Needed to indicate that the change is coming from a slider element
+      minInputParams.onRangeInput = true;
       minNumericInput.value = val
 
       // Trigger formatting and numeric checks.
@@ -165,6 +166,8 @@ export default function slider_ab(params) {
     // Check whether input event is from maxRangeInput.
     if (e.target.dataset.id === 'b') {
 
+      //Needed to indicate that the change is coming from a slider element
+      maxInputParams.onRangeInput = true;
       maxNumericInput.value = val
 
       // Trigger formatting and numeric checks.

--- a/lib/ui/elements/slider_ab.mjs
+++ b/lib/ui/elements/slider_ab.mjs
@@ -86,13 +86,8 @@ export default function slider_ab(params) {
       return false
     }
 
-    if (value < params.min) {
-      // The value is smaller than min.
-      return false
-    }
-
-    if (value > params.max) {
-
+    if (value < params.min || value > params.max) {
+      // The value is smaller than min or is it greater than max.
       return false
     }
 

--- a/lib/ui/elements/slider_ab.mjs
+++ b/lib/ui/elements/slider_ab.mjs
@@ -86,12 +86,9 @@ export default function slider_ab(params) {
       return false
     }
 
-    if (value < params.min || value > params.max) {
-      // The value is smaller than min or is it greater than max.
-      return false
-    }
+    // Check if the value is within the allowed range
+    return !(value < params.min || value > params.max);
 
-    return true
   }
 
   const element = mapp.utils.html.node`

--- a/lib/ui/elements/slider_ab.mjs
+++ b/lib/ui/elements/slider_ab.mjs
@@ -70,28 +70,28 @@ export default function slider_ab(params) {
 
     // Check whether value is a number.
     if (isNaN(value)) return false;
-   
+
     if (params.data_id === 'a' && value > maxInputParams.newValue) {
-  
+
       return false
     }
-  
+
     if (params.data_id === 'b' && value < minInputParams.newValue) {
-  
+
       return false
     }
-  
+
     if (params.min && value < params.min) {
-  
+
       // The value is smaller than min.
       return false
     }
-  
+
     if (params.max) {
-  
+
       return value <= params.max
     }
-  
+
     return true
   }
 
@@ -126,11 +126,11 @@ export default function slider_ab(params) {
         max=${params.max}
         step=${params.step}
         value=${params.val_b}
-        oninput=${onRangeInput}/>`
+        oninput=${e => onRangeInput(e, params)}/>`
 
   // The sliderElement property is required to update the range input on numeric input.
-  minInputParams.sliderElement = element 
-  maxInputParams.sliderElement = element 
+  minInputParams.sliderElement = element
+  maxInputParams.sliderElement = element
 
   /**
   @function onRangeInput
@@ -142,10 +142,11 @@ export default function slider_ab(params) {
 
   @param {Object} e oninput event from range type input.
   */
-  function onRangeInput(e) {
+  function onRangeInput(e, params) {
 
     // Range type input return a string target.value.
     const val = Number(e.target.value)
+    params.onRangeInput = true;
 
     // Check whether input event is from minRangeInput.
     if (e.target.dataset.id === 'a') {

--- a/lib/ui/elements/slider_ab.mjs
+++ b/lib/ui/elements/slider_ab.mjs
@@ -27,7 +27,6 @@ export default function slider_ab(params) {
   params.step ??= 1
 
   const minInputParams = {
-    ...params,
     data_id: 'a',
     value: params.val_a,
     rangeInput: 'minRangeInput',
@@ -35,11 +34,12 @@ export default function slider_ab(params) {
     numericChecks
   }
 
+  params = Object.assign(params, minInputParams)
+
   // Create numericInput element for formatting and numeric checks.
-  const minNumericInput = mapp.ui.elements.numericInput(minInputParams)
+  const minNumericInput = mapp.ui.elements.numericInput(params)
 
   const maxInputParams = {
-    ...params,
     data_id: 'b',
     value: params.val_b,
     rangeInput: 'maxRangeInput',
@@ -47,8 +47,10 @@ export default function slider_ab(params) {
     numericChecks
   }
 
+  params = Object.assign(params, maxInputParams)
+
   // Create numericInput element for formatting and numeric checks.
-  const maxNumericInput = mapp.ui.elements.numericInput(maxInputParams)
+  const maxNumericInput = mapp.ui.elements.numericInput(params)
 
   /**
   @function numericChecks

--- a/lib/ui/elements/slider_ab.mjs
+++ b/lib/ui/elements/slider_ab.mjs
@@ -119,7 +119,7 @@ export default function slider_ab(params) {
         max=${params.max}
         step=${params.step}
         value=${params.val_a}
-        oninput=${onRangeInput}/>
+        oninput=${e => onRangeInput(e, params)}/>
       <input data-id="b" type="range"
         name="maxRangeInput"
         min=${params.min}

--- a/lib/utils/numericFormatter.mjs
+++ b/lib/utils/numericFormatter.mjs
@@ -65,9 +65,8 @@ export function formatNumericValue(params) {
     // "integer" type values must not have fraction digits.
     params.formatterParams.options.maximumFractionDigits ??= params.round || params.type === 'integer' ? 0 : 2
 
-    params.localeString = numericValue.toLocaleString(
-      params.formatterParams.locale,
-      params.formatterParams.options)
+    // Format a numeric value into a localized string representation
+    params.localeString = new Intl.NumberFormat(params.formatterParams.locale, params.formatterParams.options).format(numericValue);
   }
 
   // The trailing fraction character will be store by the unformatStringvalue method if present.
@@ -113,26 +112,29 @@ export function unformatStringValue(params) {
 
   if (stringValue.length && params.formatterParams?.locale) {
 
-    // Determine decimal separator and fraction characters. 
-    const chars = (1234.5).toLocaleString(params.formatterParams?.locale).match(/(\D+)/g);
+    // Create a number formatter using the specified locale
+    const numberFormatter = new Intl.NumberFormat(params.formatterParams.locale);
 
-    // Remove the decimal separator from stringValue.
-    stringValue = stringValue.split(chars[0]).join('');
+    // Get the parts of a formatted number (1.1 is used as an example)
+    const parts = numberFormatter.formatToParts(1.1);
 
+    // Find the decimal separator used in this locale
+    const decimalSeperator = parts.find(part => part.type === 'decimal')?.value;
+
+    // Replace the locale-specific decimal separator with a standard period
+    const normalisedValue = stringValue.replace(decimalSeperator, '.');
+
+    // Remove any non-numeric characters, except for period and minus sign
+    const cleanedValue = normalisedValue.replace(/[^\d.-]/g, '');
+
+    //Delete the lastCharacter
     delete params.lastCharacter
 
-    // Preserve fraction character at end of stringValue
-    if (stringValue.endsWith(chars[1])) {
-      params.lastCharacter = chars[1]
-    }
+    // Parse the cleaned string into a float (decimal) number
+    stringValue = parseFloat(cleanedValue);
 
-    // Preserve 0 fraction at end of stringValue
-    if (stringValue.endsWith(chars[1] + 0)) {
-      params.lastCharacter = chars[1] + 0
-    }
+    stringValue = parseFloat(cleanedValue);
 
-    // Replace the fraction character with dot in stringValue.
-    stringValue = stringValue.split(chars[1]).join('.');
   }
 
   if (stringValue === '') return null;

--- a/lib/utils/numericFormatter.mjs
+++ b/lib/utils/numericFormatter.mjs
@@ -78,20 +78,24 @@ export function formatNumericValue(params) {
 }
 
 /**
-@function unformatStringValue
-
-@description
-The unformatStringValue will splice the suffix and prefix from a stringValue and remove seperators as defined by the localeString locale.
-
-The numeric value will be returned as parsed float.
-
-@param {Object} params The config object argument.
-@property {String} params.suffix Suffix to be removed from stringValue.
-@property {String} params.prefix Prefix to be removed from stringValue.
-@property {Object} params.formatterParams Configuration for the localeString.
-
-@returns {numeric} A numeric value extracted from the stringValue.
-*/
+ * Unformats a string value by removing prefix, suffix, and locale-specific formatting.
+ * 
+ * @function unformatStringValue
+ * @description
+ * This function removes the specified prefix and suffix from the input string,
+ * then unformats the remaining value based on the provided locale settings.
+ * It handles locale-specific decimal separators and removes non-numeric characters.
+ * The resulting numeric value is returned as a parsed float.
+ * 
+ * @param {Object} params - The configuration object.
+ * @param {string} params.stringValue - The input string to be unformatted.
+ * @param {string} [params.prefix] - Prefix to be removed from stringValue.
+ * @param {string} [params.suffix] - Suffix to be removed from stringValue.
+ * @param {Object} [params.formatterParams] - Configuration for locale-specific formatting.
+ * @param {string} [params.formatterParams.locale] - The locale to use for unformatting (e.g., 'en-US', 'de-DE').
+ * 
+ * @returns {number|null} The numeric value extracted from the stringValue, or null if the input is empty or invalid.
+ */
 export function unformatStringValue(params) {
 
   if (!params.stringValue) return null;
@@ -127,13 +131,13 @@ export function unformatStringValue(params) {
     // Remove any non-numeric characters, except for period and minus sign
     const cleanedValue = normalisedValue.replace(/[^\d.-]/g, '');
 
-    //Delete the lastCharacter
+    //Delete the lastCharacter param
     delete params.lastCharacter
 
     // Parse the cleaned string into a float (decimal) number
     stringValue = parseFloat(cleanedValue);
 
-    stringValue = parseFloat(cleanedValue);
+    return stringValue;
 
   }
 

--- a/lib/utils/numericFormatter.mjs
+++ b/lib/utils/numericFormatter.mjs
@@ -120,13 +120,19 @@ export function unformatStringValue(params) {
     const numberFormatter = new Intl.NumberFormat(params.formatterParams.locale);
 
     // Get the parts of a formatted number (1.1 is used as an example)
-    const parts = numberFormatter.formatToParts(1.1);
+    const parts = numberFormatter.formatToParts(10000.1);
 
     // Find the decimal separator used in this locale
     const decimalSeperator = parts.find(part => part.type === 'decimal')?.value;
 
+    //Find the thousand seperator used in the locale
+    const thousandSeperator = parts.find(part => part.type === 'group')?.value;
+
     // Replace the locale-specific decimal separator with a standard period
-    const normalisedValue = stringValue.replace(decimalSeperator, '.');
+    let normalisedValue = stringValue.replaceAll(thousandSeperator, '');
+
+    // Replace the locale-specific decimal separator with a standard period
+    normalisedValue = normalisedValue.replace(decimalSeperator, '.');
 
     // Remove any non-numeric characters, except for period and minus sign
     const cleanedValue = normalisedValue.replace(/[^\d.-]/g, '');

--- a/lib/utils/numericFormatter.mjs
+++ b/lib/utils/numericFormatter.mjs
@@ -127,10 +127,10 @@ export function unformatStringValue(params) {
     }
 
     // Preserve 0 fraction at end of stringValue
-    if (stringValue.endsWith(chars[1]+0)) {
-      params.lastCharacter = chars[1]+0
-    }    
-    
+    if (stringValue.endsWith(chars[1] + 0)) {
+      params.lastCharacter = chars[1] + 0
+    }
+
     // Replace the fraction character with dot in stringValue.
     stringValue = stringValue.split(chars[1]).join('.');
   }

--- a/lib/utils/numericFormatter.mjs
+++ b/lib/utils/numericFormatter.mjs
@@ -140,6 +140,16 @@ export function unformatStringValue(params) {
     //Delete the lastCharacter param
     delete params.lastCharacter
 
+    // Preserve fraction character at end of stringValue
+    if (stringValue.endsWith(decimalSeperator)) {
+      params.lastCharacter = decimalSeperator
+    }
+
+    // Preserve 0 fraction at end of stringValue
+    if (stringValue.endsWith(decimalSeperator + 0)) {
+      params.lastCharacter = decimalSeperator + 0
+    }
+
     // Parse the cleaned string into a float (decimal) number
     stringValue = parseFloat(cleanedValue);
 

--- a/tests/assets/infoj/template_infoj.json
+++ b/tests/assets/infoj/template_infoj.json
@@ -7,6 +7,21 @@
             "fieldfx": "ARRAY[ST_X(ST_PointOnSurface(geom_3857)),ST_Y(ST_PointOnSurface(geom_3857))]"
         },
         {
+            "label": "minmax",
+            "field": "numeric_field",
+            "type": "numeric",
+            "filter": {
+                "minmax_query": "minmax_query",
+                "type": "numeric"
+            },
+            "edit": {
+                "range": true
+            },
+            "formatterParams": {
+                "locale": "DE"
+            }
+        },
+        {
             "display": true,
             "type": "dataview",
             "label": "foo",

--- a/tests/assets/infoj/template_infoj.json
+++ b/tests/assets/infoj/template_infoj.json
@@ -7,6 +7,18 @@
             "fieldfx": "ARRAY[ST_X(ST_PointOnSurface(geom_3857)),ST_Y(ST_PointOnSurface(geom_3857))]"
         },
         {
+            "label": "minmax",
+            "field": "",
+            "filter": {
+                "min": -10,
+                "max": 10000,
+                "type": "numeric"
+            },
+            "formatterParams": {
+                "locale": "DE"
+            }
+        },
+        {
             "display": true,
             "type": "dataview",
             "label": "foo",

--- a/tests/assets/infoj/template_infoj.json
+++ b/tests/assets/infoj/template_infoj.json
@@ -7,18 +7,6 @@
             "fieldfx": "ARRAY[ST_X(ST_PointOnSurface(geom_3857)),ST_Y(ST_PointOnSurface(geom_3857))]"
         },
         {
-            "label": "minmax",
-            "field": "",
-            "filter": {
-                "min": -10,
-                "max": 10000,
-                "type": "numeric"
-            },
-            "formatterParams": {
-                "locale": "DE"
-            }
-        },
-        {
             "display": true,
             "type": "dataview",
             "label": "foo",

--- a/tests/browser/local.test.mjs
+++ b/tests/browser/local.test.mjs
@@ -12,7 +12,8 @@ import { ui_elementsTest } from '../lib/ui/elements/_elements.test.mjs';
 
 import { ui_layers } from '../lib/ui/layers/_layers.test.mjs';
 import { entriesTest } from '../lib/ui/locations/entries/_entries.test.mjs';
-import {uiTest} from '../lib/ui/_ui.test.mjs';
+import { uiTest } from '../lib/ui/_ui.test.mjs';
+import { utilsTest } from '../lib/utils/_utils.test.mjs';
 
 //API Tests
 await workspaceTest();
@@ -53,3 +54,5 @@ await entriesTest.geometryTest(mapview);
 await ui_layers.filtersTest(mapview);
 
 await uiTest.Tabview();
+
+await utilsTest.numericFormatterTest();

--- a/tests/lib/layer/format/vector.test.mjs
+++ b/tests/lib/layer/format/vector.test.mjs
@@ -9,7 +9,7 @@
  * @param {object} mapview 
  */
 export async function vectorTest(mapview) {
-    codi.describe('Layer Format: Vector', async () => {
+    await codi.describe('Layer Format: Vector', async () => {
 
         /**
          * ### Should be able to create a cluster layer
@@ -19,7 +19,7 @@ export async function vectorTest(mapview) {
          * 4. We expect the format of the layer to change to 'cluster'
          * @function it
          */
-        codi.it('Should create a cluster layer', async () => {
+        await codi.it('Should create a cluster layer', async () => {
             const layer_params = {
                 mapview: mapview,
                 'key': 'cluster_test',

--- a/tests/lib/ui/elements/alert.test.mjs
+++ b/tests/lib/ui/elements/alert.test.mjs
@@ -13,8 +13,6 @@ export async function alertTest() {
         await codi.describe('Should create an alert with params provided', async () => {
             const alert = await mapp.ui.elements.alert({ title: 'ALERT TITLE', text: 'ALERT TEXT' });
 
-            console.log(alert);
-
             codi.assertTrue(alert !== undefined, 'We expect to see the alert element');
 
             await codi.it('Should have a title of ALERT TITLE', async () => {

--- a/tests/lib/ui/layers/filters.test.mjs
+++ b/tests/lib/ui/layers/filters.test.mjs
@@ -9,7 +9,7 @@ export async function filtersTest(mapview) {
         //Creating the filter to be used in other tests
         let filter = {
             field: 'id',
-            minmax_query: 'minmax_query_mock'
+            minmax_query: 'minmax_query'
         };
 
         //Getting a layer

--- a/tests/lib/utils/_utils.test.mjs
+++ b/tests/lib/utils/_utils.test.mjs
@@ -1,0 +1,3 @@
+import { numericFormatterTest } from './numericFormatter.test.mjs';
+
+export const utilsTest = { numericFormatterTest }

--- a/tests/lib/utils/numericFormatter.test.mjs
+++ b/tests/lib/utils/numericFormatter.test.mjs
@@ -78,8 +78,6 @@ export async function numericFormatterTest() {
         });
 
         await codi.it('Should unformat PL locale strings', async () => {
-            //Settings the locale to 'PL'
-            params.formatterParams.locale = 'PL';
             mapp.utils.formatNumericValue(params);
 
             const unformattedString = mapp.utils.unformatStringValue(params)
@@ -101,8 +99,6 @@ export async function numericFormatterTest() {
         });
 
         await codi.it('Should unformat RUB locale strings', async () => {
-            //Settings the locale to 'RUB'
-            params.formatterParams.locale = 'RUB';
             mapp.utils.formatNumericValue(params);
 
             const unformattedString = mapp.utils.unformatStringValue(params)

--- a/tests/lib/utils/numericFormatter.test.mjs
+++ b/tests/lib/utils/numericFormatter.test.mjs
@@ -1,0 +1,44 @@
+/**
+ * @module utils/numericFormatter
+ */
+
+/**
+ * This function is used as an entry point for the numericFormatter Test
+ * @function numericFormatterTest
+ */
+export async function numericFormatterTest() {
+
+    codi.describe('Utils: numericFormatter Test', async () => {
+        const params = {
+            stringValue: '1234.5',
+            prefix: '$',
+            formatterParams: {
+                locale: 'UK'
+            }
+        };
+
+        const expected_value = 1234.5
+        /**
+         * ### Should unformat UK locale string
+         * This test is used to check if a localised string to UK returns the correct string.
+         * @function it
+         */
+        await codi.it('Should unformat UK locale strings', async () => {
+
+            const unformattedString = mapp.utils.unformatStringValue(params)
+            codi.assertEqual(unformattedString, expected_value, `We expect the value to equal ${expected_value}, we received ${unformattedString}`)
+        });
+        /**
+         * ### Should unformat DE locale string
+         * This test is used to check if a localised string to DE returns the correct string.
+         * @function it
+         */
+        await codi.it('Should unformat DE locale strings', async () => {
+            //Settings the locale to 'DE'
+            params.formatterParams.locale = 'DE'
+
+            const unformattedString = mapp.utils.unformatStringValue(params)
+            codi.assertEqual(unformattedString, expected_value, `We expect the value to equal ${expected_value}, we received ${unformattedString}`)
+        });
+    });
+}

--- a/tests/lib/utils/numericFormatter.test.mjs
+++ b/tests/lib/utils/numericFormatter.test.mjs
@@ -8,16 +8,16 @@
  */
 export async function numericFormatterTest() {
 
-    codi.describe('Utils: numericFormatter Test', async () => {
+    await codi.describe('Utils: numericFormatter Test', async () => {
         const params = {
-            stringValue: '1234.5',
+            stringValue: '654321.987',
             prefix: '$',
             formatterParams: {
                 locale: 'UK'
             }
         };
 
-        const expected_value = 1234.5
+        const expected_value = 654321.987
         /**
          * ### Should unformat UK locale string
          * This test is used to check if a localised string to UK returns the correct string.
@@ -36,6 +36,22 @@ export async function numericFormatterTest() {
         await codi.it('Should unformat DE locale strings', async () => {
             //Settings the locale to 'DE'
             params.formatterParams.locale = 'DE'
+
+            const unformattedString = mapp.utils.unformatStringValue(params)
+            codi.assertEqual(unformattedString, expected_value, `We expect the value to equal ${expected_value}, we received ${unformattedString}`)
+        });
+
+        await codi.it('Should unformat PL locale strings', async () => {
+            //Settings the locale to 'PL'
+            params.formatterParams.locale = 'PL'
+
+            const unformattedString = mapp.utils.unformatStringValue(params)
+            codi.assertEqual(unformattedString, expected_value, `We expect the value to equal ${expected_value}, we received ${unformattedString}`)
+        });
+
+        await codi.it('Should unformat RUB locale strings', async () => {
+            //Settings the locale to 'RUB'
+            params.formatterParams.locale = 'RUB'
 
             const unformattedString = mapp.utils.unformatStringValue(params)
             codi.assertEqual(unformattedString, expected_value, `We expect the value to equal ${expected_value}, we received ${unformattedString}`)

--- a/tests/lib/utils/numericFormatter.test.mjs
+++ b/tests/lib/utils/numericFormatter.test.mjs
@@ -10,14 +10,14 @@ export async function numericFormatterTest() {
 
     await codi.describe('Utils: numericFormatter Test', async () => {
         const params = {
-            stringValue: '654321.987',
+            value: 654321.987,
             prefix: '$',
             formatterParams: {
-                locale: 'UK'
+                locale: 'en-UK'
             }
         };
 
-        const expected_value = 654321.987
+        const expected_value = 654321.99
         /**
          * ### Should unformat UK locale string
          * This test is used to check if a localised string to UK returns the correct string.
@@ -25,6 +25,7 @@ export async function numericFormatterTest() {
          */
         await codi.it('Should unformat UK locale strings', async () => {
 
+            mapp.utils.formatNumericValue(params);
             const unformattedString = mapp.utils.unformatStringValue(params)
             codi.assertEqual(unformattedString, expected_value, `We expect the value to equal ${expected_value}, we received ${unformattedString}`)
         });
@@ -35,15 +36,17 @@ export async function numericFormatterTest() {
          */
         await codi.it('Should unformat DE locale strings', async () => {
             //Settings the locale to 'DE'
-            params.formatterParams.locale = 'DE'
+            params.formatterParams.locale = 'de-AT';
 
+            mapp.utils.formatNumericValue(params);
             const unformattedString = mapp.utils.unformatStringValue(params)
             codi.assertEqual(unformattedString, expected_value, `We expect the value to equal ${expected_value}, we received ${unformattedString}`)
         });
 
         await codi.it('Should unformat PL locale strings', async () => {
             //Settings the locale to 'PL'
-            params.formatterParams.locale = 'PL'
+            params.formatterParams.locale = 'PL';
+            mapp.utils.formatNumericValue(params);
 
             const unformattedString = mapp.utils.unformatStringValue(params)
             codi.assertEqual(unformattedString, expected_value, `We expect the value to equal ${expected_value}, we received ${unformattedString}`)
@@ -51,7 +54,8 @@ export async function numericFormatterTest() {
 
         await codi.it('Should unformat RUB locale strings', async () => {
             //Settings the locale to 'RUB'
-            params.formatterParams.locale = 'RUB'
+            params.formatterParams.locale = 'RUB';
+            mapp.utils.formatNumericValue(params);
 
             const unformattedString = mapp.utils.unformatStringValue(params)
             codi.assertEqual(unformattedString, expected_value, `We expect the value to equal ${expected_value}, we received ${unformattedString}`)

--- a/tests/lib/utils/numericFormatter.test.mjs
+++ b/tests/lib/utils/numericFormatter.test.mjs
@@ -17,7 +17,18 @@ export async function numericFormatterTest() {
             }
         };
 
-        const expected_value = 654321.99
+        const expected_unformated_value = 654321.99
+        let expected_formated_value = '$654,321.99'
+        /**
+         * ### Should format UK locale Numeric Values
+         * This test is used to check if a numeric value gets formatted to the correct localised UK string.
+         * @function it
+         */
+        await codi.it('Should format UK locale Numeric Values', async () => {
+
+            const formattedValue = mapp.utils.formatNumericValue(params);
+            codi.assertEqual(formattedValue, expected_formated_value, `We expect the value to equal ${expected_formated_value}, we received ${formattedValue}`)
+        });
         /**
          * ### Should unformat UK locale string
          * This test is used to check if a localised string to UK returns the correct string.
@@ -25,9 +36,21 @@ export async function numericFormatterTest() {
          */
         await codi.it('Should unformat UK locale strings', async () => {
 
-            mapp.utils.formatNumericValue(params);
             const unformattedString = mapp.utils.unformatStringValue(params)
-            codi.assertEqual(unformattedString, expected_value, `We expect the value to equal ${expected_value}, we received ${unformattedString}`)
+            codi.assertEqual(unformattedString, expected_unformated_value, `We expect the value to equal ${expected_unformated_value}, we received ${unformattedString}`)
+        });
+        /**
+         * ### Should format DE locale Numeric Values
+         * This test is used to check if a numeric value gets formatted to the correct localised DE string.
+         * @function it
+         */
+        await codi.it('Should format DE locale Numeric Values', async () => {
+            //Settings the locale to 'DE'
+            params.formatterParams.locale = 'DE';
+            expected_formated_value = '$654.321,99'
+
+            const formattedValue = mapp.utils.formatNumericValue(params);
+            codi.assertEqual(formattedValue, expected_formated_value, `We expect the value to equal ${expected_formated_value}, we received ${formattedValue}`)
         });
         /**
          * ### Should unformat DE locale string
@@ -35,12 +58,23 @@ export async function numericFormatterTest() {
          * @function it
          */
         await codi.it('Should unformat DE locale strings', async () => {
-            //Settings the locale to 'DE'
-            params.formatterParams.locale = 'de-AT';
 
-            mapp.utils.formatNumericValue(params);
             const unformattedString = mapp.utils.unformatStringValue(params)
-            codi.assertEqual(unformattedString, expected_value, `We expect the value to equal ${expected_value}, we received ${unformattedString}`)
+            codi.assertEqual(unformattedString, expected_unformated_value, `We expect the value to equal ${expected_unformated_value}, we received ${unformattedString}`)
+        });
+
+        /**
+         * ### Should format PL locale Numeric Values
+         * This test is used to check if a numeric value gets formatted to the correct localised PL string.
+         * @function it
+         */
+        await codi.it('Should format PL locale Numeric Values', async () => {
+            //Settings the locale to 'DE'
+            params.formatterParams.locale = 'PL';
+            expected_formated_value = '$654 321,99'
+
+            const formattedValue = mapp.utils.formatNumericValue(params);
+            codi.assertEqual(formattedValue, expected_formated_value, `We expect the value to equal ${expected_formated_value}, we received ${formattedValue}`)
         });
 
         await codi.it('Should unformat PL locale strings', async () => {
@@ -49,7 +83,21 @@ export async function numericFormatterTest() {
             mapp.utils.formatNumericValue(params);
 
             const unformattedString = mapp.utils.unformatStringValue(params)
-            codi.assertEqual(unformattedString, expected_value, `We expect the value to equal ${expected_value}, we received ${unformattedString}`)
+            codi.assertEqual(unformattedString, expected_unformated_value, `We expect the value to equal ${expected_unformated_value}, we received ${unformattedString}`)
+        });
+
+        /**
+         * ### Should format RUB locale Numeric Values
+         * This test is used to check if a numeric value gets formatted to the correct localised PL string.
+         * @function it
+         */
+        await codi.it('Should format RUB locale Numeric Values', async () => {
+            //Settings the locale to 'DE'
+            params.formatterParams.locale = 'RUB';
+            expected_formated_value = '$654,321.99';
+
+            const formattedValue = mapp.utils.formatNumericValue(params);
+            codi.assertEqual(formattedValue, expected_formated_value, `We expect the value to equal ${expected_formated_value}, we received ${formattedValue}`)
         });
 
         await codi.it('Should unformat RUB locale strings', async () => {
@@ -58,7 +106,7 @@ export async function numericFormatterTest() {
             mapp.utils.formatNumericValue(params);
 
             const unformattedString = mapp.utils.unformatStringValue(params)
-            codi.assertEqual(unformattedString, expected_value, `We expect the value to equal ${expected_value}, we received ${unformattedString}`)
+            codi.assertEqual(unformattedString, expected_unformated_value, `We expect the value to equal ${expected_unformated_value}, we received ${unformattedString}`)
         });
     });
 }

--- a/tests/mod/workspace/_workspace.test.mjs
+++ b/tests/mod/workspace/_workspace.test.mjs
@@ -33,11 +33,11 @@ export async function workspaceTest() {
             codi.assertTrue(!!layer.table, 'Ensure that the layer has a table');
             codi.assertTrue(!!layer.geom, 'Ensure that the layer has a geom');
             codi.assertTrue(!!layer.group, 'Ensure that the layer has a group');
-            codi.assertEqual(layer.infoj.length, 6, 'The infoj should always have 6 infoj entries')
+            codi.assertEqual(layer.infoj.length, 7, 'The infoj should always have 7 infoj entries')
             codi.assertTrue(!!layer.style, 'The layer needs to have a style object from another template')
 
             layer = await mapp.utils.xhr(`/test/api/workspace/layer?layer=template_test`);
-            codi.assertEqual(layer.infoj.length, 6, 'The infoj should always have 6 infoj entries')
+            codi.assertEqual(layer.infoj.length, 7, 'The infoj should always have 7 infoj entries')
             codi.assertTrue(!!layer.style, 'The layer needs to have a style object from another template')
             codi.assertTrue(!!layer.err, 'The layer should have a error array')
             codi.assertEqual(layer.err.length, 1, 'There should be on failure on the layer');
@@ -46,7 +46,7 @@ export async function workspaceTest() {
         await codi.it('Workspace: Getting template_test_vanilla Layer', async () => {
             let layer = await mapp.utils.xhr(`/test/api/workspace/layer?layer=template_test_vanilla`);
             codi.assertEqual(layer.key, 'template_test_vanilla', 'Ensure that we get the template_test_vanilla layer from the API')
-            codi.assertEqual(layer.infoj.length, 5, 'The infoj should always have 5 infoj entries')
+            codi.assertEqual(layer.infoj.length, 6, 'The infoj should always have 6 infoj entries')
             codi.assertTrue(!!layer.style, 'The layer needs to have a style object from another template')
         });
 

--- a/tests/workspace.json
+++ b/tests/workspace.json
@@ -25,7 +25,7 @@
         "get_location_mock": {
             "src": "file:/tests/assets/queries/get_location_mock.sql"
         },
-        "minmax_query_mock": {
+        "minmax_query": {
             "src": "file:/tests/assets/queries/minmax_mock.sql"
         },
         "data_array": {


### PR DESCRIPTION
## Description

The numeric formatter fails on slider element input elements for a user with a locale that uses comma decimals, eg. DE 🇩🇪

The comma seperator isn't displayed and the return is an integer instead of a float.
## GitHub Issue

https://github.com/GEOLYTIX/xyz/issues/1499

## Type of Change
- ✅ Bug fix (non-breaking change which fixes an issue)
- ✅ Testing

## Testing Checklist 
- ✅ Existing Tests still pass
- ✅ New Tests Added

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1208407306088410