### PR TITLE
Fix code scanning alert no. 204: Prototype-polluting function

### DIFF
--- a/lib/utils/merge.mjs
+++ b/lib/utils/merge.mjs
@@ -40,6 +40,7 @@ export default function mergeDeep(target, ...sources) {
     for (const key in source) {
 
       if (Object.getPrototypeOf(source) !== Object.getPrototypeOf({})) continue;
+      if (key === "__proto__" || key === "constructor") continue;
 
       if (source[key] instanceof HTMLElement) {
         console.warn(source[key])


### PR DESCRIPTION
Fixes [https://github.com/GEOLYTIX/xyz/security/code-scanning/204](https://github.com/GEOLYTIX/xyz/security/code-scanning/204)

To fix the prototype pollution issue in the `mergeDeep` function, we need to ensure that properties like `__proto__` and `constructor` are not copied from the `source` object to the `target` object. This can be achieved by adding explicit checks to skip these properties during the merge process.

**Steps to fix:**
1. Add checks to skip the `__proto__` and `constructor` properties in the `mergeDeep` function.
2. Ensure these checks are applied before any recursive calls or assignments.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
