### PR TITLE
Update Cloudfront Provider to Support Node.js Native Fetch API Buffer Handling

### DIFF
--- a/mod/provider/cloudfront.js
+++ b/mod/provider/cloudfront.js
@@ -62,14 +62,17 @@ module.exports = async function cloudfront(ref) {
     }
 
     const response = await fetch(signedURL)
-    
+
     logger(`${response.status} - ${url}`, 'cloudfront')
 
     if (response.status >= 300) return new Error(`${response.status} ${ref}`)
 
     if (url.match(/\.json$/i)) return await response.json()
 
-    if (ref.params?.buffer) return await response.buffer()
+    if (ref.params?.buffer) {
+      const arrayBuffer = await response.arrayBuffer()
+      return Buffer.from(arrayBuffer)
+    }
 
     return await response.text()
 


### PR DESCRIPTION
---
Update Cloudfront Provider to Support Node.js Native Fetch API Buffer Handling
---

### New implementation
Replaced the buffer handling in the cloudfront provider with:

```javascript
if (ref.params?.buffer) {
  const arrayBuffer = await response.arrayBuffer()
  return Buffer.from(arrayBuffer)
}
```