### PR TITLE
Dataview Entry: Hide/Show toolbar along with location dataview

### DIFF
--- a/lib/ui/Dataview.mjs
+++ b/lib/ui/Dataview.mjs
@@ -169,6 +169,9 @@ function show() {
     this.update instanceof Function && this.update()
   }
 
+  //Show toolbar buttons if there are any
+  this.btn_row && this.btn_row.style.setProperty('display','block')
+
   this.target.style.display = 'block'
 }
 
@@ -186,6 +189,9 @@ function hide() {
 
   this.display = false
   this.target.style.display = 'none'
+
+  //Hide toolbar buttons if there are any
+  this.btn_row && this.btn_row.style.setProperty('display','none')
 }
 
 /**
@@ -331,10 +337,13 @@ function dataviewToolbar(_this) {
     .map((key) => mapp.ui.utils[_this.dataview]?.toolbar[key]?.(_this))
     .filter((item) => !!item);
 
+  // Create an element for the toolbar buttons
+  _this.btn_row = mapp.utils.html.node`<div class="btn-row">${toolbarElements}</div>`
+
   // The panel will be assigned in a tabview.
   _this.panel = _this.target.appendChild(mapp.utils.html.node`
     <div class="flex-col">
-      <div class="btn-row">${toolbarElements}</div>
+      ${_this.btn_row}
       ${target}`);
 
   // Assign dataview target as target.

--- a/lib/ui/Dataview.mjs
+++ b/lib/ui/Dataview.mjs
@@ -170,7 +170,7 @@ function show() {
   }
 
   //Show toolbar buttons if there are any
-  this.btn_row && this.btn_row.style.setProperty('display','block')
+  this.btn_row?.style.setProperty('display','block')
 
   this.target.style.display = 'block'
 }
@@ -191,7 +191,7 @@ function hide() {
   this.target.style.display = 'none'
 
   //Hide toolbar buttons if there are any
-  this.btn_row && this.btn_row.style.setProperty('display','none')
+  this.btn_row?.style.setProperty('display','none')
 }
 
 /**

--- a/lib/ui/Dataview.mjs
+++ b/lib/ui/Dataview.mjs
@@ -170,7 +170,7 @@ function show() {
   }
 
   //Show toolbar buttons if there are any
-  this.btn_row?.style.setProperty('display','block')
+  this.btnRow?.style.setProperty('display','block')
 
   this.target.style.display = 'block'
 }
@@ -191,7 +191,7 @@ function hide() {
   this.target.style.display = 'none'
 
   //Hide toolbar buttons if there are any
-  this.btn_row?.style.setProperty('display','none')
+  this.btnRow?.style.setProperty('display','none')
 }
 
 /**
@@ -338,12 +338,15 @@ function dataviewToolbar(_this) {
     .filter((item) => !!item);
 
   // Create an element for the toolbar buttons
-  _this.btn_row = mapp.utils.html.node`<div class="btn-row">${toolbarElements}</div>`
+  _this.btnRow = mapp.utils.html.node`<div class="btn-row">${toolbarElements}</div>`
 
+  // By default btnRow is hidden
+  _this.btnRow.style.setProperty('display','none');
+  
   // The panel will be assigned in a tabview.
   _this.panel = _this.target.appendChild(mapp.utils.html.node`
     <div class="flex-col">
-      ${_this.btn_row}
+      ${_this.btnRow}
       ${target}`);
 
   // Assign dataview target as target.

--- a/lib/ui/layers/view.mjs
+++ b/lib/ui/layers/view.mjs
@@ -73,7 +73,6 @@ The layerView method will create and assign a layer.view node to the layer objec
 @param {layer} layer A decorated mapp layer.
 @property {Object} layer.view No layer view will be created with the view property null.
 @property {Object} layer.drawer The layer view will not be in a drawer element with the drawer property null.
-@property {Boolean} [layer.zoomButton] Controls whether the layers zoom button is used or not.
 @property {array} [layer.panelOrder=['draw-drawer', 'dataviews-drawer', 'filter-drawer', 'style-drawer', 'meta']] The order of layer view panel elements.
 
 @returns {layer} The layer object is returned after the layer view has been created.
@@ -139,15 +138,12 @@ export default function layerView(layer) {
     }}>`
 
   // Create a div for the magnifying glass icon
-  layer.zoomButton ??= layer.tables
+  layer.zoomBtn = layer.tables
     && mapp.utils.html.node`<button 
       data-id="zoom-to"
       title=${mapp.dictionary.zoom_to}
       class="mask-icon search"
       onclick=${() => zoomToRange(layer)}>`
-  
-  //If zoomButton is false, set it to undefined so nothing gets rendered
-  layer.zoomButton ||= undefined
 
   // Add on callback for toggle button.
   layer.showCallbacks.push(() => {
@@ -163,7 +159,7 @@ export default function layerView(layer) {
     <h2>${layer.name || layer.key}</h2>
     ${layer.zoomToExtentBtn}
     ${layer.displayToggle}
-    ${layer.zoomButton}
+    ${layer.zoomBtn}
     <div class="mask-icon expander"></div>`
 
   // An empty drawer element can not be expanded.
@@ -222,7 +218,7 @@ The [layer.tableCurrent()]{@link module:/layer/decorate~tableCurrent} method is 
 @param {layer} layer A decorated mapp layer.
 @property {HTMLElement} layer.view The layer view element.
 @property {HTMLElement} layer.displayToggle A button element which toggles the layer.display.
-@property {HTMLElement} layer.zoomButton A button element which sets the mapview into the visible zoom range for the layer.
+@property {HTMLElement} layer.zoomBtn A button element which sets the mapview into the visible zoom range for the layer.
 */
 function changeEnd(layer) {
 
@@ -232,7 +228,7 @@ function changeEnd(layer) {
   if (layer.tableCurrent()) {
 
     // The zoomBtn is hidden if the layer is in range.
-    layer.zoomButton && layer.zoomButton.style.setProoperty('display' ,'none')
+    layer.zoomBtn.style.display = 'none'
 
     // Enable layer display toggle.
     layer.displayToggle.classList.remove('disabled')
@@ -243,7 +239,7 @@ function changeEnd(layer) {
   } else {
 
     // The zoomBtn is displayed outside if the layer is out of range.
-    layer.zoomButton && layer.zoomButton.style.setProoperty('display' ,'block')
+    layer.zoomBtn.style.display = 'block'
 
     // Collapse drawer and disable layer.view.
     layer.view.querySelector('.layer-view.drawer').classList.remove('expanded')

--- a/lib/ui/layers/view.mjs
+++ b/lib/ui/layers/view.mjs
@@ -73,6 +73,7 @@ The layerView method will create and assign a layer.view node to the layer objec
 @param {layer} layer A decorated mapp layer.
 @property {Object} layer.view No layer view will be created with the view property null.
 @property {Object} layer.drawer The layer view will not be in a drawer element with the drawer property null.
+@property {Boolean} [layer.zoomButton] Controls whether the layers zoom button is used or not.
 @property {array} [layer.panelOrder=['draw-drawer', 'dataviews-drawer', 'filter-drawer', 'style-drawer', 'meta']] The order of layer view panel elements.
 
 @returns {layer} The layer object is returned after the layer view has been created.
@@ -138,12 +139,15 @@ export default function layerView(layer) {
     }}>`
 
   // Create a div for the magnifying glass icon
-  layer.zoomBtn = layer.tables
+  layer.zoomButton ??= layer.tables
     && mapp.utils.html.node`<button 
       data-id="zoom-to"
       title=${mapp.dictionary.zoom_to}
       class="mask-icon search"
       onclick=${() => zoomToRange(layer)}>`
+  
+  //If zoomButton is false, set it to undefined so nothing gets rendered
+  layer.zoomButton ||= undefined
 
   // Add on callback for toggle button.
   layer.showCallbacks.push(() => {
@@ -159,7 +163,7 @@ export default function layerView(layer) {
     <h2>${layer.name || layer.key}</h2>
     ${layer.zoomToExtentBtn}
     ${layer.displayToggle}
-    ${layer.zoomBtn}
+    ${layer.zoomButton}
     <div class="mask-icon expander"></div>`
 
   // An empty drawer element can not be expanded.
@@ -218,7 +222,7 @@ The [layer.tableCurrent()]{@link module:/layer/decorate~tableCurrent} method is 
 @param {layer} layer A decorated mapp layer.
 @property {HTMLElement} layer.view The layer view element.
 @property {HTMLElement} layer.displayToggle A button element which toggles the layer.display.
-@property {HTMLElement} layer.zoomBtn A button element which sets the mapview into the visible zoom range for the layer.
+@property {HTMLElement} layer.zoomButton A button element which sets the mapview into the visible zoom range for the layer.
 */
 function changeEnd(layer) {
 
@@ -228,7 +232,7 @@ function changeEnd(layer) {
   if (layer.tableCurrent()) {
 
     // The zoomBtn is hidden if the layer is in range.
-    layer.zoomBtn.style.display = 'none'
+    layer.zoomButton && layer.zoomButton.style.setProoperty('display' ,'none')
 
     // Enable layer display toggle.
     layer.displayToggle.classList.remove('disabled')
@@ -239,7 +243,7 @@ function changeEnd(layer) {
   } else {
 
     // The zoomBtn is displayed outside if the layer is out of range.
-    layer.zoomBtn.style.display = 'block'
+    layer.zoomButton && layer.zoomButton.style.setProoperty('display' ,'block')
 
     // Collapse drawer and disable layer.view.
     layer.view.querySelector('.layer-view.drawer').classList.remove('expanded')

--- a/tests/assets/layers/location_mock/infoj.json
+++ b/tests/assets/layers/location_mock/infoj.json
@@ -19,6 +19,29 @@
             "label": "ST_PointOnSurface",
             "field": "pin2",
             "fieldfx": "ARRAY[ST_X(ST_PointOnSurface(geom_3857)),ST_Y(ST_PointOnSurface(geom_3857))]"
+        },
+        {
+            "type": "dataview",
+            "label": "foo",
+            "toolbar": {},
+            "data": [
+                1,
+                2,
+                2,
+                2,
+                5
+            ],
+            "noDataMask": "¡No Bueno!",
+            "reload": true,
+            "chart": {
+                "labels": [
+                    "a",
+                    "b",
+                    "c",
+                    "d",
+                    "e"
+                ]
+            }
         }
     ]
 }

--- a/tests/browser/local.test.mjs
+++ b/tests/browser/local.test.mjs
@@ -23,7 +23,7 @@ export async function coreTest() {
     //UI Layers Tests
     await runAllTests(_mappTest.ui_layers, mapview);
     //UI tests
-    await runAllTests(_mappTest.uiTest);
+    await runAllTests(_mappTest.uiTest, mapview);
     //Format Tests
     await runAllTests(_mappTest.formatTest, mapview);
     //UI Locations Tests

--- a/tests/lib/ui/Dataview.test.mjs
+++ b/tests/lib/ui/Dataview.test.mjs
@@ -1,0 +1,51 @@
+import { mockLocation } from '../../utils/location.js';
+/**
+ * ## lib.ui.Dataview
+ * @module ui/Dataview
+ */
+/**
+ * This function is used to test the Dataview method
+ * @function DataviewTest 
+*/
+export async function DataviewTest(mapview) {
+    await codi.describe('UI: Dataview', async () => {
+        // Get the mocked location
+        const location = await mockLocation(mapview);
+        // Get the entry of type dataview
+        const entry = location.infoj.find(entry => entry.type === 'dataview');
+
+        await codi.it('dataview should have a show method', async () => {
+
+            codi.assertTrue(entry.show instanceof Function, 'The dataview entry has a show method.');
+
+        });
+
+        await codi.it('dataview btnRow should be display none initially', async () => {
+
+            codi.assertEqual(entry.btnRow.style.display, 'none', 'The dataview entry btnRow should be display none.');
+
+        });
+
+        await codi.it('dataview should have a hide method', async () => {
+
+            codi.assertTrue(entry.hide instanceof Function, 'The dataview entry has a hide method.');
+        });
+
+        await codi.it('dataview btnRow should be display true when show method called', async () => {
+
+            entry.show();
+            codi.assertEqual(entry.btnRow.style.display, 'block', 'The dataview entry btnRow should be display block.');
+
+        });
+
+        await codi.it('dataview btnRow should be display none when hide method called', async () => {
+
+            entry.hide();
+            codi.assertEqual(entry.btnRow.style.display, 'none', 'The dataview entry btnRow should be display none.');
+
+        });
+
+        // Remove the mocked location
+        location.remove();
+    });
+}

--- a/tests/lib/ui/_ui.test.mjs
+++ b/tests/lib/ui/_ui.test.mjs
@@ -1,5 +1,7 @@
 import { Tabview } from './Tabview.test.mjs';
+import { DataviewTest } from './Dataview.test.mjs';
 
 export const uiTest = {
-    Tabview
+    Tabview,
+    DataviewTest
 }


### PR DESCRIPTION
## Description
The toolbar elements should hide/show along with their associated dataview.

## GitHub Issue
[#1739](https://github.com/GEOLYTIX/xyz/issues/1739)

## Type of Change
- ✅ Bug fix (non-breaking change which fixes an issue)

## How have you tested this? 
Can be tested using the `Report Input` layer on `bugs_testing/ui_elements/workspace.json`. Click the checkbox that hides and shows the dataview. The toolbar should hide and show along with it. 

## Testing Checklist 
- ✅ Existing Tests still pass
- ✅ Ran locally on my machine

## Code Quality Checklist
- ✅ My code follows the guidelines of XYZ
- ✅ My code has been commented
- ✅ Documentation has been updated
- ✅ New and existing unit tests pass locally with my changes
- ✅ Main has been merged into this PR