### PR TITLE
Null Geometry - Does not refresh geometry entry on the map

### DIFF
--- a/lib/ui/locations/entries/geometry.mjs
+++ b/lib/ui/locations/entries/geometry.mjs
@@ -93,6 +93,14 @@ export default function geometry(entry) {
 
   entry.zIndex ??= entry.location?.layer?.zIndex + 1 || 99
 
+  // If the value is null, the entry must be removed from the mapview (if it exists).
+  // This is possible if the entry is already drawn, and then is a dependent of another entry.
+  if (!entry.value) {
+    // Remove the geometry layer from map.
+    entry.display = false
+    entry.L && entry.location.layer.mapview.Map.removeLayer(entry.L)
+  }
+
   // Drawing is only available within an edit context.
   if (entry.edit?.draw) {
 


### PR DESCRIPTION
# Pull Request Template

## Description

If I have a `geometry` entry that is a `dependent` of another field. 
If the `geometry` entry is already turned on, and when refreshed as a `dependent` it is then null, it is not removed from the mapview. 

This PR addresses that by checking if entry.value is null, and removing the layer if it exists.


## Type of Change
Please delete options that are not relevant, and select all options that apply. 

- ✅ Bug fix (non-breaking change which fixes an issue)

## Testing Checklist 
Please delete options that are not relevant, and select all options that apply. 

- ✅ Existing Tests still pass
- ✅ Ran locally on my machine

## Code Quality Checklist
Please delete options that are not relevant, and select all options that apply. 

- ✅ My code follows the guidelines of XYZ
- ✅ My code has been commented
- ✅ Documentation has been updated
- ✅ New and existing unit tests pass locally with my changes
- ✅ Main has been merged into this PR