### PR TITLE
Move Icon Scaling to the bottom instead of before themes

### DIFF
--- a/lib/ui/layers/panels/style.mjs
+++ b/lib/ui/layers/panels/style.mjs
@@ -153,9 +153,9 @@ export default function stylePanel(layer) {
     'label',
     'hovers',
     'hover',
-    'icon_scaling',
     'themes',
     'theme',
+    'icon_scaling',
   ]
 
   // Request style.panel element as content for drawer.


### PR DESCRIPTION
The `elements` defaults was in the wrong order. 

Icon Scaling should by default exist below the themes / theme. 

![image](https://github.com/user-attachments/assets/f5ba7d54-b849-4d52-a0f3-e985c4616abb)
