### PR TITLE
Fix code scanning alert no. 204: Prototype-polluting function

### DIFF
--- a/lib/utils/merge.mjs
+++ b/lib/utils/merge.mjs
@@ -41,19 +41,25 @@ export default function mergeDeep(target, ...sources) {
     // Iterate over object keys in source.
     for (const key in source) {
 
+      // Block prototype pollution properties.
+      if (key === "__proto__" || key === "constructor") {
+        console.warn(`Blocked prototype pollution attempt for key: ${key}`);
+        continue;
+      }
+
       // Key must not be in target object prototype.
       if (proto[key]) {
-        console.warn(`Prototype polution detected for key: ${key}`)
+        console.warn(`Prototype pollution detected for key: ${key}`);
 
       // HTMLElement objects must not be merged.
       } else if (source[key] instanceof HTMLElement) {
-        console.warn(source[key])
+        console.warn(source[key]);
 
       // source[key] is object with potential nesting.
       } else if (isObject(source[key])) {
 
         // Target key must be an object.
-        target[key] ??= {}
+        target[key] ??= {};
 
         // Call recursive merge for target key object.
         mergeDeep(target[key], source[key]);
@@ -61,7 +67,7 @@ export default function mergeDeep(target, ...sources) {
       // source[key] could be null, true, false, or Array object
       } else {
 
-        target[key] = source[key]
+        target[key] = source[key];
       }
     }
   }


### PR DESCRIPTION
Fixes [https://github.com/GEOLYTIX/xyz/security/code-scanning/204](https://github.com/GEOLYTIX/xyz/security/code-scanning/204)

To fix the prototype pollution issue in the `mergeDeep` function, we need to explicitly block the properties `__proto__` and `constructor` from being merged. This can be done by adding a check to skip these properties during the merge process. This approach ensures that these dangerous properties are not assigned to the `target` object, thus preventing prototype pollution.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
