### PR TITLE
Layer View: Layer / Layer Group distinction

### DIFF
--- a/public/css/_layerview.css
+++ b/public/css/_layerview.css
@@ -52,8 +52,10 @@
   }
   
   & .layer-view{
-    h2 {
-      font-weight: normal
+    > .header{
+      h2 {
+        font-weight: normal
+      }
     }
   }
 }

--- a/public/css/_layerview.css
+++ b/public/css/_layerview.css
@@ -29,14 +29,10 @@
   & >*:not(.header) {
     margin-top: 5px;
   }
-}
 
-.layer-view {
-  & .layer-view{
-    > .header {
-      h2{
-        font-weight: normal;
-      }
+  > .header {
+    h2{
+      font-weight: normal;
     }
   }
 }
@@ -51,13 +47,6 @@
     padding-right: 4px;
   }
   
-  & .layer-view{
-    > .header{
-      h2 {
-        font-weight: normal
-      }
-    }
-  }
 }
 
 #layers>.drawer.layer-group .drawer.layer-view {

--- a/public/css/_layerview.css
+++ b/public/css/_layerview.css
@@ -31,6 +31,16 @@
   }
 }
 
+.layer-view {
+  & .layer-view{
+    > .header {
+      h2{
+        font-weight: normal;
+      }
+    }
+  }
+}
+
 .drawer.layer-group {
   padding-left: 3px;
   padding-right: 3px;
@@ -39,6 +49,12 @@
   & >* {
     padding-left: 4px;
     padding-right: 4px;
+  }
+  
+  & .layer-view{
+    h2 {
+      font-weight: normal
+    }
   }
 }
 

--- a/public/css/ui.css
+++ b/public/css/ui.css
@@ -1435,13 +1435,9 @@ label.checkbox {
   & > *:not(.header) {
     margin-top: 5px;
   }
-}
-.layer-view {
-  & .layer-view {
-    > .header {
-      h2 {
-        font-weight: normal;
-      }
+  > .header {
+    h2 {
+      font-weight: normal;
     }
   }
 }
@@ -1452,13 +1448,6 @@ label.checkbox {
   & > * {
     padding-left: 4px;
     padding-right: 4px;
-  }
-  & .layer-view {
-    > .header {
-      h2 {
-        font-weight: normal;
-      }
-    }
   }
 }
 #layers > .drawer.layer-group .drawer.layer-view {

--- a/public/css/ui.css
+++ b/public/css/ui.css
@@ -1436,6 +1436,15 @@ label.checkbox {
     margin-top: 5px;
   }
 }
+.layer-view {
+  & .layer-view {
+    > .header {
+      h2 {
+        font-weight: normal;
+      }
+    }
+  }
+}
 .drawer.layer-group {
   padding-left: 3px;
   padding-right: 3px;
@@ -1443,6 +1452,11 @@ label.checkbox {
   & > * {
     padding-left: 4px;
     padding-right: 4px;
+  }
+  & .layer-view {
+    h2 {
+      font-weight: normal;
+    }
   }
 }
 #layers > .drawer.layer-group .drawer.layer-view {

--- a/public/css/ui.css
+++ b/public/css/ui.css
@@ -1454,8 +1454,10 @@ label.checkbox {
     padding-right: 4px;
   }
   & .layer-view {
-    h2 {
-      font-weight: normal;
+    > .header {
+      h2 {
+        font-weight: normal;
+      }
     }
   }
 }


### PR DESCRIPTION
## Description

Added css so layer headers and layer headers inside groups so they appear less bold than group headers.

Before:
![Screenshot 2024-11-12 151136](https://github.com/user-attachments/assets/f3088a7d-c010-4af2-9f36-5e59d4adb5f3)

After:
![Screenshot 2024-11-12 144415](https://github.com/user-attachments/assets/e93fd86d-8559-4cbc-b638-a260e164f345)

## GitHub Issue
#1704 

## Type of Change
- ✅ New feature (non-breaking change which adds functionality)

## How have you tested this? 
Can be tested on layer with groups. I have tested it on `bugs_testing/ui_elements/workspace.json`.

## Testing Checklist 
- ✅ Existing Tests still pass
- ✅ Ran locally on my machine

## Code Quality Checklist
- ✅ My code follows the guidelines of XYZ
- ✅ My code has been commented
- ✅ Documentation has been updated
- ✅ New and existing unit tests pass locally with my changes
- ✅ Main has been merged into this PR