### PR TITLE
acl is null checks and module export

### DIFF
--- a/mod/user/acl.js
+++ b/mod/user/acl.js
@@ -12,31 +12,29 @@ const { Pool } = require('pg');
 
 const connection = process.env.PRIVATE?.split('|') || process.env.PUBLIC?.split('|')
 
-const acl_table = connection[1]?.split('.').pop()
-
-const acl_schema = connection[1]?.split('.')[0] === acl_table ? 'public' : connection[1]?.split('.')[0]
-
-const pool = new Pool({
-  connectionString: connection[0]
-})
-
 // The acl module will export an empty require object instead of a function if no ACL connection has been defined.
 if (!connection?.[1]) {
-  module.exports = {};
-}
-else {
+  module.exports = null;
+
+} else {
+
+  const acl_table = connection[1]?.split('.').pop()
+
+  const acl_schema = connection[1]?.split('.')[0] === acl_table ? 'public' : connection[1]?.split('.')[0]
+
+  const pool = new Pool({
+    connectionString: connection[0]
+  })
+
   /**
   @function acl
   
   @description
   The acl method will connect to pg pool and query the ACL with a provided query template. The `/acl_table/` and `/acl_schema/` in the query template will be replaced with values provided as `PRIVATE` or `PUBLIC` environment variable.
   
-  @param {string} q 
-  Query template.
-  @param {array} arr 
-  Parameters to be substrituted in query template.
+  @param {string} q Query template.
+  @param {array} arr Parameters to be substrituted in query template.
   */
-
   module.exports = async function acl(q, arr) {
 
     try {

--- a/mod/user/acl.js
+++ b/mod/user/acl.js
@@ -3,6 +3,10 @@
 
 The acl module provides access to the ACL table for all User API methods.
 
+The module will split either the PRIVATE or PUBLIC process.env variables as an array of connection strings.
+
+The module will export null if neither a PRIVATE or PUBLIC process.env are provided.
+
 @requires pg
 
 @module /user/acl

--- a/mod/user/add.js
+++ b/mod/user/add.js
@@ -41,7 +41,7 @@ Requesting user is admin.
 module.exports = async function addUser(req, res) {
 
   // acl module will export an empty require object without the ACL being configured.
-  if (typeof acl !== 'function') {
+  if (acl === null) {
     return res.status(500).send('ACL unavailable.')
   }
 

--- a/mod/user/auth.js
+++ b/mod/user/auth.js
@@ -53,6 +53,8 @@ HTTP response.
 
 module.exports = async function auth(req, res) {
 
+  if (acl === null) return null;
+
   if (req.headers.authorization) {
 
     return await fromACL(req)

--- a/mod/user/cookie.js
+++ b/mod/user/cookie.js
@@ -44,7 +44,7 @@ The token user will be sent back to the client.
 module.exports = async function cookie(req, res) {
 
   // acl module will export an empty require object without the ACL being configured.
-  if (typeof acl !== 'function') {
+  if (typeof acl === null) {
     return res.status(500).send('ACL unavailable.')
   }
 

--- a/mod/user/delete.js
+++ b/mod/user/delete.js
@@ -38,7 +38,7 @@ Requesting user is admin.
 module.exports = async function deleteUser(req, res) {
 
   // acl module will export an empty require object without the ACL being configured.
-  if (typeof acl !== 'function') {
+  if (typeof acl === null) {
     return res.status(500).send('ACL unavailable.')
   }
 

--- a/mod/user/key.js
+++ b/mod/user/key.js
@@ -36,7 +36,7 @@ Requesting user.
 module.exports = async function apiKey(req, res) {
 
   // acl module will export an empty require object without the ACL being configured.
-  if (typeof acl !== 'function') {
+  if (typeof acl === null) {
     return res.status(500).send('ACL unavailable.')
   }
 

--- a/mod/user/log.js
+++ b/mod/user/log.js
@@ -35,7 +35,7 @@ Requesting user is admin.
 module.exports = async function accessLog(req, res) {
 
   // acl module will export an empty require object without the ACL being configured.
-  if (typeof acl !== 'function') {
+  if (typeof acl === null) {
     return res.status(500).send('ACL unavailable.')
   }
 

--- a/mod/user/register.js
+++ b/mod/user/register.js
@@ -47,7 +47,7 @@ Post body object with user data.
 module.exports = async function register(req, res) {
 
   // acl module will export an empty require object without the ACL being configured.
-  if (typeof acl !== 'function') {
+  if (typeof acl === null) {
     return res.status(500).send('ACL unavailable.')
   }
 

--- a/mod/user/saml.js
+++ b/mod/user/saml.js
@@ -190,7 +190,7 @@ User object or Error.
 
 async function acl_lookup(email) {
 
-  if (typeof acl !== 'function') {
+  if (typeof acl === null) {
     return new Error('ACL unavailable.')
   }
 

--- a/mod/user/update.js
+++ b/mod/user/update.js
@@ -46,7 +46,7 @@ Requesting user is admin.
 module.exports = async function update(req, res) {
 
   // acl module will export an empty require object without the ACL being configured.
-  if (typeof acl !== 'function') {
+  if (typeof acl === null) {
     return res.status(500).send('ACL unavailable.')
   }
 

--- a/mod/user/verify.js
+++ b/mod/user/verify.js
@@ -44,7 +44,7 @@ Request messaging language
 module.exports = async (req, res) => {
 
   // acl module will export an empty require object without the ACL being configured.
-  if (typeof acl !== 'function') {
+  if (typeof acl === null) {
     return res.status(500).send('ACL unavailable.')
   }
 


### PR DESCRIPTION
A condition on null is more expressive than a condition to check whether a module is not a function.

The acl module should return null instead of an empty object if the ACL cannot be initialised.

The acl module must return null before checking whether the connection variable is an array split from the PRIVATE or PUBLIC process.env.

This must be documented in the ACL module docs.