### PR TITLE
Fix svgTemplates reference in mapview

### DIFF
--- a/lib/mapview/_mapview.mjs
+++ b/lib/mapview/_mapview.mjs
@@ -55,7 +55,7 @@ The mapview decorator may return the async mapviewPromise method which must be a
 @param {object} mapview JSON params for a new mapview.
 @property {string} [mapview.host=mapp.host] The host domain/path for queries.
 @property {object} mapview.locale The locale defintion for the mapview.
-@property {array} [mapview.svgTemplates] SVG templates to load as mapp.utils.svgSymbols.templates
+@property {array} [mapview.locale.svgTemplates] SVG templates to load as mapp.utils.svgSymbols.templates
 @property {array} [mapview.syncPlugins] locale.plugins[] must be loaded prior to the execution of syncPlugins.
 
 @returns {mapview} Decorated Mapview.
@@ -278,18 +278,10 @@ export default function decorate(mapview) {
       .dispatchEvent(new CustomEvent('changeEnd'), 500))
   })
 
-  // Check whether svgSymbols.templates have been loaded.
-  if (!mapp.utils.svgSymbols.templates) {
 
-    mapview.svgTemplates ??= mapview.locale.svg_templates
-  }
+  mapview.locale.svgTemplates ??= mapview.locale.svg_templates
 
-  if (mapview.loadPlugins) {
-
-    mapview.syncPlugins ??= mapview.locale.syncPlugins
-  }
-
-  if (mapview.syncPlugins?.length || mapview.svgTemplates) {
+  if (mapview.locale.syncPlugins?.length || mapview.locale.svgTemplates) {
 
     return mapviewPromise(mapview)
   }
@@ -335,25 +327,25 @@ function changeEnd() {
 mapviewPromise is an async method which resolves to the mapview object. The method is returned from the mapview decorator if the creation of the mapview must be awaited in order to import and execute synchronous plugin methods or load svg_templates required for synchronous feature style render methods.
 
 @param {object} mapview 
-@property {array} [mapview.svgTemplates] Array of svg_templates [objects] to be loaded.
-@property {array} [mapview.syncPlugins] Array of plugins [key] to be executed in sync.
 @property {locale} mapview.locale The locale defintion for the mapview.
 @property {array} locale.plugins Array of plugins to dynamically import.
+@property {array} [locale.syncPlugins] Array of plugins [key] to be executed in sync.
+@property {array} [locale.svgTemplates] Array of svg_templates [objects] to be loaded.
 
 @returns {Promise<mapview>} The async method resolves to the decorated mapview object.
 */
 async function mapviewPromise(mapview) {
 
-  await mapp.utils.svgTemplates(mapview.svgTemplates)
+  await mapp.utils.svgTemplates(mapview.locale.svgTemplates)
 
   await mapp.utils.loadPlugins(mapview.locale.plugins);
 
-  mapview.syncPlugins ??= [];
+  mapview.locale.syncPlugins ??= [];
 
-  const syncPlugins = new Set(mapview.syncPlugins)
+  const syncPlugins = new Set(mapview.locale.syncPlugins)
 
   // Execute synchronous plugins in order of array.
-  for (const key of mapview.syncPlugins) {
+  for (const key of mapview.locale.syncPlugins) {
 
     if (typeof mapp.plugins[key] !== 'function') continue;
 

--- a/lib/mapview/_mapview.mjs
+++ b/lib/mapview/_mapview.mjs
@@ -280,8 +280,8 @@ export default function decorate(mapview) {
 
   // Check whether svgSymbols.templates have been loaded.
   if (!mapp.utils.svgSymbols.templates) {
-    
-    mapview.svgTemplates = mapview.locale.svg_templates
+
+    mapview.svgTemplates ??= mapview.locale.svg_templates
   }
 
   if (mapview.loadPlugins) {
@@ -349,7 +349,7 @@ async function mapviewPromise(mapview) {
   await mapp.utils.loadPlugins(mapview.locale.plugins);
 
   mapview.syncPlugins ??= [];
-  
+
   const syncPlugins = new Set(mapview.syncPlugins)
 
   // Execute synchronous plugins in order of array.

--- a/lib/mapview/_mapview.mjs
+++ b/lib/mapview/_mapview.mjs
@@ -55,7 +55,7 @@ The mapview decorator may return the async mapviewPromise method which must be a
 @param {object} mapview JSON params for a new mapview.
 @property {string} [mapview.host=mapp.host] The host domain/path for queries.
 @property {object} mapview.locale The locale defintion for the mapview.
-@property {Object} [locale.svgTemplates] Object of template key and src values to be loaded as svg strings.
+@property {Object} [locale.svgTemplates] Object of template key and src values to be loaded as svg strings. locale.svg_templates is the legacy property.
 @property {array} [locale.syncPlugins] An array plugins to be loaded in order.
 
 @returns {mapview} Decorated Mapview.
@@ -278,7 +278,7 @@ export default function decorate(mapview) {
       .dispatchEvent(new CustomEvent('changeEnd'), 500))
   })
 
-
+  // svgTemplates replaces the legacy svg_templates configuration
   mapview.locale.svgTemplates ??= mapview.locale.svg_templates
 
   if (mapview.locale.syncPlugins?.length || mapview.locale.svgTemplates) {

--- a/lib/mapview/_mapview.mjs
+++ b/lib/mapview/_mapview.mjs
@@ -55,8 +55,8 @@ The mapview decorator may return the async mapviewPromise method which must be a
 @param {object} mapview JSON params for a new mapview.
 @property {string} [mapview.host=mapp.host] The host domain/path for queries.
 @property {object} mapview.locale The locale defintion for the mapview.
-@property {array} [mapview.locale.svgTemplates] SVG templates to load as mapp.utils.svgSymbols.templates
-@property {array} [mapview.syncPlugins] locale.plugins[] must be loaded prior to the execution of syncPlugins.
+@property {Object} [locale.svgTemplates] Object of template key and src values to be loaded as svg strings.
+@property {array} [locale.syncPlugins] An array plugins to be loaded in order.
 
 @returns {mapview} Decorated Mapview.
 */

--- a/public/tests/_base.test.mjs
+++ b/public/tests/_base.test.mjs
@@ -457,7 +457,8 @@ export async function base() {
                     Openlayers: 'https://openlayers.org',
                 }
             },
-            syncPlugins: locale.syncPlugins
+            syncPlugins: locale.syncPlugins,
+            svgTemplates: locale.svg_templates
         });
 
 

--- a/public/views/_default.html
+++ b/public/views/_default.html
@@ -651,7 +651,8 @@
     },
 
     // mapp.Mapview must be awaited.
-    syncPlugins: locale.syncPlugins
+    syncPlugins: locale.syncPlugins,
+    svgTemplates: locale.svgTemplates
   });
 
   if (!locale.layers?.length && !(locale instanceof Error)) {

--- a/public/views/_default.html
+++ b/public/views/_default.html
@@ -649,10 +649,6 @@
         Openlayers: 'https://openlayers.org',
       }
     },
-
-    // mapp.Mapview must be awaited.
-    syncPlugins: locale.syncPlugins,
-    svgTemplates: locale.svgTemplates
   });
 
   if (!locale.layers?.length && !(locale instanceof Error)) {

--- a/tests/lib/utils/svgTemplates.test.mjs
+++ b/tests/lib/utils/svgTemplates.test.mjs
@@ -11,25 +11,6 @@ export async function svgTemplatesTest() {
     await codi.describe('Utils: SVG Templates', async () => {
 
         /**
-         * ### We should be able to load new svg templates with the util
-         * @function it
-         */
-        await codi.it('We should load new svg templates', async () => {
-            const svgTemplates = {
-                'dot_test': 'https://geolytix.github.io/MapIcons/templates/dot_10px.svg',
-                'target_test': 'https://geolytix.github.io/MapIcons/templates/target.svg',
-                'square_test': 'https://geolytix.github.io/MapIcons/templates/square_10px.svg',
-                'diamond_test': 'https://geolytix.github.io/MapIcons/templates/diamond_10px.svg',
-                'triangle_test': 'https://geolytix.github.io/MapIcons/templates/triangle_10px.svg',
-                'template_pin_test': 'https://geolytix.github.io/MapIcons/pins/pink_master_pin.svg'
-            };
-
-            await mapp.utils.svgTemplates(svgTemplates);
-
-            const dot_test_svg = await mapp.utils.svgSymbols.templates['dot_test'];
-            codi.assertTrue(!!dot_test_svg, 'We should be able to get a new svg template')
-        });
-        /**
          * ### We shouldn't be able to replace already existing templates
          * @function it
          */

--- a/tests/workspace.json
+++ b/tests/workspace.json
@@ -60,6 +60,14 @@
             "admin",
             "login"
         ],
+        "svg_templates": {
+            "dot_test": "https://geolytix.github.io/MapIcons/templates/dot_10px.svg",
+            "target_test": "https://geolytix.github.io/MapIcons/templates/target.svg",
+            "square_test": "https://geolytix.github.io/MapIcons/templates/square_10px.svg",
+            "diamond_test": "https://geolytix.github.io/MapIcons/templates/diamond_10px.svg",
+            "triangle_test": "https://geolytix.github.io/MapIcons/templates/triangle_10px.svg",
+            "template_pin_test": "https://geolytix.github.io/MapIcons/pins/pink_master_pin.svg"
+        },
         "link_button": [
             {
                 "href": "/url/url",


### PR DESCRIPTION
# Pull Request Template

## Description
The mapview on the default script was not passing in the svg_templates in from the locale.

There is inconsistency when it comes to the naming of different variables. It's a mix between snake_case & camelCase.

```js
syncPlugins,
svg_templates
```

We might want to discuss how we handle this for the future, and set some eslint checks. 

## GitHub Issue

#1679 

## Type of Change

- ✅ Bug fix (non-breaking change which fixes an issue)


## How have you tested this? 
You can run the local tests

## Testing Checklist 
- ✅ Existing Tests still pass
- ✅ Updated Existing Tests