### PR TITLE
Infoj Order Can Be Specified on a Layer

### DIFF
--- a/lib/ui/locations/infoj.mjs
+++ b/lib/ui/locations/infoj.mjs
@@ -46,6 +46,10 @@ export default function infoj(location, infoj_order) {
   // Create object to hold view groups.
   groups = {}
 
+
+  // The infoj_order may be assigned to the layer.
+  infoj_order ??= location?.layer?.infoj_order
+
   // infoj argument is provided as an array of strings to filter the location infoj entries.
   const infoj = Array.isArray(infoj_order) ?
     infoj_order

--- a/tests/lib/ui/locations/infoj.test.mjs
+++ b/tests/lib/ui/locations/infoj.test.mjs
@@ -7,10 +7,11 @@ export function infojTest() {
     /**
      * ### It should create an infoj with a correct order
      * 1. We define an infoj with a combination of different entries with keys, fields and queries
-     * 2. We assert against the order
+     * 2. We assert against the order when calling the infoj method
+     * 3. We assert against the order when calling the infoj method with a different order as defined in the layer
      * @function it
      */
-    codi.it('It should create an infoj with certain order', () => {
+    codi.it('It should create an infoj with certain order as specified directly to the method', () => {
 
       const location = {
         infoj: [
@@ -56,6 +57,73 @@ export function infojTest() {
 
       // Get listview element from the infoj object
       const infoj = mapp.ui.locations.infoj(location, infoj_order);
+
+      // Get textvalues from location listview elements.
+      const results = Array.from(infoj.children)
+        .map(el => el.firstChild.innerText.trim())
+
+      // Expected results
+      const expected = [
+        'value_2',
+        'value_3',
+        'value_4',
+        'value_5',
+        'value_6'
+      ];
+
+      // Asserting we get the expected results and order
+      codi.assertEqual(results, expected, 'The infoj order needs to be as defined in the expected');
+
+    });
+
+    codi.it('It should create an infoj with certain order as defined on the layer', () => {
+
+      const location = {
+        infoj: [
+          {
+            field: 'field_1',
+            key: 'key_1',
+            label: 'test_1',
+            value: 'test 1 value'
+          },
+          {
+            field: 'field_2',
+            label: 'test_2',
+            value: 'value_2'
+          },
+          {
+            field: 'field_3',
+            label: 'test_3',
+            value: 'value_3'
+          },
+          {
+            key: 'key_4',
+            value: 'value_4'
+          },
+          {
+            query: 'query_5',
+            value: 'value_5',
+            location: {}
+          }
+        ]
+      };
+
+      // Set the order on the layer
+      location.layer = {};
+      location.layer.infoj_order = [
+        '_field_1',
+        'field_2',
+        'field_3',
+        'key_4',
+        'query_5',
+        {
+          field: 'field6',
+          value: 'value_6'
+        }
+      ];
+
+      // Get listview element from the infoj object
+      const infoj = mapp.ui.locations.infoj(location);
 
       // Get textvalues from location listview elements.
       const results = Array.from(infoj.children)


### PR DESCRIPTION
# Pull Request Template

## Description

We previously (pre-v4.10.0) had the ability to define the `infoj_order` on the layer. 
This was erroneously removed, this PR reinstates this functionality and provides a test for it to avoid removing it again accidentally. 

## Type of Change
Please delete options that are not relevant, and select all options that apply. 

- ✅ Bug fix (non-breaking change which fixes an issue)
- ✅ Testing

## Testing Checklist 
Please delete options that are not relevant, and select all options that apply. 

- ✅ Existing Tests still pass
- ✅ Updated Existing Tests
- ✅ New Tests Added
- ✅ Ran locally on my machine

## Code Quality Checklist
Please delete options that are not relevant, and select all options that apply. 

- ✅ My code follows the guidelines of XYZ
- ✅ My code has been commented
- ✅ Documentation has been updated
- ✅ New and existing unit tests pass locally with my changes
- ✅ Main has been merged into this PR