### PR TITLE
compose util documentation

### DIFF
--- a/lib/utils/_utils.mjs
+++ b/lib/utils/_utils.mjs
@@ -18,16 +18,7 @@ const areSetsEqual = (a, b) => a.size === b.size && [...a].every(value => b.has(
 
 import csvDownload from './csvDownload.mjs'
 
-/**
-## mapp.utils.compose()
-@function compose
-@memberof module:/utils
-*/
-const compose = (...fns) => {
-  return arg => fns.reduce((acc, fn) => {
-    return fn(acc);
-  }, arg)
-}
+import compose from './compose.mjs'
 
 import convert from './convert.mjs'
 

--- a/lib/utils/compose.mjs
+++ b/lib/utils/compose.mjs
@@ -1,0 +1,48 @@
+/**
+## /utils/compose
+
+The compose module exports a utility method allowing to compose functions.
+
+Function composition allows to expand function logic by inheriting the product of an existing function in a composition.
+
+A function can be composed into itself by binding the original method.
+
+Each function in the composition must accept and return 1 argument which is passed left to right through the composition.
+
+For example the [mapp.layer.decorate(layer)]{@link module:/layer/decorate~decorate} method accepts a JSON layer and returns a promise which resolves into a decorated layer object. We can compose this method with a second method which awaits layer decorator and logs the decorated layer to the console.
+
+```js
+async function logLayer(layer) {
+  await layer
+  console.log(layer)
+}
+
+mapp.layer.decorate = mapp.utils.compose(
+  mapp.layer.decorate.bind(),
+  logLayer)
+```
+
+@module /utils/compose
+*/
+
+/**
+@function compose
+
+@description
+The compose method reduces an array of n Function arguments which are spread into the fns array.
+
+An arrow method which provides the argument provided to the first method in the function composition is provided as initial value to the Array.reduce of functions. Each function is executed in the order of the fns array. The return of any function in the composition is provided as argument to the next function [fn].
+
+@returns {*} The single argument passed through all functions in composition.
+*/
+export default function compose(...fns) {
+
+  // reduce the spread functions to execute in succession.
+  return arg => fns.reduce((acc, fn) => {
+
+    // Execute function with reduce accumulator as only argument.
+    return fn(acc);
+
+  // Provide argument as initial value to the reduce function
+  }, arg)
+}


### PR DESCRIPTION
The compose method wants to be in its own module file for this.

This wants a code example as well.

```js
async function logLayer(layer) {
  await layer
  console.log(layer)
}

mapp.layer.decorate = mapp.utils.compose(
  mapp.layer.decorate.bind(),
  logLayer)
```