### PR TITLE
`globalThis` replacing `self`.

### DIFF
--- a/lib/mapp.mjs
+++ b/lib/mapp.mjs
@@ -54,7 +54,7 @@ if (window.ol === undefined) {
   }
 }
 
-self.mapp = {
+globalThis.mapp = {
   ol: _ol,
 
   version: '4.13.0-alpha',

--- a/lib/ui.mjs
+++ b/lib/ui.mjs
@@ -39,8 +39,8 @@ const ui = {
   Tabview,
 };
 
+globalThis.ui = ui
+
 if (mapp) {
   mapp.ui = ui
-} else {
-  globalThis.ui = ui
 }

--- a/lib/ui.mjs
+++ b/lib/ui.mjs
@@ -29,7 +29,7 @@ import utils from './ui/utils/_utils.mjs'
 
 import Gazetteer from './ui/Gazetteer.mjs'
 
-self.ui = {
+const ui = {
   layers,
   locations,
   elements,
@@ -37,9 +37,10 @@ self.ui = {
   Gazetteer,
   Dataview,
   Tabview,
-}
+};
 
 if (mapp) {
-
   mapp.ui = ui
+} else {
+  globalThis.ui = ui
 }

--- a/public/views/_test.html
+++ b/public/views/_test.html
@@ -312,7 +312,7 @@
 
         import * as _codi from "codi";
 
-        self.codi = _codi;
+        globalThis.codi = _codi;
 
         const urlParams = new URLSearchParams(window.location.search);
         const integrity = urlParams.get('integrity');

--- a/tests/_mapp.test.mjs
+++ b/tests/_mapp.test.mjs
@@ -17,7 +17,7 @@ import { utilsTest } from './lib/utils/_utils.test.mjs';
 import { formatTest } from './lib/layer/format/_format.test.mjs';
 import { ui_locations } from './lib/ui/locations/_locations.test.mjs';
 
-self._mappTest = {
+globalThis._mappTest = {
     base,
     coreTest,
     mappTest,


### PR DESCRIPTION
# `globalThis` replacing `self`

I have replaced the self. assignment for the more moden [`globalThis`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/globalThis)

The main benefit of this is that we will be able to see the exact references and have better intelliSense for the `mapp` & `ui` objects.

Bellow are some examples of what you should see in vscode.

![image](https://github.com/user-attachments/assets/3a72bf56-2ca3-4fcb-88cd-783bc08ac70d)

![image](https://github.com/user-attachments/assets/883dcd26-c47d-49e8-80a1-a886e77ff61c)

![image](https://github.com/user-attachments/assets/b395488e-54f2-4ac8-af42-a197bed9ee21)

![image](https://github.com/user-attachments/assets/be95eda9-27ee-4133-8ca4-92db8e62f05a)