### PR TITLE
JSON Toolbar Method

### DIFF
--- a/lib/ui/utils/jsonDataview.mjs
+++ b/lib/ui/utils/jsonDataview.mjs
@@ -11,7 +11,7 @@ The jsonDataview module exports as default an object with a create method for JS
 export default {
   create,
   toolbar: {
-    button
+    jsonfile
   }
 }
 
@@ -43,16 +43,17 @@ function setData(data) {
 }
 
 /**
-@function button
+@function jsonfile
 @description
 The button method creates a button element. 
-The button element is appended to the toolbar node, and when clicked the mapp.ui.elements.alert is called with the dataview title.
+
+The button will call the textFile utility method to create a json file download.
 
 @param {dataview} dataview Dataview object.
 
 @returns {HTMLElement} Returns the button element.
 */
-function button(dataview) {
+function jsonfile(dataview) {
 
   dataview.title ??= dataview.label || 'Unknown';
 

--- a/lib/ui/utils/jsonDataview.mjs
+++ b/lib/ui/utils/jsonDataview.mjs
@@ -7,7 +7,10 @@ The jsonDataview module exports as default an object with a create method for JS
 */
 
 export default {
-  create
+  create,
+  toolbar: {
+    button
+  }
 }
 
 /**
@@ -34,4 +37,25 @@ The [json] dataview setData method sets the stringified JSON data as textcontent
 function setData(data) {
 
   this.target.textContent = JSON.stringify(data)
+}
+
+/**
+ * @function button
+ * @description
+ * The button method creates a button element. 
+ * The button element is appended to the toolbar node, and when clicked the mapp.ui.elements.alert is called with the dataview title.
+ * @param {Object} toolbar Toolbar object.
+ * 
+ * @returns {HTMLElement} Returns the button element.
+ */
+
+function button(dataview) {
+
+  const label = dataview.title || dataview.label || 'Unknown';
+
+  const button = mapp.utils.html.node`<button onclick=${() => {
+    mapp.ui.elements.alert({ title:'Dataview Pressed', text: `Dataview Pressed: ${label}` });
+  }}>${label}</button>`
+
+  return button;
 }

--- a/lib/ui/utils/jsonDataview.mjs
+++ b/lib/ui/utils/jsonDataview.mjs
@@ -3,6 +3,8 @@
 
 The jsonDataview module exports as default an object with a create method for JSON dataviews.
 
+@requires /utils/textFile
+
 @module /ui/utils/jsonDataview
 */
 
@@ -36,26 +38,34 @@ The [json] dataview setData method sets the stringified JSON data as textcontent
 */
 function setData(data) {
 
+  this.data = data
   this.target.textContent = JSON.stringify(data)
 }
 
 /**
- * @function button
- * @description
- * The button method creates a button element. 
- * The button element is appended to the toolbar node, and when clicked the mapp.ui.elements.alert is called with the dataview title.
- * @param {Object} toolbar Toolbar object.
- * 
- * @returns {HTMLElement} Returns the button element.
- */
+@function button
+@description
+The button method creates a button element. 
+The button element is appended to the toolbar node, and when clicked the mapp.ui.elements.alert is called with the dataview title.
 
+@param {dataview} dataview Dataview object.
+
+@returns {HTMLElement} Returns the button element.
+*/
 function button(dataview) {
 
-  const label = dataview.title || dataview.label || 'Unknown';
+  dataview.title ??= dataview.label || 'Unknown';
 
   const button = mapp.utils.html.node`<button onclick=${() => {
-    mapp.ui.elements.alert({ title:'Dataview Pressed', text: `Dataview Pressed: ${label}` });
-  }}>${label}</button>`
+
+    const textFile = {
+      text: JSON.stringify(dataview.data, null, 2),
+      type: 'application/json'
+    }
+  
+    mapp.utils.textFile(textFile)
+
+  }}>${dataview.title}</button>`
 
   return button;
 }

--- a/lib/ui/utils/jsonDataview.mjs
+++ b/lib/ui/utils/jsonDataview.mjs
@@ -7,10 +7,7 @@ The jsonDataview module exports as default an object with a create method for JS
 */
 
 export default {
-  create,
-  toolbar: {
-    button
-  }
+  create
 }
 
 /**
@@ -37,25 +34,4 @@ The [json] dataview setData method sets the stringified JSON data as textcontent
 function setData(data) {
 
   this.target.textContent = JSON.stringify(data)
-}
-
-/**
- * @function button
- * @description
- * The button method creates a button element. 
- * The button element is appended to the toolbar node, and when clicked the mapp.ui.elements.alert is called with the dataview title.
- * @param {Object} toolbar Toolbar object.
- * 
- * @returns {HTMLElement} Returns the button element.
- */
-
-function button(dataview) {
-
-  const label = dataview.title || dataview.label || 'Unknown';
-
-  const button = mapp.utils.html.node`<button onclick=${() => {
-    mapp.ui.elements.alert({ title:'Dataview Pressed', text: `Dataview Pressed: ${label}` });
-  }}>${label}</button>`
-
-  return button;
 }

--- a/lib/utils/_utils.mjs
+++ b/lib/utils/_utils.mjs
@@ -52,6 +52,8 @@ import * as svgSymbols from './svgSymbols.mjs'
 
 import svgTemplates from './svgTemplates.mjs'
 
+import textFile from './textFile.mjs'
+
 import * as userIndexedDB from './userIndexedDB.mjs'
 
 import * as gazetteer from './gazetteer.mjs'
@@ -91,6 +93,7 @@ export default {
   style,
   svgSymbols,
   svgTemplates,
+  textFile,
   userIndexedDB,
   verticeGeoms,
   xhr,

--- a/lib/utils/textFile.mjs
+++ b/lib/utils/textFile.mjs
@@ -1,0 +1,32 @@
+/**
+## /utils/textFile
+
+@module /utils/textFile
+*/
+
+/**
+@function textFile
+
+@description
+
+@param {Object} params 
+@property  {string} params.text
+*/
+export default function textFile(params) {
+
+  if (typeof params.text !== 'string') return;
+
+  params.filename ??= 'file.txt'
+
+  params.type ??= 'text'
+
+  const blob = new Blob([params.text], {
+    type: params.type,
+  });
+  const url = URL.createObjectURL(blob);
+  const a = document.createElement('a');
+  a.href = url;
+  a.download = `${params.filename}`;
+  a.click();
+  URL.revokeObjectURL(url);
+}

--- a/tests/assets/dataviews/dataviews_json.json
+++ b/tests/assets/dataviews/dataviews_json.json
@@ -3,6 +3,9 @@
         "json_1": {
             "display": true,
             "dataview": "Json",
+            "toolbar": {
+                "button": true
+            },
             "query": "num_999",
             "template": {
                 "key": "num_999",
@@ -15,6 +18,9 @@
             "dataview": "Json",
             "query": "num_2012",
             "target": "tabview",
+            "toolbar": {
+                "button": true
+            },
             "template": {
                 "key": "num_2012",
                 "template": "SELECT 2012 as value"

--- a/tests/assets/dataviews/dataviews_json.json
+++ b/tests/assets/dataviews/dataviews_json.json
@@ -3,9 +3,6 @@
         "json_1": {
             "display": true,
             "dataview": "Json",
-            "toolbar": {
-                "button": true
-            },
             "query": "num_999",
             "template": {
                 "key": "num_999",
@@ -18,9 +15,6 @@
             "dataview": "Json",
             "query": "num_2012",
             "target": "tabview",
-            "toolbar": {
-                "button": true
-            },
             "template": {
                 "key": "num_2012",
                 "template": "SELECT 2012 as value"


### PR DESCRIPTION


## Description

Added a simple `toolbar` method ` button` that calls the `mapp.ui.elements.alert` when clicked. 
This will allow us to test for `toolbar` functionality without requiring third party plugins. 

![image](https://github.com/user-attachments/assets/3a31748c-1aaa-449c-a327-e7c12ba7551f)

## GitHub Issue

#1744 

## Type of Change
Please delete options that are not relevant, and select all options that apply. 
- ✅ New feature (non-breaking change which adds functionality)
- ✅ Testing

## Testing Checklist 
Please delete options that are not relevant, and select all options that apply. 

- ✅ Existing Tests still pass
- ✅ Ran locally on my machine

## Code Quality Checklist
Please delete options that are not relevant, and select all options that apply. 

- ✅ My code follows the guidelines of XYZ
- ✅ My code has been commented
- ✅ Documentation has been updated
- ✅ New and existing unit tests pass locally with my changes
- ✅ Main has been merged into this PR