### PR TITLE
Remove legacy node-fetch and document mod/cloudfront ☁️

### DIFF
--- a/mod/provider/cloudfront.js
+++ b/mod/provider/cloudfront.js
@@ -1,6 +1,15 @@
 /**
- * @module /provider/cloudfront
- */
+## /provider/cloudfront
+
+The cloudfront provider module exports a method to fetch resources from an AWS cloudfront service.
+
+@requires fs
+@requires path
+@requires module:/utils/logger
+@requires @aws-sdk/cloudfront-signer
+
+@module /provider/cloudfront
+*/
 
 const { readFileSync } = require('fs')
 const { join } = require('path')
@@ -8,44 +17,35 @@ const { getSignedUrl } = require('@aws-sdk/cloudfront-signer');
 const logger = require('../utils/logger')
 
 /**
- * Fetches and processes content from CloudFront with signed URLs
- * @async
- * @param {Object|string} ref - Reference object or URL string
- * @param {Object} [ref.params] - Optional parameters for the request
- * @param {string} [ref.params.url] - URL to fetch from CloudFront
- * @param {boolean} [ref.params.signedURL] - If true, returns only the signed URL
- * @param {boolean} [ref.params.buffer] - If true, returns response as buffer
- * @returns {Promise<string|Object|Buffer|Error>} 
- *          - String for text responses
- *          - Object for JSON responses
- *          - Buffer if buffer parameter is true
- *          - Error if response status >= 300
- * @throws {Error} Logs error to console if request fails
- * 
- * @example
- * // Fetch JSON with signed URL
- * const data = await cloudfront({ 
- *   params: { 
- *     url: 'example.com/data.json'
- *   }
- * });
- * 
- * @example
- * // Get only signed URL
- * const signedUrl = await cloudfront({
- *   params: {
- *     url: 'example.com/file.txt',
- *     signedURL: true
- *   }
- * });
- */
+@function cloudfront
+@async
+
+@decsription
+The method creates a signed URL for a cloudfront resource, fetches the resource and returns the fetched resource.
+
+A buffer is returned with the ref.params.buffer flag.
+
+JSON is returned if the URL path matches the .json file ending to fetch a JSON resource from the cloudfront service.
+
+The fetch response will be parsed as text by default.
+
+@param {Object|string} ref Reference object or URL string.
+@property {Object} [ref.params] Optional parameters for the request.
+@property {string} [params.url] Cloudfront resource URL.
+@property {boolean} [params.signedURL] Return a signedURL only.
+@property {boolean} [params.buffer] Return a buffer from the fetch.
+
+@returns {Promise<String|JSON|Buffer|Error>} The method resolves to either JSON, Text, or Buffer dependent ref.params.
+*/
 module.exports = async function cloudfront(ref) {
   try {
+
     // Substitutes {*} with process.env.SRC_* key values.
     const url = (ref.params?.url || ref).replace(/{(?!{)(.*?)}/g,
       matched => process.env[`SRC_${matched.replace(/(^{)|(}$)/g, '')}`])
 
     const date = new Date(Date.now())
+
     date.setDate(date.getDate() + 1);
 
     const signedURL = getSignedUrl({
@@ -61,6 +61,7 @@ module.exports = async function cloudfront(ref) {
     }
 
     const response = await fetch(signedURL)
+    
     logger(`${response.status} - ${url}`, 'cloudfront')
 
     if (response.status >= 300) return new Error(`${response.status} ${ref}`)
@@ -75,5 +76,4 @@ module.exports = async function cloudfront(ref) {
 
     console.error(err)
   }
-
 }

--- a/mod/provider/cloudfront.js
+++ b/mod/provider/cloudfront.js
@@ -20,7 +20,7 @@ const logger = require('../utils/logger')
 @function cloudfront
 @async
 
-@decsription
+@description
 The method creates a signed URL for a cloudfront resource, fetches the resource and returns the fetched resource.
 
 A buffer is returned with the ref.params.buffer flag.
@@ -38,6 +38,7 @@ The fetch response will be parsed as text by default.
 @returns {Promise<String|JSON|Buffer|Error>} The method resolves to either JSON, Text, or Buffer dependent ref.params.
 */
 module.exports = async function cloudfront(ref) {
+
   try {
 
     // Substitutes {*} with process.env.SRC_* key values.

--- a/mod/provider/cloudfront.js
+++ b/mod/provider/cloudfront.js
@@ -1,20 +1,47 @@
 /**
-@module /provider/cloudfront
-*/
+ * @module /provider/cloudfront
+ */
 
 const { readFileSync } = require('fs')
-
 const { join } = require('path')
-
 const { getSignedUrl } = require('@aws-sdk/cloudfront-signer');
-
 const logger = require('../utils/logger')
 
-module.exports = async ref => {
-
+/**
+ * Fetches and processes content from CloudFront with signed URLs
+ * @async
+ * @param {Object|string} ref - Reference object or URL string
+ * @param {Object} [ref.params] - Optional parameters for the request
+ * @param {string} [ref.params.url] - URL to fetch from CloudFront
+ * @param {boolean} [ref.params.signedURL] - If true, returns only the signed URL
+ * @param {boolean} [ref.params.buffer] - If true, returns response as buffer
+ * @returns {Promise<string|Object|Buffer|Error>} 
+ *          - String for text responses
+ *          - Object for JSON responses
+ *          - Buffer if buffer parameter is true
+ *          - Error if response status >= 300
+ * @throws {Error} Logs error to console if request fails
+ * 
+ * @example
+ * // Fetch JSON with signed URL
+ * const data = await cloudfront({ 
+ *   params: { 
+ *     url: 'example.com/data.json'
+ *   }
+ * });
+ * 
+ * @example
+ * // Get only signed URL
+ * const signedUrl = await cloudfront({
+ *   params: {
+ *     url: 'example.com/file.txt',
+ *     signedURL: true
+ *   }
+ * });
+ */
+module.exports = async function cloudfront(ref) {
   try {
-
-    // Subtitutes {*} with process.env.SRC_* key values.
+    // Substitutes {*} with process.env.SRC_* key values.
     const url = (ref.params?.url || ref).replace(/{(?!{)(.*?)}/g,
       matched => process.env[`SRC_${matched.replace(/(^{)|(}$)/g, '')}`])
 
@@ -30,12 +57,10 @@ module.exports = async ref => {
 
     // Return signedURL only from request.
     if (ref.params?.signedURL) {
-
       return signedURL;
     }
 
     const response = await fetch(signedURL)
-
     logger(`${response.status} - ${url}`, 'cloudfront')
 
     if (response.status >= 300) return new Error(`${response.status} ${ref}`)
@@ -47,6 +72,7 @@ module.exports = async ref => {
     return await response.text()
 
   } catch (err) {
+
     console.error(err)
   }
 

--- a/mod/provider/cloudfront.js
+++ b/mod/provider/cloudfront.js
@@ -10,8 +10,6 @@ const { getSignedUrl } = require('@aws-sdk/cloudfront-signer');
 
 const logger = require('../utils/logger')
 
-const nodeFetch = require('node-fetch')
-
 module.exports = async ref => {
 
   try {
@@ -36,9 +34,9 @@ module.exports = async ref => {
       return signedURL;
     }
 
-    const response = await nodeFetch(signedURL)
+    const response = await fetch(signedURL)
 
-    logger(`${response.status} - ${url}`,'cloudfront')
+    logger(`${response.status} - ${url}`, 'cloudfront')
 
     if (response.status >= 300) return new Error(`${response.status} ${ref}`)
 
@@ -48,7 +46,7 @@ module.exports = async ref => {
 
     return await response.text()
 
-  } catch(err) {
+  } catch (err) {
     console.error(err)
   }
 


### PR DESCRIPTION
## Description

I have removed the `node-fetch` reference in the cloudfront.js mod.

I also added in documentation for the script.
## GitHub Issue

https://github.com/GEOLYTIX/xyz/issues/1641 

## Type of Change
Please delete options that are not relevant, and select all options that apply. 

- ✅ Bug fix (non-breaking change which fixes an issue)
- ✅ Documentation

## Code Quality Checklist

- ✅ My code follows the guidelines of XYZ
- ✅ My code has been commented
- ✅ Documentation has been updated
- ✅ New and existing unit tests pass locally with my changes
- ✅ Main has been merged into this PR