### PR TITLE
MVT reload doesn't refresh source

### DIFF
--- a/lib/layer/format/mvt.mjs
+++ b/lib/layer/format/mvt.mjs
@@ -88,6 +88,9 @@ export default function MVT(layer) {
 
     layer.source.clear()
     layer.source.refresh()
+
+    // Reset source tiles to force refresh.
+    layer.source.sourceTiles_ = {};
     layer.featureSource.refresh()
 
     if (callback instanceof Function) callback(layer)
@@ -108,7 +111,7 @@ export default function MVT(layer) {
   layer.source = new ol.source.VectorTile({
     format: new ol.format.MVT(),
     transition: layer.transition,
-    cacheSize: layer.cacheSize
+    cacheSize: layer.cacheSize || 0
   })
 
   // Assign wkt properties load method.


### PR DESCRIPTION
This is a workaround for the issue until resolved in the OL library.