### PR TITLE
Query Templates: Location count template

### DIFF
--- a/mod/workspace/templates/_queries.js
+++ b/mod/workspace/templates/_queries.js
@@ -79,6 +79,9 @@ module.exports = {
   location_update: {
     render: require('./location_update'),
   },
+  location_count: {
+    template: require('./location_count')
+  },
   mvt: {
     render: require('./mvt'),
     value_only: true

--- a/mod/workspace/templates/_queries.js
+++ b/mod/workspace/templates/_queries.js
@@ -80,7 +80,8 @@ module.exports = {
     render: require('./location_update'),
   },
   location_count: {
-    template: require('./location_count')
+    template: require('./location_count'),
+    value_only: true
   },
   mvt: {
     render: require('./mvt'),

--- a/mod/workspace/templates/location_count.js
+++ b/mod/workspace/templates/location_count.js
@@ -1,4 +1,4 @@
-module.exports = `
-  SELECT count(*) as location_count
-  FROM \${table}
-  WHERE true \${filter}`
+module.exports =  `
+    SELECT count(*) as location_count
+    FROM \${table}
+    WHERE true \${filter} \${viewport}`

--- a/mod/workspace/templates/location_count.js
+++ b/mod/workspace/templates/location_count.js
@@ -1,0 +1,4 @@
+module.exports = `
+  SELECT count(*) as location_count
+  FROM \${table}
+  WHERE true \${filter}`


### PR DESCRIPTION
## Description
Adds  a query that performs a count on the locations that pass the filter of a layer.

## GitHub Issue
[#1519](https://github.com/GEOLYTIX/xyz/issues/1519)

## Type of Change
- ✅ New feature (non-breaking change which adds functionality)

## How have you tested this? 
Tested locally on `bugs_testing/filter/filter.json` -> catchment_statistics, location count button on the layer.
![Screenshot 2024-10-02 153809](https://github.com/user-attachments/assets/cba2ea7d-a8cb-4354-96fe-5ffb000e435f)

You will need a SRC_CLIENTPLUGINS key in your settings to see it.
## Testing Checklist 
- ✅ Existing Tests still pass
- ✅ Ran locally on my machine

## Code Quality Checklist
- ✅ Main has been merged into this PR