### PR TITLE
Force workspace cache

### DIFF
--- a/mod/workspace/_workspace.js
+++ b/mod/workspace/_workspace.js
@@ -307,6 +307,9 @@ async function test(req, res) {
     return
   }
 
+  // Force re-caching of workspace.
+  workspace = await workspaceCache(true)
+
   const test = {
     results: {},
     errArr: [],

--- a/mod/workspace/cache.js
+++ b/mod/workspace/cache.js
@@ -32,9 +32,17 @@ The age of the cached timestamp is checked against the WORKSPACE_AGE environment
 
 The cacheWorkspace method is called if the cache is invalid.
 
+@param {Boolean} [force] The workspace cache will be cleared with the force param flag.
+
 @returns {workspace} JSON Workspace.
 */
-module.exports = function checkWorkspaceCache() {
+module.exports = function checkWorkspaceCache(force) {
+
+  if (force) {
+
+    // Reset the cache with force flag.
+    cache = null
+  }
 
   // cache is null on first request for workspace.
   // cacheWorkspace is async and must be awaited.

--- a/tests/lib/utils/_utils.test.mjs
+++ b/tests/lib/utils/_utils.test.mjs
@@ -5,9 +5,9 @@ import { queryParamsTest } from './queryParams.test.mjs';
 import { composeTest } from './compose.test.mjs';
 
 export const utilsTest = {
-  numericFormatterTest,
-  mergeTest,
-  paramStringTest,
-  queryParamsTest,
-  composeTest
+    numericFormatterTest,
+    mergeTest,
+    paramStringTest,
+    queryParamsTest,
+    composeTest
 }

--- a/tests/mod/workspace/_workspace.test.mjs
+++ b/tests/mod/workspace/_workspace.test.mjs
@@ -112,5 +112,14 @@ export async function workspaceTest(mapview) {
                 codi.assertTrue(!roles['*']);
             });
         });
+
+        await codi.it('Workspace: Testing the test endpoint', async () => {
+            const workspace_test = await mapp.utils.xhr(`/test/api/workspace/test`);
+
+            codi.assertTrue(workspace_test.errors.length > 0, 'The errors array needs to have more than 1 entry')
+            codi.assertTrue(workspace_test.overwritten_templates.length > 0, 'The overwritten templates array needs to have more than 1 entry')
+            codi.assertTrue(workspace_test.unused_templates.length > 0, 'The unsused templates array needs to have more than 1 entry')
+            codi.assertTrue(Object.keys(workspace_test.usage).length > 0, 'The usage object needs to have keys')
+        });
     });
 }

--- a/tests/mod/workspace/_workspace.test.mjs
+++ b/tests/mod/workspace/_workspace.test.mjs
@@ -114,12 +114,26 @@ export async function workspaceTest(mapview) {
         });
 
         await codi.it('Workspace: Testing the test endpoint', async () => {
-            const workspace_test = await mapp.utils.xhr(`/test/api/workspace/test`);
+            let workspace_test = await mapp.utils.xhr(`/test/api/workspace/test`);
+
+            const counts = {
+                errors: workspace_test.errors.length,
+                overwritten_templates: workspace_test.overwritten_templates.length,
+                unused_templates: workspace_test.unused_templates.length,
+                usage: Object.keys(workspace_test.usage).length
+            }
 
             codi.assertTrue(workspace_test.errors.length > 0, 'The errors array needs to have more than 1 entry')
             codi.assertTrue(workspace_test.overwritten_templates.length > 0, 'The overwritten templates array needs to have more than 1 entry')
             codi.assertTrue(workspace_test.unused_templates.length > 0, 'The unsused templates array needs to have more than 1 entry')
             codi.assertTrue(Object.keys(workspace_test.usage).length > 0, 'The usage object needs to have keys')
+
+            workspace_test = await mapp.utils.xhr(`/test/api/workspace/test`);
+
+            codi.assertEqual(workspace_test.errors.length, counts.errors, 'The errors array needs to have the same number of entries we did the first run')
+            codi.assertEqual(workspace_test.overwritten_templates.length, counts.overwritten_templates, 'The overwritten templates array needs to have the same number of entries we did the first run')
+            codi.assertEqual(workspace_test.unused_templates.length, counts.unused_templates, 'The unused templates array needs to have the same number of entries we did the first run')
+            codi.assertEqual(Object.keys(workspace_test.usage).length, counts.usage, 'The usage templates object needs to have the same number of entries we did the first run')
         });
     });
 }


### PR DESCRIPTION
The [workspace] cache will be set to null, forcing re-caching with the force param flag.

This allows to clear the cached workspace everytime the workspace test method is called.
