### PR TITLE
Dialog: Show function and related tests

### DIFF
--- a/lib/ui/elements/dialog.mjs
+++ b/lib/ui/elements/dialog.mjs
@@ -33,6 +33,7 @@ const dialog = mapp.ui.elements.dialog({
 @property {boolean} [dialog.closeBtn] The flag property will become the closeBtn element.
 @property {Function} [dialog.close] A function called by default when the dialog is closed. The dialog element is closed and removed from DOM.
 @property {Function} [dialog.onClose] Optional function to run after dialog element is closed - uses onclose dialog event and overrides dialog.close().
+@property {boolean} [dialog.new] Optional parameter which specifies whether a new dialog should be created on re-opening the dialog.
 @property {number} [dialog.top] The top position of the dialog.
 @property {number} [dialog.left] The left position of the dialog.
 @property {number} [dialog.right] The right position of the dialog (used to calculate left position).
@@ -61,6 +62,11 @@ export default function dialog(dialog) {
 
     dialog.header = mapp.utils.html.node`
       <header class="headerDrag">${dialog.header}`
+  }
+
+  //Add the show method if new is falsy
+  if(!dialog.new){
+    dialog.show = show
   }
 
   const classList = `${dialog.modal ? 'modal' : 'dialog'} ${dialog.class || ''}`
@@ -207,6 +213,9 @@ export default function dialog(dialog) {
     dialog.node.style.top = `${dialog.node.offsetTop + topShift}px`
   }
 
+  // Maintain a reference to the dialog
+  dialog.dialog = dialog
+
   return dialog
 };
 
@@ -312,4 +321,20 @@ function shiftContainedCentre(dialog, leftShift, topShift) {
     // Shift bottom
     dialog.node.style.top = `${dialog.node.offsetTop + topShift}px`
   }
+}
+
+/**
+@function show
+
+@description
+Appends the dialog node to its target. 
+Called upon re-opening a dialog. 
+*/
+function show(){
+
+  //check for a node
+  if(!this.node) return;
+
+  //append the node to the target if there is one
+  this.target instanceof HTMLElement && this.target.append(this.node)
 }

--- a/lib/ui/elements/dialog.mjs
+++ b/lib/ui/elements/dialog.mjs
@@ -45,6 +45,11 @@ const dialog = mapp.ui.elements.dialog({
 
 export default function dialog(dialog) {
 
+  //if there is a node and show method, execute the show method
+  if(dialog.node instanceof HTMLElement && typeof dialog.show === 'function'){
+    return dialog.show()
+  }
+
   if (!dialog.target) {
 
     // The dialog must be modal if no target is provided.

--- a/lib/ui/elements/dialog.mjs
+++ b/lib/ui/elements/dialog.mjs
@@ -23,6 +23,8 @@ const dialog = mapp.ui.elements.dialog({
 });
 ```
 
+The show method will be called on an existing dialog unless the creation is implicit with the new property flag.
+
 @param {Object} dialog The dialog configuration object.
 @property {HTMLElement} dialog.target The target element where the dialog will be appended.
 @property {string} [dialog.css_style] The CSS styles to apply to the dialog dialog.
@@ -45,10 +47,14 @@ const dialog = mapp.ui.elements.dialog({
 
 export default function dialog(dialog) {
 
-  //if there is a node and show method, execute the show method
-  if(dialog.node instanceof HTMLElement && typeof dialog.show === 'function'){
-    return dialog.show()
+  // Shortcircuit method and show existing dialog.
+  // The new flag can be used to always create a new dialog.
+  if(!dialog.new && typeof dialog.show === 'function'){
+    dialog.show()
+    return;
   }
+
+  dialog.show = show
 
   if (!dialog.target) {
 
@@ -67,11 +73,6 @@ export default function dialog(dialog) {
 
     dialog.header = mapp.utils.html.node`
       <header class="headerDrag">${dialog.header}`
-  }
-
-  //Add the show method if new is falsy
-  if(!dialog.new){
-    dialog.show = show
   }
 
   const classList = `${dialog.modal ? 'modal' : 'dialog'} ${dialog.class || ''}`

--- a/tests/lib/ui/elements/dialog.test.mjs
+++ b/tests/lib/ui/elements/dialog.test.mjs
@@ -5,24 +5,25 @@
  */
 export async function dialogTest() {
     await codi.describe('UI Elements: dialog/modal', async () => {
+
+        const params = {
+            target: document.getElementById('Map'),
+            closeBtn: true,
+            headerDrag: true,
+            header: 'I am a header',
+            content: 'I am so content',
+            top: '5em',
+            left: '5em',
+            contained: true
+        };
+
         /**
          * We should be able to create a basic dialog with some params
          * @function it
          */
         await codi.it('Should create a basic dialog', async () => {
 
-            const params = {
-                target: document.getElementById('Map'),
-                closeBtn: true,
-                headerDrag: true,
-                header: 'I am a header',
-                content: 'I am so content',
-                top: '5em',
-                left: '5em',
-                contained: true
-            };
-
-            const dialog = mapp.ui.elements.dialog(params);
+            const dialog = mapp.ui.elements.dialog({...params});
 
             /**
              * The dialog should be able to close
@@ -33,6 +34,32 @@ export async function dialogTest() {
                 const dialog_element = document.querySelector('#Map > dialog');
                 codi.assertEqual(dialog_element, null, 'The dialog should be removed from the DOM on close');
             });
+
+            /**
+             * The dialog should be able to be shown again
+             * @function it
+             */
+            await codi.it('Dialog should be able to be shown again', async () => {
+                dialog.show();
+                const dialog_element = document.querySelector('#Map > dialog');
+                codi.assertEqual(dialog_element, dialog.node, 'The dialog should be in the DOM again');
+            });
+
+            dialog.close();
+        });
+
+        /**
+         * Created dialog should not have a show method
+         * @function it
+         */
+        await codi.it('Should create a basic dialog without a show method', async () => {
+
+            params.new = true;
+            const dialog = mapp.ui.elements.dialog({...params});
+            
+            codi.assertEqual(typeof dialog.show, 'undefined', 'The dialog show method should not be available');
+
+            dialog.close()
         });
     });
 }

--- a/tests/lib/ui/elements/dialog.test.mjs
+++ b/tests/lib/ui/elements/dialog.test.mjs
@@ -50,17 +50,22 @@ export function dialogTest() {
         });
 
         /**
-         * Created dialog should not have a show method
+         * Created dialog should not call show method
          * @function it
          */
-        codi.it('Should create a basic dialog without a show method', () => {
+        codi.it('Should recreate a basic dialog', () => {
 
             params.new = true;
-            const dialog = mapp.ui.elements.dialog({ ...params });
+            const new_params = {...params}
 
-            codi.assertEqual(typeof dialog.show, 'undefined', 'The dialog show method should not be available');
+            const dialog = mapp.ui.elements.dialog(new_params);
+            dialog.close();
 
-            dialog.close()
+            const new_dialog = mapp.ui.elements.dialog(new_params);
+
+            codi.assertEqual(dialog, new_dialog, 'The dialog should be recreated');
+
+            new_dialog.close();
         });
     });
 }

--- a/tests/lib/ui/elements/dialog.test.mjs
+++ b/tests/lib/ui/elements/dialog.test.mjs
@@ -3,8 +3,8 @@
  * This function is used to test the dialog ui element.
  * @function dialogTest
  */
-export async function dialogTest() {
-    await codi.describe('UI Elements: dialog/modal', async () => {
+export function dialogTest() {
+    codi.describe('UI Elements: dialog/modal', () => {
 
         const params = {
             target: document.getElementById('Map'),
@@ -21,15 +21,15 @@ export async function dialogTest() {
          * We should be able to create a basic dialog with some params
          * @function it
          */
-        await codi.it('Should create a basic dialog', async () => {
+        codi.it('Should create a basic dialog', () => {
 
-            const dialog = mapp.ui.elements.dialog({...params});
+            const dialog = mapp.ui.elements.dialog({ ...params });
 
             /**
              * The dialog should be able to close
              * @function it
              */
-            await codi.it('Dialog should be able to close', async () => {
+            codi.it('Dialog should be able to close', () => {
                 dialog.close();
                 const dialog_element = document.querySelector('#Map > dialog');
                 codi.assertEqual(dialog_element, null, 'The dialog should be removed from the DOM on close');
@@ -39,7 +39,7 @@ export async function dialogTest() {
              * The dialog should be able to be shown again
              * @function it
              */
-            await codi.it('Dialog should be able to be shown again', async () => {
+            codi.it('Dialog should be able to be shown again', () => {
                 dialog.show();
                 const dialog_element = document.querySelector('#Map > dialog');
                 codi.assertEqual(dialog_element, dialog.node, 'The dialog should be in the DOM again');
@@ -52,11 +52,11 @@ export async function dialogTest() {
          * Created dialog should not have a show method
          * @function it
          */
-        await codi.it('Should create a basic dialog without a show method', async () => {
+        codi.it('Should create a basic dialog without a show method', () => {
 
             params.new = true;
-            const dialog = mapp.ui.elements.dialog({...params});
-            
+            const dialog = mapp.ui.elements.dialog({ ...params });
+
             codi.assertEqual(typeof dialog.show, 'undefined', 'The dialog show method should not be available');
 
             dialog.close()

--- a/tests/lib/ui/elements/dialog.test.mjs
+++ b/tests/lib/ui/elements/dialog.test.mjs
@@ -9,6 +9,7 @@ export function dialogTest() {
         const params = {
             target: document.getElementById('Map'),
             closeBtn: true,
+            data_id: 'dialog-test',
             headerDrag: true,
             header: 'I am a header',
             content: 'I am so content',
@@ -31,7 +32,7 @@ export function dialogTest() {
              */
             codi.it('Dialog should be able to close', () => {
                 dialog.close();
-                const dialog_element = document.querySelector('#Map > dialog');
+                const dialog_element = document.querySelector('[data-id="dialog-test"]')
                 codi.assertEqual(dialog_element, null, 'The dialog should be removed from the DOM on close');
             });
 
@@ -41,7 +42,7 @@ export function dialogTest() {
              */
             codi.it('Dialog should be able to be shown again', () => {
                 dialog.show();
-                const dialog_element = document.querySelector('#Map > dialog');
+                const dialog_element = document.querySelector('[data-id="dialog-test"]')
                 codi.assertEqual(dialog_element, dialog.node, 'The dialog should be in the DOM again');
             });
 


### PR DESCRIPTION
## Description

Provide a show method for dialogs. This will prevent the recreation of dialogs that already exist.
Specifying `new: true` within the dialog params will prevent the show method form being provided.  

## GitHub Issue
[#1513](https://github.com/GEOLYTIX/xyz/issues/1513)

## Type of Change
- ✅ New feature (non-breaking change which adds functionality)
- ✅ Documentation
- ✅ Testing

## How have you tested this? 
Tested locally using the test suite.

## Testing Checklist 
- ✅ Existing Tests still pass
- ✅ Updated Existing Tests
- ✅ New Tests Added
- ✅ Ran locally on my machine

## Code Quality Checklist
- ✅ My code follows the guidelines of XYZ
- ✅ My code has been commented
- ✅ Documentation has been updated
- ✅ New and existing unit tests pass locally with my changes
- ✅ Main has been merged into this PR

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1208488860427080