### PR TITLE
fix merge template object issue

### DIFF
--- a/mod/workspace/mergeTemplates.js
+++ b/mod/workspace/mergeTemplates.js
@@ -131,13 +131,13 @@ The method will call itself for nested objects.
 @param {Object} obj 
 */
 function assignWorkspaceTemplates(obj) {
-
+  // Return early if object is null or empty
   if (obj === null) return;
 
   if (obj instanceof Object && !Object.keys(obj)) return;
 
   Object.entries(obj).forEach(entry => {
-
+    // Process template objects - if found, add type and merge into workspace templates
     if (entry[0] === 'template' && entry[1].key) {
 
       entry[1]._type = 'template';
@@ -146,12 +146,14 @@ function assignWorkspaceTemplates(obj) {
       return;
     }
 
+    // Recursively process each item if we find an array
     if (Array.isArray(entry[1])) {
 
       entry[1].forEach(assignWorkspaceTemplates)
       return;
     }
 
+    // Recursively process nested objects
     if (entry[1] instanceof Object) {
 
       assignWorkspaceTemplates(entry[1]);

--- a/mod/workspace/mergeTemplates.js
+++ b/mod/workspace/mergeTemplates.js
@@ -100,7 +100,7 @@ module.exports = async function mergeTemplates(obj) {
 
       //The object template must not be overwritten by a templates template.
       delete template.template;
-      
+
       // Merge template --> obj
       obj = merge(obj, template)
     }
@@ -154,7 +154,7 @@ function assignWorkspaceTemplates(obj) {
 
     if (entry[1] instanceof Object) {
 
-      Object.values(entry[1])?.forEach(assignWorkspaceTemplates)
+      assignWorkspaceTemplates(entry[1]);
     }
 
   })


### PR DESCRIPTION
# Object Template parsing correction

The `assignWorkspaceTemplate` function was calling itself with the actual values of each object key, which would result in the templates never to be assigned to the workspace.templates as the key & value is needed on the entry to make the assignment on the workspace.

## GitHub Issue

#1716 

## Type of Change

Please delete options that are not relevant, and select all options that apply.

- ✅ Bug fix (non-breaking change which fixes an issue)
