### PR TITLE
sqlFilter export

### DIFF
--- a/mod/utils/sqlFilter.js
+++ b/mod/utils/sqlFilter.js
@@ -70,7 +70,9 @@ If the filter is a string, the filter will be returned as is.
 @param {Array} params
 @returns {string} SQL query string
 */
-module.exports = function sqlfilter(filter, params) {
+module.exports = sqlfilter; 
+
+function sqlfilter(filter, params) {
 
   //Check to see that params is an array and that the values of the params are of valid type.
   if (!Array.isArray(params)) {


### PR DESCRIPTION
## Description

The `sqlFilter` export needed to be altered from this
``` js
module.exports = 
function sqlfilter(filter, params) {}
```
to this 
``` js

module.exports = sqlfilter; 

function sqlfilter(filter, params) {}
```
Otherwise on line 128 the return to the method was undefined and would crash the process.
``` js
 // Map filter entries
    .map((entry) => {

      const field = entry[0]
      const value = entry[1]

      // Array entry values represent conditional OR
      if (value.length) return sqlfilter(value);
```

## GitHub Issue

Provide the link to the relevant GitHub issue it addresses. 

## Type of Change
Please delete options that are not relevant, and select all options that apply. 

- ✅ Bug fix (non-breaking change which fixes an issue)

## Testing Checklist 
Please delete options that are not relevant, and select all options that apply. 

- ✅ Existing Tests still pass
- ✅ Updated Existing Tests
- ✅ New Tests Added
- ✅ Ran locally on my machine

## Code Quality Checklist
Please delete options that are not relevant, and select all options that apply. 

- ✅ My code follows the guidelines of XYZ
- ✅ My code has been commented
- ✅ Documentation has been updated
- ✅ New and existing unit tests pass locally with my changes
- ✅ Main has been merged into this PR