### PR TITLE
Spread properties into wkt features

### DIFF
--- a/lib/layer/featureFormats.mjs
+++ b/lib/layer/featureFormats.mjs
@@ -95,7 +95,7 @@ export function wkt(layer, features) {
         dataProjection: 'EPSG:' + layer.srid,
         featureProjection: 'EPSG:' + layer.mapview.srid,
       }),
-      properties
+      ...properties
     })
 
   })


### PR DESCRIPTION
To prevent having a properties property on WKT feature the properties object should be spread into the feature on creation.