### PR TITLE
callback on invalid numericInput

### DIFF
--- a/lib/ui/elements/numericInput.mjs
+++ b/lib/ui/elements/numericInput.mjs
@@ -81,7 +81,7 @@ function oninput(e, params) {
   }
 
   // The invalid input should not be formatted.
-  if (params.invalid) return;
+  if (params.invalid) return params.callback();
 
   // Pass valid newValue to callback method.
   params.callback(params.newValue)


### PR DESCRIPTION
The location.view valChange event method checks for `.some` invalid entry in the location.layer infoj array.

However the valChange method is only triggered in the entry.callback method.

It is required for the numericInput module method to return with the callback method if the input is invalid.