### PR TITLE
Infoj Order Correction

### DIFF
--- a/lib/ui/locations/infoj.mjs
+++ b/lib/ui/locations/infoj.mjs
@@ -45,33 +45,47 @@ export default function infoj(location, infoj_order) {
   // Create object to hold view groups.
   groups = {}
 
-  // The infoj_order may be assigned to the layer.
-  infoj_order ??= location?.layer?.infoj_order
-
   // infoj argument is provided as an array of strings to filter the location infoj entries.
   const infoj = Array.isArray(infoj_order) ?
-    infoj_order.map(_entry => {
-
-      if (typeof _entry === 'string') {
-
-
-        const infoj_order_field = location.infoj.find(entry => new Set([entry.key, entry.field, entry.query]).has(_entry));
-
-        // if undefined then warn the user.
-        if (!infoj_order_field) console.warn(`infoj_order field: "${_entry}" not found in location.infoj. Please add entry.key, entry.field, or entry.query to the entry.`);
-
-        // Check whether the _entry string matches an infoj entry keyvalue.
-        return infoj_order_field
-
-      } else if (typeof _entry === 'object') {
-
-        _entry.location = location
-
-        // Return object _entry.
-        return _entry
-      }
-    }).filter(entry => entry !== undefined)
+    infoj_order
+      .map(infoj_orderMap)
+      .filter(entry => entry !== undefined)
     : location.infoj;
+
+  /**
+  @function infoj_orderMap
+
+  @description
+  The infoj_order argument allows to order and filter the location.layer.infoj array.
+
+  The map function attempts to find and return an infoj-entry whose key, field, or query property values match the _entry string.
+
+  If typeof object the _entry itself will be returned. This allows for additional infoj-entry objects to be spliced into the infoj array.
+
+  @param {string||object} _entry 
+  @returns {infoj-entry} Either the _entry object itself, a lookup entry from the location.layer.infoj array, or undefined.
+  */
+  function infoj_orderMap(_entry) {
+
+    if (typeof _entry === 'string') {
+
+      // Find infoj-entry with matching key, field, or query property.
+      const infoj_order_field = location.infoj
+        .find(entry => new Set([entry.key, entry.field, entry.query]).has(_entry));
+
+      if (!infoj_order_field) {
+        console.warn(`infoj_order field: "${_entry}" not found in location.infoj. Please add entry.key, entry.field, or entry.query to the entry.`);
+      }
+
+      return infoj_order_field
+
+    } else if (typeof _entry === 'object') {
+
+      _entry.location = location
+
+      return _entry
+    }
+  }
 
   let keyIdx = 0;
 

--- a/lib/ui/locations/infoj.mjs
+++ b/lib/ui/locations/infoj.mjs
@@ -53,7 +53,9 @@ export default function infoj(location, infoj_order) {
     infoj_order.map(_entry => {
 
       if (typeof _entry === 'string') {
-        const infoj_order_field = location.infoj.find(entry => (entry.key || entry.field || entry.query) === _entry);
+
+
+        const infoj_order_field = location.infoj.find(entry => new Set([entry.key, entry.field, entry.query]).has(_entry));
 
         // if undefined then warn the user.
         if (!infoj_order_field) console.warn(`infoj_order field: "${_entry}" not found in location.infoj. Please add entry.key, entry.field, or entry.query to the entry.`);
@@ -70,7 +72,7 @@ export default function infoj(location, infoj_order) {
       }
     }).filter(entry => entry !== undefined)
     : location.infoj;
-  
+
   let keyIdx = 0;
 
   // Iterate through info fields and add to info table.
@@ -314,7 +316,7 @@ The group layout will be expanded by adding the expanded class to the group elem
 @property {HTMLElement} entry.listview The listview element will be returned from the infoj method and appended to the location.view.
 */
 function entryGroup(entry) {
-  
+
   if (!entry.group) return;
 
   // Create new group

--- a/tests/browser/local.test.mjs
+++ b/tests/browser/local.test.mjs
@@ -14,6 +14,8 @@ import { ui_layers } from '../lib/ui/layers/_layers.test.mjs';
 import { entriesTest } from '../lib/ui/locations/entries/_entries.test.mjs';
 import { uiTest } from '../lib/ui/_ui.test.mjs';
 import { formatTest } from '../lib/layer/format/_format.test.mjs';
+import { ui_locations } from '../lib/ui/locations/_locations.test.mjs';
+
 //API Tests
 await workspaceTest();
 await queryTest();
@@ -55,3 +57,5 @@ await ui_layers.filtersTest(mapview);
 await uiTest.Tabview();
 
 await formatTest.vectorTest(mapview);
+
+await ui_locations.infojTest();

--- a/tests/lib/ui/locations/_locations.test.mjs
+++ b/tests/lib/ui/locations/_locations.test.mjs
@@ -1,0 +1,3 @@
+import { infojTest } from './infoj.test.mjs';
+
+export const ui_locations = { infojTest };

--- a/tests/lib/ui/locations/infoj.test.mjs
+++ b/tests/lib/ui/locations/infoj.test.mjs
@@ -3,82 +3,76 @@
  * @function injojTest
  */
 export async function infojTest() {
-    codi.describe('UI Locations: infojTest', async () => {
-        /**
-         * ### It should create an infoj with a correct order
-         * 1. We define an infoj with a combination of different entries with keys, fields and queries
-         * 2. We assert against the order
-         * @function it
-         */
-        await codi.it('It should create an infoj with certain order', async () => {
+  codi.describe('UI Locations: infojTest', async () => {
+    /**
+     * ### It should create an infoj with a correct order
+     * 1. We define an infoj with a combination of different entries with keys, fields and queries
+     * 2. We assert against the order
+     * @function it
+     */
+    await codi.it('It should create an infoj with certain order', async () => {
 
-            //Result array to get values from list view
-            const results = [];
+      const location = {
+        infoj: [
+          {
+            field: 'field_1',
+            key: 'key_1',
+            label: 'test_1',
+            value: 'test 1 value'
+          },
+          {
+            field: 'field_2',
+            label: 'test_2',
+            value: 'value_2'
+          },
+          {
+            field: 'field_3',
+            label: 'test_3',
+            value: 'value_3'
+          },
+          {
+            key: 'key_4',
+            value: 'value_4'
+          },
+          {
+            query: 'query_5',
+            value: 'value_5',
+            location: {}
+          }
+        ]
+      };
 
-            //Expected results
-            const expected = [
-                'value_2',
-                'value_3',
-                'value_4',
-                'value_5',
-                'value_6'
-            ];
+      const infoj_order = [
+        '_field_1',
+        'field_2',
+        'field_3',
+        'key_4',
+        'query_5',
+        {
+          field: 'field6',
+          value: 'value_6'
+        }
+      ];
 
-            //location object used in infoj method
-            const location = {
-                infoj: [
-                    {
-                        field: 'field_1',
-                        key: 'key_1',
-                        label: 'test_1',
-                        value: 'test 1 value'
-                    },
-                    {
-                        field: 'field_2',
-                        label: 'test_2',
-                        value: 'value_2'
-                    },
-                    {
-                        field: 'field_3',
-                        label: 'test_3',
-                        value: 'value_3'
-                    },
-                    {
-                        key: 'key_4',
-                        value: 'value_4'
-                    },
-                    {
-                        query: 'query_5',
-                        value: 'value_5',
-                        location: {}
-                    }
-                ]
-            };
+      // Expected results
+      const expected = [
+        'value_2',
+        'value_3',
+        'value_4',
+        'value_5',
+        'value_6'
+      ];
 
-            //This is the infoj_order we expect
-            const infoj_order = [
-                '_field_1',
-                'field_2',
-                'field_3',
-                'key_4',
-                'query_5',
-                {
-                    field: 'field6',
-                    value: 'value_6'
-                }
-            ];
+      // Get listview element from the infoj object
+      const infoj = mapp.ui.locations.infoj(location, infoj_order);
 
-            //Geting the listview from the infoj object
-            const infoj = mapp.ui.locations.infoj(location, infoj_order);
+      // Get textvalues from location listview elements.
+      const results = Array.from(infoj.children)
+        .map(el => el.firstChild.innerText.trim())
 
-            //Pushing the values from the listview returned
-            for (let entry of infoj.children) {
-                results.push(entry.firstChild.innerText.trim());
-            }
+      // Asserting we get the expected results and order
+      codi.assertEqual(results, expected, 'The infoj order needs to be as defined in the expected');
 
-            //Asserting we get the expected results and order
-            codi.assertEqual(results, expected, 'The infoj order needs to be as defined in the expected');
-
-        });
     });
+  });
 }

--- a/tests/lib/ui/locations/infoj.test.mjs
+++ b/tests/lib/ui/locations/infoj.test.mjs
@@ -1,0 +1,84 @@
+/**
+ * This function is used as an entry point for the infoj test
+ * @function injojTest
+ */
+export async function infojTest() {
+    codi.describe('UI Locations: infojTest', async () => {
+        /**
+         * ### It should create an infoj with a correct order
+         * 1. We define an infoj with a combination of different entries with keys, fields and queries
+         * 2. We assert against the order
+         * @function it
+         */
+        await codi.it('It should create an infoj with certain order', async () => {
+
+            //Result array to get values from list view
+            const results = [];
+
+            //Expected results
+            const expected = [
+                'value_2',
+                'value_3',
+                'value_4',
+                'value_5',
+                'value_6'
+            ];
+
+            //location object used in infoj method
+            const location = {
+                infoj: [
+                    {
+                        field: 'field_1',
+                        key: 'key_1',
+                        label: 'test_1',
+                        value: 'test 1 value'
+                    },
+                    {
+                        field: 'field_2',
+                        label: 'test_2',
+                        value: 'value_2'
+                    },
+                    {
+                        field: 'field_3',
+                        label: 'test_3',
+                        value: 'value_3'
+                    },
+                    {
+                        key: 'key_4',
+                        value: 'value_4'
+                    },
+                    {
+                        query: 'query_5',
+                        value: 'value_5',
+                        location: {}
+                    }
+                ]
+            };
+
+            //This is the infoj_order we expect
+            const infoj_order = [
+                '_field_1',
+                'field_2',
+                'field_3',
+                'key_4',
+                'query_5',
+                {
+                    field: 'field6',
+                    value: 'value_6'
+                }
+            ];
+
+            //Geting the listview from the infoj object
+            const infoj = mapp.ui.locations.infoj(location, infoj_order);
+
+            //Pushing the values from the listview returned
+            for (let entry of infoj.children) {
+                results.push(entry.firstChild.innerText.trim());
+            }
+
+            //Asserting we get the expected results and order
+            codi.assertEqual(results, expected, 'The infoj order needs to be as defined in the expected');
+
+        });
+    });
+}

--- a/tests/lib/ui/locations/infoj.test.mjs
+++ b/tests/lib/ui/locations/infoj.test.mjs
@@ -54,6 +54,13 @@ export async function infojTest() {
         }
       ];
 
+      // Get listview element from the infoj object
+      const infoj = mapp.ui.locations.infoj(location, infoj_order);
+
+      // Get textvalues from location listview elements.
+      const results = Array.from(infoj.children)
+        .map(el => el.firstChild.innerText.trim())
+
       // Expected results
       const expected = [
         'value_2',
@@ -61,14 +68,7 @@ export async function infojTest() {
         'value_4',
         'value_5',
         'value_6'
-      ];
-
-      // Get listview element from the infoj object
-      const infoj = mapp.ui.locations.infoj(location, infoj_order);
-
-      // Get textvalues from location listview elements.
-      const results = Array.from(infoj.children)
-        .map(el => el.firstChild.innerText.trim())
+      ];        
 
       // Asserting we get the expected results and order
       codi.assertEqual(results, expected, 'The infoj order needs to be as defined in the expected');


### PR DESCRIPTION
## Description

The lookup for the infoj_order checks on key, then field, and finally query. This fails when a key exists but doesn't match.

We have created a set of the different fields that will then be compared with a has check on the entry.

## [GitHub Issue](https://github.com/GEOLYTIX/xyz/issues/1497)

## Type of Change
Please delete options that are not relevant, and select all options that apply. 

- ✅ Bug fix (non-breaking change which fixes an issue)
- ✅ Testing

## How have you tested this? 
Run the local tests.
## Testing Checklist 

- ✅ Existing Tests still pass
- ✅ New Tests Added
- ✅ Ran locally on my machine