### PR TITLE
Prevent Crash when role access denied on /workspace/test

### DIFF
--- a/mod/workspace/_workspace.js
+++ b/mod/workspace/_workspace.js
@@ -328,6 +328,16 @@ async function test(req, res) {
     // Will get layer and assignTemplates to workspace.
     const locale = await getLocale({ locale: localeKey, user: req.params.user })
 
+    // If you can't get the locale, access is denied, add the error to the errArr.
+    if (locale.message === 'Role access denied') {
+      test.errArr.push(`${localeKey}: ${locale.message}`)
+      continue;
+    };
+
+    // If the locale has no layers, just skip it.
+    if (!locale.layers) continue;
+    
+
     for (const layerKey of Object.keys(locale.layers)) {
 
       // Will get layer and assignTemplates to workspace.


### PR DESCRIPTION
#  Prevent Crash when role access denied on /workspace/test

## Description

When running the `api/workspace/test`, if your user does not have access to a locale, it will currently crash the process.
This PR addresses this by checking on the `Role access denied` message and pushing this to the `test.errors` array.

Secondly, if you have a locale with no layers, this is also checked for and just skipped. There's no error for this as it is valid.

## Type of Change
Please delete options that are not relevant, and select all options that apply. 

- ✅ Bug fix (non-breaking change which fixes an issue)
- ✅ New feature (non-breaking change which adds functionality)
- ✅ Breaking change (fix or feature that would cause existing functionality to not work as expected)
- ✅ Documentation
- ✅ Testing

## How have you tested this? 
Tested locally.

## Testing Checklist 
Please delete options that are not relevant, and select all options that apply. 

- ✅ Existing Tests still pass
- ✅ Updated Existing Tests
- ✅ New Tests Added
- ✅ Ran locally on my machine

## Code Quality Checklist
Please delete options that are not relevant, and select all options that apply. 

- ✅ My code follows the guidelines of XYZ
- ✅ My code has been commented
- ✅ Documentation has been updated
- ✅ New and existing unit tests pass locally with my changes
- ✅ Main has been merged into this PR