### PR TITLE
Shortcircuit keyvalue_dictionary parseObject on mapview key

### DIFF
--- a/lib/location/_location.mjs
+++ b/lib/location/_location.mjs
@@ -8,7 +8,7 @@ import create from './create.mjs'
 
 import decorate from './decorate.mjs'
 
-import {get, getInfoj} from './get.mjs'
+import { get, getInfoj } from './get.mjs'
 
 import nnearest from './nnearest.mjs'
 

--- a/lib/plugins/keyvalue_dictionary.mjs
+++ b/lib/plugins/keyvalue_dictionary.mjs
@@ -45,7 +45,7 @@ Parses an object and replaces its string values with dictionary entries.
 function parseObject(obj, dictionary) {
   for (const [key, value] of Object.entries(obj)) {
 
-    // Prevents crash where the mapview with the local itself maybe nested in a locale plugin object.
+    // Prevents crash where the mapview with the locale itself maybe nested in a locale plugin object.
     if (key === 'mapview') continue;
 
     if (isArrayObject(value, dictionary)) continue;

--- a/lib/plugins/keyvalue_dictionary.mjs
+++ b/lib/plugins/keyvalue_dictionary.mjs
@@ -1,4 +1,18 @@
 /**
+### /plugins/keyvalue_dictionary
+
+A keyvalue_dictionary can be configured in the locale. The keyvalue_dictionary plugin method will parse the mapview.locale for properties with key/value pairs matching entries in the dictionary. The property value will be replaced with a language lookup in the dictionary or the default value.
+
+```js
+"keyvalue_dictionary": [
+  {
+    "key": "name",
+    "value": "OSM",
+    "default": "OpenStreetMap",
+    "uk": "Sława OpenStreetMap 🇺🇦"
+  }
+]
+```
 @module /plugins/keyvalue_dictionary
 */
 
@@ -30,6 +44,10 @@ Parses an object and replaces its string values with dictionary entries.
 */
 function parseObject(obj, dictionary) {
   for (const [key, value] of Object.entries(obj)) {
+
+    // Prevents crash where the mapview with the local itself maybe nested in a locale plugin object.
+    if (key === 'mapview') continue;
+
     if (isArrayObject(value, dictionary)) continue;
     if (typeof value === 'string') replaceKeyValue(obj, key, value, dictionary);
   }

--- a/tests/assets/plugins/assignMapview.js
+++ b/tests/assets/plugins/assignMapview.js
@@ -1,0 +1,3 @@
+mapp.plugins.assignMapview = (plugin, mapview) => {
+    plugin.mapview = { ...mapview }
+}

--- a/tests/plugins/_plugins.test.mjs
+++ b/tests/plugins/_plugins.test.mjs
@@ -11,5 +11,5 @@
 import { linkButtonTest } from './link_button.test.mjs';
 
 export const pluginsTest = {
-    linkButtonTest
+    linkButtonTest,
 };

--- a/tests/workspace.json
+++ b/tests/workspace.json
@@ -57,7 +57,8 @@
         ],
         "plugins": [
             "${PLUGINS}v4.8.0/coordinates.js",
-            "${PLUGINS}v4.8.0/chartjs.js"
+            "${PLUGINS}v4.8.0/chartjs.js",
+            "/test/api/provider/file?content_type=application/javascript&url=./tests/assets/plugins/assignMapview.js"
         ],
         "syncPlugins": [
             "zoomBtn",
@@ -96,6 +97,7 @@
                 "css_style": "mask-image: url(https://geolytix.github.io/MapIcons/services/component_exchange.svg); -webkit-mask-image: url(https://geolytix.github.io/MapIcons/services/component_exchange.svg);"
             }
         ],
+        "assignMapview": {},
         "keyvalue_dictionary": [
             {
                 "key": "name",


### PR DESCRIPTION
A mapview with the locale itself may be assigned to a plugin object.

This would cause the keyvalue_dictionary parse method to parse the locale object until the maximum callstack size is exceeded.

I also provide an example for the keyvalue_dictionary in the module jsdocs block.
