### PR TITLE
Fix code scanning alert no. 191: Type confusion through parameter tampering

### DIFF
--- a/mod/query.js
+++ b/mod/query.js
@@ -228,7 +228,9 @@ function getQueryFromTemplate(req, template) {
 
       // Ensure that the $n substitute params match the SQL length on layer queries without a ${filter}
       delete req.params.filter
-      req.params.SQL = Array.isArray(req.params.SQL) ? req.params.SQL : []
+      //We remove the SQL params because there is no filter at this stage so we don't have any values to substitute.
+      //If there are any other substitues they get added after.
+      req.params.SQL.length = 0
     }
 
     const query_template = template.template
@@ -321,7 +323,7 @@ async function executeQuery(req, res, template, query) {
   // Return without executing the query if a param errs.
   if (req.params.SQL.some(param => param instanceof Error)) {
 
-    const paramsArray = req.params.SQL.map(param => param instanceof Error? param.message : param)
+    const paramsArray = req.params.SQL.map(param => param instanceof Error ? param.message : param)
 
     paramsArray.unshift('Parameter validation failed.')
 

--- a/mod/query.js
+++ b/mod/query.js
@@ -228,7 +228,7 @@ function getQueryFromTemplate(req, template) {
 
       // Ensure that the $n substitute params match the SQL length on layer queries without a ${filter}
       delete req.params.filter
-      req.params.SQL = []
+      req.params.SQL = Array.isArray(req.params.SQL) ? req.params.SQL : []
     }
 
     const query_template = template.template
@@ -274,7 +274,7 @@ function getQueryFromTemplate(req, template) {
         }
 
         // Push value from request params object into params array.
-        req.params.SQL.push(val)
+        req.params.SQL.push(val);
 
         return `$${req.params.SQL.length}`
       })


### PR DESCRIPTION
Fixes [https://github.com/GEOLYTIX/xyz/security/code-scanning/191](https://github.com/GEOLYTIX/xyz/security/code-scanning/191)

To fix the problem, we need to ensure that `req.params.SQL` is an array before performing any operations on it. If it is not an array, we should initialize it as an empty array. This will prevent type confusion and ensure that the code behaves as expected.

- Check the type of `req.params.SQL` before using it.
- If `req.params.SQL` is not an array, initialize it as an empty array.
- This change should be made in the `getQueryFromTemplate` function where `req.params.SQL` is used.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
