### PR TITLE
Layer May Not Have Params.Fields

### DIFF
--- a/lib/layer/format/vector.mjs
+++ b/lib/layer/format/vector.mjs
@@ -51,7 +51,7 @@ export default function vector(layer) {
   }
 
   // Set default layer params if nullish.
-  layer.params ??= {}
+  layer.params ??= { fields: [] }
 
   clusterConfig(layer)
 


### PR DESCRIPTION
# Pull Request Template

## Description

A layer may not have a `fields` parameter. 
This PR just nullish assigns it to make sure that when the `featureFormat` is hit, the spread using `layer.params.fields` does not fail with the error, 'e.params.fields is not iterable'. 

## Type of Change
Please delete options that are not relevant, and select all options that apply. 

- ✅ Bug fix (non-breaking change which fixes an issue)

## Testing Checklist 
Please delete options that are not relevant, and select all options that apply. 

- ✅ Existing Tests still pass
- ✅ Updated Existing Tests
- ✅ Ran locally on my machine

## Code Quality Checklist
Please delete options that are not relevant, and select all options that apply. 

- ✅ My code follows the guidelines of XYZ
- ✅ My code has been commented
- ✅ Documentation has been updated
- ✅ New and existing unit tests pass locally with my changes
- ✅ Main has been merged into this PR