### PR TITLE
CSV Download Fix when string includes commas

### DIFF
--- a/lib/utils/csvDownload.mjs
+++ b/lib/utils/csvDownload.mjs
@@ -58,7 +58,7 @@ function fieldsFunction(record, fields) {
     // Escape quotes in string value.
     if (typeof record[field.field] === 'string' && field.string) {
 
-      return `"${record[field.field].replaceAll('"', '\\"')}"`
+      return `"${record[field.field].replaceAll('"', '""')}"`
     }
 
     // Format number toLocaleString


### PR DESCRIPTION
# CSV Download Fix when string includes commas and backlashes

## Description

The previous code
``` js 
return `"${record[field.field].replaceAll('"', '\\"')}"`;
```
Replaces any double quotes (") in the string with an escaped version (\\").
It then wraps the string in double quotes.

However,
In CSV format, if a field contains a comma, newline, or double quote, the field must be enclosed in double quotes (").
Double quotes inside such fields must be escaped by doubling them (""), not by using a backslash (\\").

**Issue with Commas and backlashes:**

When the string "test, test" is output as "test, test" using this approach, it looks fine at first glance.
However, if a CSV parser encounters a backslash (\\") in the data, it might interpret it literally, leading to incorrect parsing or errors.


**Changes**
``` js
return `"${record[field.field].replaceAll('"', '""')}"`;
```

Double quotes (") are replaced with two double quotes (""), following the CSV standard.
The entire field is then enclosed in double quotes.
This approach adheres to the CSV specification. The comma within the field does not cause issues because the field is properly quoted.
Double quotes inside the field are escaped in a way that CSV parsers understand.

## GitHub Issue

Provide the link to the relevant GitHub issue it addresses. 

## Type of Change
Please delete options that are not relevant, and select all options that apply. 

- ✅ Bug fix (non-breaking change which fixes an issue)

## How have you tested this? 
If you test with values of "test,test" and "/test /, test" you should be able to see the resolution.

## Testing Checklist 
Please delete options that are not relevant, and select all options that apply. 

- ✅ Existing Tests still pass
- ✅ Updated Existing Tests
- ✅ New Tests Added
- ✅ Ran locally on my machine

## Code Quality Checklist
Please delete options that are not relevant, and select all options that apply. 

- ✅ My code follows the guidelines of XYZ
- ✅ My code has been commented
- ✅ Documentation has been updated
- ✅ New and existing unit tests pass locally with my changes
- ✅ Main has been merged into this PR