### PR TITLE
Warn on entry.layer not in locale

### DIFF
--- a/lib/ui/locations/entries/layer.mjs
+++ b/lib/ui/locations/entries/layer.mjs
@@ -43,6 +43,12 @@ export default function layer(entry) {
     const layer = entry.mapview.locale.layers
       .find(layer => layer.key === entry.layer)
 
+    if (!layer) {
+
+      console.warn(`Layer [${entry.layer}] not found in mapview.locale`)
+      return;
+    }
+
     // Spread locale layer into entry.
     entry = {
       ...structuredClone(layer),
@@ -90,6 +96,19 @@ async function decorateLayer(entry) {
     }
   })
 
+  // The layer may be zoom level restricted.
+  if (entry.tables) {
+
+    if (!entry.tableCurrent()) entry.display_toggle.classList.add('disabled');
+
+    entry.mapview.Map.getTargetElement().addEventListener('changeEnd', () => {
+
+      entry.tableCurrent()
+        ? entry.display_toggle.classList.remove('disabled')
+        : entry.display_toggle.classList.add('disabled')
+    })
+  }
+
   entry.panel.append(entry.display_toggle)
 
   entry.style.elements ??= [
@@ -106,14 +125,6 @@ async function decorateLayer(entry) {
   entry.style.panel = mapp.ui.elements.layerStyle.panel(entry)
 
   entry.style.panel && entry.panel.append(entry.style.panel)
-
-  // The layer may be zoom level restricted.
-  entry.tables && entry.mapview.Map.getTargetElement().addEventListener('changeEnd', () => {
-
-    entry.tableCurrent()
-      ? entry.display_toggle.classList.remove('disabled')
-      : entry.display_toggle.classList.add('disabled')
-  })
 
   entry.location.removeCallbacks.push(() => {
     entry.hide()


### PR DESCRIPTION
The layer entry as a replacement for the mvt_clone will have an entry.layer property used to lookup a layer in the mapview.locale.

The [layer] entry method must return and should warn if the entry.layer property is defined but the layer is not found in the mapview.locale.

I also noticed that the [entry] layer.tables zoom restriction is not respected on first execution of the method but only once the changeEnd event is executed. This has been fixed in this patch PR as well.