### PR TITLE
Input Elements: CSS changes

### DIFF
--- a/lib/ui/elements/numericInput.mjs
+++ b/lib/ui/elements/numericInput.mjs
@@ -26,7 +26,7 @@ export default function numericInput(params) {
 
   const value = mapp.utils.formatNumericValue(params)
   const width = params.dynamicWidth ? (value.length + 1.3) + 'ch' : '100%'
-  const style = `text-align: right;width:${width}`
+  const style = `text-align: center; width: ${width}`
 
   const numericInput = mapp.utils.html.node`<input
     data-id=${params.data_id}

--- a/lib/ui/elements/numericInput.mjs
+++ b/lib/ui/elements/numericInput.mjs
@@ -24,12 +24,16 @@ export default function numericInput(params) {
   params.data_id ??= 'numeric-input'
   params.numericChecks ??= numericChecks
 
+  const value = mapp.utils.formatNumericValue(params)
+  const width = params.dynamicWidth ? (value.length + 1.3) + 'ch' : '100%'
+  const style = `text-align: right;width:${width}`
+
   const numericInput = mapp.utils.html.node`<input
     data-id=${params.data_id}
     type="text"
-    style="text-align: right"
+    style=${style}
     placeholder=${params.placeholder}
-    value=${mapp.utils.formatNumericValue(params)}
+    value=${value}
     onchange=${e => oninput(e, params)}
     oninput=${e => oninput(e, params)}>`
 
@@ -88,6 +92,10 @@ function oninput(e, params) {
 
   // Re-format the params numeric value (newValue || value) and set as input string value.
   e.target.value = mapp.utils.formatNumericValue(params)
+
+  if(params.dynamicWidth){
+    e.target.style.width = (e.target.value.length + 1.3) + 'ch'
+  }
   //Mark the onRangeInput to false is the origin of the input call could come from either a slider or input
   params.onRangeInput = false;
 }

--- a/lib/ui/elements/slider_ab.mjs
+++ b/lib/ui/elements/slider_ab.mjs
@@ -31,6 +31,7 @@ export default function slider_ab(params) {
     data_id: 'a',
     value: params.val_a,
     rangeInput: 'minRangeInput',
+    dynamicWidth: true,
     callback: params.callback_a,
     numericChecks
   }
@@ -43,6 +44,7 @@ export default function slider_ab(params) {
     data_id: 'b',
     value: params.val_b,
     rangeInput: 'maxRangeInput',
+    dynamicWidth: true,
     callback: params.callback_b,
     numericChecks
   }
@@ -103,10 +105,7 @@ export default function slider_ab(params) {
         --b: ${params.val_b};`}>
       <div 
         class="label-row">
-        <label>${params.label_a || 'A'}
-          ${minNumericInput}</label>
-        <label>${params.label_b || 'B'}
-          ${maxNumericInput}</label>
+        <span class="bold">Range:</span> ${minNumericInput} — ${maxNumericInput}
       </div>
       <div class="track-bg"></div>
       <input data-id="a" type="range"

--- a/lib/ui/elements/slider_ab.mjs
+++ b/lib/ui/elements/slider_ab.mjs
@@ -105,7 +105,7 @@ export default function slider_ab(params) {
         --b: ${params.val_b};`}>
       <div 
         class="label-row">
-        <span class="bold">Range:</span> ${minNumericInput} — ${maxNumericInput}
+        ${minNumericInput} ${maxNumericInput}
       </div>
       <div class="track-bg"></div>
       <input data-id="a" type="range"

--- a/public/css/_colours.css
+++ b/public/css/_colours.css
@@ -20,6 +20,4 @@
     
     --color-changed: #ffffa7;
 
-    --color-light-off-black: #c9c9c933
-
 }

--- a/public/css/_colours.css
+++ b/public/css/_colours.css
@@ -20,4 +20,6 @@
     
     --color-changed: #ffffa7;
 
+    --color-light-off-black: #c9c9c933
+
 }

--- a/public/css/_dialog.css
+++ b/public/css/_dialog.css
@@ -19,6 +19,7 @@ dialog.dialog {
   cursor: grab;
   user-select: none;
   padding: 5px;
+  overflow: unset !important;
 }
 
 dialog.modal {

--- a/public/css/_dialog.css
+++ b/public/css/_dialog.css
@@ -16,7 +16,6 @@ dialog.dialog {
   background-color: #fff;
   border: none !important;
   border-radius: 2px;
-  box-shadow: 1px 1px 3px var(--color-primary-light);
   cursor: grab;
   user-select: none;
   padding: 5px;

--- a/public/css/_dialog.css
+++ b/public/css/_dialog.css
@@ -19,10 +19,6 @@ dialog.dialog {
   cursor: grab;
   user-select: none;
   padding: 5px;
-
-  & .dropdown > ul {
-    position: fixed;
-  }
 }
 
 dialog.modal {
@@ -78,10 +74,6 @@ dialog.alert-confirm h4 {
 
 dialog.alert-confirm .content {
   padding: 1em;
-}
-
-dialog > .content{
-  padding: 2px;
 }
 
 dialog.alert-confirm p {

--- a/public/css/_dialog.css
+++ b/public/css/_dialog.css
@@ -16,8 +16,10 @@ dialog.dialog {
   background-color: #fff;
   border: none !important;
   border-radius: 2px;
+  box-shadow: 1px 1px 3px var(--color-primary-light);
   cursor: grab;
   user-select: none;
+  padding: 5px;
 }
 
 dialog.modal {
@@ -73,6 +75,10 @@ dialog.alert-confirm h4 {
 
 dialog.alert-confirm .content {
   padding: 1em;
+}
+
+dialog > .content{
+  padding: 2px;
 }
 
 dialog.alert-confirm p {

--- a/public/css/_dialog.css
+++ b/public/css/_dialog.css
@@ -19,6 +19,10 @@ dialog.dialog {
   cursor: grab;
   user-select: none;
   padding: 5px;
+
+  & .dropdown > ul {
+    position: fixed;
+  }
 }
 
 dialog.modal {

--- a/public/css/_inputs.css
+++ b/public/css/_inputs.css
@@ -291,7 +291,10 @@ label.checkbox {
    
   &.multi {
     & >.label-row {
-      display: inline-block;
+      display: flex;
+      justify-content: space-between;
+      padding-bottom: 3px;
+      padding-top: 3px;
 
       & >div {
         flex-grow: 1

--- a/public/css/_inputs.css
+++ b/public/css/_inputs.css
@@ -52,7 +52,7 @@ input[type=text],
 input[type=number] {
   padding: 5px;
   border: none;
-  background-color: var(--color-light-off-black);
+  background-color: var(--color-light-secondary);
   border-bottom: 0.5px dotted;
   display: inline-block;
   width: 100%;
@@ -202,7 +202,7 @@ label.checkbox {
 
   &>ul {
     display: none;
-    position: absolute;
+    position: fixed;
     max-height: 500px;
     overflow-y: auto;
     overflow-x: hidden;
@@ -293,8 +293,6 @@ label.checkbox {
     & >.label-row {
       display: flex;
       justify-content: space-between;
-      padding-bottom: 3px;
-      padding-top: 3px;
 
       & >div {
         flex-grow: 1

--- a/public/css/_inputs.css
+++ b/public/css/_inputs.css
@@ -23,6 +23,9 @@ input::-moz-focus-outer {
 textarea {
   width: 100%;
   resize: none;
+  border: none;
+  border-bottom: 0.5px dotted;
+  background-color: var(--color-light-secondary);
 }
 
 input[type=number] {

--- a/public/css/_inputs.css
+++ b/public/css/_inputs.css
@@ -202,7 +202,7 @@ label.checkbox {
 
   &>ul {
     display: none;
-    position: fixed;
+    position: absolute;
     max-height: 500px;
     overflow-y: auto;
     overflow-x: hidden;

--- a/public/css/_inputs.css
+++ b/public/css/_inputs.css
@@ -36,14 +36,27 @@ input[type=number]::-webkit-outer-spin-button {
   margin: 0;
 }
 
-input[type=text],
 input[type=search],
-input[type=number],
 input[type=date],
 input[type=time],
 input[type=datetime-local] {
   border: 1px solid #ccc;
   padding: 5px;
+
+  &:focus {
+    cursor: text;
+  }
+}
+
+input[type=text],
+input[type=number] {
+  padding: 5px;
+  border: none;
+  background-color: var(--color-light-off-black);
+  border-bottom: 0.5px dotted;
+  display: inline-block;
+  width: 100%;
+  min-width: 2.4ch;
 
   &:focus {
     cursor: text;
@@ -278,9 +291,7 @@ label.checkbox {
    
   &.multi {
     & >.label-row {
-      display: grid;
-      grid-template-columns: repeat(auto-fill, minmax(240px, 1fr));
-      grid-gap: 5px;
+      display: inline-block;
 
       & >div {
         flex-grow: 1

--- a/public/css/ui.css
+++ b/public/css/ui.css
@@ -249,6 +249,9 @@ dialog.dialog {
   cursor: grab;
   user-select: none;
   padding: 5px;
+  & .dropdown > ul {
+    position: fixed;
+  }
 }
 dialog.modal {
   position: fixed;
@@ -1327,6 +1330,8 @@ label.checkbox {
     & > .label-row {
       display: flex;
       justify-content: space-between;
+      padding-bottom: 3px;
+      padding-top: 3px;
       & > div {
         flex-grow: 1;
       }

--- a/public/css/ui.css
+++ b/public/css/ui.css
@@ -246,7 +246,6 @@ dialog.dialog {
   background-color: #fff;
   border: none !important;
   border-radius: 2px;
-  box-shadow: 1px 1px 3px var(--color-primary-light);
   cursor: grab;
   user-select: none;
   padding: 5px;
@@ -1326,7 +1325,8 @@ label.checkbox {
   }
   &.multi {
     & > .label-row {
-      display: inline-block;
+      display: flex;
+      justify-content: space-between;
       & > div {
         flex-grow: 1;
       }

--- a/public/css/ui.css
+++ b/public/css/ui.css
@@ -12,7 +12,6 @@
   --color-on: #E18335;
   --color-no: #A21309;
   --color-changed: #ffffa7;
-  --color-light-off-black: #c9c9c933 ;
 }
 
 /* public/css/_button.css */
@@ -249,9 +248,6 @@ dialog.dialog {
   cursor: grab;
   user-select: none;
   padding: 5px;
-  & .dropdown > ul {
-    position: fixed;
-  }
 }
 dialog.modal {
   position: fixed;
@@ -298,9 +294,6 @@ dialog.alert-confirm h4 {
 }
 dialog.alert-confirm .content {
   padding: 1em;
-}
-dialog > .content {
-  padding: 2px;
 }
 dialog.alert-confirm p {
   white-space: pre;
@@ -1118,7 +1111,7 @@ input[type=text],
 input[type=number] {
   padding: 5px;
   border: none;
-  background-color: var(--color-light-off-black);
+  background-color: var(--color-light-secondary);
   border-bottom: 0.5px dotted;
   display: inline-block;
   width: 100%;
@@ -1243,7 +1236,7 @@ label.checkbox {
   }
   & > ul {
     display: none;
-    position: absolute;
+    position: fixed;
     max-height: 500px;
     overflow-y: auto;
     overflow-x: hidden;
@@ -1330,8 +1323,6 @@ label.checkbox {
     & > .label-row {
       display: flex;
       justify-content: space-between;
-      padding-bottom: 3px;
-      padding-top: 3px;
       & > div {
         flex-grow: 1;
       }

--- a/public/css/ui.css
+++ b/public/css/ui.css
@@ -12,6 +12,7 @@
   --color-on: #E18335;
   --color-no: #A21309;
   --color-changed: #ffffa7;
+  --color-light-off-black: #c9c9c933 ;
 }
 
 /* public/css/_button.css */
@@ -248,6 +249,7 @@ dialog.dialog {
   box-shadow: 1px 1px 3px var(--color-primary-light);
   cursor: grab;
   user-select: none;
+  padding: 5px;
 }
 dialog.modal {
   position: fixed;
@@ -294,6 +296,9 @@ dialog.alert-confirm h4 {
 }
 dialog.alert-confirm .content {
   padding: 1em;
+}
+dialog > .content {
+  padding: 2px;
 }
 dialog.alert-confirm p {
   white-space: pre;
@@ -1097,14 +1102,25 @@ input[type=number]::-webkit-outer-spin-button {
   -webkit-appearance: none;
   margin: 0;
 }
-input[type=text],
 input[type=search],
-input[type=number],
 input[type=date],
 input[type=time],
 input[type=datetime-local] {
   border: 1px solid #ccc;
   padding: 5px;
+  &:focus {
+    cursor: text;
+  }
+}
+input[type=text],
+input[type=number] {
+  padding: 5px;
+  border: none;
+  background-color: var(--color-light-off-black);
+  border-bottom: 0.5px dotted;
+  display: inline-block;
+  width: 100%;
+  min-width: 2.4ch;
   &:focus {
     cursor: text;
   }
@@ -1310,9 +1326,7 @@ label.checkbox {
   }
   &.multi {
     & > .label-row {
-      display: grid;
-      grid-template-columns: repeat(auto-fill, minmax(240px, 1fr));
-      grid-gap: 5px;
+      display: inline-block;
       & > div {
         flex-grow: 1;
       }

--- a/public/css/ui.css
+++ b/public/css/ui.css
@@ -248,6 +248,7 @@ dialog.dialog {
   cursor: grab;
   user-select: none;
   padding: 5px;
+  overflow: unset !important;
 }
 dialog.modal {
   position: fixed;

--- a/public/css/ui.css
+++ b/public/css/ui.css
@@ -1236,7 +1236,7 @@ label.checkbox {
   }
   & > ul {
     display: none;
-    position: fixed;
+    position: absolute;
     max-height: 500px;
     overflow-y: auto;
     overflow-x: hidden;

--- a/public/css/ui.css
+++ b/public/css/ui.css
@@ -1088,6 +1088,9 @@ input::-moz-focus-outer {
 textarea {
   width: 100%;
   resize: none;
+  border: none;
+  border-bottom: 0.5px dotted;
+  background-color: var(--color-light-secondary);
 }
 input[type=number] {
   -moz-appearance: textfield;


### PR DESCRIPTION
## Description

Changes the css for input elements.
1. The input boxes above a slider now appear on either end of the slider elements thumbs.
2. Added a new parameter to numericInput which lets the input element grow and shrink dynamically according the length of the value.
3. Input elements are now borderless except the bottom and have a slight grey background.
4. The Range editor will place the slider below the input box.
5. Added padding to the dialog element and to the content element of the dialog to avoid scrolling.
## GitHub Issue

[#1548](https://github.com/GEOLYTIX/xyz/issues/1548)


## Type of Change
- ✅ New feature (non-breaking change which adds functionality)

## How have you tested this? 
Tested using the multi_filter PR and any instance that has filters and editing.

## Testing Checklist 
- ✅ Existing Tests still pass
- ✅ Ran locally on my machine

## Code Quality Checklist
- ✅ My code follows the guidelines of XYZ
- ✅ My code has been commented
- ✅ Documentation has been updated
- ✅ New and existing unit tests pass locally with my changes
- ✅ Main has been merged into this PR