### PR TITLE
Assign and check filter.li element in dropdown callback

### DIFF
--- a/lib/ui/layers/filters.mjs
+++ b/lib/ui/layers/filters.mjs
@@ -108,6 +108,8 @@ function removeFilter(layer, filter) {
     }
   }
 
+  filter.li?.classList.remove('selected')
+
   filter.card?.remove()
 
   delete filter.card

--- a/lib/ui/layers/panels/filter.mjs
+++ b/lib/ui/layers/panels/filter.mjs
@@ -161,6 +161,16 @@ export default function filterPanel(layer) {
     entries: layer.filter.list,
     callback: async (e, filter) => {
 
+      filter.li = e.target
+
+      if (filter.li.classList.contains('selected')) {
+
+        mapp.ui.layers.filters.removeFilter(layer, filter)
+        return;
+      }
+
+      filter.li.classList.add('selected')
+
       // Return if filter card already exists.
       if (filter?.card) return;
 


### PR DESCRIPTION
The filter panel dropdown assigns the (e.target) li element to the filter object and sets the selected class.

The selected class is removed from the li element in the filter remove method.

The filter remove method is  called when the li is already selected in the dropdown callback.
