### PR TITLE
mapview.addLayer merge/clone issue

### DIFF
--- a/lib/mapview/addLayer.mjs
+++ b/lib/mapview/addLayer.mjs
@@ -45,7 +45,7 @@ export default async function addLayer(layers) {
   for (let i = 0; i < layers.length; i++) {
 
     // The JSON layer is merged into the locale.layer
-    const layer = mapp.utils.merge(
+    const layer = mapp.utils.merge({},
       structuredClone(this.locale.layer || {}),
       structuredClone(layers[i]))
 

--- a/lib/mapview/addLayer.mjs
+++ b/lib/mapview/addLayer.mjs
@@ -14,7 +14,7 @@ A single or an array of JSON layer can be added to the mapview with the addLayer
 
 A default zIndex is assigned to layer without an implicit zIndex.
 
-The layer to be added to be added to the mapview is clone created from the JSON layer being merged into the locale.layer.
+A structuredClone of the JSON layer will be merged into a clone of the locale.layer template to be decorated and assigned to the mapview [this] layers.
 
 The mapview [this] to which the addLayer method is bound will be assigned to the layer object.
 
@@ -45,10 +45,9 @@ export default async function addLayer(layers) {
   for (let i = 0; i < layers.length; i++) {
 
     // The JSON layer is merged into the locale.layer
-    const layer = mapp.utils.merge({}, this.locale.layer || {}, layers[i])
-
-    // Replace layer object in layers array with layer clone from merge.
-    decoratedLayers.push(layer)
+    const layer = mapp.utils.merge(
+      structuredClone(this.locale.layer || {}),
+      structuredClone(layers[i]))
 
     // The layer.err is an array of errors from failing to retrieve templates asscoiated with a layer.
     layer.err && console.error(layer.err)
@@ -79,6 +78,9 @@ export default async function addLayer(layers) {
     await mapp.layer.decorate(layer);
 
     if (!layer.L) continue;
+
+    // Assign layer to array returned from method.
+    decoratedLayers.push(layer)
 
     this.layers[layer.key] = layer;
 

--- a/tests/lib/mapview/addLayer.test.mjs
+++ b/tests/lib/mapview/addLayer.test.mjs
@@ -10,6 +10,16 @@
  * @function addLayerTest
  */
 export async function addLayerTest(mapview) {
+
+  const OL = document.getElementById('OL');
+
+  const _mapview = await mapp.Mapview({
+    host: mapp.host,
+    target: OL,
+    locale: mapview.locale,
+    svgTemplates: mapview.locale.svg_templates
+  });
+
   await codi.describe('Mapview: addLayerTest', async () => {
 
     /**
@@ -23,11 +33,11 @@ export async function addLayerTest(mapview) {
         'URI': 'https://{a-c}.tile.openstreetmap.org/{z}/{x}/{y}.png'
       }
 
-      const layers = await mapview.addLayer(layer)
+      const layers = await _mapview.addLayer(layer)
 
       codi.assertEqual(layers.length, 1, 'We expect to see 1 layer being returned from getLayers method.');
       codi.assertTrue(layers[0].show instanceof Function, 'The decorated layer has a show method.');
-      codi.assertTrue(Object.hasOwn(mapview.layers, layers[0].key), 'The layer has been added to the mapview.');
+      codi.assertTrue(Object.hasOwn(_mapview.layers, layers[0].key), 'The layer has been added to the mapview.');
     });
 
     /**
@@ -41,11 +51,12 @@ export async function addLayerTest(mapview) {
         'URI': 'https://{a-c}.tile.openstreetmap.org/{z}/{x}/{y}.png'
       }
 
-      const layers = await mapview.addLayer([layer, layer])
+      const layers = await _mapview.addLayer([layer, layer])
 
       codi.assertEqual(layers.length, 2, 'We expect to see 2 layer being returned from getLayers method.');
       codi.assertTrue(layers[0].show instanceof Function, 'The first decorated layer has a show method.');
-      codi.assertTrue(Object.hasOwn(mapview.layers, layers[0].key), 'The first layer has been added to the mapview.');
+      codi.assertTrue(Object.hasOwn(_mapview.layers, layers[0].key), 'The first layer has been added to the mapview.');
+      codi.assertFalse(layers[0] === layers[1], 'The layers returned from the addLayer method should not be equal even if they have the exactly the same config')
     });
   });
 }


### PR DESCRIPTION
I was under the assumption that mapp.utils.merge() creates a clone if objects are merged into an empty object. This is not the case.

In this PR I pass structured clones of the layer and locale.layer to the merge() utility method in order to make sure that the layer added to the mapview is indeed a clone.
