### PR TITLE
Infoj Entry - Layer Dependents

### DIFF
--- a/lib/location/decorate.mjs
+++ b/lib/location/decorate.mjs
@@ -110,7 +110,7 @@ An xhr POST request with all newValues is passed to location_update query templa
 
 infoj entry values are set to the newValues after a successful update.
 
-Dependent fields for updated entries are filtered out and passed to the syncFields method. The dependents_layer for updated fields are reloaded in the process.
+Dependent fields for updated entries are filtered out and passed to the syncFields method. The dependents_layers for updated fields are reloaded in the process.
 */
 async function update() {
 
@@ -187,21 +187,36 @@ async function update() {
 
       // Update entry.values with newValues.
       entry.value = entry.newValue;
+      // Remove newValue
+      delete entry.newValue;
 
-      if (Array.isArray(entry.dependents_layer)) {
+      // Iterate through the dependents_layers array
+      if (Array.isArray(entry.dependents_layers)) {
 
-        entry.dependents_layer.forEach(layer => {
+        entry.dependents_layers.forEach(layer => {
 
-          // Iterate through the dependents_layer array and reload matching layers in mapview.
-          entry.location.layer.mapview.layers[layer].reload()
+          // Find the layer in mapview.
+          const mapview_layer = entry.location.layer.mapview.layers[layer]
+
+          // If the layer exists, reload it.
+          if (mapview_layer) mapview_layer.reload();
         })
       }
 
       return entry.dependents
-    }).flat()
+    })
+    // Flatten dependents array and filter out undefined values.
+    .flat()
+    .filter(dependents => dependents !== undefined)
 
-  // Sync dependent fields
-  if (dependents.length) await this.syncFields([...new Set(dependents)]);
+  // sync dependent fields
+  if (dependents.length) await this.syncFields([...new Set(dependents)])
+
+  // Reload layer.
+  this.layer.reload()
+
+  // Execute update callbacks.
+  this.updateCallbacks?.forEach(fn => typeof fn === 'function' && fn(this))
 }
 
 async function syncFields(fields) {

--- a/lib/location/decorate.mjs
+++ b/lib/location/decorate.mjs
@@ -163,33 +163,29 @@ async function update() {
     return;
   }
 
-// Update entry.values with newValues.
-// Return dependents and layer_dependents from updated entries.
-const result = this.infoj
-  .filter(entry => typeof entry.newValue !== 'undefined')
-  .map(entry => {
-    entry.value = entry.newValue;
 
-    return {
-      'dependents': entry.dependents,
-      'layer_dependents': entry.layer_dependents
-    };
-  })
-  .filter(entry => entry.dependents || entry.layer_dependents);
+  // Find newValue entries for update.
+  const dependents = this.infoj
+    .filter(entry => typeof entry.newValue !== 'undefined')
+    .map(entry => {
 
-const dependents = result.map(entry => entry.dependents).flat().filter(Boolean);
-const layer_dependents = result.map(entry => entry.layer_dependents).flat().filter(Boolean);
+      // Update entry.values with newValues.
+      entry.value = entry.newValue;
 
-// Sync dependent fields
-if (dependents.length) await this.syncFields([...new Set(dependents)]);
+      if (Array.isArray(entry.dependents_layer)) {
 
-// Reload dependent layers
-if (layer_dependents.length) layer_dependents.forEach(layer => this.layer.mapview.layers[layer].reload());
+        entry.dependents_layer.forEach(layer => {
 
-  // Reload layer.
-  this.layer.reload()
+          // Iterate through the dependents_layer array and reload matching layers in mapview.
+          entry.location.layer.mapview.layers[layer].reload()
+        })
+      }
 
-  this.updateCallbacks?.forEach(fn => typeof fn === 'function' && fn(this))
+      return entry.dependents
+    }).flat()
+
+  // Sync dependent fields
+  if (dependents.length) await this.syncFields([...new Set(dependents)]);
 }
 
 async function syncFields(fields) {

--- a/lib/location/decorate.mjs
+++ b/lib/location/decorate.mjs
@@ -107,19 +107,19 @@ async function update() {
   }
 
   this.infoj
-  .filter(entry => entry.jsonb_key)
-  .filter(entry => entry.jsonb_field)
-  .filter(entry => typeof entry.newValue !== 'undefined')
-  .forEach(entry => {
+    .filter(entry => entry.jsonb_key)
+    .filter(entry => entry.jsonb_field)
+    .filter(entry => typeof entry.newValue !== 'undefined')
+    .forEach(entry => {
 
-    entry.newValue = {
-      'jsonb': {
-        [entry.jsonb_field]: {
-          [entry.jsonb_key]: entry.newValue
+      entry.newValue = {
+        'jsonb': {
+          [entry.jsonb_field]: {
+            [entry.jsonb_key]: entry.newValue
+          }
         }
       }
-    }
-  })
+    })
 
   this.infoj
     .filter(entry => entry.json_field)
@@ -163,22 +163,28 @@ async function update() {
     return;
   }
 
-  // Update entry.values with newValues.
-  // Return dependents from updated entries.
-  const dependents = this.infoj
-    .filter(entry => typeof entry.newValue !== 'undefined')
-    .map(entry => {
+// Update entry.values with newValues.
+// Return dependents and layer_dependents from updated entries.
+const result = this.infoj
+  .filter(entry => typeof entry.newValue !== 'undefined')
+  .map(entry => {
+    entry.value = entry.newValue;
 
-      entry.value = entry.newValue;
-      delete entry.newValue;
+    return {
+      'dependents': entry.dependents,
+      'layer_dependents': entry.layer_dependents
+    };
+  })
+  .filter(entry => entry.dependents || entry.layer_dependents);
 
-      return entry.dependents
-    })
-    .flat()
-    .filter(dependents => dependents !== undefined)
+const dependents = result.map(entry => entry.dependents).flat().filter(Boolean);
+const layer_dependents = result.map(entry => entry.layer_dependents).flat().filter(Boolean);
 
-  // sync dependent fields
-  if (dependents.length) await this.syncFields([...new Set(dependents)])
+// Sync dependent fields
+if (dependents.length) await this.syncFields([...new Set(dependents)]);
+
+// Reload dependent layers
+if (layer_dependents.length) layer_dependents.forEach(layer => this.layer.mapview.layers[layer].reload());
 
   // Reload layer.
   this.layer.reload()
@@ -236,7 +242,7 @@ function flyTo(maxZoom) {
 
 async function trash() {
 
-  const confirm = await mapp.ui.elements.confirm({text: mapp.dictionary.confirm_delete})
+  const confirm = await mapp.ui.elements.confirm({ text: mapp.dictionary.confirm_delete })
 
   if (!confirm) return;
 

--- a/lib/location/decorate.mjs
+++ b/lib/location/decorate.mjs
@@ -110,7 +110,10 @@ An xhr POST request with all newValues is passed to location_update query templa
 
 infoj entry values are set to the newValues after a successful update.
 
-Dependent fields for updated entries are filtered out and passed to the syncFields method. The dependents_layers for updated fields are reloaded in the process.
+Dependent fields for updated entries is an array of fields that is passed to the syncFields method, to retrieve the updated values from the location. 
+These dependents fields are reloaded with the updated values from the location.
+
+Dependent layers is an array of layer keys that will be reloaded after the update.
 */
 async function update() {
 

--- a/lib/location/decorate.mjs
+++ b/lib/location/decorate.mjs
@@ -1,6 +1,8 @@
 /**
 ### /location/decorate
 
+@requires /utils/xhr
+
 @module /location/decorate
 */
 
@@ -95,8 +97,20 @@ function remove() {
 }
 
 /**
-Update a location from host
 @function update
+
+@description
+The update method is bound to the location (this) in the decorator method.
+
+The update method will abort if some of the location.infoj entries is invalid.
+
+JSON newValues are created for any json or jsonb type entries in the location.infoj array.
+
+An xhr POST request with all newValues is passed to location_update query template.
+
+infoj entry values are set to the newValues after a successful update.
+
+Dependent fields for updated entries are filtered out and passed to the syncFields method. The dependents_layer for updated fields are reloaded in the process.
 */
 async function update() {
 
@@ -106,6 +120,7 @@ async function update() {
     return new Error('Unable to update.');
   }
 
+  // Create newValue for jsonb entries.
   this.infoj
     .filter(entry => entry.jsonb_key)
     .filter(entry => entry.jsonb_field)
@@ -121,6 +136,7 @@ async function update() {
       }
     })
 
+  // Create newValue on json_field entries.
   this.infoj
     .filter(entry => entry.json_field)
     .filter(entry => entry.json_key)
@@ -136,11 +152,12 @@ async function update() {
       delete entry.newValue
     })
 
-  // Map new values into newValues object.
+  // Map newValues from infoj entry objects.
   const newValues = Object.fromEntries(this.infoj
     .filter(entry => typeof entry.newValue !== 'undefined')
     .map(entry => [entry.field, entry.newValue]))
 
+  // Shortcircuit if no update is required.
   if (!Object.keys(newValues).length) return;
 
   const location_update = await mapp.utils.xhr({
@@ -162,7 +179,6 @@ async function update() {
     this.view?.classList.remove('disabled')
     return;
   }
-
 
   // Find newValue entries for update.
   const dependents = this.infoj

--- a/tests/assets/layers/scratch/infoj.json
+++ b/tests/assets/layers/scratch/infoj.json
@@ -22,11 +22,6 @@
         {
             "title": "char_field",
             "field": "char_field"
-        },
-        {
-            "title": "minutes",
-            "field": "integer_field",
-            "inline": true
         }
     ]
 }

--- a/tests/workspace.json
+++ b/tests/workspace.json
@@ -156,6 +156,25 @@
                     "polygon": true,
                     "point": true
                 },
+                "infoj": [
+                    {
+                        "label": "check",
+                        "field": "bool_field",
+                        "edit": true,
+                        "inline": true,
+                        "type": "boolean",
+                        "dependents": [
+                            "integer_field"
+                        ]
+                    },
+                    {
+                        "title": "minutes",
+                        "field": "integer_field",
+                        "value": null,
+                        "edit": "true",
+                        "inline": true
+                    }
+                ],
                 "infoj_skip": [
                     "textarea"
                 ]


### PR DESCRIPTION
## Description

It needs to be possible to reload other layers when an infoj entry is altered. I have added a new array to the infoj `dependents_layers`. This is simply an array of layers to reload when an `infoj` entry is edited. 

Use Case
- Layer A contains Sites that have a catchment that is a 500m buffer when the Site is set to 'Big' or 250m buffer when the Site is set to 'Small'. This is handled by a db trigger function.
- Layer B is an mvt layer that simply shows the Sites Catchments. We need to reload this layer when a Site on Layer A is altered.

We need to be able to specify that layer B should be reloaded. 

## GitHub Issue

Provide the link to the relevant GitHub issue it addresses. 

## Type of Change
Please delete options that are not relevant, and select all options that apply. 

- ✅ New feature (non-breaking change which adds functionality)

## Testing Checklist 
Please delete options that are not relevant, and select all options that apply. 

- ✅ Existing Tests still pass
- ✅ Updated Existing Tests
- ✅ Ran locally on my machine

## Code Quality Checklist
Please delete options that are not relevant, and select all options that apply. 

- ✅ My code follows the guidelines of XYZ
- ✅ My code has been commented
- ✅ Documentation has been updated
- ✅ New and existing unit tests pass locally with my changes
- ✅ Main has been merged into this PR