### PR TITLE
Update feature_info plugin with css

### DIFF
--- a/lib/plugins/feature_info.mjs
+++ b/lib/plugins/feature_info.mjs
@@ -1,9 +1,14 @@
 /**
- *  
+## /plugins/feature_info
+
+The feature_info plugin module exports the feature_info plugin method.
+
 Dictionary entries:
 - toolbar_current_location
 
 @requires /dictionary
+@requires /mapview/interactions/highlight
+@requires /mapview/popup
 
 @module /plugins/feature_info
 */
@@ -11,86 +16,94 @@ Dictionary entries:
 /**
 @function feature_info
 @description
-The feature_info plugin method creates a button for the mapButton list.
+The feature_info plugin method adds a button to the #mapButton element to call the toggleFeatureInfoHighlight method.
 
-The button will toggle a custom highlight interaction with the getFeature method displaying the feature info in a popup.
+The plugin param will turned into an object if configured as true in the locale.
 
-@param {mapview} mapview The mapview for the highlight feature info interaction.
 @param {Object} plugin The plugin config object from the locale.
-
-@property {boolean} [plugin.log] Log the feature in the dev console.
-@property {boolean} [plugin.features] Include the cluster features[] label in the output.
-
+@param {mapview} mapview The mapview for the highlight feature info interaction.
 */
-
 export function feature_info(plugin, mapview) {
 
   const btnColumn = document.getElementById('mapButton');
 
-  // The btnColumn element only exists in the default mapp view.
   if (!btnColumn) return;
 
-  const btn = mapp.utils.html.node`
-      <button
-        title=${mapp.dictionary.toolbar_current_location}
-        onclick=${toggleFeatureInfoHighlight}><div class="mask-icon feature-info">`;
-
-  btnColumn.append(btn);
-
-  function toggleFeatureInfoHighlight() {
-
-    if (btn.firstChild.classList.toggle('active')) {
-
-      mapview.interactions.highlight({
-        getFeature: feature => {
-
-          const featureProperties = feature.F.getProperties()
-
-          // The OL Styles array is meaningless for the feature_info popup.
-          delete featureProperties.Styles
-
-          if (!plugin.geometry) {
-
-            delete featureProperties.geometry
-          }
-
-          // Check for cluster feature.
-          if (Array.isArray(featureProperties.features)) {
-
-            // Reduce features to length or properties dependent on the flag.
-            featureProperties.features = plugin.features
-              ? featureProperties.features.map(F => F.getProperties()[feature.layer.cluster.label])
-              : featureProperties.features.length
-          }
-
-          if (plugin.log) {
-
-            console.log(feature.F)
-          }
-
-          const feature_info = {
-            id: feature.id,
-            layer: feature.layer.key,
-            properties: featureProperties,
-          }
-
-          const content = mapp.utils.html.node`<pre
-            style="padding: 1em;"
-            >${JSON.stringify(feature_info, undefined, 2)}`
-
-          mapview.popup({
-            content
-          })
-        },
-        callback: () => {
-          btn.firstChild.classList.remove('active')
-        }
-      });
-
-    } else {
-
-      mapview.interactions.highlight()
-    };
-
+  if (plugin === true) {
+    plugin = {}
   }
+
+  plugin.btn = mapp.utils.html.node`<button
+    title=${mapp.dictionary.toolbar_current_location}
+    onclick=${()=>toggleFeatureInfoHighlight(plugin, mapview)}>
+    <div class="mask-icon feature-info">`;
+
+  btnColumn.append(plugin.btn);
+}
+
+/**
+@function toggleFeatureInfoHighlight
+@description
+The meathod will toggle a highlight interaction with a custom getFeature callback method.
+
+The getFeature method will log the feature properties to the dev console and create a mapview popup with the stringified feature properties object in a pre-code block.
+
+@param {Object} plugin The plugin config object from the locale.
+@param {mapview} mapview The mapview for the highlight feature info interaction.
+@property {boolean} [plugin.features] Include the cluster features[] label in the output.
+@property {string} [plugin.css] The css for the content element passed to the mapview popup.
+*/
+function toggleFeatureInfoHighlight(plugin, mapview) {
+
+  // Toggle will return true if class is added.
+  if (plugin.btn.firstElementChild.classList.toggle('active')) {
+
+    mapview.interactions.highlight({
+      getFeature: feature => {
+
+        const featureProperties = feature.F.getProperties()
+
+        // The OL Styles array is meaningless for the feature_info popup.
+        delete featureProperties.Styles
+
+        delete featureProperties.geometry
+
+        // Check for cluster feature.
+        if (Array.isArray(featureProperties.features)) {
+
+          // Reduce features to length or properties dependent on the flag.
+          featureProperties.features = plugin.features
+            ? featureProperties.features.map(F => F.getProperties()[feature.layer.cluster.label])
+            : featureProperties.features.length
+        }
+
+        console.log(feature.F)
+
+        const feature_info = {
+          id: feature.id,
+          layer: feature.layer.key,
+          properties: featureProperties,
+        }
+
+        plugin.css ??= 'padding: 1em; max-width: 250px; overflow: auto;'
+
+        const content = mapp.utils.html.node`<pre
+          style=${plugin.css}
+          >${JSON.stringify(feature_info, undefined, 2)}`
+
+        mapview.popup({
+          content
+        })
+      },
+      callback: () => {
+        plugin.btn.firstChild.classList.remove('active')
+      }
+    });
+
+  } else {
+
+    // Will finish the feature_info highlight method.
+    mapview.interactions.highlight()
+  };
+
 }


### PR DESCRIPTION
A default css will now be assigned to the plugin config which is set on the content element.

```js
plugin.css ??= 'padding: 1em; max-width: 250px; overflow: auto;'
```

![image](https://github.com/user-attachments/assets/4b6e8bcc-f061-45b9-9459-7ee0856a795b)

The plugin is now fully documented.