### PR TITLE
Provide fields array param as array.

### DIFF
--- a/lib/utils/paramString.mjs
+++ b/lib/utils/paramString.mjs
@@ -50,6 +50,13 @@ function paramString(params) {
 
     .map(entry => {
 
+      if (Array.isArray(entry[1]) && entry[0] === 'fields') {
+
+      //if (entry[1] instanceof Set) {
+
+        return encodeURI(`${entry[0]}=[${entry[1]}]`)
+      }
+
       // Stringify non array objects.
       if (typeof entry[1] === 'object' && !Array.isArray(entry[1])) {
 

--- a/mod/workspace/templates/cluster.js
+++ b/mod/workspace/templates/cluster.js
@@ -4,11 +4,9 @@ module.exports = _ => {
     _.geom ??= _.layer.geom
 
     // Get fields array from query params.
-    const fields = _.fields?.split(',')
-        .map(field => `${_.workspace.templates[field]?.template || field} as ${field}`)
+    const fields = _.fields?.map(field => `${_.workspace.templates[field]?.template || field} as ${field}`)
 
-    const aggFields = _.fields?.split(',')
-        .map(field => `CASE WHEN count(*)::int = 1 THEN (array_agg(${field}))[1] END as ${field}`)
+    const aggFields = _.fields?.map(field => `CASE WHEN count(*)::int = 1 THEN (array_agg(${field}))[1] END as ${field}`)
 
     const where = _.viewport || `AND ${_.geom} IS NOT NULL` 
 

--- a/mod/workspace/templates/cluster_hex.js
+++ b/mod/workspace/templates/cluster_hex.js
@@ -4,11 +4,9 @@ module.exports = _ => {
     _.geom ??= _.layer.geom
 
     // Get fields array from query params.
-    const fields = _.fields?.split(',')
-        .map(field => `${_.workspace.templates[field]?.template || field} as ${field}`)
+    const fields = _.fields?.map(field => `${_.workspace.templates[field]?.template || field} as ${field}`)
 
-    const aggFields = _.fields?.split(',')
-        .map(field => `CASE WHEN count(*)::int = 1 THEN (array_agg(${field}))[1] END as ${field}`)
+    const aggFields = _.fields?.map(field => `CASE WHEN count(*)::int = 1 THEN (array_agg(${field}))[1] END as ${field}`)
 
     const where = _.viewport || `AND ${_.geom} IS NOT NULL`
 

--- a/mod/workspace/templates/geojson.js
+++ b/mod/workspace/templates/geojson.js
@@ -3,7 +3,7 @@ module.exports = _ => {
     let properties = '';
 
     if (_.fields) {
-        const propertyKeyValuePairs = _.fields?.split(',').map(field => {
+        const propertyKeyValuePairs = _.fields?.map(field => {
             const value = _.workspace.templates[field]?.template || field;
             return `'${field}',${value}`;
         });

--- a/mod/workspace/templates/location_get.js
+++ b/mod/workspace/templates/location_get.js
@@ -9,7 +9,7 @@ module.exports = _ => {
     .filter(entry => entry.field)
 
     // Only include fields from the fields[] array param.
-    .filter(entry => !_.fields || _.fields?.split(',').includes(entry.field))
+    .filter(entry => !_.fields || _.fields?.includes(entry.field))
 
     // Map either fieldfx or template SQL if available.
     .map(entry => `(${entry.fieldfx || _.workspace.templates[entry.field]?.template || entry.field}) AS ${entry.field}`))

--- a/mod/workspace/templates/mvt.js
+++ b/mod/workspace/templates/mvt.js
@@ -1,8 +1,7 @@
 module.exports = _ => {
 
   // Get fields array from query params.
-  const fields = _.fields?.split(',')
-    .map(field => `${_.workspace.templates[field]?.template || field} AS ${field}`)
+  const fields = _.fields?.map(field => `${_.workspace.templates[field]?.template || field} AS ${field}`)
     .filter(field => !!field)
     || []
 

--- a/mod/workspace/templates/wkt.js
+++ b/mod/workspace/templates/wkt.js
@@ -1,10 +1,8 @@
 module.exports = _ => {
 
   // Get fields array from query params.
-  const fields = _.fields?.split(',')
-    .map(field => `${_.workspace.templates[field]?.template || field} AS ${field}`)
-    .filter(field => !!field)
-    || []
+  const fields = _.fields?.map(field => `${_.workspace.templates[field]?.template || field} AS ${field}`)
+    .filter(field => !!field) || []
 
   // Unshift the geom field into the array.
   if (_.geom && !_.no_geom) {


### PR DESCRIPTION
A bracketed string param `[a,b,c]` is split into an array type request param by the API module.

Fields for query templates should be provided as an array and not split in the template render method.