### PR TITLE
Nullish Assign syncPlugins

### DIFF
--- a/lib/mapview/_mapview.mjs
+++ b/lib/mapview/_mapview.mjs
@@ -343,6 +343,8 @@ async function mapviewPromise(mapview) {
 
   await mapp.utils.loadPlugins(mapview.locale.plugins);
 
+  mapview.syncPlugins ??= [];
+  
   const syncPlugins = new Set(mapview.syncPlugins)
 
   // Execute synchronous plugins in order of array.


### PR DESCRIPTION
## Description

In a custom view, there may not be any syncPlugins defined to a mapview. 
In this scenario, currently the custom view crashes on line 351 as it tries to iterate over `mapview.syncPlugins` which doesn't exist. 
This PR simply assigns an empty array if not provided, to resolve this.

## GitHub Issue

Provide the link to the relevant GitHub issue it addresses. 

## Type of Change
Please delete options that are not relevant, and select all options that apply. 

- ✅ Bug fix (non-breaking change which fixes an issue)

## Testing Checklist 
Please delete options that are not relevant, and select all options that apply. 

- ✅ Existing Tests still pass
- ✅ Ran locally on my machine

## Code Quality Checklist
Please delete options that are not relevant, and select all options that apply. 

- ✅ My code follows the guidelines of XYZ
- ✅ My code has been commented
- ✅ Documentation has been updated
- ✅ New and existing unit tests pass locally with my changes
- ✅ Main has been merged into this PR