### PR TITLE
mapview.interactions.Click

### DIFF
--- a/lib/mapview/interactions/highlight.mjs
+++ b/lib/mapview/interactions/highlight.mjs
@@ -20,8 +20,8 @@ The module exports the highlight interaction method which is bound to a mapview 
 @property {Number} hitTolerance Pixel distance for detection of features on pixel. Defaults to 5pixel.
 @property {Set} candidateKeys A set of candidate features under the cursor.
 @property {Object} current The current highlighted feature.
-@property {Object} Click The click method for the interaction. This will shortcircuit the getFeature method.
-@property {Object} noLocationClick The noLocationClick method for the interaction, this is only ran if there is no current highlight interaction, and Click method is not available. This will shortcircuit the getFeature method.
+@property {Function} Click The click method for the interaction. This will shortcircuit the getFeature method.
+@property {Function} noLocationClick The noLocationClick method for the interaction, this is only ran if there is no current highlight interaction, and Click method is not available. This will shortcircuit the getFeature method.
 @property {Boolean} clicked The click method was recently called.
 */
 
@@ -346,6 +346,7 @@ export default function highlight(params) {
 
     // if there's a mapview.interaction.Click method, execute it.
     if (typeof mapview.interaction.Click === 'function') {
+      
       // Execute the Click method
       mapview.interaction.Click(e)
       return

--- a/lib/mapview/interactions/highlight.mjs
+++ b/lib/mapview/interactions/highlight.mjs
@@ -345,7 +345,7 @@ export default function highlight(params) {
     mapview.popup(null)
 
     // if there's a mapview.interaction.Click method, execute it.
-    if (mapview.interaction.Click && typeof mapview.interaction.Click === 'function') {
+    if (typeof mapview.interaction.Click === 'function') {
       // Execute the Click method
       mapview.interaction.Click(e)
       return

--- a/lib/mapview/interactions/highlight.mjs
+++ b/lib/mapview/interactions/highlight.mjs
@@ -20,6 +20,8 @@ The module exports the highlight interaction method which is bound to a mapview 
 @property {Number} hitTolerance Pixel distance for detection of features on pixel. Defaults to 5pixel.
 @property {Set} candidateKeys A set of candidate features under the cursor.
 @property {Object} current The current highlighted feature.
+@property {Object} Click The click method for the interaction. This will shortcircuit the getFeature method.
+@property {Object} noLocationClick The noLocationClick method for the interaction, this is only ran if there is no current highlight interaction, and Click method is not available. This will shortcircuit the getFeature method.
 @property {Boolean} clicked The click method was recently called.
 */
 
@@ -295,12 +297,13 @@ export default function highlight(params) {
 
   @description
   The click() method is assigned to the mapview.Map element click event listener.
-
   The method will reset the cursor and check for execution of the interaction.longClickMethod.
 
   The method is debounced to 600ms with interaction.clicked flag.
 
   The pointerMove method will be called with the click event [location] to get a feature without a cursor.
+
+  The interaction.Click method will be called if it exists. This will shortcircuit the getFeature method.
 
   The interaction.noLocationClick method will be called if no current location is available.
 
@@ -341,6 +344,14 @@ export default function highlight(params) {
     // Remove any existing popup. e.g. Cluster select dialogue.
     mapview.popup(null)
 
+    // if there's a mapview.interaction.Click method, execute it.
+    if (mapview.interaction.Click && typeof mapview.interaction.Click === 'function') {
+      // Execute the Click method
+      mapview.interaction.Click(e)
+      return
+    };
+
+    // if there's a mapview.interaction.noLocationClick method
     if (!mapview.interaction.current && typeof mapview.interaction.noLocationClick === 'function') {
 
       // Execute the noLocationClick method
@@ -348,6 +359,7 @@ export default function highlight(params) {
       return;
     }
 
+    // Get the feature from the current highlight.
     if (mapview.interaction.current) {
 
       mapview.interaction.getFeature(mapview.interaction.current);


### PR DESCRIPTION
# Pull Request Template

## Description

Adds the `mapview.interaction.higlight.Click` method. 
This methods will call the function assigned to the `Click` method on any click of the map. 
This methods shortcircuits the `highlight` and takes priority over the `noLocationClick` and `current` methods.

Documentation has also been tweaked to include this method. 

## GitHub Issue

#1720 

## Type of Change
Please delete options that are not relevant, and select all options that apply. 

- ✅ New feature (non-breaking change which adds functionality)
- ✅ Documentation


## Testing Checklist 
Please delete options that are not relevant, and select all options that apply. 

- ✅ Existing Tests still pass
- ✅ Updated Existing Tests
- ✅ Ran locally on my machine

## Code Quality Checklist
Please delete options that are not relevant, and select all options that apply. 

- ✅ My code follows the guidelines of XYZ
- ✅ My code has been commented
- ✅ Documentation has been updated
- ✅ New and existing unit tests pass locally with my changes
- ✅ Main has been merged into this PR