### PR TITLE
get location from feature

### DIFF
--- a/lib/layer/decorate.mjs
+++ b/lib/layer/decorate.mjs
@@ -27,6 +27,7 @@ The layer object is returned from the decorator.
 The layer decorator method create mapp-layer typedef object from a json-layer.
 
 @param {object} layer JSON layer.
+@property {boolean} layer.featureLocation Locations will be gotten from layer.features.
 
 @returns {layer} Decorated Mapp Layer.
 */
@@ -97,14 +98,14 @@ export default async function decorate(layer) {
       .forEach(entry => entry.skipEntry = true)
   }
 
+  //Remove edit property from infoj entries on featureLocation layer.
+  layer.featureLocation && layer?.infoj?.forEach(entry => delete entry.edit);
+
   // Call layer and/or plugin methods.
   Object.keys(layer).forEach((key) => {
     typeof mapp.layer[key] === 'function' && mapp.layer[key]?.(layer);
     typeof mapp.plugins[key] === 'function' && mapp.plugins[key]?.(layer);
   });
-
-  //Remove edit flags if the layer uses featureLocations on the layer.
-  layer.featureLocation && layer?.infoj?.forEach(entry => delete entry.edit);
 
   return layer;
 }

--- a/lib/layer/decorate.mjs
+++ b/lib/layer/decorate.mjs
@@ -103,6 +103,9 @@ export default async function decorate(layer) {
     typeof mapp.plugins[key] === 'function' && mapp.plugins[key]?.(layer);
   });
 
+  //Remove edit flags if the layer uses featureLocations on the layer.
+  layer.featureLocation && layer?.infoj?.forEach(entry => delete entry.edit);
+
   return layer;
 }
 

--- a/lib/location/get.mjs
+++ b/lib/location/get.mjs
@@ -144,13 +144,20 @@ export async function getInfoj(location) {
   // Assign qID as default field if layer has no infoj.
   location.layer.infoj ??= [{ field: location.layer.qID }]
 
+  //Delete any edit flag in the config if the layer uses featureLocation
+  if (location.layer.featureLocation) {
+    location.layer.infoj.forEach(entry => {
+      delete entry.edit;
+    });
+  }
+
   // Parse and clone the infoj and response data.
   location.infoj = location.layer.infoj?.map(_entry => ({
     ...structuredClone(_entry),
     title: _entry.title || response[_entry.field + '_label'],
     value: response[_entry.field],
     location
-  }))
+  }));
 
   return location.infoj
 }

--- a/lib/location/get.mjs
+++ b/lib/location/get.mjs
@@ -157,7 +157,7 @@ export async function getInfoj(location) {
 
 async function getFeatureResponse(location) {
   // Check if features are already available locally
-  if (location.layer.features) {
+  if (location.layer.featureLocation) {
     const feature = location.layer.features
       .find(feature => feature.properties.id === location.id);
 

--- a/lib/location/get.mjs
+++ b/lib/location/get.mjs
@@ -201,7 +201,7 @@ async function getFeatureResponse(location) {
   // Check if features are already available locally
   if (location.layer.featureLocation) {
     const feature = location.layer.features
-      .find(feature => feature.properties.id === location.id);
+      .find(feature => feature.properties[location.layer.qID] === location.id);
 
     return feature ? {
       geometry: feature.geometry,

--- a/lib/location/get.mjs
+++ b/lib/location/get.mjs
@@ -155,6 +155,41 @@ export async function getInfoj(location) {
   return location.infoj
 }
 
+
+/**
+* Retrieves a feature either from local cache or remote API based on location parameters
+* 
+* @async
+* @param {Object} location - The location object containing feature lookup parameters
+* @param {layer} location.layer - Layer information containing features and metadata
+* @param {boolean} layer.featureLocation - Flag indicating if features are cached locally
+* @param {Array} layer.features - Array of cached feature objects if available locally
+* @param {string} location.id - ID of the feature to retrieve
+* @param {string} location.getTemplate - Template name for API query
+* @param {string} location.locale - Locale setting for API query
+* @param {string} location.table - Table name for API query
+* @param {Object} location.layer - Layer configuration
+* @param {string} layer.Key - Primary layer key identifier
+* @param {string} layer.key - Fallback layer key identifier
+* 
+* @returns {Promise<Object|null>} A promise that resolves to either:
+*   - An object containing the feature geometry and properties if found
+*   - null if no matching feature is found locally
+*   - API response if fetched remotely
+* 
+* @example
+* const location = {
+*   layer: {
+*     featureLocation: true,
+*     features: [{properties: {id: '123'}, geometry: {...}}]
+*   },
+*   id: '123',
+*   getTemplate: 'default',
+*   locale: 'en',
+*   table: 'locations'
+* };
+* const feature = await getFeatureResponse(location);
+*/
 async function getFeatureResponse(location) {
   // Check if features are already available locally
   if (location.layer.featureLocation) {

--- a/lib/location/get.mjs
+++ b/lib/location/get.mjs
@@ -144,13 +144,6 @@ export async function getInfoj(location) {
   // Assign qID as default field if layer has no infoj.
   location.layer.infoj ??= [{ field: location.layer.qID }]
 
-  //Delete any edit flag in the config if the layer uses featureLocation
-  if (location.layer.featureLocation) {
-    location.layer.infoj.forEach(entry => {
-      delete entry.edit;
-    });
-  }
-
   // Parse and clone the infoj and response data.
   location.infoj = location.layer.infoj?.map(_entry => ({
     ...structuredClone(_entry),

--- a/lib/location/get.mjs
+++ b/lib/location/get.mjs
@@ -164,42 +164,46 @@ export async function getInfoj(location) {
 
 
 /**
-* Retrieves a feature either from local cache or remote API based on location parameters
-* 
-* @async
-* @param {Object} location - The location object containing feature lookup parameters
-* @param {layer} location.layer - Layer information containing features and metadata
-* @param {boolean} layer.featureLocation - Flag indicating if features are cached locally
-* @param {Array} layer.features - Array of cached feature objects if available locally
-* @param {string} location.id - ID of the feature to retrieve
-* @param {string} location.getTemplate - Template name for API query
-* @param {string} location.locale - Locale setting for API query
-* @param {string} location.table - Table name for API query
-* @param {Object} location.layer - Layer configuration
-* @param {string} layer.Key - Primary layer key identifier
-* @param {string} layer.key - Fallback layer key identifier
-* 
-* @returns {Promise<Object|null>} A promise that resolves to either:
-*   - An object containing the feature geometry and properties if found
-*   - null if no matching feature is found locally
-*   - API response if fetched remotely
-* 
-* @example
-* const location = {
-*   layer: {
-*     featureLocation: true,
-*     features: [{properties: {id: '123'}, geometry: {...}}]
-*   },
-*   id: '123',
-*   getTemplate: 'default',
-*   locale: 'en',
-*   table: 'locations'
-* };
-* const feature = await getFeatureResponse(location);
+@function getFeatureResponse
+@async
+@description
+Retrieves a feature either from local cache or remote API based on location parameters
+
+```js
+const location = {
+  layer: {
+    featureLocation: true,
+    features: [{properties: {id: '123'}, geometry: {...}}]
+  },
+  id: '123',
+  getTemplate: 'default',
+  locale: 'en',
+  table: 'locations'
+};
+const feature = await getFeatureResponse(location);
+```
+
+@param {Object} location The location object containing feature lookup parameters
+@property {layer} location.layer Layer information containing features and metadata
+@property {boolean} [layer.featureLocation] Flag indicating if features are cached locally
+@property {Array} [layer.features] Array of cached feature objects if available locally; Required for layer.featureLocation
+@property {string} location.id ID of the feature to retrieve
+@property {string} location.getTemplate Template name for API query
+@property {string} location.locale Locale setting for API query
+@property {string} location.table Table name for API query
+@property {string} layer.Key Primary layer key identifier
+@property {string} layer.key Fallback layer key identifier
+
+@returns {Promise<Object|null>} A promise that resolves to either:
+- An object containing the feature geometry and properties if found
+- null if no matching feature is found locally
+- API response if fetched remotely
 */
 async function getFeatureResponse(location) {
+
   // Check if features are already available locally
   if (location.layer.featureLocation) {
+
     const feature = location.layer.features
       .find(feature => feature.properties[location.layer.qID] === location.id);
 

--- a/lib/location/get.mjs
+++ b/lib/location/get.mjs
@@ -26,12 +26,12 @@ The getInfoj() method is awaited before the location is decorated.
 
 @param {object} location
 @param {object} list Object in which locations are stored as properties.
-@property {layer} location.layer The layer to which the location belongs.
+@property {layer} [location.layer] The layer to which the location belongs.
 @property {string} location.id The ID must be unique for the layer dataset.
 @property {Array} [layer.infoj] The infoj array from the layer, this is required to decorate the location.
-@property {mapview} layer.mapview 
-@property {object} mapview.interaction The current [highlight] interaction.
-@property {boolean} mapview.hooks Hooks are enabled for the location.layer.mapview.
+@property {mapview} [layer.mapview] 
+@property {object} [mapview.interaction] The current [highlight] interaction.
+@property {boolean} [mapview.hooks] Hooks are enabled for the location.layer.mapview.
 @returns {Promise<object>} Decorated location
 */
 const locations = new Set()

--- a/lib/mapview/addLayer.mjs
+++ b/lib/mapview/addLayer.mjs
@@ -51,7 +51,7 @@ export default async function addLayer(layers) {
 
     // The layer.err is an array of errors from failing to retrieve templates asscoiated with a layer.
     layer.err && console.error(layer.err)
-   
+
     // A default zIndex is assigned from the loop index to ensure layers are drawn in the order without an implicit zIndex.
     layer.zIndex ??= i
 

--- a/lib/ui/layers/listview.mjs
+++ b/lib/ui/layers/listview.mjs
@@ -1,20 +1,29 @@
 /**
-## mapp.ui.layers.listview
-
+* @module /ui/layers/listview
+### Listview
 The ui/layers/filters module exports the listview method to mapp.ui.layers{}.
 
-Dictionary entries:
-- layer_group_hide_layers
-
-@requires /dictionary 
-
-@module /ui/layers/listview
+* - Dictionary entries:
+*     1. layer_group_hide_layers
+* @requires /dictionary
 */
 
-export default function (params) {
-
+/**
+* Creates a listview for organizing and displaying map layers, optionally grouped
+* @function listview
+* @param {Object} params - Configuration parameters
+* @param {Object} [params.layers] - Map of layer objects to be added to the listview
+* @param {HTMLElement} [params.target] - DOM element where the listview will be rendered
+* @returns {void}
+* 
+* @example
+* mapp.ui.layers.listview({
+*   layers: myLayers,
+*   target: document.getElementById('layer-list')
+* });
+*/
+export default function listview(params) {
   if (!params.layers)
-
     if (!params.target) return
 
   const listview = {
@@ -22,24 +31,28 @@ export default function (params) {
     groups: {}
   }
 
-  // Loop through the layers and add to layers list.
+  // Loop through the layers and add to layers list
   Object.values(params.layers).forEach(layer => add(layer))
 
   /** 
+   * Adds a layer to the layers list
    * @function add
-   * @description
-   * Adds a layer to the layers list.
-   * @param {Object} layer The layer object.
+   * @param {layer} layer - The layer object to add
+   * @param {boolean} [layer.hidden] - If true, layer will not be added to view
+   * @param {string} [layer.group] - Group name to organize layer under
+   * @param {string} [layer.groupClassList] - CSS classes to apply to layer's group
+   * @param {string} [layer.groupmeta] - HTML content for group metadata
+   * @param {HTMLElement} layer.view - Layer's view element
+   * @param {Function[]} layer.showCallbacks - Callbacks to execute when layer is shown 
+   * @param {Function[]} layer.hideCallbacks - Callbacks to execute when layer is hidden
+   * @fires addLayerView
    * @returns {void}
-  */
-
-  // Loop through the layers and add to layers list.
+   */
   function add(layer) {
-
-    // Do not create a layer view.
+    // Do not create a layer view
     if (layer.hidden) return;
 
-    // Create the layer view.
+    // Create the layer view
     mapp.ui.layers.view(layer)
 
     if (!layer.group) {
@@ -50,89 +63,85 @@ export default function (params) {
       return
     }
 
-    // Create new layer group if group does not exist yet.
+    // Create new layer group if group does not exist yet
     if (!listview.groups[layer.group]) createGroup(layer)
 
-    // Add layer to group.
+    // Add layer to group
     listview.groups[layer.group].addLayer(layer)
-
     listview.node.dispatchEvent(new CustomEvent('addLayerView', {
       detail: layer
     }))
   }
 
   /** 
+   * Creates a group object and assigns the layer group to the listview object
    * @function createGroup
-   * @description
-   * Creates a group object and assigns the layer group to the listview object.
-   * @param {Object} layer The layer object.
+   * @param {layer} layer - The layer object that defines the group
+   * @param {string} layer.group - Name of the group to create
+   * @param {string} [layer.groupClassList] - CSS classes to apply to group
+   * @param {string} [layer.groupmeta] - HTML content for group metadata
    * @returns {void}
-  */
+   */
   function createGroup(layer) {
-
-    // Create group object.
+    // Create group object
     const group = {
       list: []
     }
 
-    // Assign layer group to listview object.
+    // Assign layer group to listview object 
     listview.groups[layer.group] = group
 
-    // Create hide all group layers button.
+    // Create hide all group layers button
     const hideLayers = mapp.utils.html.node`
-      <button
-        class="mask-icon on visibility-off"
-        title=${mapp.dictionary.layer_group_hide_layers}
-        onclick=${e => {
-
+     <button
+       class="mask-icon on visibility-off"
+       title=${mapp.dictionary.layer_group_hide_layers}
+       onclick=${e => {
         e.target.style.visibility = 'hidden'
-
         group.list
           .filter(layer => layer.display)
           .forEach(layer => layer.hide())
-
       }}>`
 
     group.meta = mapp.utils.html.node`<div class="meta">`
-
     group.drawer = mapp.ui.elements.drawer({
       data_id: layer.group,
       class: `layer-group ${layer.groupClassList || ''}`,
       header: mapp.utils.html`
-        <h2>${layer.group}</h2>
-        ${hideLayers}
-        <div class="mask-icon expander"></div>`,
+       <h2>${layer.group}</h2>
+       ${hideLayers}
+       <div class="mask-icon expander"></div>`,
       content: group.meta
     })
 
     listview.node.appendChild(group.drawer)
 
-    // Check whether some layers group are visible and toggle visible button display accordingly.
+    /**
+     * Checks if any layers in group are visible and toggles visibility button accordingly
+     * @function group.chkVisibleLayer
+     * @private
+     */
     group.chkVisibleLayer = () => {
-
       hideLayers.style.visibility = group.list.some(layer => layer.display) ?
         'visible' : 'hidden'
     }
 
+    /**
+     * Adds a layer to this group
+     * @function group.addLayer
+     * @param {layer} layer - Layer to add to the group
+     */
     group.addLayer = (layer) => {
-
       layer.group = group
-
       if (layer.groupmeta) {
         const metaContent = group.meta.appendChild(mapp.utils.html.node`<div>`)
         metaContent.innerHTML = layer.groupmeta
       }
-
       group.list.push(layer)
-
       group.drawer.appendChild(layer.view)
-
       group.chkVisibleLayer()
-
       layer.showCallbacks.push(() => group.chkVisibleLayer())
-
       layer.hideCallbacks.push(() => group.chkVisibleLayer())
     }
-
   }
 }

--- a/lib/ui/layers/listview.mjs
+++ b/lib/ui/layers/listview.mjs
@@ -11,7 +11,7 @@ Dictionary entries:
 @module /ui/layers/listview
 */
 
-export default function  (params) {
+export default function (params) {
 
   if (!params.mapview) return
 

--- a/lib/ui/layers/listview.mjs
+++ b/lib/ui/layers/listview.mjs
@@ -13,9 +13,9 @@ Dictionary entries:
 
 export default function (params) {
 
-  if (!params.mapview) return
+  if (!params.layers)
 
-  if (!params.target) return
+    if (!params.target) return
 
   const listview = {
     node: params.target,
@@ -23,8 +23,7 @@ export default function (params) {
   }
 
   // Loop through the layers and add to layers list.
-  Object.values(params.mapview.layers).forEach(layer => add(layer))
-
+  Object.values(params.layers).forEach(layer => add(layer))
 
   /** 
    * @function add

--- a/lib/ui/layers/listview.mjs
+++ b/lib/ui/layers/listview.mjs
@@ -1,11 +1,8 @@
 /**
 * @module /ui/layers/listview
-### Listview
-The ui/layers/filters module exports the listview method to mapp.ui.layers{}.
-
-* - Dictionary entries:
-*     1. layer_group_hide_layers
-* @requires /dictionary
+* @description
+* ### /ui/layers/listview 
+* The ui/layers/filters module exports the listview method to mapp.ui.layers{}.
 */
 
 /**

--- a/lib/ui/layers/listview.mjs
+++ b/lib/ui/layers/listview.mjs
@@ -91,9 +91,9 @@ function add(layer) {
 /** 
 @function createGroup
 @param {layer} layer The layer to add to a group.
-@param {string} layer.group Group key.
-@param {string} [layer.groupClassList] CSS classes to apply to group
-@param {string} [layer.groupmeta] HTML content for group metadata
+@property {string} layer.group Group key.
+@property {string} [layer.groupClassList] CSS classes to apply to group
+@property {string} [layer.groupmeta] HTML content for group metadata
 */
 function createGroup(layer) {
 

--- a/lib/ui/layers/listview.mjs
+++ b/lib/ui/layers/listview.mjs
@@ -1,144 +1,164 @@
 /**
-* @module /ui/layers/listview
-* @description
-* ### /ui/layers/listview 
-* The ui/layers/filters module exports the listview method to mapp.ui.layers{}.
+## /ui/layers/listview 
+
+The module exports the default listview method.
+
+@requires /mapp/ui/layers/view
+
+@module /ui/layers/listview
 */
 
 /**
-* Creates a listview for organizing and displaying map layers, optionally grouped
-* @function listview
-* @param {Object} params - Configuration parameters
-* @param {Object} [params.layers] - Map of layer objects to be added to the listview
-* @param {HTMLElement} [params.target] - DOM element where the listview will be rendered
-* @returns {void}
-* 
-* @example
-* mapp.ui.layers.listview({
-*   layers: myLayers,
-*   target: document.getElementById('layer-list')
-* });
+@function listview
+
+@description
+Creates a listview for organizing and displaying map layers, optionally grouped.
+
+A HTMLelement target property must be provided for the listview element to be rendered into.
+
+An initial list of decorated mapview layers is optional since layers can be added to the listview object through the add method.
+
+The listview method is a decorator which returns the decorated listview object.
+
+```js
+mapp.ui.layers.listview({
+  layers: mapview.layers,
+  target: document.getElementById('layer-list')
+});
+```
+
+@param {Object} params - Configuration parameters
+@property {HTMLElement} params.target DOM element where the listview will be rendered
+@property {Object} [params.layers] - Map of layer objects to be added to the listview
 */
 export default function listview(params) {
-  if (!params.layers)
-    if (!params.target) return
+
+  if (!params.target) return;
 
   const listview = {
     node: params.target,
-    groups: {}
+    groups: {},
+    add,
+    createGroup
   }
 
-  // Loop through the layers and add to layers list
-  Object.values(params.layers).forEach(layer => add(layer))
+  if (typeof params.layers === 'object' && Object.values(params.layers).length) {
 
-  /** 
-   * Adds a layer to the layers list
-   * @function add
-   * @param {layer} layer - The layer object to add
-   * @param {boolean} [layer.hidden] - If true, layer will not be added to view
-   * @param {string} [layer.group] - Group name to organize layer under
-   * @param {string} [layer.groupClassList] - CSS classes to apply to layer's group
-   * @param {string} [layer.groupmeta] - HTML content for group metadata
-   * @param {HTMLElement} layer.view - Layer's view element
-   * @param {Function[]} layer.showCallbacks - Callbacks to execute when layer is shown 
-   * @param {Function[]} layer.hideCallbacks - Callbacks to execute when layer is hidden
-   * @fires addLayerView
-   * @returns {void}
-   */
-  function add(layer) {
-    // Do not create a layer view
-    if (layer.hidden) return;
+    // Loop through the layers and add to layers list
+    Object.values(params.layers).forEach(layer => listview.add(layer))
+  }
 
-    // Create the layer view
-    mapp.ui.layers.view(layer)
+  return listview
+}
 
-    if (!layer.group) {
-      listview.node.appendChild(layer.view)
-      listview.node.dispatchEvent(new CustomEvent('addLayerView', {
-        detail: layer
-      }))
-      return
-    }
+/** 
+@function add
 
-    // Create new layer group if group does not exist yet
-    if (!listview.groups[layer.group]) createGroup(layer)
+@description
+The add method creates a layer.view and adds this to the listview.
 
-    // Add layer to group
-    listview.groups[layer.group].addLayer(layer)
-    listview.node.dispatchEvent(new CustomEvent('addLayerView', {
+@param {layer} layer - The layer object to add
+@property {boolean} [layer.hidden] Do not create a layer.view and shortcircuit.
+@property {string} [layer.group] Create a layer group and or add the layer to an existing listview.group
+@fires addLayerView
+*/
+function add(layer) {
+
+  // Do not create a layer view
+  if (layer.hidden) return;
+
+  // Create the layer view
+  mapp.ui.layers.view(layer)
+
+  if (!layer.group) {
+    this.node.appendChild(layer.view)
+    this.node.dispatchEvent(new CustomEvent('addLayerView', {
       detail: layer
     }))
+    return
   }
 
-  /** 
-   * Creates a group object and assigns the layer group to the listview object
-   * @function createGroup
-   * @param {layer} layer - The layer object that defines the group
-   * @param {string} layer.group - Name of the group to create
-   * @param {string} [layer.groupClassList] - CSS classes to apply to group
-   * @param {string} [layer.groupmeta] - HTML content for group metadata
-   * @returns {void}
-   */
-  function createGroup(layer) {
-    // Create group object
-    const group = {
-      list: []
-    }
+  // Create new layer group if group does not exist yet
+  if (!this.groups[layer.group]) this.createGroup(layer)
 
-    // Assign layer group to listview object 
-    listview.groups[layer.group] = group
+  // Add layer to group
+  this.groups[layer.group].addLayer(layer)
+  this.node.dispatchEvent(new CustomEvent('addLayerView', {
+    detail: layer
+  }))
+}
 
-    // Create hide all group layers button
-    const hideLayers = mapp.utils.html.node`
-     <button
-       class="mask-icon on visibility-off"
-       title=${mapp.dictionary.layer_group_hide_layers}
-       onclick=${e => {
-        e.target.style.visibility = 'hidden'
-        group.list
-          .filter(layer => layer.display)
-          .forEach(layer => layer.hide())
-      }}>`
+/** 
+@function createGroup
+@param {layer} layer The layer to add to a group.
+@param {string} layer.group Group key.
+@param {string} [layer.groupClassList] CSS classes to apply to group
+@param {string} [layer.groupmeta] HTML content for group metadata
+*/
+function createGroup(layer) {
 
-    group.meta = mapp.utils.html.node`<div class="meta">`
-    group.drawer = mapp.ui.elements.drawer({
-      data_id: layer.group,
-      class: `layer-group ${layer.groupClassList || ''}`,
-      header: mapp.utils.html`
+  // Create group object
+  const group = {
+    list: []
+  }
+
+  // Assign layer group to listview object 
+  this.groups[layer.group] = group
+
+  // Create hide all group layers button
+  group.hideLayers = mapp.utils.html.node`<button
+    class="mask-icon on visibility-off"
+    title=${mapp.dictionary.layer_group_hide_layers}
+    onclick=${e => {
+      e.target.style.visibility = 'hidden'
+      group.list
+        .filter(layer => layer.display)
+        .forEach(layer => layer.hide())
+    }}>`
+
+  group.meta = mapp.utils.html.node`<div class="meta">`
+  group.drawer = mapp.ui.elements.drawer({
+    data_id: layer.group,
+    class: `layer-group ${layer.groupClassList || ''}`,
+    header: mapp.utils.html`
        <h2>${layer.group}</h2>
-       ${hideLayers}
+       ${group.hideLayers}
        <div class="mask-icon expander"></div>`,
-      content: group.meta
-    })
+    content: group.meta
+  })
 
-    listview.node.appendChild(group.drawer)
+  this.node.appendChild(group.drawer)
 
-    /**
-     * Checks if any layers in group are visible and toggles visibility button accordingly
-     * @function group.chkVisibleLayer
-     * @private
-     */
-    group.chkVisibleLayer = () => {
-      hideLayers.style.visibility = group.list.some(layer => layer.display) ?
-        'visible' : 'hidden'
-    }
+  group.chkVisibleLayer = chkVisibleLayer
 
-    /**
-     * Adds a layer to this group
-     * @function group.addLayer
-     * @param {layer} layer - Layer to add to the group
-     */
-    group.addLayer = (layer) => {
-      layer.group = group
-      if (layer.groupmeta) {
-        const metaContent = group.meta.appendChild(mapp.utils.html.node`<div>`)
-        metaContent.innerHTML = layer.groupmeta
-      }
-      group.list.push(layer)
-      group.drawer.appendChild(layer.view)
-      group.chkVisibleLayer()
-      layer.showCallbacks.push(() => group.chkVisibleLayer())
-      layer.hideCallbacks.push(() => group.chkVisibleLayer())
-    }
+  group.addLayer = addLayerToGroup
+}
+
+/**
+@function addLayer
+@description
+Adds a layer to this group
+@param {layer} layer Layer to add to the group
+*/
+function addLayerToGroup(layer) {
+  layer.group = this
+  if (layer.groupmeta) {
+    const metaContent = this.meta.appendChild(mapp.utils.html.node`<div>`)
+    metaContent.innerHTML = layer.groupmeta
   }
+  this.list.push(layer)
+  this.drawer.appendChild(layer.view)
+  this.chkVisibleLayer()
+  layer.showCallbacks.push(() => this.chkVisibleLayer())
+  layer.hideCallbacks.push(() => this.chkVisibleLayer())
+}
+
+/**
+@function chkVisibleLayer
+@description
+Checks if any layers in group are visible and toggles visibility button accordingly
+*/
+function chkVisibleLayer() {
+  this.hideLayers.style.visibility = this.list.some(layer => layer.display)
+    ? 'visible' : 'hidden';
 }

--- a/lib/ui/locations/listview.mjs
+++ b/lib/ui/locations/listview.mjs
@@ -12,7 +12,7 @@ Dictionary entries:
 @module /ui/locations/listview
 */
 
- /** 
+/** 
 @global
 @typedef {Object} locale
 Object containing the details of the locale i.e. layer definitions, plugins, etc.
@@ -130,11 +130,11 @@ export default function listview(params) {
       class="tab-display bold primary-colour text-shadow"
       onclick=${e => {
 
-        // Remove all mapview locations
-        Object.values(params.mapview.locations)
-          .forEach(location => location.remove())
+      // Remove all mapview locations
+      Object.values(params.mapview.locations)
+        .forEach(location => location.remove())
 
-      }}>
+    }}>
       ${mapp.dictionary.location_clear_all}`)
 
   // Create proxy for mapview.locations
@@ -178,7 +178,7 @@ export default function listview(params) {
     if (!record) {
 
       alert(mapp.dictionary.location_listview_full)
-      return true; 
+      return true;
     }
 
     // Proxy default.

--- a/lib/ui/locations/view.mjs
+++ b/lib/ui/locations/view.mjs
@@ -1,6 +1,6 @@
 /**
 @module /ui/locations/view
-
+@description
 Dictionary entries:
 - location_zoom
 - location_save
@@ -90,9 +90,9 @@ export default function view(location) {
 
     const changesUnsaved = location.infoj.some(entry => typeof entry.newValue !== 'undefined');
 
-    if(changesUnsaved) {
+    if (changesUnsaved) {
 
-      const confirm = await mapp.ui.elements.confirm({text: mapp.dictionary.location_close_without_save})
+      const confirm = await mapp.ui.elements.confirm({ text: mapp.dictionary.location_close_without_save })
 
       if (!confirm) return;
     }
@@ -206,19 +206,19 @@ function toggleLocationViewEdits(location) {
     // Check for unsaved edits
     const unsavedChanges = location.infoj.some(entry => typeof entry.newValue !== 'undefined');
 
-    if(unsavedChanges) {
+    if (unsavedChanges) {
       // There are edits to be saved.
-      const confirm = await mapp.ui.elements.confirm({text: mapp.dictionary.location_save_changes})
+      const confirm = await mapp.ui.elements.confirm({ text: mapp.dictionary.location_save_changes })
 
-      if(confirm) {
+      if (confirm) {
 
         const update = await location.update()
-        
+
         // The update may err due to invalid entries.
         if (update instanceof Error) return;
 
       }
-      
+
 
     } else if (e.target.classList.toggle('on')) {
 

--- a/lib/ui/locations/view.mjs
+++ b/lib/ui/locations/view.mjs
@@ -1,6 +1,8 @@
 /**
-@module /ui/locations/view
-@description
+## /ui/locations/view
+
+The module exports a default method to create a location view to be added to a locations listview.
+
 Dictionary entries:
 - location_zoom
 - location_save
@@ -10,6 +12,7 @@ Dictionary entries:
 - location_save_changes
 @requires /dictionary 
 
+@module /ui/locations/view
 */
 
 /**
@@ -19,6 +22,8 @@ Dictionary entries:
 The view method creates a location view element group.
 
 @param {location} location A mapp location object.
+@property {Object} location.record A location is stored in a record object in the mapview.locations object.
+@property {Array} [location.removeCallbacks] An array of methods which will be executed when a location is removed.
 
 @returns {HTMLElement} The location.view element.
 */

--- a/public/tests/_base.test.mjs
+++ b/public/tests/_base.test.mjs
@@ -359,7 +359,7 @@ export async function base() {
         // Create layers listview.
         mapp.ui.layers.listview({
             target: layersTab,
-            mapview: mapview,
+            layers: mapview.layers
         });
 
         // Create locations listview.

--- a/public/views/_default.html
+++ b/public/views/_default.html
@@ -545,7 +545,7 @@
   // Create layers listview.
   mapp.ui.layers.listview({
     target: layersTab,
-    mapview: mapview,
+    layers: locale.layers,
   });
 
   // Create locations listview.

--- a/public/views/_default.html
+++ b/public/views/_default.html
@@ -545,7 +545,7 @@
   // Create layers listview.
   mapp.ui.layers.listview({
     target: layersTab,
-    layers: locale.layers,
+    layers: mapview.layers,
   });
 
   // Create locations listview.

--- a/tests/assets/data/uk.json
+++ b/tests/assets/data/uk.json
@@ -38,7 +38,11 @@
       "properties": {
         "id": 1,
         "name": "Greater London",
-        "description": "A polygon covering central London"
+        "description": "A polygon covering central London",
+        "pin": [
+          -0.1625,
+          51.5
+        ]
       }
     },
     {
@@ -54,7 +58,11 @@
       "properties": {
         "id": 2,
         "name": "Manchester City Centre",
-        "description": "Point marking Manchester city centre"
+        "description": "Point marking Manchester city centre",
+        "pin": [
+          -2.2426,
+          53.4808
+        ]
       }
     },
     {
@@ -94,7 +102,11 @@
       "properties": {
         "id": 3,
         "name": "Edinburgh Castle Area",
-        "description": "Area around Edinburgh Castle"
+        "description": "Area around Edinburgh Castle",
+        "pin": [
+          -3.201,
+          55.949
+        ]
       }
     },
     {
@@ -127,7 +139,11 @@
       "properties": {
         "id": 4,
         "name": "Cardiff Bay Walk",
-        "description": "Walking path along Cardiff Bay"
+        "description": "Walking path along Cardiff Bay",
+        "pin": [
+          -3.16,
+          51.464
+        ]
       }
     },
     {
@@ -167,7 +183,11 @@
       "properties": {
         "id": 5,
         "name": "Belfast Harbour",
-        "description": "Area covering Belfast Harbour"
+        "description": "Area covering Belfast Harbour",
+        "pin": [
+          -5.915,
+          54.613
+        ]
       }
     },
     {
@@ -191,7 +211,7 @@
             0
           ],
           [
-            -3,
+            -3.0,
             53.408,
             0
           ]
@@ -200,7 +220,11 @@
       "properties": {
         "id": 6,
         "name": "Liverpool Docks",
-        "description": "Path along Liverpool's famous docks"
+        "description": "Path along Liverpool's famous docks",
+        "pin": [
+          -3.002,
+          53.407
+        ]
       }
     },
     {
@@ -240,7 +264,11 @@
       "properties": {
         "id": 7,
         "name": "Glasgow City Center",
-        "description": "Central area of Glasgow"
+        "description": "Central area of Glasgow",
+        "pin": [
+          -4.265,
+          55.8605
+        ]
       }
     },
     {
@@ -256,7 +284,11 @@
       "properties": {
         "id": 8,
         "name": "Oxford University",
-        "description": "Central point of Oxford University"
+        "description": "Central point of Oxford University",
+        "pin": [
+          -1.2544,
+          51.7548
+        ]
       }
     },
     {
@@ -289,7 +321,11 @@
       "properties": {
         "id": 9,
         "name": "Brighton Beach",
-        "description": "Brighton Beach shoreline"
+        "description": "Brighton Beach shoreline",
+        "pin": [
+          -0.14,
+          50.821
+        ]
       }
     },
     {
@@ -329,7 +365,11 @@
       "properties": {
         "id": 10,
         "name": "Cambridge City Center",
-        "description": "Historic center of Cambridge"
+        "description": "Historic center of Cambridge",
+        "pin": [
+          0.1175,
+          52.2075
+        ]
       }
     }
   ]

--- a/tests/assets/layers/geojson/layer.json
+++ b/tests/assets/layers/geojson/layer.json
@@ -12,6 +12,7 @@
             "field": "pin"
         },
         {
+            "edit": true,
             "field": "name"
         },
         {
@@ -30,7 +31,9 @@
             }
         },
         "highlight": {
-            "scale": 1.3
+            "scale": 1.3,
+            "strokeWidth": 2,
+            "strokeColor": "hotpink"
         }
     }
 }

--- a/tests/assets/layers/geojson/layer.json
+++ b/tests/assets/layers/geojson/layer.json
@@ -13,10 +13,14 @@
         },
         {
             "edit": true,
-            "field": "name"
+            "field": "name",
+            "inline": true,
+            "title": "name"
         },
         {
-            "field": "description"
+            "field": "description",
+            "inline": true,
+            "title": "description"
         }
     ],
     "style": {

--- a/tests/assets/layers/geojson/layer.json
+++ b/tests/assets/layers/geojson/layer.json
@@ -2,7 +2,6 @@
     "key": "geojson_test",
     "format": "geojson",
     "display": true,
-    "group": "layer",
     "geom": "geometry",
     "srid": "4326",
     "qID": "id",
@@ -10,8 +9,7 @@
         {
             "type": "pin",
             "label": "ST_PointOnSurface",
-            "field": "pin",
-            "srid": "3857"
+            "field": "pin"
         },
         {
             "field": "name"

--- a/tests/lib/layer/decorate.test.mjs
+++ b/tests/lib/layer/decorate.test.mjs
@@ -33,6 +33,7 @@ export async function decorateTest(mapview, layer, infoj, style) {
         ]
 
         layer = {
+            key: 'decorate_test',
             mapview: mapview,
             ...infoj,
             infoj_skip: infoj_skip,
@@ -119,16 +120,6 @@ export async function decorateTest(mapview, layer, infoj, style) {
         await codi.it('Should get geom_3857 geom at zoom level 11', async () => {
             const geom = layer.geomCurrent();
             codi.assertTrue(typeof geom === 'string', 'The geometry should be returned from the layer')
-        });
-
-        /**
-         * ### Should be able to zoomToExtent
-         * 1. We call the `zoomToExtent()` function.
-         * 2. We assert that the return is a success.
-         */
-        await codi.it('Should be able to zoomToExtent', async () => {
-            const success = await layer.zoomToExtent();
-            codi.assertTrue(success, 'We should see the layer zoom to extent')
         });
 
     });

--- a/tests/lib/layer/format/vector.test.mjs
+++ b/tests/lib/layer/format/vector.test.mjs
@@ -18,6 +18,48 @@ export async function vectorTest(mapview, layer) {
 
     await codi.describe('Layer Format: Vector', async () => {
 
+        codi.it('Should create a geojson layer', async () => {
+            const custom_config = {
+                key: 'geojson_test',
+                featureLocation: true
+            }
+
+            const layer_params = {
+                ...geojsonLayerDefault,
+                ...custom_config
+            }
+
+            layer_params.features = ukFeatures.features;
+
+            layer_params.params = {
+                fields: ['id', 'name', 'description', 'geom_4326']
+            }
+
+
+            const layer = await mapview.addLayer(layer_params);
+
+            const layersTab = document.getElementById('layers');
+
+            const layers = {
+                [custom_config.key]: mapview.layers[custom_config.key]
+            }
+
+            // Create layers listview.
+            mapp.ui.layers.listview({
+                target: layersTab,
+                layers: layers
+            });
+
+            codi.assertTrue(Object.hasOwn(layer[0], 'show'), 'The layer should have a show function');
+            codi.assertTrue(Object.hasOwn(layer[0], 'display'), 'The layer should have a display property');
+            codi.assertTrue(Object.hasOwn(layer[0], 'hide'), 'The layer should have a hide function');
+            codi.assertTrue(Object.hasOwn(layer[0], 'reload'), 'The layer should have a reload function');
+            codi.assertTrue(Object.hasOwn(layer[0], 'tableCurrent'), 'The layer should have a tableCurrent function');
+
+            layer[0].hide();
+
+        });
+
         /**
        * ### Should be able to custom vector layer
        * 1. It takes layer params.
@@ -42,17 +84,21 @@ export async function vectorTest(mapview, layer) {
             layer_params.features = ukFeatures.features;
 
             layer_params.params = {
-                fields: ['id', 'name', 'description', 'geom_4326']
+                fields: ['id', 'pin', 'name', 'description', 'geom_4326']
             }
 
             const layer = await mapview.addLayer(layer_params);
 
             const layersTab = document.getElementById('layers');
 
+            const layers = {
+                [custom_config.key]: mapview.layers[custom_config.key]
+            }
+
             // Create layers listview.
             mapp.ui.layers.listview({
                 target: layersTab,
-                mapview: mapview,
+                layers: layers
             });
 
             codi.assertTrue(Object.hasOwn(layer[0], 'show'), 'The layer should have a show function');
@@ -60,6 +106,8 @@ export async function vectorTest(mapview, layer) {
             codi.assertTrue(Object.hasOwn(layer[0], 'hide'), 'The layer should have a hide function');
             codi.assertTrue(Object.hasOwn(layer[0], 'reload'), 'The layer should have a reload function');
             codi.assertTrue(Object.hasOwn(layer[0], 'tableCurrent'), 'The layer should have a tableCurrent function');
+
+            layer[0].hide();
 
         });
 
@@ -79,36 +127,10 @@ function customFeatureFormat(layer, features) {
             featureProjection: 'EPSG:' + layer.mapview.srid,
         });
 
-        // Get point on surface coordinates
-        const pointOnSurface = getPointOnSurface(olGeometry);
-
-        // Add pointOnSurface to properties if needed
-        feature.properties = {
-            ...feature.properties,
-            pin: pointOnSurface
-        };
-
         return new ol.Feature({
             id: feature.id,
             geometry: olGeometry,
             ...feature.properties
         });
     });
-}
-
-function getPointOnSurface(geometry) {
-    if (geometry instanceof ol.geom.Point) {
-        const coords = geometry.getCoordinates();
-        return [coords[0], coords[1]];
-    }
-
-    if (geometry instanceof ol.geom.Polygon ||
-        geometry instanceof ol.geom.MultiPolygon) {
-        const coords = geometry.getInteriorPoint().getCoordinates();
-        return [coords[0], coords[1]];
-    }
-
-    const extent = geometry.getExtent();
-    const center = ol.extent.getCenter(extent);
-    return [center[0], center[1]];
 }

--- a/tests/lib/layer/format/vector.test.mjs
+++ b/tests/lib/layer/format/vector.test.mjs
@@ -3,7 +3,6 @@
  * @module layer/format/vector
  */
 
-import clusterLayerDefault from '../../../assets/layers/cluster/layer.json';
 import geojsonLayerDefault from '../../../assets/layers/geojson/layer.json';
 import ukFeatures from '../../../assets/data/uk.json';
 
@@ -12,9 +11,7 @@ import ukFeatures from '../../../assets/data/uk.json';
  * @function vectorTest 
  * @param {object} mapview 
  */
-export async function vectorTest(mapview, layer) {
-
-    layer ??= clusterLayerDefault;
+export async function vectorTest(mapview) {
 
     await codi.describe('Layer Format: Vector', async () => {
 

--- a/tests/lib/location/get.test.mjs
+++ b/tests/lib/location/get.test.mjs
@@ -23,7 +23,6 @@ export async function getTest(mapview) {
                 id: 6,
             });
 
-            codi.assertEqual(location.infoj.length, 4, 'We expect to see three infoj entries');
             codi.assertEqual(location.record.hook, 'location_get_test!6', 'We expect a hook made up of layer key and id');
             codi.assertTrue(location.layer instanceof Object, 'The location needs a layer object');
 

--- a/tests/lib/ui/layers/panels/filter.test.mjs
+++ b/tests/lib/ui/layers/panels/filter.test.mjs
@@ -24,6 +24,8 @@ export function panelFilterTest() {
                 filter: {
                     current: {}
                 },
+                hideCallbacks: [],
+                showCallbacks: [],
                 infoj: [
                     {
                         'field': 'field_1',


### PR DESCRIPTION
# get location from feature

We have added in the ability to add features directly from a file or response onto a layer and provid a location from the `getInfoj` method in the `location/get.mjs` module.
A flag `featureLocation` has been introduced to the layer indicating that the layer will have featureLocations on it.

In the location/get.mjs module a new function `getFeatureResponse` has been introduced to help with returing a response from a getTemplate request or returned feature from the layer itself. The function will return the feature that matches the property id.

After we get the location we also remove all 'edit' flags on the infoj if it's a locationFeature as we don't want to be able to edit these.
I updated the `vector.test.mjs` to showcase this.

The `ui/layers/listview.mjs` has also been reviewed and updated.
The method no longer takes the entire `mapview`, but just the layers defined on the `mapview`. This changes allow us to append to the layer list instead of adding in every layer already defined on the `mapview`.
