### PR TITLE
versioncheck util

### DIFF
--- a/lib/utils/_utils.mjs
+++ b/lib/utils/_utils.mjs
@@ -58,6 +58,8 @@ import { xhr } from './xhr.mjs'
 
 import { formatNumericValue, unformatStringValue } from './numericFormatter.mjs';
 
+import { versionCheck } from './versionCheck.mjs';
+
 export default {
   stats,
   render,
@@ -87,4 +89,5 @@ export default {
   userIndexedDB,
   verticeGeoms,
   xhr,
+  versionCheck
 }

--- a/lib/utils/versionCheck.mjs
+++ b/lib/utils/versionCheck.mjs
@@ -6,9 +6,10 @@
 /**
 @function versionCheck
 @description Compare the current version of the application with a given value. 
-If the version is more than or equal to the given value, return true.
-This will first compare the major version number, then the minor version number.
+If the major version is more than or equal to the given value, return true.
 If the major version numbers are equal, it will compare the minor version numbers.
+If the minor version is more than or equal to the given value, return true.
+Otherwise, return false.
 @param {String} value - The value to compare with the current version.
 @return {boolean} - Return true if the current version is more than or equal to the given value.
 */
@@ -27,12 +28,9 @@ export function versionCheck(value) {
     if (majorVersion > majorcheckAgainst) {
         return true;
     }
-    // If major version numbers are equal, compare the minor version numbers.
-    if (majorVersion === majorcheckAgainst && minorVersion >= minorcheckAgainst) {
-        return true;
-    }
 
+    // If major version numbers are equal, compare the minor version numbers.
     // If the major version number is equal, but the minor version number is less than the given value, return false.
-    return false;
+    return majorVersion === majorcheckAgainst && minorVersion >= minorcheckAgainst;
 
 }

--- a/lib/utils/versionCheck.mjs
+++ b/lib/utils/versionCheck.mjs
@@ -1,0 +1,22 @@
+/**
+## mapp.utils.versionCheck()
+
+@module /utils/versionCheck
+*/
+/**
+@function versionCheck
+@description Compare the current version of the application with a given value. 
+If the version is more than or equal to the given value, return true.
+@param {String} value - The value to compare with the current version. This is allowed to be a string or number, but it will be converted to a number for comparison.
+@return {boolean} - Return true if the current version is more than or equal to the given value.
+*/
+export function versionCheck(value)  {
+    // Regex to remove all dots from the version string e.g. '5.0.0' -> 500
+    const checkAgainst = parseFloat(String(value).replace(/\./g, ''));
+
+    const version = parseFloat(mapp.version.replace(/\./g, ''));
+    
+    // If version is more than or equal to checkAgainst return true.
+    return version >= checkAgainst;
+
+}

--- a/lib/utils/versionCheck.mjs
+++ b/lib/utils/versionCheck.mjs
@@ -1,36 +1,52 @@
 /**
-## mapp.utils.versionCheck()
+## /utils/versionCheck
 
 @module /utils/versionCheck
 */
+
 /**
 @function versionCheck
-@description Compare the current version of the application with a given value. 
-If the major version is more than or equal to the given value, return true.
-If the major version numbers are equal, it will compare the minor version numbers.
-If the minor version is more than or equal to the given value, return true.
-Otherwise, return false.
-@param {String} value - The value to compare with the current version.
-@return {boolean} - Return true if the current version is more than or equal to the given value.
+
+@description
+Compare the mapp.version string property against as string value provided as argument.
+
+The versionCheck returns true if the provided value argument equals or exceeds the mapp.version.
+
+```js
+versionCheck('4.12') //returns true with mapp.version = '4.12.0' or smaller.
+```
+
+@param {String} value The value to compare with the current version.
+@return {boolean} Return true if the current version is more than or equal to the given value.
 */
 export function versionCheck(value) {
-    // Extract the major version (first number) from the version string.
-    const majorVersion = parseFloat(mapp.version.split('.')[0]);
-    // Extract the minor version (second number) from the version string.
-    const minorVersion = parseFloat(mapp.version.split('.')[1]);
 
-    // Extract the major version (first number) from the value string.
-    const majorcheckAgainst = parseFloat(value.toString().split('.')[0]);
-    // Extract the minor version (second number) from the value string.
-    const minorcheckAgainst = parseFloat(value.toString().split('.')[1]);
+  const majorVersion = parseInt(mapp.version.split('.')[0]);
 
-    // Compare the major version numbers.
-    if (majorVersion > majorcheckAgainst) {
-        return true;
-    }
+  const minorVersion = parseInt(mapp.version.split('.')[1]);
 
-    // If major version numbers are equal, compare the minor version numbers.
-    // If the major version number is equal, but the minor version number is less than the given value, return false.
-    return majorVersion === majorcheckAgainst && minorVersion >= minorcheckAgainst;
+  const patchVersion = parseInt(mapp.version.split('.')[2]);
 
+  const majorValue = parseInt(value.toString().split('.')[0]);
+
+  const minorValue = parseInt(value.toString().split('.')[1]);
+
+  const patchValue = parseInt(value.toString().split('.')[2]) || 0;
+
+  // The major version exceeds the value.
+  if (majorVersion > majorValue) {
+    return true;
+  }
+
+  // The major versions are equal.
+  if (majorVersion === majorValue) {
+
+    // The minor version exceeds the mapp.version minor.
+    if (minorVersion > minorValue) return true;
+
+    return minorVersion === minorValue && patchVersion >= patchValue
+  }
+
+  // The value exceeds the mapp.version
+  return false;
 }

--- a/lib/utils/versionCheck.mjs
+++ b/lib/utils/versionCheck.mjs
@@ -7,16 +7,32 @@
 @function versionCheck
 @description Compare the current version of the application with a given value. 
 If the version is more than or equal to the given value, return true.
-@param {String} value - The value to compare with the current version. This is allowed to be a string or number, but it will be converted to a number for comparison.
+This will first compare the major version number, then the minor version number.
+If the major version numbers are equal, it will compare the minor version numbers.
+@param {String} value - The value to compare with the current version.
 @return {boolean} - Return true if the current version is more than or equal to the given value.
 */
-export function versionCheck(value)  {
-    // Regex to remove all dots from the version string e.g. '5.0.0' -> 500
-    const checkAgainst = parseFloat(String(value).replace(/\./g, ''));
+export function versionCheck(value) {
+    // Extract the major version (first number) from the version string.
+    const majorVersion = parseFloat(mapp.version.split('.')[0]);
+    // Extract the minor version (second number) from the version string.
+    const minorVersion = parseFloat(mapp.version.split('.')[1]);
 
-    const version = parseFloat(mapp.version.replace(/\./g, ''));
-    
-    // If version is more than or equal to checkAgainst return true.
-    return version >= checkAgainst;
+    // Extract the major version (first number) from the value string.
+    const majorcheckAgainst = parseFloat(value.toString().split('.')[0]);
+    // Extract the minor version (second number) from the value string.
+    const minorcheckAgainst = parseFloat(value.toString().split('.')[1]);
+
+    // Compare the major version numbers.
+    if (majorVersion > majorcheckAgainst) {
+        return true;
+    }
+    // If major version numbers are equal, compare the minor version numbers.
+    if (majorVersion === majorcheckAgainst && minorVersion >= minorcheckAgainst) {
+        return true;
+    }
+
+    // If the major version number is equal, but the minor version number is less than the given value, return false.
+    return false;
 
 }

--- a/tests/lib/utils/_utils.test.mjs
+++ b/tests/lib/utils/_utils.test.mjs
@@ -4,12 +4,13 @@ import { paramStringTest } from './paramString.test.mjs';
 import { queryParamsTest } from './queryParams.test.mjs';
 import { composeTest } from './compose.test.mjs';
 import { svgTemplatesTest } from './svgTemplates.test.mjs';
-
+import { versionCheck } from './versionCheck.mjs';
 export const utilsTest = {
     numericFormatterTest,
     mergeTest,
     paramStringTest,
     queryParamsTest,
     composeTest,
-    svgTemplatesTest
+    svgTemplatesTest,
+    versionCheck
 }

--- a/tests/lib/utils/versionCheck.mjs
+++ b/tests/lib/utils/versionCheck.mjs
@@ -10,8 +10,8 @@ export async function versionCheck() {
 
     await codi.describe('Utils: versionCheck Test', async () => {
 
-        await codi.it('should return true if the current version is more than or equal to the given value (passing a number)', async () => {
-            const value = 480;
+        await codi.it('should return true if the major version is more than', async () => {
+            const value = '3.9.0';
 
             // Set mapp.version for the test
             mapp.version = '4.9.1';
@@ -21,15 +21,37 @@ export async function versionCheck() {
             codi.assertEqual(result, true);
         });
 
-        await codi.it('should return false if the current version is less than the given value (passing a string)', async () => {
-            const value = '4.12.0';
+        await codi.it('should return false if the major version is the same and the minor version is less', async () => {
+            const value = '4.10.0';
+
+            // Set mapp.version for the test
+            mapp.version = '4.9.0';
+
+            const result = mapp.utils.versionCheck(value);
+
+            codi.assertEqual(result, false);
+        });
+
+        await codi.it('should return true if the major version is the same and the minor version is more', async () => {
+            const value = '4.10.0';
 
             // Set mapp.version for the test
             mapp.version = '4.11.0';
 
             const result = await mapp.utils.versionCheck(value);
 
-            codi.assertEqual(result, false);
+            codi.assertEqual(result, true);
+        });
+
+        await codi.it('should return true if the major version is the same and the minor version is the same', async () => {
+            const value = '4.11.1';
+
+            // Set mapp.version for the test
+            mapp.version = '4.11.2';
+
+            const result = await mapp.utils.versionCheck(value);
+
+            codi.assertEqual(result, true);
         });
     });
 }

--- a/tests/lib/utils/versionCheck.mjs
+++ b/tests/lib/utils/versionCheck.mjs
@@ -1,0 +1,35 @@
+/**
+ * @module utils/versionCheck
+ */
+
+/**
+ * This function is used to test the versionCheck function
+ * @function versionCheck
+ */
+export async function versionCheck() {
+
+    await codi.describe('Utils: versionCheck Test', async () => {
+
+        await codi.it('should return true if the current version is more than or equal to the given value (passing a number)', async () => {
+            const value = 480;
+
+            // Set mapp.version for the test
+            mapp.version = '4.9.1';
+
+            const result = mapp.utils.versionCheck(value);
+
+            codi.assertEqual(result, true);
+        });
+
+        await codi.it('should return false if the current version is less than the given value (passing a string)', async () => {
+            const value = '4.12.0';
+
+            // Set mapp.version for the test
+            mapp.version = '4.11.0';
+
+            const result = await mapp.utils.versionCheck(value);
+
+            codi.assertEqual(result, false);
+        });
+    });
+}

--- a/tests/lib/utils/versionCheck.mjs
+++ b/tests/lib/utils/versionCheck.mjs
@@ -10,46 +10,47 @@ export async function versionCheck() {
 
     await codi.describe('Utils: versionCheck Test', async () => {
 
-        await codi.it('should return true if the major version is more than', async () => {
-            const value = '3.9.0';
+        await codi.it('should return false if the major and minor are the same but version patch exceeds', async () => {
 
-            // Set mapp.version for the test
+            mapp.version = '4.11.1';
+
+            const result = await mapp.utils.versionCheck('4.11');
+
+            codi.assertEqual(result, true);
+        });
+
+        await codi.it('should return true if the major version is more than', async () => {
+
             mapp.version = '4.9.1';
 
-            const result = mapp.utils.versionCheck(value);
+            const result = mapp.utils.versionCheck('3.9');
 
             codi.assertEqual(result, true);
         });
 
         await codi.it('should return false if the major version is the same and the minor version is less', async () => {
-            const value = '4.10.0';
 
-            // Set mapp.version for the test
             mapp.version = '4.9.0';
 
-            const result = mapp.utils.versionCheck(value);
+            const result = mapp.utils.versionCheck('4.10.0');
 
             codi.assertEqual(result, false);
         });
 
         await codi.it('should return true if the major version is the same and the minor version is more', async () => {
-            const value = '4.10.0';
 
-            // Set mapp.version for the test
             mapp.version = '4.11.0';
 
-            const result = await mapp.utils.versionCheck(value);
+            const result = await mapp.utils.versionCheck('4.10.0');
 
             codi.assertEqual(result, true);
         });
 
         await codi.it('should return true if the major version is the same and the minor version is the same', async () => {
-            const value = '4.11.1';
 
-            // Set mapp.version for the test
             mapp.version = '4.11.2';
 
-            const result = await mapp.utils.versionCheck(value);
+            const result = await mapp.utils.versionCheck('4.11.1');
 
             codi.assertEqual(result, true);
         });


### PR DESCRIPTION
# Version Check Util

## Description

Utility function for checking the current `mapp.version` against a provided value. 
The provided value is a string such as  '4.8.0'.
The utility splits the provided value and the mapp version into major and minor versions, and compares them separately. 
The logic is as follows: 
- If the major version is more than or equal to the given value, return true.
- If the major version numbers are equal, it will compare the minor version numbers.
- If the minor version numbers are equal, it will compare the patch version numbers.
- Otherwise, return false.

I have also provided tests that are currently passing.

## GitHub Issue

Provide the link to the relevant GitHub issue it addresses. 

## Type of Change
Please delete options that are not relevant, and select all options that apply. 

- ✅ New feature (non-breaking change which adds functionality)


## Testing Checklist 
Please delete options that are not relevant, and select all options that apply. 

- ✅ Existing Tests still pass
- ✅ Updated Existing Tests
- ✅ New Tests Added
- ✅ Ran locally on my machine

## Code Quality Checklist
Please delete options that are not relevant, and select all options that apply. 

- ✅ My code follows the guidelines of XYZ
- ✅ My code has been commented
- ✅ Documentation has been updated
- ✅ New and existing unit tests pass locally with my changes
- ✅ Main has been merged into this PR