### PR TITLE
Filter panel: reset all function

### DIFF
--- a/lib/ui/elements/card.mjs
+++ b/lib/ui/elements/card.mjs
@@ -21,7 +21,7 @@ export default function card(params) {
   
   params.data_id ??= 'card'
 
-  params.card = mapp.utils.html.node`
+  const card = mapp.utils.html.node`
   <div 
     data-id=${params.data_id}
     class="drawer">
@@ -38,5 +38,5 @@ export default function card(params) {
     </header>
     ${params.content}`
 
-  return params.card;
+  return card;
 }

--- a/lib/ui/layers/filters.mjs
+++ b/lib/ui/layers/filters.mjs
@@ -92,6 +92,23 @@ function reloadCallback(layer) {
   return layer;
 }
 
+/**
+@function removeFilter
+
+@description
+The removeFilter function removes the selected filter from the panel.
+Calls {@link module:/ui/layers/filters~applyFilter} once the card has been removed to update the layer.
+
+Hides the clearAll and resetAll button if they are no more cards in the panel.
+
+@param {layer} layer The layer to reload.
+@property {Object} layer.filter The filter thats active on the layer.
+@param {Object} filter The filter definition.
+@property {Object} filter.field The field the filter works on.
+@property {String} filter.type The filters' type e.g like, in, etc.
+@property {HTMLElement} [filter.card] The html element of the filter.
+@property {HTMLElement} [filter.li] The list element if applicable.
+*/
 function removeFilter(layer, filter) {
 
   if (layer.filter.current[filter.field]) {
@@ -118,25 +135,45 @@ function removeFilter(layer, filter) {
   mapp.ui.layers.filters.applyFilter(layer)
 
   if(!layer.filter.list.some(filter => filter.card)){
-    layer.filter.clearAll instanceof HTMLElement && layer.filter.clearAll.setProperty('display','none')
-    layer.filter.resetAll instanceof HTMLElement && layer.filter.resetAll.setProperty('display','none')
+    layer.filter.clearAll instanceof HTMLElement && layer.filter.clearAll.style.setProperty('display','none')
+    layer.filter.resetAll instanceof HTMLElement && layer.filter.resetAll.style.setProperty('display','none')
   }
 }
 
+/**
+@function resetFilter
+
+@description
+The resetFilter function removes the parameters from the filter but leaves the filter in the DOM.
+Calls {@link module:/ui/layers/filters~applyFilter} once the input elements have been reset to update the layer.
+
+@param {layer} layer The layer to reload.
+@property {Object} layer.filter The filter thats active on the layer.
+@param {Object} filter The filter definition.
+@property {Object} filter.field The field the filter works on.
+@property {String} filter.type The filters' type e.g like, in, etc.
+@property {HTMLElement} filter.card The html element of the filter.
+@property {HTMLElement} [filter.li] The list element if applicable.
+*/
 function resetFilter(layer, filter) {
 
   if (layer.filter.current[filter.field]) {
 
-    if (Object.hasOwn(layer.filter.current[filter.field], filter.type)) {
+    if (Object.hasOwn(layer.filter.current[filter.field], filter.type) && filter.card) {
 
-      Array.from(filter.card.querySelectorAll('input')).forEach( 
+      //Check for an input element
+      Array.from(filter.card?.querySelectorAll('input')).forEach( 
         element => {
+
+          //Set the input to null or uncheck the checkbox
           element.value = null
           if(element.getAttribute('type') === 'checkbox') element.checked = false
       })
       
+      //Fire input to event to trigger applyFilter
       filter.card.querySelector('input')?.dispatchEvent(new Event('input'))
 
+      //Unclick selected elements
       Array.from(filter.card.querySelector('ul')?.children || []).forEach(
         element => {
           element.classList.contains('selected') && element.dispatchEvent(new Event('click'))
@@ -147,8 +184,8 @@ function resetFilter(layer, filter) {
       delete layer.filter.current[filter.field]
     }
 
-    if (Object.hasOwn(layer.filter.current, filter.field)) {
-
+    else if (Object.hasOwn(layer.filter.current, filter.field) && filter.card) {
+      //Set numeric and integer filter values to the min and max
       Array.from(filter.card?.querySelectorAll('[type=range]') || []).forEach(
         element => {
           if (element.getAttribute('data-id') === 'a') element.value = filter.min
@@ -158,13 +195,21 @@ function resetFilter(layer, filter) {
         }
       )
 
-      Array.from(filter.card?.querySelectorAll('[type=date]') || []).forEach(element => {
+      const date_input = [...filter.card?.querySelectorAll('[type=date]'),...filter.card?.querySelectorAll('[type=datetime-local]')]
+
+      //Empty date filters
+      date_input.forEach(element => {
         element.value = ''
         element.dispatchEvent(new Event('input'))
       })
 
-      // Delete type property from filter
-      delete layer.filter.current[filter.field]
+      if(layer.filter.current[filter.field].gte){
+        layer.filter.current[filter.field].gte = filter.min
+        layer.filter.current[filter.field].lte = filter.max
+      }
+      else{
+        delete layer.filter.current[filter.field]
+      }
     }
 
     filterMethods.applyFilter(layer)

--- a/lib/ui/layers/filters.mjs
+++ b/lib/ui/layers/filters.mjs
@@ -148,7 +148,7 @@ function removeFilter(layer, filter) {
 
   delete filter.card
 
-  if(!layer.filter.list.some(filter => filter.card)){
+  if(!layer.filter.list?.some(filter => filter.card)){
     layer.filter.clearAll instanceof HTMLElement && layer.filter.clearAll.style.setProperty('display','none')
     layer.filter.resetAll instanceof HTMLElement && layer.filter.resetAll.style.setProperty('display','none')
   }
@@ -169,6 +169,8 @@ async function resetFilter(layer, filter) {
   deleteFilter(layer, filter)
 
   // Get interface content for filter card.
+  if(!filter.card) return
+  
   filter.content = [await mapp.ui.layers.filters[filter.type](layer, filter)].flat()
 
   const newCard = mapp.ui.elements.card(filter)

--- a/lib/ui/layers/filters.mjs
+++ b/lib/ui/layers/filters.mjs
@@ -30,6 +30,7 @@ const filterMethods = {
   null: filter_null,
   applyFilter,
   removeFilter,
+  resetFilter,
   reloadCallback
 }
 
@@ -116,9 +117,57 @@ function removeFilter(layer, filter) {
 
   mapp.ui.layers.filters.applyFilter(layer)
 
-  if (layer.filter.clearAll instanceof HTMLElement
-    && !layer.filter.list.some(filter => filter.card)) {
-    layer.filter.clearAll.style.display = 'none';
+  if(!layer.filter.list.some(filter => filter.card)){
+    layer.filter.clearAll instanceof HTMLElement && layer.filter.clearAll.setProperty('display','none')
+    layer.filter.resetAll instanceof HTMLElement && layer.filter.resetAll.setProperty('display','none')
+  }
+}
+
+function resetFilter(layer, filter) {
+
+  if (layer.filter.current[filter.field]) {
+
+    if (Object.hasOwn(layer.filter.current[filter.field], filter.type)) {
+
+      Array.from(filter.card.querySelectorAll('input')).forEach( 
+        element => {
+          element.value = null
+          if(element.getAttribute('type') === 'checkbox') element.checked = false
+      })
+      
+      filter.card.querySelector('input')?.dispatchEvent(new Event('input'))
+
+      Array.from(filter.card.querySelector('ul')?.children || []).forEach(
+        element => {
+          element.classList.contains('selected') && element.dispatchEvent(new Event('click'))
+        }
+      )
+
+      // Delete type property from filter
+      delete layer.filter.current[filter.field]
+    }
+
+    if (Object.hasOwn(layer.filter.current, filter.field)) {
+
+      Array.from(filter.card?.querySelectorAll('[type=range]') || []).forEach(
+        element => {
+          if (element.getAttribute('data-id') === 'a') element.value = filter.min
+          if (element.getAttribute('data-id') === 'b') element.value = filter.max
+
+          element.dispatchEvent(new Event('input'))
+        }
+      )
+
+      Array.from(filter.card?.querySelectorAll('[type=date]') || []).forEach(element => {
+        element.value = ''
+        element.dispatchEvent(new Event('input'))
+      })
+
+      // Delete type property from filter
+      delete layer.filter.current[filter.field]
+    }
+
+    filterMethods.applyFilter(layer)
   }
 }
 

--- a/lib/ui/layers/filters.mjs
+++ b/lib/ui/layers/filters.mjs
@@ -93,23 +93,18 @@ function reloadCallback(layer) {
 }
 
 /**
-@function removeFilter
+@function deleteFilter
 
 @description
-The removeFilter function removes the selected filter from the panel.
-Calls {@link module:/ui/layers/filters~applyFilter} once the card has been removed to update the layer.
-
-Hides the clearAll and resetAll button if they are no more cards in the panel.
+The deleteFilter function deletes the filter in the layer.filter.current object. And applies the changes to the layer.
 
 @param {layer} layer The layer to reload.
 @property {Object} layer.filter The filter thats active on the layer.
 @param {Object} filter The filter definition.
 @property {Object} filter.field The field the filter works on.
 @property {String} filter.type The filters' type e.g like, in, etc.
-@property {HTMLElement} [filter.card] The html element of the filter.
-@property {HTMLElement} [filter.li] The list element if applicable.
 */
-function removeFilter(layer, filter) {
+function deleteFilter(layer, filter) {
 
   if (layer.filter.current[filter.field]) {
 
@@ -126,13 +121,32 @@ function removeFilter(layer, filter) {
     }
   }
 
+  mapp.ui.layers.filters.applyFilter(layer)
+}
+
+/**
+@function removeFilter
+
+@description
+The removeFilter function removes the selected filter from the panel.
+Calls {@link module:/ui/layers/filters~applyFilter} once the card has been removed to update the layer.
+
+Hides the clearAll and resetAll button if they are no more cards in the panel.
+
+@param {layer} layer The layer to reload.
+@param {Object} filter The filter definition.
+@property {HTMLElement} [filter.card] The html element of the filter.
+@property {HTMLElement} [filter.li] The list element if applicable.
+*/
+function removeFilter(layer, filter) {
+
+  deleteFilter(layer, filter)
+
   filter.li?.classList.remove('selected')
 
   filter.card?.remove()
 
   delete filter.card
-
-  mapp.ui.layers.filters.applyFilter(layer)
 
   if(!layer.filter.list.some(filter => filter.card)){
     layer.filter.clearAll instanceof HTMLElement && layer.filter.clearAll.style.setProperty('display','none')
@@ -144,76 +158,24 @@ function removeFilter(layer, filter) {
 @function resetFilter
 
 @description
-The resetFilter function removes the parameters from the filter but leaves the filter in the DOM.
-Calls {@link module:/ui/layers/filters~applyFilter} once the input elements have been reset to update the layer.
+The resetFilter method deletes the filter and replaces the filter.card with a new card with initial filter config.
 
 @param {layer} layer The layer to reload.
-@property {Object} layer.filter The filter thats active on the layer.
 @param {Object} filter The filter definition.
-@property {Object} filter.field The field the filter works on.
-@property {String} filter.type The filters' type e.g like, in, etc.
 @property {HTMLElement} filter.card The html element of the filter.
-@property {HTMLElement} [filter.li] The list element if applicable.
 */
-function resetFilter(layer, filter) {
+async function resetFilter(layer, filter) {
 
-  if (layer.filter.current[filter.field]) {
+  deleteFilter(layer, filter)
 
-    if (Object.hasOwn(layer.filter.current[filter.field], filter.type) && filter.card) {
+  // Get interface content for filter card.
+  filter.content = [await mapp.ui.layers.filters[filter.type](layer, filter)].flat()
 
-      //Check for an input element
-      Array.from(filter.card?.querySelectorAll('input')).forEach( 
-        element => {
+  const newCard = mapp.ui.elements.card(filter)
 
-          //Set the input to null or uncheck the checkbox
-          element.value = null
-          if(element.getAttribute('type') === 'checkbox') element.checked = false
-      })
-      
-      //Fire input to event to trigger applyFilter
-      filter.card.querySelector('input')?.dispatchEvent(new Event('input'))
+  filter.card.replaceWith(newCard)
 
-      //Unclick selected elements
-      Array.from(filter.card.querySelector('ul')?.children || []).forEach(
-        element => {
-          element.classList.contains('selected') && element.dispatchEvent(new Event('click'))
-        }
-      )
-
-      // Delete type property from filter
-      delete layer.filter.current[filter.field]
-    }
-
-    else if (Object.hasOwn(layer.filter.current, filter.field) && filter.card) {
-      //Set numeric and integer filter values to the min and max
-      Array.from(filter.card?.querySelectorAll('[type=range]') || []).forEach(
-        element => {
-          if (element.getAttribute('data-id') === 'a') element.value = filter.min
-          if (element.getAttribute('data-id') === 'b') element.value = filter.max
-
-          element.dispatchEvent(new Event('input'))
-        }
-      )
-
-      const date_input = [...filter.card.querySelectorAll('[type=date]'),...filter.card.querySelectorAll('[type=datetime-local]')]
-
-      //Empty date filters
-      date_input.forEach(element => {
-        element.value = ''
-        element.dispatchEvent(new Event('input'))
-      })
-
-      if(layer.filter.current[filter.field].gte){
-        layer.filter.current[filter.field].gte = filter.min
-        layer.filter.current[filter.field].lte = filter.max
-      }
-      else{
-        delete layer.filter.current[filter.field]
-      }
-    }
-
-    filterMethods.applyFilter(layer)
-  }
+  filter.card = newCard
 }
 
 /**

--- a/lib/ui/layers/filters.mjs
+++ b/lib/ui/layers/filters.mjs
@@ -195,7 +195,7 @@ function resetFilter(layer, filter) {
         }
       )
 
-      const date_input = [...filter.card?.querySelectorAll('[type=date]'),...filter.card?.querySelectorAll('[type=datetime-local]')]
+      const date_input = [...filter.card.querySelectorAll('[type=date]'),...filter.card.querySelectorAll('[type=datetime-local]')]
 
       //Empty date filters
       date_input.forEach(element => {

--- a/lib/ui/layers/panels/filter.mjs
+++ b/lib/ui/layers/panels/filter.mjs
@@ -124,9 +124,8 @@ export default function filterPanel(layer) {
   layer.filter.list = layer.infoj
     .filter(entry => entry.filter !== undefined)
     .filter(entry => entry.field !== undefined)
-    .filter(entry => entry.type !== undefined)
     .map(entry => {
-      
+
       // The filter is defined as a string e.g. "like"
       if (typeof entry.filter === 'string') {
 
@@ -211,7 +210,7 @@ export default function filterPanel(layer) {
       layer.filter.list
         .forEach(filter => mapp.ui.layers.filters.resetFilter(layer, filter))
 
-    }}>${mapp.dictionary.layer_filter_reset_all}`  
+    }}>${mapp.dictionary.layer_filter_reset_all}`
 
   layer.filter.view = mapp.ui.elements.drawer({
     data_id: `filter-drawer`,

--- a/lib/ui/layers/panels/filter.mjs
+++ b/lib/ui/layers/panels/filter.mjs
@@ -197,8 +197,7 @@ export default function filterPanel(layer) {
 
   layer.filter.clearAll = mapp.utils.html.node`<button
     data-id=clearall
-    class="flat"
-    style="display: none; margin-bottom: 5px;text-decoration: underline"
+    class="flat underline"
     onclick=${e => {
       layer.filter.list
         .forEach(filter => mapp.ui.layers.filters.removeFilter(layer, filter))
@@ -207,8 +206,7 @@ export default function filterPanel(layer) {
 
   layer.filter.resetAll = mapp.utils.html.node`<button
     data-id=resetall
-    class="flat"
-    style="display: none; margin-bottom: 5px;text-decoration: underline"
+    class="flat underline"
     onclick=${e => {
       layer.filter.list
         .forEach(filter => mapp.ui.layers.filters.resetFilter(layer, filter))

--- a/lib/ui/layers/panels/filter.mjs
+++ b/lib/ui/layers/panels/filter.mjs
@@ -224,7 +224,7 @@ export default function filterPanel(layer) {
     content: mapp.utils.html`
       ${layer.filter.dropdown}
       ${layer.filter.clearAll}
-       ${layer.filter.resetAll}`
+      ${layer.filter.resetAll}`
   })
 
   return layer.filter.view

--- a/lib/ui/layers/panels/filter.mjs
+++ b/lib/ui/layers/panels/filter.mjs
@@ -11,6 +11,7 @@ mapp.utils.merge(mapp.dictionaries, {
     layer_filter_header: 'Filter',
     layer_filter_select: 'Select filter from list',
     layer_filter_clear_all: 'Clear all filters',
+    layer_filter_reset_all: 'Reset all filters',
     layer_filter_greater_than: 'Greater than',
     layer_filter_less_than: 'Less than',
     layer_filter_set_filter: 'Set filter',
@@ -174,8 +175,9 @@ export default function filterPanel(layer) {
       // Return if filter card already exists.
       if (filter?.card) return;
 
-      // Display clear all button.
-      layer.filter.clearAll.style.display = 'block';
+      // Display clear and reset all button.
+      layer.filter.clearAll.style.display = 'inline-block';
+      layer.filter.resetAll.style.display = 'inline-block';
 
       // Get interface content for filter card.
       filter.content = [await mapp.ui.layers.filters[filter.type](layer, filter)].flat()
@@ -195,13 +197,23 @@ export default function filterPanel(layer) {
 
   layer.filter.clearAll = mapp.utils.html.node`<button
     data-id=clearall
-    class="primary-colour"
-    style="display: none; margin-bottom: 5px;"
+    class="flat"
+    style="display: none; margin-bottom: 5px;text-decoration: underline"
     onclick=${e => {
       layer.filter.list
         .forEach(filter => mapp.ui.layers.filters.removeFilter(layer, filter))
 
     }}>${mapp.dictionary.layer_filter_clear_all}`
+
+  layer.filter.resetAll = mapp.utils.html.node`<button
+    data-id=resetall
+    class="flat"
+    style="display: none; margin-bottom: 5px;text-decoration: underline"
+    onclick=${e => {
+      layer.filter.list
+        .forEach(filter => mapp.ui.layers.filters.resetFilter(layer, filter))
+
+    }}>${mapp.dictionary.layer_filter_reset_all}`  
 
   layer.filter.view = mapp.ui.elements.drawer({
     data_id: `filter-drawer`,
@@ -211,7 +223,8 @@ export default function filterPanel(layer) {
       <div class="mask-icon expander"></div>`,
     content: mapp.utils.html`
       ${layer.filter.dropdown}
-      ${layer.filter.clearAll}`
+      ${layer.filter.clearAll}
+       ${layer.filter.resetAll}`
   })
 
   return layer.filter.view

--- a/public/css/_button.css
+++ b/public/css/_button.css
@@ -42,6 +42,12 @@ button {
     }
   }
 
+  &.underline {
+    display: none; 
+    margin-bottom: 5px;
+    text-decoration: underline
+  }
+
   &.raised {
     border-radius: 3px;
     border: 1px solid var(--color-light-secondary);

--- a/public/css/ui.css
+++ b/public/css/ui.css
@@ -49,6 +49,11 @@ button {
       border-bottom: 3px solid var(--color-on);
     }
   }
+  &.underline {
+    display: none;
+    margin-bottom: 5px;
+    text-decoration: underline;
+  }
   &.raised {
     border-radius: 3px;
     border: 1px solid var(--color-light-secondary);

--- a/tests/lib/ui/layers/panels/filter.test.mjs
+++ b/tests/lib/ui/layers/panels/filter.test.mjs
@@ -1,4 +1,7 @@
 /**
+ * @module lib/ui/elements/layers/panels/filters
+ */
+/**
  * This is the entry point function for the ui/layers/panels/filter test
  * @function panelFilterTest
  */
@@ -11,10 +14,10 @@ export function panelFilterTest() {
             */
         codi.it('Create a filter panel', () => {
             const layer = {
-                reload: () => {},
+                reload: () => { },
                 mapview: {
                     Map: {
-                        getTargetElement: () => {return document.getElementById('Map')}
+                        getTargetElement: () => { return document.getElementById('Map') }
                     }
                 },
                 key: 'panel_test',
@@ -51,7 +54,7 @@ export function panelFilterTest() {
 
             const resetButton = filterPanel.querySelector('[data-id=resetall]')
 
-            layer.filter.current['field_1'] ??= {'like':'a'}
+            layer.filter.current['field_1'] ??= { 'like': 'a' }
 
             resetButton.dispatchEvent(new Event('click'))
 

--- a/tests/lib/ui/layers/panels/filter.test.mjs
+++ b/tests/lib/ui/layers/panels/filter.test.mjs
@@ -11,6 +11,12 @@ export function panelFilterTest() {
             */
         codi.it('Create a filter panel', () => {
             const layer = {
+                reload: () => {},
+                mapview: {
+                    Map: {
+                        getTargetElement: () => {return document.getElementById('Map')}
+                    }
+                },
                 key: 'panel_test',
                 filter: {
                     current: {}
@@ -38,6 +44,18 @@ export function panelFilterTest() {
             const drop_down_elements = filterPanelDropDown.querySelector('ul');
 
             codi.assertEqual(drop_down_elements.children.length, 2, 'We expect two entries into the dropdown from the infoj')
+
+            filterPanel.querySelector('ul').children[0].dispatchEvent(new Event('click'))
+
+            codi.assertEqual(filterPanel.querySelector('ul').children[0].classList.contains('selected'), true, 'Expect an element to be selected')
+
+            const resetButton = filterPanel.querySelector('[data-id=resetall]')
+
+            layer.filter.current['field_1'] ??= {'like':'a'}
+
+            resetButton.dispatchEvent(new Event('click'))
+
+            codi.assertEqual(layer.filter.current, {}, ' `layer.current.filter` should be empty')
 
         });
     });


### PR DESCRIPTION
## Description
Adds the ability to reset the filters back to their starting positions.

Reset all will leave the filter in the dom, but just remove any user provided input and clear the parameters from the filter. 

## GitHub Issue

[#1566](https://github.com/GEOLYTIX/xyz/issues/1566)

## Type of Change
- ✅ New feature (non-breaking change which adds functionality)
- ✅ Documentation

## How have you tested this? 
Tested on the demo multi_filter.  Can be tested on `bugs_testing/filter/all_filters.json`. To test the multi_filter please use the PR.
(The multi filter is present on `bugs_testing/filter/all_filters.json`)

## Testing Checklist 
- ✅ Existing Tests still pass
- ✅ Ran locally on my machine

## Code Quality Checklist
- ✅ My code follows the guidelines of XYZ
- ✅ My code has been commented
- ✅ Documentation has been updated
- ✅ New and existing unit tests pass locally with my changes
- ✅ Main has been merged into this PR

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1208550579293270