### PR TITLE
Fix Ol Version Check

### DIFF
--- a/lib/mapp.mjs
+++ b/lib/mapp.mjs
@@ -37,11 +37,6 @@ const _ol = {
   current: '10.2.1'
 }
 
-async function olLoad() {
-
-
-}
-
 if (window.ol === undefined) {
 
   console.warn(`Openlayers has not been loaded.`)

--- a/lib/mapp.mjs
+++ b/lib/mapp.mjs
@@ -58,10 +58,11 @@ if (window.ol === undefined) {
 } else {
 
   const olVersion = parseFloat(ol?.util.VERSION)
+  const olCurrent = parseFloat(_ol.current);
 
   console.log(`OpenLayers version ${olVersion}`)
 
-  if (olVersion < _ol.current) {
+  if (olVersion < olCurrent) {
 
     console.warn(`Update the current OpenLayers version:${ol?.util.VERSION} to ${_ol.current}.`)
   }

--- a/lib/mapp.mjs
+++ b/lib/mapp.mjs
@@ -34,21 +34,12 @@ import plugins from './plugins/_plugins.mjs'
 hooks.parse();
 
 const _ol = {
-  current: '10.2.1',
-  load: async () => await new Promise(resolve => {
+  current: '10.2.1'
+}
 
-    const script = document.createElement('script')
+async function olLoad() {
 
-    script.type = 'application/javascript'
 
-    script.src = 'https://cdn.jsdelivr.net/npm/ol@v10.2.1/dist/ol.js'
-
-    script.onload = resolve
-
-    document.head.append(script)
-
-    console.warn('Openlayers library loaded from script tag.')
-  })
 }
 
 if (window.ol === undefined) {

--- a/lib/utils/_utils.mjs
+++ b/lib/utils/_utils.mjs
@@ -34,6 +34,10 @@ import getCurrentPosition from './getCurrentPosition.mjs'
 
 import merge from './merge.mjs'
 
+import mobile from './mobile.mjs';
+
+import olScript from './olScript.mjs'
+
 import paramString from './paramString.mjs'
 
 import { polygonIntersectFeatures } from './polygonIntersectFeatures.mjs'
@@ -60,8 +64,6 @@ import { formatNumericValue, unformatStringValue } from './numericFormatter.mjs'
 
 import { versionCheck } from './versionCheck.mjs';
 
-import mobile from './mobile.mjs';
-
 export default {
   stats,
   render,
@@ -81,7 +83,7 @@ export default {
   loadPlugins,
   merge,
   mobile,
-  olScript: () => mapp.ol.load(),
+  olScript,
   paramString,
   polygonIntersectFeatures,
   promiseAll,

--- a/lib/utils/olScript.mjs
+++ b/lib/utils/olScript.mjs
@@ -1,0 +1,34 @@
+/**
+## /utils/olScript
+
+Exports the olScript utility method as default.
+
+@module /utils/olScript
+*/
+
+/**
+@function olScript
+@async
+
+@description
+The olScript method assigns a script tag to the document head for the Openlayers cdn src. The tag is appended in a promise which assigns the resolve to the onload method of the tag element.
+
+It is recommended to load Openlayers by defining the script in the document markup header. A warning will be logged if the script is loaded through the utility method.
+*/
+export default async function olScript() {
+
+  await new Promise(resolve => {
+
+    const script = document.createElement('script')
+
+    script.type = 'application/javascript'
+
+    script.src = 'https://cdn.jsdelivr.net/npm/ol@v10.2.1/dist/ol.js'
+
+    script.onload = resolve
+
+    document.head.append(script)
+
+    console.warn('Openlayers v10.2.1 loaded from script tag.')
+  })
+}

--- a/tests/browser/local.test.mjs
+++ b/tests/browser/local.test.mjs
@@ -1,4 +1,5 @@
 import { base } from '../../public/tests/_base.test.mjs';
+import { mappTest } from '../lib/mapp.test.mjs';
 import { layerTest } from '../lib/layer/_layer.test.mjs';
 import { dictionaryTest } from '../lib/dictionaries/_dictionaries.test.mjs';
 import { locationTest } from '../lib/location/_location.test.mjs';
@@ -23,6 +24,8 @@ await queryTest();
 await runAllTests(userTest);
 
 const mapview = await base();
+
+await runAllTests(mappTest);
 
 // Run the dictionary Tests
 await runAllTests(dictionaryTest, mapview);
@@ -68,7 +71,7 @@ await runAllTests(utilsTest, mapview);
  */
 async function runAllTests(tests, mapview) {
     const testFunctions = Object.values(tests).filter(item => typeof item === 'function');
-  
+
     for (const testFn of testFunctions) {
         try {
             await testFn(mapview);

--- a/tests/lib/mapp.test.mjs
+++ b/tests/lib/mapp.test.mjs
@@ -1,0 +1,27 @@
+export const mappTest = {
+    base
+}
+
+/**
+ * Function used to test the mapp objct to see if all the base objects * properties are present
+ * @function base
+ */
+function base() {
+    codi.describe('Mapp base object test', () => {
+        codi.it('Mapp: Ensure we have base objects', () => {
+            codi.assertTrue(Object.hasOwn(mapp, 'ol', 'The mapp object needs to have an ol object'));
+            codi.assertTrue(Object.hasOwn(mapp, 'version', 'The mapp object needs to have an version object'));
+            codi.assertTrue(Object.hasOwn(mapp, 'hash', 'The mapp object needs to have an hash object'));
+            codi.assertTrue(Object.hasOwn(mapp, 'host', 'The mapp object needs to have an host object'));
+            codi.assertTrue(Object.hasOwn(mapp, 'language', 'The mapp object needs to have an language object'));
+            codi.assertTrue(Object.hasOwn(mapp, 'dictionaries', 'The mapp object needs to have an dictionaries object'));
+            codi.assertTrue(Object.hasOwn(mapp, 'dictionary', 'The mapp object needs to have an dictionary object'));
+            codi.assertTrue(Object.hasOwn(mapp, 'hooks', 'The mapp object needs to have an hooks object'));
+            codi.assertTrue(Object.hasOwn(mapp, 'layer', 'The mapp object needs to have an layer object'));
+            codi.assertTrue(Object.hasOwn(mapp, 'location', 'The mapp object needs to have an location object'));
+            codi.assertTrue(Object.hasOwn(mapp, 'Mapview', 'The mapp object needs to have an Mapview object'));
+            codi.assertTrue(Object.hasOwn(mapp, 'utils', 'The mapp object needs to have an utils object'));
+            codi.assertTrue(Object.hasOwn(mapp, 'plugins', 'The mapp object needs to have an plugins object'));
+        });
+    });
+}


### PR DESCRIPTION
# Fix Version Check

## Description

Both the OpenLayers version defined in a custom view and the current OpenLayers version of MAPP needs to be parsed to float - otherwise the check is comparing a number to a string and it will never warn on an outdated version. 

## GitHub Issue

#1673 

## Type of Change
Please delete options that are not relevant, and select all options that apply. 

- ✅ Bug fix (non-breaking change which fixes an issue)

## How have you tested this? 
Please describe how to test this change and how you verified it worked. 

## Testing Checklist 
Please delete options that are not relevant, and select all options that apply. 

- ✅ Existing Tests still pass
- ✅ Ran locally on my machine

## Code Quality Checklist
Please delete options that are not relevant, and select all options that apply. 

- ✅ My code follows the guidelines of XYZ
- ✅ My code has been commented
- ✅ Documentation has been updated
- ✅ New and existing unit tests pass locally with my changes
- ✅ Main has been merged into this PR