### PR TITLE
Template bug

### DIFF
--- a/mod/query.js
+++ b/mod/query.js
@@ -35,7 +35,7 @@ const getLayer = require('./workspace/getLayer');
 @description
 The [SQL] query method requests a query template from the getTemplate method and checks whether the requesting user is permitted to execute the query.
 
-The layerQuery() method must be awaited for queries that reference a layer.
+The layerQuery() method must be awaited for queries that reference a layer. The layerQuery must be run before the getTemplate() request since the query template may be defined in the layer [template].
 
 A template is turned into a query by the getQueryFromTemplate() method.
 
@@ -49,8 +49,16 @@ The query is executed by the executeQuery() method.
 */
 module.exports = async function query(req, res) {
 
+  // The SQL param is restricted to hold substitute values.
+  req.params.SQL = [];
+
+  // Assign role filter and viewport params from layer object.
+  await layerQuery(req, res)
+
+  if (res.finished) return;  
+
   // Get the template.
-  const template = await getTemplate(req.params.template, req.params.purge)
+  const template = await getTemplate(req.params.template)
 
   if (template instanceof Error) {
     return res.status(500).send(template.message)
@@ -77,14 +85,6 @@ module.exports = async function query(req, res) {
 
     return res.status(403).send('Role access denied for query template.')
   }
-
-  // The SQL param is restricted to hold substitute values.
-  req.params.SQL = [];
-
-  // Assign role filter and viewport params from layer object.
-  await layerQuery(req, res)
-
-  if (res.finished) return;
 
   // Get workspace from cache.
   req.params.workspace = await workspaceCache()

--- a/mod/query.js
+++ b/mod/query.js
@@ -50,7 +50,7 @@ The query is executed by the executeQuery() method.
 module.exports = async function query(req, res) {
 
   // Get the template.
-  const template = await getTemplate(req.params.template)
+  const template = await getTemplate(req.params.template, req.params.purge)
 
   if (template instanceof Error) {
     return res.status(500).send(template.message)

--- a/mod/workspace/getTemplate.js
+++ b/mod/workspace/getTemplate.js
@@ -45,10 +45,10 @@ Module templates will be constructed before being returned.
 
 @returns {Promise<Object|Error>} JSON Template
 */
-module.exports = async function getTemplate(template) {
+module.exports = async function getTemplate(template, purge) {
 
   if (typeof template === 'string') {
-    const workspace = await workspaceCache()
+    const workspace = await workspaceCache(purge)
 
     if (workspace instanceof Error) {
       return workspace

--- a/mod/workspace/getTemplate.js
+++ b/mod/workspace/getTemplate.js
@@ -45,10 +45,10 @@ Module templates will be constructed before being returned.
 
 @returns {Promise<Object|Error>} JSON Template
 */
-module.exports = async function getTemplate(template, purge) {
+module.exports = async function getTemplate(template) {
 
   if (typeof template === 'string') {
-    const workspace = await workspaceCache(purge)
+    const workspace = await workspaceCache()
 
     if (workspace instanceof Error) {
       return workspace

--- a/tests/mod/workspace/getTemplate.test.mjs
+++ b/tests/mod/workspace/getTemplate.test.mjs
@@ -1,10 +1,7 @@
 export function getTemplateTest() {
     codi.describe('Workspace: Get Template Test', async () => {
         codi.it('Layer template test', async () => {
-            await mapp.utils.xhr(`/test/api/workspace/test`);
-
-            const res = await mapp.utils.xhr('/test/api/query?layer=template_test&template=layer_data_array')
-
+            const res = await mapp.utils.xhr('/test/api/query?layer=template_test&template=layer_data_array&purge=true')
             codi.assertEqual(res, [1, 2, 5, 3, 4], 'We expect the query to be able to return from the workspace before the layer has been merged')
         })
     });

--- a/tests/mod/workspace/getTemplate.test.mjs
+++ b/tests/mod/workspace/getTemplate.test.mjs
@@ -1,7 +1,7 @@
 export function getTemplateTest() {
     codi.describe('Workspace: Get Template Test', async () => {
         codi.it('Layer template test', async () => {
-            const res = await mapp.utils.xhr('/test/api/query?layer=template_test&template=layer_data_array&purge=true')
+            const res = await mapp.utils.xhr('/test/api/query?layer=template_test&template=layer_data_array')
             codi.assertEqual(res, [1, 2, 5, 3, 4], 'We expect the query to be able to return from the workspace before the layer has been merged')
         })
     });


### PR DESCRIPTION
## Description

> The layerQuery must be run before the getTemplate request in the query module. This ensures that a query template defined in the layer [template] will be loaded if the workspace is not cached.
> 
> This can only be tested to pass.

## GitHub Issue

#1717

## Type of Change
- ✅ Bug fix (non-breaking change which fixes an issue)
- ✅ Testing