### PR TITLE
Helpdialog - Minimize and Close Buttons

### DIFF
--- a/lib/ui/elements/helpDialog.mjs
+++ b/lib/ui/elements/helpDialog.mjs
@@ -14,7 +14,9 @@ export default (params) => {
     top: '3em',
     left: '6em',
     contained: true,
-    close: true,
+    closeBtn: true,
+    minimizeBtn: true,
+    headerDrag: true,
     ...params
   }
 


### PR DESCRIPTION
# Help Dialog Tweak
## Description

Added the minimize and close buttons to the help Dialog to help allow the user control over their display. This is required when geometry editing as they may cover the popup on the map canvas.

## GitHub Issue

#1699 

## Type of Change
Please delete options that are not relevant, and select all options that apply. 

- ✅ Bug fix (non-breaking change which fixes an issue)

## How have you tested this? 
Tested locally.

## Testing Checklist 
Please delete options that are not relevant, and select all options that apply. 

- ✅ Existing Tests still pass
- ✅ Updated Existing Tests
- ✅ Ran locally on my machine

## Code Quality Checklist
Please delete options that are not relevant, and select all options that apply. 

- ✅ My code follows the guidelines of XYZ
- ✅ My code has been commented
- ✅ Documentation has been updated
- ✅ New and existing unit tests pass locally with my changes