### PR TITLE
Tabview BtnRow must be set to display block in the `activate`

### DIFF
--- a/lib/ui/Tabview.mjs
+++ b/lib/ui/Tabview.mjs
@@ -78,10 +78,10 @@ function addTab(entry) {
 
   const tabview = this
 
-  entry.activate ??= function(){
+  entry.activate ??= function () {
 
     if (entry.create === undefined) {
-     
+
       entry.create ??= function () {
         mapp.ui.utils[entry.dataview]?.create(entry);
       }
@@ -101,26 +101,29 @@ function addTab(entry) {
         entry.update()
       }
     }
+
+    //Show toolbar buttons if there are any
+    entry.btnRow?.style.setProperty('display', 'block')
   }
 
   if (entry.location) {
- 
+
     // The tabview should be removed if the location is removed.
-    entry.location.removeCallbacks.push(()=>entry.remove())
+    entry.location.removeCallbacks.push(() => entry.remove())
 
   }
-  
+
   else if (entry.layer) {
 
     // Show tab when layer is displayed.
-    entry.layer.showCallbacks.push(()=>{
+    entry.layer.showCallbacks.push(() => {
 
       // Entry must have display flag.
       entry.display && entry.show()
     })
-  
+
     // Hide tab when layer is hidden.
-    entry.layer.hideCallbacks.push(()=>{
+    entry.layer.hideCallbacks.push(() => {
       entry.remove()
     })
   }
@@ -134,7 +137,7 @@ function addTab(entry) {
         class="header"
         style="${entry.tab_style || ''}"
         onclick=${showTab}>${entry.label}`
-   
+
   entry.panel ??= entry.target || mapp.utils.html.node`
     <div class="${`panel ${entry.class || ''}`}">`
 

--- a/lib/ui/Tabview.mjs
+++ b/lib/ui/Tabview.mjs
@@ -78,42 +78,14 @@ function addTab(entry) {
 
   const tabview = this
 
-  entry.activate ??= function () {
-
-    if (entry.create === undefined) {
-
-      entry.create ??= function () {
-        mapp.ui.utils[entry.dataview]?.create(entry);
-      }
-
-      entry.create()
-
-    } else if (entry.dynamic) {
-
-      entry.create()
-    }
-
-    if (entry.update instanceof Function) {
-
-      if (!entry.data || entry.activateUpdate) {
-
-        // Call dataview update method if data is falsy or activateUpdate flag is set.
-        entry.update()
-      }
-    }
-
-    //Show toolbar buttons if there are any
-    entry.btnRow?.style.setProperty('display', 'block')
-  }
+  entry.activate ??= activateTab
 
   if (entry.location) {
 
     // The tabview should be removed if the location is removed.
     entry.location.removeCallbacks.push(() => entry.remove())
 
-  }
-
-  else if (entry.layer) {
+  } else if (entry.layer) {
 
     // Show tab when layer is displayed.
     entry.layer.showCallbacks.push(() => {
@@ -147,6 +119,44 @@ function addTab(entry) {
 
   // Must override dataview hide method.
   entry.hide = removeTab
+
+  /**
+  @function activateTab
+
+  @description
+  The activateTab method is debounced for tabs being shown/added to a tabview. A tab may be a dataview object which requires to be created/updated within the context of the tab.
+
+  The dataview may have an associated toolbar [btnRow element] which must be displayed.
+  */
+  function activateTab() {
+
+    const entry = this;
+
+    if (entry.create === undefined) {
+
+      entry.create ??= function () {
+        mapp.ui.utils[entry.dataview]?.create(entry);
+      }
+
+      entry.create()
+
+    } else if (entry.dynamic) {
+
+      entry.create()
+    }
+
+    if (entry.update instanceof Function) {
+
+      if (!entry.data || entry.activateUpdate) {
+
+        // Call dataview update method if data is falsy or activateUpdate flag is set.
+        entry.update()
+      }
+    }
+
+    //Show toolbar buttons if there are any
+    entry.btnRow?.style.setProperty('display', 'block')
+  }
 
   /**
   @function showTab

--- a/lib/ui/Tabview.mjs
+++ b/lib/ui/Tabview.mjs
@@ -130,8 +130,6 @@ function addTab(entry) {
   */
   function activateTab() {
 
-    const entry = this;
-
     if (entry.create === undefined) {
 
       entry.create ??= function () {


### PR DESCRIPTION
The activate event method which is triggered when a tabview tab is added/shown must check for and display a toolbar associated to a dataview in the tab which is being activated.