### PR TITLE
Allow for layer reload callback from applyFilter

### DIFF
--- a/lib/layer/format/mvt.mjs
+++ b/lib/layer/format/mvt.mjs
@@ -50,7 +50,21 @@ export default layer => {
   // Assigns changeEnd event/method for zoom restricted layers.
   mapp.layer.changeEnd(layer)
 
-  layer.reload = () => {
+  layer.reload = reload
+
+  /**
+  @function reload
+
+  @description
+  The reload method executes the changeEndLoad method for MVT layer with wkt_properties features.
+
+  Otherwise the source and featureSource [Openlayers VectorTile]{@link https://openlayers.org/en/latest/apidoc/module-ol_source_VectorTile.html} sources are cleared and refreshed.
+
+  Finally the optional callback function param will be executed if provided.
+
+  @param {Function} [callback] Optional callback function.
+  */
+  function reload(callback) {
 
     if (layer.wkt_properties) {
       changeEndLoad(layer)
@@ -60,6 +74,8 @@ export default layer => {
     layer.source.clear()
     layer.source.refresh()
     layer.featureSource.refresh()
+
+    if (callback instanceof Function) callback(layer)
   }
 
   layer.clones = new Set()

--- a/lib/layer/format/vector.mjs
+++ b/lib/layer/format/vector.mjs
@@ -180,10 +180,13 @@ The xhr request is debounced by 100ms to prevent requests in quick succession on
 
 The reload method is bound to the layer object and doesn't require any arguments.
 
+Finally the optional callback function param will be executed if provided.
+
+@param {Function} [callback] Optional callback function.
 @property {Object} layer.params Parameter for data request.
 @property {Object} layer.timeout Timeout for the xhr request.
 */
-function reload() {
+function reload(callback) {
 
   const layer = this;
 
@@ -233,6 +236,8 @@ function reload() {
       })
 
   }, 100)
+
+  if (callback instanceof Function) callback(layer)
 }
 
 /**

--- a/lib/ui/layers/filters.mjs
+++ b/lib/ui/layers/filters.mjs
@@ -79,12 +79,15 @@ function applyFilter(layer) {
 The reloadCallback renders the layer.style.legend. The legend may reflect changes to the layer.filter.current. The applyFilter method used debounce the layer.reload() provides the reloadCallback as callback argument.
 
 @param {Object} layer The layer to reload.
+@returns {Object} layer - To allow for functional compostion of itself.
 */
 function reloadCallback(layer) {
 
   if (layer.style.legend) {
     mapp.ui.layers.legends[layer.style.theme.type](layer)
   }
+
+  return layer;
 }
 
 /**
@@ -241,7 +244,7 @@ async function filter_numeric(layer, filter) {
     },
     layer.filter.current[filter.field]);
 
-    filterMethods.applyFilter(layer);
+  filterMethods.applyFilter(layer);
 
   // If filter.min and filter.max are identical, return a message.
   if (filter.min === filter.max) {

--- a/lib/ui/layers/filters.mjs
+++ b/lib/ui/layers/filters.mjs
@@ -17,7 +17,7 @@ The ui/layers/filters module exports a lookup object for the different layer fil
 @module /ui/layers/filters
 */
 
-export default {
+const filterMethods = {
   like: filter_text,
   match: filter_text,
   numeric: filter_numeric,
@@ -27,8 +27,12 @@ export default {
   date: filter_date,
   datetime: filter_date,
   boolean: filter_boolean,
-  null: filter_null
+  null: filter_null,
+  applyFilter,
+  reloadCallback
 }
+
+export default filterMethods
 
 mapp.utils.merge(mapp.dictionaries, {
   en: {
@@ -42,30 +46,40 @@ mapp.utils.merge(mapp.dictionaries, {
 });
 
 /**
-### applyFilter(layer)
-
-The applyFilter method reloads the layer data and legend.
-
-The method is debounce through the module `timeout` variable.
-
 @function applyFilter
-@param {Object} layer Decorated MAPP Layer Object.
+
+@description
+The applyFilter method is used to debounce the layer.reload() from filter. This is required in order to not fire layer [data] reload in quick succession by moving a slider element.
+
+The reloadCallback method is provided as callback argument to the layer.reload()
+
+@param {Object} layer The layer to reload.
 */
-
 let timeout;
-
 function applyFilter(layer) {
 
   clearTimeout(timeout);
 
   // Debounce layer reload by 500
   timeout = setTimeout(() => {
-    if (layer.style.legend) {
-      mapp.ui.layers.legends[layer.style.theme.type](layer)
-    }
-    layer.reload();
-    layer.mapview.Map.getTargetElement().dispatchEvent(new Event('changeEnd'))
+
+    layer.reload(filterMethods.reloadCallback);
   }, 500);
+}
+
+/**
+@function reloadCallback
+
+@description
+The reloadCallback renders the layer.style.legend. The legend may reflect changes to the layer.filter.current. The applyFilter method used debounce the layer.reload() provides the reloadCallback as callback argument.
+
+@param {Object} layer The layer to reload.
+*/
+function reloadCallback(layer) {
+
+  if (layer.style.legend) {
+    mapp.ui.layers.legends[layer.style.theme.type](layer)
+  }
 }
 
 /**
@@ -94,7 +108,7 @@ function filter_text(layer, filter) {
         layer.filter.current[filter.field] ??= {}
         layer.filter.current[filter.field][filter.type] = encodeURIComponent(`${filter.leading_wildcard && '%' || ''}${e.target.value}`)
       }
-      applyFilter(layer)
+      filterMethods.applyFilter(layer)
     }}>`;
 }
 
@@ -111,7 +125,7 @@ function filter_boolean(layer, filter) {
     layer.filter.current[filter.field] = {
       boolean: checked
     }
-    applyFilter(layer)
+    filterMethods.applyFilter(layer)
   }
 
   booleanFilter(false)
@@ -135,7 +149,7 @@ function filter_null(layer, filter) {
     layer.filter.current[filter.field] = {
       null: checked
     }
-    applyFilter(layer)
+    filterMethods.applyFilter(layer)
   }
 
   nullFilter(false)
@@ -222,7 +236,7 @@ async function filter_numeric(layer, filter) {
     },
     layer.filter.current[filter.field]);
 
-  applyFilter(layer);
+    filterMethods.applyFilter(layer);
 
   // If filter.min and filter.max are identical, return a message.
   if (filter.min === filter.max) {
@@ -253,12 +267,12 @@ async function filter_numeric(layer, filter) {
 
   filter.callback_a = val => {
     layer.filter.current[filter.field].gte = val
-    applyFilter(layer)
+    filterMethods.applyFilter(layer)
   }
 
   filter.callback_b = val => {
     layer.filter.current[filter.field].lte = val
-    applyFilter(layer)
+    filterMethods.applyFilter(layer)
   }
 
   // Create the range slider element.
@@ -359,7 +373,7 @@ async function filter_in(layer, filter) {
           })
         }
 
-        applyFilter(layer)
+        filterMethods.applyFilter(layer)
       }
     })
 
@@ -378,7 +392,7 @@ async function filter_in(layer, filter) {
             [filter.type]: [...pills]
           }
         });
-        applyFilter(layer);
+        filterMethods.applyFilter(layer);
       },
       removeCallback: (val, pills) => {
 
@@ -396,7 +410,7 @@ async function filter_in(layer, filter) {
           })
         }
 
-        applyFilter(layer);
+        filterMethods.applyFilter(layer);
       }
     });
 
@@ -478,7 +492,7 @@ async function filter_in(layer, filter) {
         }
       }
 
-      applyFilter(layer)
+      filterMethods.applyFilter(layer)
     }
   }))
 
@@ -526,7 +540,7 @@ function filter_date(layer, filter) {
         })
     }
 
-    applyFilter(layer)
+    filterMethods.applyFilter(layer)
   }
 
   return mapp.utils.html`

--- a/lib/ui/layers/filters.mjs
+++ b/lib/ui/layers/filters.mjs
@@ -53,6 +53,8 @@ The applyFilter method is used to debounce the layer.reload() from filter. This 
 
 The reloadCallback method is provided as callback argument to the layer.reload()
 
+The 'changeEnd' event is dispatched the layer.mapview in order to trigger the update of dataviews with the mapChange flag.
+
 @param {Object} layer The layer to reload.
 */
 let timeout;
@@ -64,6 +66,9 @@ function applyFilter(layer) {
   timeout = setTimeout(() => {
 
     layer.reload(filterMethods.reloadCallback);
+
+    // The 'changeEnd' event triggers dataview updates with the mapChange flag.
+    layer.mapview.Map.getTargetElement().dispatchEvent(new Event('changeEnd'))
   }, 500);
 }
 

--- a/tests/lib/ui/layers/filters.test.mjs
+++ b/tests/lib/ui/layers/filters.test.mjs
@@ -68,6 +68,10 @@ export async function filtersTest(mapview) {
             codi.assertEqual(maxInput.value, '1000', 'The max should return 1000');
         });
 
+        /**
+         * Testing providing a layer.current as explicit values.
+         * @function it
+         */
         await codi.it('Numeric Filter: layer.current specified as `lte: 200` and `gte: 800`', async () => {
 
             layer.filter.current[filter.field].lte = 800


### PR DESCRIPTION
It should be possible to alter the applyFilter method. In order to do so the applyFilter method will be added to the filterMethods object exported from ui/layers/filter module.

The applyFilter debounces the layer.reload()

The vector and mvt layer.reload() methods now support a callback argument. This allows the applyFilter method to provide the reloadCallback method which renders the style.legend. This callback should only be executed when the reload is called from the applyFilter method, not on every reload of the layer, eg. when the layer.show method is called.

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1208488860427076