### PR TITLE
Maplibre v4.7.1

### DIFF
--- a/lib/layer/format/maplibre.mjs
+++ b/lib/layer/format/maplibre.mjs
@@ -16,7 +16,7 @@ async function MaplibreGL() {
 
     try {
 
-      const mod = await import('https://esm.sh/maplibre-gl@4.0.2')
+      const mod = await import('https://esm.sh/maplibre-gl@4.7.1')
 
       maplibregl = mod.default
 


### PR DESCRIPTION
Bump the maplibre import to version 4.7.1 https://github.com/maplibre/maplibre-gl-js/releases/tag/v4.7.1