### PR TITLE
/ui/locations/entries/pin default_icon without a location.record property

### DIFF
--- a/lib/ui/locations/entries/geometry.mjs
+++ b/lib/ui/locations/entries/geometry.mjs
@@ -202,13 +202,16 @@ async function show() {
 
   if (this.L) {
 
-    // Remove existing layer to prevent assertion error.
     this.location.layer.mapview.Map.removeLayer(this.L)
 
+    // Layer object must be filtered from the Layers array before being deleted.
     this.location.Layers = this.location.Layers.filter(L => L.ol_uid !== this.L.ol_uid)
 
     delete this.L
   }
+
+  // An ol layer L can only be created with a value.
+  if (!this.value) return;
 
   // Create new geometry layer from entry value
   this.L = this.location.layer.mapview.geometry(this)

--- a/lib/ui/locations/entries/pin.mjs
+++ b/lib/ui/locations/entries/pin.mjs
@@ -48,6 +48,8 @@ mapp.utils.merge(mapp.dictionaries, {
 @description
 Places a pin on the selected location on the map. A checkbox is supplied to turn the pin on and off.
 
+The pin will be styled by the entry.style property if provided. Otherwise the location.pinStyle assigned by the locations [listview]{@link module:/ui/locations/listview~listview} method will be used. A location may not have a pinStyle if no listview has been configured for the mapview.
+
 @param {infoj-entry} entry type:pin entry.
 @property {location} entry.location The entry location.
 @property {array} entry.value An array containing entrys' co-ordinates.

--- a/lib/ui/locations/entries/pin.mjs
+++ b/lib/ui/locations/entries/pin.mjs
@@ -88,9 +88,9 @@ export default function pin(entry) {
 
   if (entry.L) {
 
-    // Remove existing layer to prevent assertion error.
     entry.location.layer.mapview.Map.removeLayer(entry.L)
 
+    // Layer object must be filtered from the Layers array before being deleted.
     entry.location.Layers = entry.location.Layers.filter(L => L.ol_uid !== entry.L.ol_uid)
 
     delete entry.L

--- a/lib/ui/locations/entries/pin.mjs
+++ b/lib/ui/locations/entries/pin.mjs
@@ -67,14 +67,6 @@ export default function pin(entry) {
     return;
   }
 
-  const default_icon = {
-    type: 'markerLetter',
-    letter: entry.location?.record?.symbol,
-    color: entry.location?.record?.colour,
-    scale: entry.style?.scale || 3,
-    anchor: [0.5, 1]
-  }
-
   // Assign srid from location.layer if not implicit.
   entry.srid ??= entry.location.layer.srid
 
@@ -83,11 +75,7 @@ export default function pin(entry) {
 
   entry.zIndex ??= Infinity
 
-  if (entry.style) {
-    entry.style.icon = default_icon
-  }
-
-  entry.Style ??= entry.style ? mapp.utils.style(entry.style) : entry.location.pinStyle
+  entry.Style ??= entry.style ? mapp.utils.style(entry.style): entry.location.pinStyle
 
   entry.srid ??= entry.location.layer.srid
 

--- a/lib/ui/locations/entries/pin.mjs
+++ b/lib/ui/locations/entries/pin.mjs
@@ -69,8 +69,8 @@ export default function pin(entry) {
 
   const default_icon = {
     type: 'markerLetter',
-    letter: entry.location.record.symbol,
-    color: entry.location.record.colour,
+    letter: entry.location?.record?.symbol,
+    color: entry.location?.record?.colour,
     scale: entry.style?.scale || 3,
     anchor: [0.5, 1]
   }

--- a/lib/ui/locations/listview.mjs
+++ b/lib/ui/locations/listview.mjs
@@ -162,9 +162,6 @@ export default function listview(params) {
     fillOpacity: 0.1
   };
 
-  //Spread assign to the default `markerLetter` pin if only one property is provided
-  locale.locations.pinStyle = {...{ type: 'markerLetter',scale: 3, anchor: [0.5, 1] }, ...locale.locations.pinStyle}
-
   //Assign default records or `listview_records` to the location
   locale.locations.records ??= locale.listview_records || structuredClone(records)
 
@@ -210,7 +207,6 @@ export default function listview(params) {
 
   Triggers the event to add the location to view.
   Prepends new locations to the listview, minimizing the other locations when a new one is selected
-
 
   @param {location} location 
   */
@@ -275,7 +271,6 @@ export default function listview(params) {
 
     return !!location
   }
-
 }
 
 /**
@@ -288,7 +283,6 @@ Controls whether the clear all button is shown by checking if any locations are 
 
 @param {locale} locale 
 */
-
 function gazCheck(locale) {
 
   // clearAll should not be shown without locations to clear


### PR DESCRIPTION
## Description

In a custom view, when calling ` mapp.ui.locations.infoj` - the location may not have a record. 
As such the `pin.mjs` would fail as it was looking for `entry.location.record.symbol`. 

This PR adds a check on this to prevent it.

## GitHub Issue

#1597 

## Type of Change
Please delete options that are not relevant, and select all options that apply. 

- ✅ Bug fix (non-breaking change which fixes an issue)

## Testing Checklist 
Please delete options that are not relevant, and select all options that apply. 

- ✅ Existing Tests still pass
- ✅ Updated Existing Tests
- ✅ New Tests Added
- ✅ Ran locally on my machine

## Code Quality Checklist
Please delete options that are not relevant, and select all options that apply. 

- ✅ My code follows the guidelines of XYZ
- ✅ My code has been commented
- ✅ Documentation has been updated
- ✅ New and existing unit tests pass locally with my changes
- ✅ Main has been merged into this PR