### PR TITLE
Adjust min width of 2nd div in location view grid column

### DIFF
--- a/public/css/_locationview.css
+++ b/public/css/_locationview.css
@@ -25,6 +25,11 @@
       grid-column: 1;
     }
 
+    &.inline>div:nth-of-type(2) {
+      grid-column: 2;
+      min-width: 0;
+    }
+
     &.inline>.val {
       grid-column: 2;
       text-align: right;

--- a/public/css/ui.css
+++ b/public/css/ui.css
@@ -1487,6 +1487,10 @@ label.checkbox {
     &.inline > .label {
       grid-column: 1;
     }
+    &.inline > div:nth-of-type(2) {
+      grid-column: 2;
+      min-width: 0;
+    }
     &.inline > .val {
       grid-column: 2;
       text-align: right;


### PR DESCRIPTION
This fixes the issue where an inline dropdown button element messes with the grid layout.

![image](https://github.com/user-attachments/assets/d9d81385-034a-41e7-a806-d930e7d109dc)
