### PR TITLE
Spread this.location.layer

### DIFF
--- a/lib/ui/Dataview.mjs
+++ b/lib/ui/Dataview.mjs
@@ -95,6 +95,7 @@ export default async function Dataview(_this) {
   _this.queryparams = {
     ..._this.layer?.mapview?.locale?.queryparams,
     ..._this.layer?.queryparams,
+    ..._this.location?.layer?.queryparams,
     ..._this.queryparams,
   }
 


### PR DESCRIPTION
# Spread this.location.layer queryparams

## Description

`this.location.layer.queryparams` need to be spread into the `dataview`. Otherwise if the location layer has queryparams they are not passed to the dataview entry, resulting in failing queries in custom views.

## Type of Change
Please delete options that are not relevant, and select all options that apply. 

- ✅ Bug fix (non-breaking change which fixes an issue)

## How have you tested this? 
Please describe how to test this change and how you verified it worked. 

## Testing Checklist 
Please delete options that are not relevant, and select all options that apply. 

- ✅ Existing Tests still pass
- ✅ Ran locally on my machine

## Code Quality Checklist
Please delete options that are not relevant, and select all options that apply. 

- ✅ My code follows the guidelines of XYZ
- ✅ My code has been commented
- ✅ Documentation has been updated
- ✅ Main has been merged into this PR