### PR TITLE
Warn on feature properties properties

### DIFF
--- a/lib/layer/featureStyle.mjs
+++ b/lib/layer/featureStyle.mjs
@@ -130,7 +130,7 @@ export default function featureStyle(layer) {
     if (feature.properties?.properties) {
 
       // This shouldn't happen anymore.
-      // console.warn(`Feature with properties.properties`)
+      console.warn(`Feature with properties.properties`)
       Object.assign(feature.properties, feature.properties.properties)
       delete feature.properties.properties
     }


### PR DESCRIPTION
The warning was previously commented since this was happening a lot.

There should not be any feature with a properties property anymore.

I will re-instate the warning now for the check to be removed in the next point release.