### PR TITLE
Layer View: Hide zoom button 

### DIFF
--- a/lib/ui/layers/view.mjs
+++ b/lib/ui/layers/view.mjs
@@ -73,6 +73,7 @@ The layerView method will create and assign a layer.view node to the layer objec
 @param {layer} layer A decorated mapp layer.
 @property {Object} layer.view No layer view will be created with the view property null.
 @property {Object} layer.drawer The layer view will not be in a drawer element with the drawer property null.
+@property {Boolean} [layer.zoomButton] Controls whether the layers zoom button is used or not.
 @property {array} [layer.panelOrder=['draw-drawer', 'dataviews-drawer', 'filter-drawer', 'style-drawer', 'meta']] The order of layer view panel elements.
 
 @returns {layer} The layer object is returned after the layer view has been created.
@@ -138,12 +139,15 @@ export default function layerView(layer) {
     }}>`
 
   // Create a div for the magnifying glass icon
-  layer.zoomBtn = layer.tables
+  layer.zoomButton ??= layer.tables
     && mapp.utils.html.node`<button 
       data-id="zoom-to"
       title=${mapp.dictionary.zoom_to}
       class="mask-icon search"
       onclick=${() => zoomToRange(layer)}>`
+  
+  //If zoomButton is false, set it to undefined so nothing gets rendered
+  layer.zoomButton ||= undefined
 
   // Add on callback for toggle button.
   layer.showCallbacks.push(() => {
@@ -159,7 +163,7 @@ export default function layerView(layer) {
     <h2>${layer.name || layer.key}</h2>
     ${layer.zoomToExtentBtn}
     ${layer.displayToggle}
-    ${layer.zoomBtn}
+    ${layer.zoomButton}
     <div class="mask-icon expander"></div>`
 
   // An empty drawer element can not be expanded.
@@ -218,7 +222,7 @@ The [layer.tableCurrent()]{@link module:/layer/decorate~tableCurrent} method is 
 @param {layer} layer A decorated mapp layer.
 @property {HTMLElement} layer.view The layer view element.
 @property {HTMLElement} layer.displayToggle A button element which toggles the layer.display.
-@property {HTMLElement} layer.zoomBtn A button element which sets the mapview into the visible zoom range for the layer.
+@property {HTMLElement} layer.zoomButton A button element which sets the mapview into the visible zoom range for the layer.
 */
 function changeEnd(layer) {
 
@@ -228,7 +232,7 @@ function changeEnd(layer) {
   if (layer.tableCurrent()) {
 
     // The zoomBtn is hidden if the layer is in range.
-    layer.zoomBtn.style.display = 'none'
+    layer.zoomButton && layer.zoomButton.style.setProoperty('display' ,'none')
 
     // Enable layer display toggle.
     layer.displayToggle.classList.remove('disabled')
@@ -239,7 +243,7 @@ function changeEnd(layer) {
   } else {
 
     // The zoomBtn is displayed outside if the layer is out of range.
-    layer.zoomBtn.style.display = 'block'
+    layer.zoomButton && layer.zoomButton.style.setProoperty('display' ,'block')
 
     // Collapse drawer and disable layer.view.
     layer.view.querySelector('.layer-view.drawer').classList.remove('expanded')


### PR DESCRIPTION
## Description
The layer zoom does not always make sense contextually. This PR gives us the ability to hide it by specifying `layer.zoomButton`.

Specifying `layer.zoomButton` should turn this:
![Screenshot 2024-11-21 094211](https://github.com/user-attachments/assets/1bc123f6-af53-4210-b437-f422f30da26e)

into:
![Screenshot 2024-11-21 094333](https://github.com/user-attachments/assets/83a706ab-3a49-467f-9ead-3d6dba2dfb3a)


## GitHub Issue
[#1718](https://github.com/GEOLYTIX/xyz/issues/1718)

## Type of Change
- ✅ New feature (non-breaking change which adds functionality)
- ✅ Documentation

## How have you tested this? 
Can be tested locally on any instance that has a zoom restricted layer.

## Testing Checklist 
- ✅ Existing Tests still pass
- ✅ Ran locally on my machine

## Code Quality Checklist
- ✅ My code follows the guidelines of XYZ
- ✅ My code has been commented
- ✅ Documentation has been updated
- ✅ New and existing unit tests pass locally with my changes
- ✅ Main has been merged into this PR