### PR TITLE
Autofix: Warn on entry.layer not in locale

### DIFF
--- a/lib/ui/locations/entries/layer.mjs
+++ b/lib/ui/locations/entries/layer.mjs
@@ -24,7 +24,6 @@ A layer.view will be created for the decorated layer and appended to the entry.n
 @return {HTMLElement} Node element to hold the layer view drawer.
 */
 export default function layer(entry) {
-
   entry.mapview ??= entry.location.layer.mapview
 
   //An entry needs to have a featureLookup array as it's used in the show method,
@@ -32,16 +31,20 @@ export default function layer(entry) {
 
   // The layer lookup is optional. An entry maybe defined as a layer.
   if (entry.layer) {
+    // Find JSON layer in locale
+    const layer = entry.mapview.locale.layers
+      .find(layer => layer.key === entry.layer)
+
+    if (!layer) {
+      console.warn(`Layer ${entry.layer} not found in mapview.locale.`)
+      return
+    }
 
     // The layer.key must be unique.
     entry.key = `${entry.layer}|${entry.location.hook}`
 
     // The locale layer key.
     entry.Key = entry.layer
-
-    // Find JSON layer in locale
-    const layer = entry.mapview.locale.layers
-      .find(layer => layer.key === entry.layer)
 
     // Spread locale layer into entry.
     entry = {
@@ -52,15 +55,24 @@ export default function layer(entry) {
     // The assignment should only happen once.
     delete entry.layer
   }
-
   entry.zIndex ??= entry.location.layer.zIndex++
 
   entry.show ?? decorateLayer(entry)
 
   entry.panel ??= mapp.utils.html.node`<div class="entry-layer">`
 
+  // Apply zoom restriction immediately
+  if (entry.tables) {
+    const updateZoomRestriction = () => {
+      entry.tableCurrent()
+        ? entry.display_toggle.classList.remove('disabled')
+        : entry.display_toggle.classList.add('disabled')
+    }
+    updateZoomRestriction()
+    entry.mapview.Map.getTargetElement().addEventListener('changeEnd', updateZoomRestriction)
+  }
+
   return entry.panel
-}
 
 /**
 @function decorateLayer
@@ -108,12 +120,6 @@ async function decorateLayer(entry) {
   entry.style.panel && entry.panel.append(entry.style.panel)
 
   // The layer may be zoom level restricted.
-  entry.tables && entry.mapview.Map.getTargetElement().addEventListener('changeEnd', () => {
-
-    entry.tableCurrent()
-      ? entry.display_toggle.classList.remove('disabled')
-      : entry.display_toggle.classList.add('disabled')
-  })
 
   entry.location.removeCallbacks.push(() => {
     entry.hide()


### PR DESCRIPTION
Modified the layer entry method to warn and return if the entry.layer is defined but not found in mapview.locale. Also fixed the zoom restriction issue for layer.tables. 
> [!CAUTION]
> Disclaimer: This fix was created by Latta AI and you should never merge before you check the correctness of generated code!
>
> The fix provided by Latta AI might not be complete and it can serve as an inspiration.

---
This bug was fixed for free by Latta AI - https://latta.ai/ourmission

If you no longer want Latta AI to attempt fixing issues on your repository, you can block this account.
    