### PR TITLE
Header links not working on deployed documentation

### DIFF
--- a/api/README.md
+++ b/api/README.md
@@ -6,7 +6,7 @@ An example Express application script is provided in the project root.
 
 XYZ API modules should be run with a Node.js runtime v18 or higher.
 
-The [XYZ API](/docs/module-_api.html) module is located in the api folder as a requirement for using the offical Node.js runtime in Vercel's Edge Network.
+The [XYZ API](/xyz/module-_api.html) module is located in the api folder as a requirement for using the offical Node.js runtime in Vercel's Edge Network.
 
 All other XYZ API modules are located in the /mod directory.
 
@@ -16,12 +16,12 @@ The [clean-jsdoc-theme](https://www.npmjs.com/package/clean-jsdoc-theme) is used
 
 The XYZ API modules are:
 
-### [Workspace](/docs/module-_workspace)
+### [Workspace](/xyz/module-_workspace)
 
-### [View](/docs/module-_view)
+### [View](/xyz/module-_view)
 
-### [Query](/docs/module-_query)
+### [Query](/xyz/module-_query)
 
-### [User](/docs/module-_user)
+### [User](/xyz/module-_user)
 
-### [Sign](/docs/module-_sign)
+### [Sign](/xyz/module-_sign)

--- a/express.js
+++ b/express.js
@@ -6,7 +6,7 @@ const cookieParser = require('cookie-parser')
 
 const app = express()
 
-app.use('/docs', express.static('docs', {
+app.use('/xyz', express.static('docs', {
     extensions: ['html']
 }))
 

--- a/jsdoc_mapp.json
+++ b/jsdoc_mapp.json
@@ -8,7 +8,6 @@
   "plugins": [
     "plugins/markdown"
   ],
-  
   "opts": {
     "encoding": "utf8",
     "readme": "./lib/README.md",
@@ -22,9 +21,9 @@
       "favicon": "../public/icons/favicon.ico",
       "menu": [
         {
-            "title": "Github",
-            "id": "github",
-            "link": "https://github.com/GEOLYTIX/xyz"
+          "title": "Github",
+          "id": "github",
+          "link": "https://github.com/GEOLYTIX/xyz"
         },
         {
           "title": "XYZ",

--- a/jsdoc_mapp.json
+++ b/jsdoc_mapp.json
@@ -29,7 +29,7 @@
         {
           "title": "XYZ",
           "id": "xyz",
-          "link": "/docs"
+          "link": "/xyz"
         }
       ]
     }

--- a/jsdoc_xyz.json
+++ b/jsdoc_xyz.json
@@ -31,7 +31,7 @@
         {
           "title": "Mapp",
           "id": "mapp",
-          "link": "/docs/mapp"
+          "link": "/xyz/mapp"
         }
       ]
     }

--- a/jsdoc_xyz.json
+++ b/jsdoc_xyz.json
@@ -1,7 +1,8 @@
 {
   "source": {
     "include": [
-      "api", "mod"
+      "api",
+      "mod"
     ],
     "includePattern": ".js$"
   },

--- a/lib/README.md
+++ b/lib/README.md
@@ -1,9 +1,9 @@
 ## MAPP API
 
-The MAPP API is a collection of javascript modules to interface with the [XYZ API](/docs).
+The MAPP API is a collection of javascript modules to interface with the [XYZ API](/xyz).
 
-The [mapp.mjs](/docs/mapp/module-mapp) module imports any modules required to create an interactive Openlayers mapview in a web document.
+The [mapp.mjs](/xyz/mapp/module-mapp) module imports any modules required to create an interactive Openlayers mapview in a web document.
 
 ### MAPP/UI
 
-A collection of modules for the creation of user interfaces to support the interaction with MAPP elements like the mapview, layer, and locations can be accessed through the [ui.mjs](/docs/mapp/module-ui).
+A collection of modules for the creation of user interfaces to support the interaction with MAPP elements like the mapview, layer, and locations can be accessed through the [ui.mjs](/xyz/mapp/module-ui).

--- a/lib/mapp.mjs
+++ b/lib/mapp.mjs
@@ -7,7 +7,7 @@ The `mapp.mjs` module is used as entry point for the esbuild process to bundle t
 
 @requires /mapview
 @requires /layer
-@requires /layer
+@requires /location
 @requires /utils
 @requires /dictionary
 @requires /dictionaries


### PR DESCRIPTION
https://geolytix.github.io/xyz/mapp/

![image](https://github.com/user-attachments/assets/ec2ee657-eb2a-4f24-aaba-fae80579ccf8)

The deployed documentation does not use the /docs path.