### PR TITLE
Fix code scanning alert no. 204: Prototype-polluting function

### DIFF
--- a/lib/utils/merge.mjs
+++ b/lib/utils/merge.mjs
@@ -40,6 +40,7 @@ export default function mergeDeep(target, ...sources) {
     for (const key in source) {
 
       if (Object.getPrototypeOf(source) !== Object.getPrototypeOf({})) continue;
+      if (key === "__proto__" || key === "constructor") continue;
 
       if (source[key] instanceof HTMLElement) {
         console.warn(source[key])

--- a/lib/utils/merge.mjs
+++ b/lib/utils/merge.mjs
@@ -34,31 +34,34 @@ export default function mergeDeep(target, ...sources) {
   const source = sources.shift();
 
   // target & source are both objects.
-  if (isObject(target) && isObject(source)) {
+  if (!isObject(target) || !isObject(source)) {
 
-    // Iterate over object keys in source.
-    for (const key in source) {
+    return mergeDeep(target, ...sources);
+  }
 
-      if (Object.getPrototypeOf(source) !== Object.getPrototypeOf({})) continue;
-      if (key === "__proto__" || key === "constructor") continue;
+  // Iterate over object keys in source.
+  for (const key in source) {
 
-      if (source[key] instanceof HTMLElement) {
-        console.warn(source[key])
+    if (Object.getPrototypeOf(source) !== Object.getPrototypeOf({})) continue;
+
+    if (key === "__proto__" || key === "constructor") continue;
+
+    if (source[key] instanceof HTMLElement) {
+      console.warn(source[key])
 
       // source[key] is object with potential nesting.
-      } else if (isObject(source[key])) {
+    } else if (isObject(source[key])) {
 
-        // Target key must be an object.
-        target[key] ??= {}
+      // Target key must be an object.
+      target[key] ??= {}
 
-        // Call recursive merge for target key object.
-        mergeDeep(target[key], source[key]);
+      // Call recursive merge for target key object.
+      mergeDeep(target[key], source[key]);
+
+    } else {
 
       // source[key] could be null, true, false, or Array object
-      } else {
-
-        target[key] = source[key]
-      }
+      target[key] = source[key]
     }
   }
 


### PR DESCRIPTION
Fixes [https://github.com/GEOLYTIX/xyz/security/code-scanning/204](https://github.com/GEOLYTIX/xyz/security/code-scanning/204)

To fix the prototype pollution issue in the `mergeDeep` function, we need to ensure that properties like `__proto__` and `constructor` are not copied from the `source` object to the `target` object. This can be achieved by adding explicit checks to skip these properties during the merge process.

**Steps to fix:**
1. Add checks to skip the `__proto__` and `constructor` properties in the `mergeDeep` function.
2. Ensure these checks are applied before any recursive calls or assignments.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
