### PR TITLE
Graduated theme parser

### DIFF
--- a/lib/layer/styleParser.mjs
+++ b/lib/layer/styleParser.mjs
@@ -134,241 +134,81 @@ export default function styleParser(layer) {
   if (layer.style?.labels) {
     layer.style.label = typeof layer.style.label === 'object' ? layer.style.label : layer.style.labels[layer.style.label || Object.keys(layer.style.labels)[0]];
   }
+}
 
-  function warnings(layer) {
+/**
+@function warnings
 
-    if (!layer.style.default) {
+@description
+The warnings method parses the layer style configuration and warns on legacy configurations while trying to rectify these issues.
 
-      console.warn(`Layer: ${layer.key} has no implicit default style. Please add style.default.`)
+@param {layer} layer A json layer object.
+@property {Object} [layer.cluster] Cluster configuration for a point layer.
+@property {Object} [layer.hover] Legacy configuration for style.hover.
+@property {Object} [layer.icon_scaling] Legacy configuration for style.icon_scaling.
+@property {layer-style} layer.style The mapp-layer style configuration.
+@property {feature-style} style.default Default feature style.
+@property {integer} [style.zIndex] Legacy configuration for layer.zIndex.
+*/
+function warnings(layer) {
 
-      // Assign default style for vector layer.
-      // Non cluster layer do not have a default icon style
-      layer.style.default = layer.cluster
-        ? {
-          icon: {
-            type: 'dot'
-          }
-        } : {
-          strokeColor: '#333',
-          fillColor: '#fff9',
+  if (!layer.style.default) {
+
+    console.warn(`Layer: ${layer.key} has no implicit default style. Please add style.default.`)
+
+    // Assign default style for vector layer.
+    // Non cluster layer do not have a default icon style
+    layer.style.default = layer.cluster
+      ? {
+        icon: {
+          type: 'dot'
         }
-    }
-
-    if (layer.style.default.style) {
-
-      console.warn(`Layer: ${layer.key} has a style object within the default style configuration.`)
-
-      layer.style.default = layer.style.default.style
-
-      delete layer.style.default.style
-    }
-
-    iconObject(layer.style.default)
-
-    // Handle deprecated layer.hover configuration.
-    if (layer.hover) {
-      console.warn(`Layer: ${layer.key}, layer.hover{} should be defined within layer.style{}.`);
-      layer.style.hover = layer.hover;
-      delete layer.hover;
-    }
-
-    // Handle deprecated layer.style.hover and layer.style.hovers.
-    if (layer.style?.hovers && layer.style?.hover) {
-      console.warn(`Layer: ${layer.key}, cannot use both layer.style.hover and layer.style.hovers. Layer.style.hover has been deleted.`);
-      delete layer.style.hover;
-    }
-
-    // Handle deprecated layer.style.label and layer.style.labels.
-    if (layer.style?.labels && layer.style?.label) {
-      console.warn(`Layer: ${layer.key}, cannot use both layer.style.label and layer.style.labels. Layer.style.label has been deleted.`);
-      delete layer.style.label;
-    }
-
-    // Handle layer.style.zIndex deprecation.
-    if (layer.style.zIndex) {
-      console.warn(`Layer: ${layer.key}, layer.style.zIndex has been deprecated. Use layer.zIndex instead.`);
-    }
-
-    if (layer.icon_scaling) {
-
-      console.warn(`Layer: ${layer.key}, layer.icon_scaling has been assigned to layer.style.icon_scaling`)
-
-      layer.style.icon_scaling ??= layer.icon_scaling
-    }
+      } : {
+        strokeColor: '#333',
+        fillColor: '#fff9',
+      }
   }
 
-  function parseTheme(theme, layer) {
+  if (layer.style.default.style) {
 
-    if (typeof theme === 'string') {
+    console.warn(`Layer: ${layer.key} has a style object within the default style configuration.`)
 
-      // Attempt theme lookup in themes from string[key]
-      theme = layer.style.themes?.[theme]
-    }
+    layer.style.default = layer.style.default.style
 
-    if (typeof theme.style === 'object') {
-
-      // Assign the default style to the theme.style
-      theme.style = {
-        ...structuredClone(layer.style.default),
-        ...theme.style
-      }
-    }
-
-    if (typeof theme.cat === 'object') {
-
-      theme.categories = Object.keys(theme.cat).map(key => {
-
-        const cat = theme.cat[key]
-
-        cat.label ??= key
-        cat.value ??= key
-
-        return cat
-      })
-
-      delete theme.cat
-    }
-
-    if (Array.isArray(theme.cat_arr)) {
-
-      theme.categories = theme.cat_arr
-
-      delete theme.cat_arr
-    }
-
-    // Check if graduated breaks is not defined, or is not less_than or greater_than.
-    if (theme.type === 'graduated') {
-
-      if (!['less_than', 'greater_than'].includes(theme.graduated_breaks)) {
-
-        console.warn(`You must provide a graduated_breaks value of either greater_than or less_than for graduated theme on layer: ${layer.key}; field: ${theme.field}. less_than is assumed.`);
-
-        theme.graduated_breaks ??= 'less_than';
-      }
-
-      if (theme.graduated_breaks === 'greater_than') {
-
-        // The cat array must be reversed when checking whether a value is supposed to be greater.
-        theme.categories.reverse()
-      }
-    }
-
-    theme.categories?.forEach(cat => {
-
-      cat.label ??= cat.value
-
-      if (cat.icon) {
-
-        cat.style = {
-          icon: cat.icon
-        }
-
-        delete cat.icon
-      }
-
-      styleObject(cat, structuredClone(layer.style.default))
-    })
-
-    // Check validity of categorized theme with multiple fields.
-    if (theme.type === 'categorized' && Array.isArray(theme.fields)) {
-
-      theme.categories.forEach(cat => {
-
-        if (!theme.fields.includes(cat.field)) {
-
-          console.warn(`Layer: ${layer.key}; Cat ${cat.label} missed valid field.`)
-        }
-
-        // Multiple field cat theme style must be icon.
-        if (!cat.style.icon) {
-
-          console.warn(`Layer: ${layer.key}; Cat ${cat.label} has invalid icon style.`)
-
-          cat.style.icon = { type: 'dot' }
-        }
-      })
-
-    }
+    delete layer.style.default.style
   }
 
-  function styleObject(cat, defaultStyle) {
+  iconObject(layer.style.default)
 
-    cat.style ??= {}
-
-    // Style arrays are assumed to be valid.
-    if (Array.isArray(cat.style)) return;
-
-    if (cat.icon) {
-      cat.style = {
-        icon: cat.icon
-      }
-      delete cat.icon
-    }
-
-    if (cat.style.icon) {
-
-      // Do not merge default style into icon array.
-      if (Array.isArray(cat.style.icon)) return;
-
-      // Do not merge default style into icon with type definition.
-      if (cat.style.icon.type) return;
-
-      // Do not merge default style into svg [type] icons.
-      if (cat.style.icon.svg) return;
-
-      if (defaultStyle.icon && !Array.isArray(defaultStyle.icon)) {
-
-        cat.style.icon = {
-          ...defaultStyle.icon,
-          ...cat.style.icon
-        }
-      }
-      return;
-
-    }
-
-    // Create a mergeStyle from valid styleKeys
-    const mergeStyle = {}
-
-    Object.keys(defaultStyle)
-      .filter(key => styleKeys.has(key))
-      .forEach(key => mergeStyle[key] = defaultStyle[key])
-
-    cat.style = {
-      ...mergeStyle,
-      ...cat.style,
-    }
-
-    Object.keys(cat)
-      .filter(key => styleKeys.has(key))
-      .forEach(key => {
-        cat.style[key] = cat[key]
-        delete cat[key]
-      })
-
-    iconObject(cat.style)
-
-    // Assign default icon if no cat style icon could be created.
-    if (!cat.style.icon && defaultStyle.icon) {
-
-      console.warn(`Layer:${layer.key}, Failed to evaluate icon: ${JSON.stringify(cat)}. Default icon will be assigned.`)
-
-      cat.style.icon = defaultStyle.icon
-    }
+  // Handle deprecated layer.hover configuration.
+  if (layer.hover) {
+    console.warn(`Layer: ${layer.key}, layer.hover{} should be defined within layer.style{}.`);
+    layer.style.hover = layer.hover;
+    delete layer.hover;
   }
 
-  function iconObject(style) {
+  // Handle deprecated layer.style.hover and layer.style.hovers.
+  if (layer.style?.hovers && layer.style?.hover) {
+    console.warn(`Layer: ${layer.key}, cannot use both layer.style.hover and layer.style.hovers. Layer.style.hover has been deleted.`);
+    delete layer.style.hover;
+  }
 
-    // The style object already has an icon object.
-    if (style.icon) return;
+  // Handle deprecated layer.style.label and layer.style.labels.
+  if (layer.style?.labels && layer.style?.label) {
+    console.warn(`Layer: ${layer.key}, cannot use both layer.style.label and layer.style.labels. Layer.style.label has been deleted.`);
+    delete layer.style.label;
+  }
 
-    Object.keys(style)
-      .filter(key => iconKeys.has(key))
-      .forEach(key => {
-        style.icon ??= {};
-        style.icon[key] = style[key]
-        delete style[key]
-      })
+  // Handle layer.style.zIndex deprecation.
+  if (layer.style.zIndex) {
+    console.warn(`Layer: ${layer.key}, layer.style.zIndex has been deprecated. Use layer.zIndex instead.`);
+  }
+
+  if (layer.icon_scaling) {
+
+    console.warn(`Layer: ${layer.key}, layer.icon_scaling has been assigned to layer.style.icon_scaling`)
+
+    layer.style.icon_scaling ??= layer.icon_scaling
   }
 }
 
@@ -440,4 +280,229 @@ function clusterChecks(layer) {
 
     delete layer.style.cluster.zoomOutScale
   }
+}
+
+/**
+@function parseTheme
+
+@description
+The parseTheme method checks whether a theme and it's categories have consistent style objects.
+
+@param {Object} theme A json theme object.
+@param {layer} layer A json layer object.
+@property {string} theme.type The type of the theme.
+@property {array} theme.categories An ordered array of theme categories.
+@property {layer-style} layer.style The mapp-layer style configuration.
+@property {feature-style} style.default Default feature style.
+*/
+function parseTheme(theme, layer) {
+
+  if (typeof theme === 'string') {
+
+    // Attempt theme lookup in themes from string[key]
+    theme = layer.style.themes?.[theme]
+  }
+
+  if (typeof theme.style === 'object') {
+
+    // Assign the default style to the theme.style
+    theme.style = {
+      ...structuredClone(layer.style.default),
+      ...theme.style
+    }
+  }
+
+  if (typeof theme.cat === 'object') {
+
+    theme.categories = Object.keys(theme.cat).map(key => {
+
+      const cat = theme.cat[key]
+
+      cat.label ??= key
+      cat.value ??= key
+
+      return cat
+    })
+
+    delete theme.cat
+  }
+
+  if (Array.isArray(theme.cat_arr)) {
+
+    theme.categories = theme.cat_arr
+
+    delete theme.cat_arr
+  }
+
+  graduatedTheme(theme)
+  
+  theme.categories?.forEach(cat => {
+
+    cat.label ??= cat.value
+
+    if (cat.icon) {
+
+      cat.style = {
+        icon: cat.icon
+      }
+
+      delete cat.icon
+    }
+
+    catStyle(cat, structuredClone(layer.style.default))
+  })
+
+  // Check validity of categorized theme with multiple fields.
+  if (theme.type === 'categorized' && Array.isArray(theme.fields)) {
+
+    theme.categories.forEach(cat => {
+
+      if (!theme.fields.includes(cat.field)) {
+
+        console.warn(`Layer: ${layer.key}; Cat ${cat.label} missed valid field.`)
+      }
+
+      // Multiple field cat theme style must be icon.
+      if (!cat.style.icon) {
+
+        console.warn(`Layer: ${layer.key}; Cat ${cat.label} has invalid icon style.`)
+
+        cat.style.icon = { type: 'dot' }
+      }
+    })
+
+  }
+}
+
+/**
+@function graduatedTheme
+
+@description
+The checks the order of theme categories according to their value. The method will shortcircuit if the type of the theme is not graduated.
+
+@param {Object} theme A json theme object.
+@param {layer} layer A json layer object.
+@property {string} theme.type The type of the theme.
+@property {string} theme.graduated_breaks The value order of categories, eg. 'less_than' or 'greater_than'
+@property {array} theme.categories An ordered array of theme categories.
+*/
+function graduatedTheme(theme) {
+
+  if (theme.type !== 'graduated') return;
+
+  if (!['less_than', 'greater_than'].includes(theme.graduated_breaks)) {
+
+    theme.graduated_breaks = 'less_than';
+  }
+
+  theme.categories.forEach(cat => cat.value = Number(cat.value))
+
+  if (theme.graduated_breaks === 'less_than') {
+
+    theme.categories.sort((a, b) => (a.value > b.value ? 0 : -1));
+  } else {
+
+    theme.categories.sort((a, b) => (a.value > b.value ? -1 : 0));
+  }
+}
+
+/**
+@function catStyle
+
+@description
+The catStyle method parses the style object of a theme category object.
+
+Category themes are attempted to be merged with the default style if possible.
+
+@param {object} cat The category object.
+@param {feature-style} defaultStyle The layer default style object.
+*/
+function catStyle(cat, defaultStyle) {
+
+  cat.style ??= {}
+
+  // Style arrays are assumed to be valid.
+  if (Array.isArray(cat.style)) return;
+
+  // Ensure that the icon object is within a style object.
+  if (cat.icon) {
+    cat.style = {
+      icon: cat.icon
+    }
+    delete cat.icon
+  }
+
+  if (cat.style.icon) {
+
+    // Do not merge default style into icon array.
+    if (Array.isArray(cat.style.icon)) return;
+
+    // Do not merge default style into icon with type definition.
+    if (cat.style.icon.type) return;
+
+    // Do not merge default style into svg [type] icons.
+    if (cat.style.icon.svg) return;
+
+    if (defaultStyle.icon && !Array.isArray(defaultStyle.icon)) {
+
+      cat.style.icon = {
+        ...defaultStyle.icon,
+        ...cat.style.icon
+      }
+    }
+
+    return;
+  }
+
+  // Create a mergeStyle from valid styleKeys
+  const mergeStyle = {}
+
+  Object.keys(defaultStyle)
+    .filter(key => styleKeys.has(key))
+    .forEach(key => mergeStyle[key] = defaultStyle[key])
+
+  cat.style = {
+    ...mergeStyle,
+    ...cat.style,
+  }
+
+  Object.keys(cat)
+    .filter(key => styleKeys.has(key))
+    .forEach(key => {
+      cat.style[key] = cat[key]
+      delete cat[key]
+    })
+
+  iconObject(cat.style)
+
+  // Assign default icon if no cat style icon could be created.
+  if (!cat.style.icon && defaultStyle.icon) {
+
+    console.warn(`Layer:${layer.key}, Failed to evaluate icon: ${JSON.stringify(cat)}. Default icon will be assigned.`)
+
+    cat.style.icon = defaultStyle.icon
+  }
+}
+
+/**
+@function iconObject
+
+@description
+The iconObject method parses a feature-style object without an icon object to check whether there are icon object specific properties defined in the style object. An icon object will be created from the icon specific properties with these properties being removed from the style object itself.
+
+@param {feature-style} style
+@property {object} [style.icon] The style object already has an icon definition.
+*/
+function iconObject(style) {
+
+  // The style object already has an icon object.
+  if (style.icon) return;
+
+  Object.keys(style)
+    .filter(key => iconKeys.has(key))
+    .forEach(key => {
+      style.icon ??= {};
+      style.icon[key] = style[key]
+      delete style[key]
+    })
 }

--- a/lib/layer/styleParser.mjs
+++ b/lib/layer/styleParser.mjs
@@ -362,7 +362,7 @@ function parseTheme(theme, layer) {
   }
 
   graduatedTheme(theme)
-  
+
   theme.categories?.forEach(cat => {
 
     cat.label ??= cat.value

--- a/lib/layer/styleParser.mjs
+++ b/lib/layer/styleParser.mjs
@@ -376,7 +376,7 @@ function parseTheme(theme, layer) {
       delete cat.icon
     }
 
-    catStyle(cat, structuredClone(layer.style.default))
+    catStyle(cat, layer)
   })
 
   // Check validity of categorized theme with multiple fields.
@@ -442,9 +442,9 @@ The catStyle method parses the style object of a theme category object.
 Category themes are attempted to be merged with the default style if possible.
 
 @param {object} cat The category object.
-@param {feature-style} defaultStyle The layer default style object.
+@param {layer} layer The layer reference for the style/theme/cat object.
 */
-function catStyle(cat, defaultStyle) {
+function catStyle(cat, layer) {
 
   cat.style ??= {}
 
@@ -458,6 +458,8 @@ function catStyle(cat, defaultStyle) {
     }
     delete cat.icon
   }
+
+  const defaultStyle = structuredClone(layer.style.default)
 
   if (cat.style.icon) {
 

--- a/lib/layer/styleParser.mjs
+++ b/lib/layer/styleParser.mjs
@@ -114,32 +114,7 @@ export default function styleParser(layer) {
     }
   }
 
-  // Handle multiple hovers in layer style.
-  if (layer.style?.hovers) {
-
-    Object.keys(layer.style.hovers).forEach(key => {
-
-      // required for the lookup of self referenced objects
-      layer.style.hovers[key].key = key
-
-      // assign key as fallback title
-      layer.style.hovers[key].title ??= key;
-    })
-
-    // Assign the first key from hovers object as hover string property if undefined.
-    layer.style.hover ??= Object.keys(layer.style.hovers)[0]
-
-    // Assign hover property from hovers object if string.
-    if (typeof layer.style.hover === 'string') {
-
-      layer.style.hover = layer.style.hovers[layer.style.hover]
-    }
-  }
-
-  // Set default featureHover method if not provided.
-  if (layer.style?.hover) {
-    layer.style.hover.method ??= mapp.layer.featureHover;
-  }
+  handleHovers(layer);
 
   // Handle multiple labels in layer style.
   if (layer.style?.labels) {
@@ -534,4 +509,43 @@ function iconObject(style) {
       style.icon[key] = style[key]
       delete style[key]
     })
+}
+
+/**
+ @description
+  The handleHovers method parses the layer's hover/s properties. 
+  It provides fallback values to the hover/s key, title properties as well as assign a featureHover method if not provided. 
+  It also assigns the first hover string from the hovers if undefined.
+  @param {layer} layer The layer reference for the style/hover/s object.
+  @property {layer-style} layer.style The mapp-layer style configuration.
+  @property {string} [style.hover] The current hover applied to the feature styling.
+  @property {array} [style.hovers] An array of hover objects available to be applied as the layer.style.hover.
+ */
+function handleHovers(layer) {
+  // Handle multiple hovers in layer style.
+  if (layer.style?.hovers) {
+
+    Object.keys(layer.style.hovers).forEach(key => {
+
+      // required for the lookup of self referenced objects
+      layer.style.hovers[key].key = key
+
+      // assign key as fallback title
+      layer.style.hovers[key].title ??= key;
+    })
+
+    // Assign the first key from hovers object as hover string property if undefined.
+    layer.style.hover ??= Object.keys(layer.style.hovers)[0]
+
+    // Assign hover property from hovers object if string.
+    if (typeof layer.style.hover === 'string') {
+
+      layer.style.hover = layer.style.hovers[layer.style.hover]
+    }
+  }
+
+  // Set default featureHover method if not provided.
+  if (layer.style?.hover) {
+    layer.style.hover.method ??= mapp.layer.featureHover;
+  }
 }

--- a/lib/layer/styleParser.mjs
+++ b/lib/layer/styleParser.mjs
@@ -1,38 +1,7 @@
 /**
-### mapp.layer.styleParser()
+### /layer/styleParser
 
-The `styleParser` module method is responsible for parsing and validating the layer.style object for assigning feature styles.
-
-The main tasks performed by the `styleParser` module include:
-
-1. Assigning default styles:
-  - It assigns a default highlight style to the layer if not explicitly provided.
-  - It sets the default `zIndex` value for the highlight style to `Infinity`.
-  - It assigns an empty object to `layer.style` if it doesn't exist.
-  - It assigns an empty object to `layer.style.default` if it doesn't exist.
-
-2. Parsing theme styles:
-  - If `layer.style.theme` exists, it calls the `parseTheme` function to process the theme style configuration.
-  - If `layer.style.themes` exists, it iterates over each theme and calls the `parseTheme` function for each theme.
-
-3. Handling multiple themes, hovers, and labels:
-  - If multiple themes are defined in `layer.style.themes`, it selects the appropriate theme based on the `layer.style.theme` value or the first theme in the object.
-  - If multiple hovers are defined in `layer.style.hovers`, it selects the appropriate hover style based on the `layer.style.hover` value or the first hover style in the object.
-  - If multiple labels are defined in `layer.style.labels`, it selects the appropriate label style based on the `layer.style.label` value or the first label style in the object.
-
-4. Handling warnings and deprecation notices:
-  - It calls the `warnings` function to handle warnings and deprecation notices related to the layer style configuration.
-  - It checks for deprecated properties and provides appropriate warnings or fallback values.
-
-5. Processing style objects:
-  - It calls the `styleObject` function to process individual style objects within themes or categories.
-  - It merges the category style with the default style and handles icon styles separately.
-
-6. Processing icon style objects:
-  - It calls the `iconObject` function to process icon style objects within the layer style.
-  - It moves icon-related properties into a separate `icon` object within the style.
-
-Overall, the `styleParser` module ensures that the layer style configuration is properly structured, applies default styles where necessary, handles multiple themes, hovers, and labels, and processes individual style objects and icon styles. It helps to maintain a consistent and valid style configuration for the layer in the mapping application.
+The styleParser module exports the styleParser method as default which is intended to check the consistency of layer styles and issue console warnings in regards to backwards compatibility.
 
 @module /layer/styleParser
 */
@@ -79,8 +48,25 @@ const styleKeys = new Set([
 @description
 The styleParser method parses and validates the mapp.style object and its properties.
 
+The styleParser method checks the highlight features style and calls the warnings method.
+
+The clusterStyle method is called to ensure that cluster layer have a cluster style.
+
+Individual themes in the themes object are parsed and a theme is assigned to the 
+
+The parseTheme method is called for the layer.style.theme and each of the layer.style.themes.
+
+A lookup will be attempted if the theme property is a string. Otherwise the first theme object property from the themes object is assigned as theme if undefined.
+
+A lookup will be attempted if the hover property is a string. Otherwise the first hover object property from the hovers object is assigned as hover if undefined.
+
+A lookup will be attempted if the label property is a string. Otherwise the first label object property from the labels object is assigned as label if undefined.
+
 @param {layer} layer A json layer object.
 @property {layer-style} layer.style The mapp-layer style configuration.
+@property {feature-style} [style.highlight] The feature style applied to features by the highlight interaction.
+@property {object} [style.theme] The current theme applied to the feature styling.
+@property {array} [style.themes] An array of theme objects available to be applied as the layer.style.theme.
 */
 export default function styleParser(layer) {
 
@@ -98,31 +84,40 @@ export default function styleParser(layer) {
 
   clusterChecks(layer)
 
-  if (layer.style?.theme) {
-    parseTheme(layer.style.theme, layer)
-  }
+  parseTheme(layer.style.theme, layer)
 
   if (layer.style?.themes) {
+
     Object.keys(layer.style.themes).forEach(key => {
+
+      if (layer.style.themes[key].skip) {
+        delete layer.style.themes[key];
+        return;
+      }
+
+      layer.style.themes[key].title ??= key;
       parseTheme(layer.style.themes[key], layer)
     })
-  }
 
-  // Handle multiple themes in layer style.
-  if (layer.style?.themes) {
-    Object.keys(layer.style.themes).forEach(key => {
-      layer.style.themes[key].title ??= key;
-      if (layer.style.themes[key].skip) delete layer.style.themes[key];
-    });
+    // Assign the first key from themes object as theme string property if undefined.
+    layer.style.theme ??= Object.keys(layer.style.themes)[0]
 
+    // Assign theme object from themes object if not already an object.
     layer.style.theme = typeof layer.style.theme === 'object'
       ? layer.style.theme
-      : layer.style.themes[layer.style.theme || Object.keys(layer.style.themes)[0]];
+      : layer.style.themes[layer.style.theme];
   }
 
   // Handle multiple hovers in layer style.
   if (layer.style?.hovers) {
-    layer.style.hover = typeof layer.style.hover === 'object' ? layer.style.hover : layer.style.hovers[layer.style.hover || Object.keys(layer.style.hovers)[0]];
+
+    // Assign the first key from hovers object as hover string property if undefined.
+    layer.style.hover ??= Object.keys(layer.style.hovers)[0]
+    
+    // Assign hover object from hovers object if not already an object.
+    typeof layer.style.hover === 'object'
+      ? layer.style.hover
+      : layer.style.hovers[layer.style.hover];
   }
 
   // Set default featureHover method if not provided.
@@ -132,7 +127,14 @@ export default function styleParser(layer) {
 
   // Handle multiple labels in layer style.
   if (layer.style?.labels) {
-    layer.style.label = typeof layer.style.label === 'object' ? layer.style.label : layer.style.labels[layer.style.label || Object.keys(layer.style.labels)[0]];
+
+    // Assign the first key from labels object as label string property if undefined.
+    layer.style.label ??= Object.keys(layer.style.labels)[0]
+    
+    // Assign label object from labels object if not already an object.
+    layer.style.label = typeof layer.style.label === 'object'
+      ? layer.style.label
+      : layer.style.labels[layer.style.label];
   }
 }
 
@@ -141,6 +143,18 @@ export default function styleParser(layer) {
 
 @description
 The warnings method parses the layer style configuration and warns on legacy configurations while trying to rectify these issues.
+
+The method ensures that the layer-style object has a default feature-style. The default feature-style must have an icon if the layer is a cluster layer.
+
+The default is a feature-style which must not contain a style object property.
+
+The icon object of the default style is checked.
+
+The layer.hover legacy configuration is checked.
+
+The layer.style.zIndex legacy configuration is checked.
+
+The layer.icon_scaling legacy configuartion is checked.
 
 @param {layer} layer A json layer object.
 @property {Object} [layer.cluster] Cluster configuration for a point layer.
@@ -169,6 +183,7 @@ function warnings(layer) {
       }
   }
 
+  // The default is a feature-style which must not contain a style object property.
   if (layer.style.default.style) {
 
     console.warn(`Layer: ${layer.key} has a style object within the default style configuration.`)
@@ -180,30 +195,19 @@ function warnings(layer) {
 
   iconObject(layer.style.default)
 
-  // Handle deprecated layer.hover configuration.
+  // Handle legacy layer.hover configuration.
   if (layer.hover) {
     console.warn(`Layer: ${layer.key}, layer.hover{} should be defined within layer.style{}.`);
     layer.style.hover = layer.hover;
     delete layer.hover;
   }
 
-  // Handle deprecated layer.style.hover and layer.style.hovers.
-  if (layer.style?.hovers && layer.style?.hover) {
-    console.warn(`Layer: ${layer.key}, cannot use both layer.style.hover and layer.style.hovers. Layer.style.hover has been deleted.`);
-    delete layer.style.hover;
-  }
-
-  // Handle deprecated layer.style.label and layer.style.labels.
-  if (layer.style?.labels && layer.style?.label) {
-    console.warn(`Layer: ${layer.key}, cannot use both layer.style.label and layer.style.labels. Layer.style.label has been deleted.`);
-    delete layer.style.label;
-  }
-
-  // Handle layer.style.zIndex deprecation.
+  // Handle legacy layer.style.zIndex configuration.
   if (layer.style.zIndex) {
     console.warn(`Layer: ${layer.key}, layer.style.zIndex has been deprecated. Use layer.zIndex instead.`);
   }
 
+  // Handle legacy layer.icon_scaling configuration.
   if (layer.icon_scaling) {
 
     console.warn(`Layer: ${layer.key}, layer.icon_scaling has been assigned to layer.style.icon_scaling`)
@@ -297,11 +301,7 @@ The parseTheme method checks whether a theme and it's categories have consistent
 */
 function parseTheme(theme, layer) {
 
-  if (typeof theme === 'string') {
-
-    // Attempt theme lookup in themes from string[key]
-    theme = layer.style.themes?.[theme]
-  }
+  if (typeof theme !== 'object') return;
 
   if (typeof theme.style === 'object') {
 

--- a/lib/layer/styleParser.mjs
+++ b/lib/layer/styleParser.mjs
@@ -95,7 +95,12 @@ export default function styleParser(layer) {
         return;
       }
 
+      // required for the lookup of self referenced objects
+      layer.style.themes[key].key = key
+
+      // assign key as fallback title
       layer.style.themes[key].title ??= key;
+
       parseTheme(layer.style.themes[key], layer)
     })
 
@@ -111,6 +116,15 @@ export default function styleParser(layer) {
 
   // Handle multiple hovers in layer style.
   if (layer.style?.hovers) {
+
+    Object.keys(layer.style.hovers).forEach(key => {
+
+      // required for the lookup of self referenced objects
+      layer.style.hovers[key].key = key
+
+      // assign key as fallback title
+      layer.style.hovers[key].title ??= key;
+    })
 
     // Assign the first key from hovers object as hover string property if undefined.
     layer.style.hover ??= Object.keys(layer.style.hovers)[0]
@@ -129,6 +143,15 @@ export default function styleParser(layer) {
 
   // Handle multiple labels in layer style.
   if (layer.style?.labels) {
+
+    Object.keys(layer.style.labels).forEach(key => {
+
+      // required for the lookup of self referenced objects
+      layer.style.labels[key].key = key
+
+      // assign key as fallback title
+      layer.style.labels[key].title ??= key;
+    })
 
     // Assign the first key from labels object as label string property if undefined.
     layer.style.label ??= Object.keys(layer.style.labels)[0]

--- a/lib/layer/styleParser.mjs
+++ b/lib/layer/styleParser.mjs
@@ -102,10 +102,11 @@ export default function styleParser(layer) {
     // Assign the first key from themes object as theme string property if undefined.
     layer.style.theme ??= Object.keys(layer.style.themes)[0]
 
-    // Assign theme object from themes object if not already an object.
-    layer.style.theme = typeof layer.style.theme === 'object'
-      ? layer.style.theme
-      : layer.style.themes[layer.style.theme];
+    // Assign theme property from themes object if string.
+    if (typeof layer.style.theme === 'string') {
+
+      layer.style.theme = layer.style.themes[layer.style.theme]
+    }
   }
 
   // Handle multiple hovers in layer style.
@@ -113,11 +114,12 @@ export default function styleParser(layer) {
 
     // Assign the first key from hovers object as hover string property if undefined.
     layer.style.hover ??= Object.keys(layer.style.hovers)[0]
-    
-    // Assign hover object from hovers object if not already an object.
-    typeof layer.style.hover === 'object'
-      ? layer.style.hover
-      : layer.style.hovers[layer.style.hover];
+
+    // Assign hover property from hovers object if string.
+    if (typeof layer.style.hover === 'string') {
+
+      layer.style.hover = layer.style.hovers[layer.style.hover]
+    }
   }
 
   // Set default featureHover method if not provided.
@@ -130,11 +132,13 @@ export default function styleParser(layer) {
 
     // Assign the first key from labels object as label string property if undefined.
     layer.style.label ??= Object.keys(layer.style.labels)[0]
-    
-    // Assign label object from labels object if not already an object.
-    layer.style.label = typeof layer.style.label === 'object'
-      ? layer.style.label
-      : layer.style.labels[layer.style.label];
+
+
+    // Assign label property from labels object if string.
+    if (typeof layer.style.label === 'string') {
+
+      layer.style.label = layer.style.labels[layer.style.label]
+    }
   }
 }
 

--- a/tests/assets/styles/styleParser.json
+++ b/tests/assets/styles/styleParser.json
@@ -1,0 +1,137 @@
+{
+    "key": "test_layer",
+    "cluster": true,
+    "hover": {
+        "method": "legacy_hover_method"
+    },
+    "icon_scaling": {
+        "legacy": true
+    },
+    "style": {
+        "zIndex": 100,
+        "default": {
+            "icon": {
+                "type": "dot",
+                "fillColor": "#13336B"
+            },
+            "strokeColor": "#000",
+            "fillColor": "#fff"
+        },
+        "cluster": {
+            "icon": {
+                "type": "target",
+                "fillColor": "#E6FFFF",
+                "layers": {
+                    "1": "#13336B",
+                    "0.85": "#E6FFFF"
+                }
+            },
+            "zoomInScale": 1.2,
+            "zoomOutScale": 0.8
+        },
+        "highlight": {
+            "scale": 1.3
+        },
+        "themes": {
+            "graduated_theme": {
+                "title": "Graduated Theme",
+                "type": "graduated",
+                "field": "value_field",
+                "graduated_breaks": "less_than",
+                "categories": [
+                    {
+                        "value": 10,
+                        "label": "0-10",
+                        "style": {
+                            "icon": {
+                                "fillColor": "#ffffcc"
+                            }
+                        }
+                    },
+                    {
+                        "value": 20,
+                        "label": "11-20",
+                        "style": {
+                            "fillColor": "#a1dab4"
+                        }
+                    }
+                ]
+            },
+            "categorized_theme": {
+                "title": "Categorized Theme",
+                "type": "categorized",
+                "fields": [
+                    "field1",
+                    "field2"
+                ],
+                "categories": [
+                    {
+                        "value": "category1",
+                        "field": "field1",
+                        "label": "Category 1",
+                        "icon": {
+                            "type": "dot",
+                            "fillColor": "#red"
+                        }
+                    },
+                    {
+                        "value": "category2",
+                        "field": "field2",
+                        "label": "Category 2",
+                        "style": {
+                            "icon": {
+                                "type": "svg",
+                                "svg": "<svg>...</svg>"
+                            }
+                        }
+                    }
+                ]
+            },
+            "legacy_theme": {
+                "title": "Legacy Theme",
+                "type": "categorized",
+                "cat": {
+                    "cat1": {
+                        "value": "value1",
+                        "icon": {
+                            "type": "dot"
+                        }
+                    },
+                    "cat2": {
+                        "value": "value2",
+                        "style": {
+                            "strokeColor": "#000"
+                        }
+                    }
+                }
+            }
+        },
+        "hovers": {
+            "hover1": {
+                "title": "Hover Style 1",
+                "method": "customHoverMethod",
+                "scale": 1.2
+            },
+            "hover2": {
+                "title": "Hover Style 2",
+                "scale": 1.4
+            }
+        },
+        "labels": {
+            "label1": {
+                "title": "Label Style 1",
+                "field": "name",
+                "scale": 1
+            },
+            "label2": {
+                "title": "Label Style 2",
+                "field": "description",
+                "scale": 1.2
+            }
+        },
+        "icon_scaling": {
+            "zoomInScale": 1.5,
+            "zoomOutScale": 0.5
+        }
+    }
+}

--- a/tests/lib/layer/_layer.test.mjs
+++ b/tests/lib/layer/_layer.test.mjs
@@ -20,7 +20,7 @@ import { featureFieldsTest } from './featureFields.test.mjs';
 import { featureFormatsTest } from './featureFormats.test.mjs';
 import { featureHoverTest } from './featureHover.test.mjs';
 import { featureStyleTest } from './featureStyle.test.mjs';
-import { styleParserTest } from './styleParser.test.mjs';
+import { styleParser } from './styleParser.test.mjs';
 
 export const layerTest = {
     decorateTest,
@@ -29,5 +29,5 @@ export const layerTest = {
     featureFormatsTest,
     featureHoverTest,
     featureStyleTest,
-    styleParserTest
+    styleParser
 };

--- a/tests/lib/layer/styleParser.test.mjs
+++ b/tests/lib/layer/styleParser.test.mjs
@@ -1,24 +1,113 @@
-export async function styleParserTest(mapview) {
+import styleParserJson from '../../assets/styles/styleParser.json' with {type: 'json'};
+
+export async function styleParser(mapview) {
   await codi.describe('TODO: Layer: styleParserTest', async () => {
-    // const workspace = await mapp.utils.xhr(`/test/tests/workspace.json`);
-    // const layer = workspace.locale.layers['styleParser'];
-    // layer.key = 'Style Parser Test';
-    // await mapp.layer.styleParser(layer);
 
-    // await codi.it('The Layer should have a default object', () => {
-    //   codi.assertTrue(!!layer.style.default, 'The Layer should always have a default object')
-    // });
+    await codi.it('stypeParser Test:', async () => {
 
-    // await codi.it('The parser should remove the hover object, and add it into the layer.style object', () => {
-    //   codi.assertTrue(!layer.hover, 'The layer shouldnt have a layer.hover object')
-    //   codi.assertTrue(!!layer.style.hover, 'The layer should have a layer.style.hover object')
-    // });
+      const layer = styleParserJson;
 
-    // await codi.it('The parse should remove the label property if both labels and label are present', () => {
-    //   codi.assertTrue(!layer.style.label, 'The layer shouldnt have a layer.style.label object')
-    //   codi.assertTrue(!!layer.style.labels, 'The layer should have a layer.style.labels object')
-    // });
+      mapp.layer.styleParser(layer);
+      // Test legacy property migrations
+      codi.assertFalse(layer.hasOwnProperty('hover'), 'Legacy hover property should be removed');
+      codi.assertTrue(layer.hasOwnProperty('icon_scaling'), 'Legacy icon_scaling property should be removed');
 
-    console.warn('The Style parse modules need to be broken up and exported for easier testability');
+      // Test style property existence and structure
+      codi.assertTrue(layer.hasOwnProperty('style'), 'Style object should exist');
+      codi.assertTrue(layer.style.hasOwnProperty('hover'), 'Hover should be moved to style object');
+      codi.assertEqual(layer.style.hover.method, 'legacy_hover_method', 'Hover method should be preserved');
+
+      // Test default style
+      codi.assertTrue(layer.style.hasOwnProperty('default'), 'Default style should exist');
+      codi.assertTrue(layer.style.default.hasOwnProperty('icon'), 'Default style should have icon for cluster layer');
+      codi.assertFalse(layer.style.default.hasOwnProperty('strokeColor'), 'Stroke color should be removed from cluster layer default style');
+      codi.assertFalse(layer.style.default.hasOwnProperty('fillColor'), 'Fill color should be removed from cluster layer default style');
+
+      // Test cluster style
+      codi.assertTrue(layer.style.hasOwnProperty('cluster'), 'Cluster style should exist');
+      codi.assertTrue(layer.style.cluster.hasOwnProperty('clusterScale'), 'Cluster style should have clusterScale');
+      codi.assertEqual(layer.style.cluster.clusterScale, 1, 'Cluster scale should default to 1');
+      codi.assertFalse(layer.style.cluster.hasOwnProperty('zoomInScale'), 'zoomInScale should be moved from cluster style');
+      codi.assertFalse(layer.style.cluster.hasOwnProperty('zoomOutScale'), 'zoomOutScale should be moved from cluster style');
+
+      // Test zoom scale properties
+      codi.assertTrue(layer.style.hasOwnProperty('zoomInScale'), 'zoomInScale should be moved to style root');
+      codi.assertTrue(layer.style.hasOwnProperty('zoomOutScale'), 'zoomOutScale should be moved to style root');
+      codi.assertEqual(layer.style.zoomInScale, 1.2, 'zoomInScale value should be preserved');
+      codi.assertEqual(layer.style.zoomOutScale, 0.8, 'zoomOutScale value should be preserved');
+
+      // Test icon styling
+      codi.assertTrue(layer.style.default.icon.hasOwnProperty('type'), 'Default icon should have type');
+      codi.assertEqual(layer.style.default.icon.type, 'dot', 'Default icon type should be preserved');
+
+      // Test highlight style
+      if (layer.style.highlight) {
+        codi.assertTrue(layer.style.highlight.hasOwnProperty('zIndex'), 'Highlight should have zIndex');
+        codi.assertEqual(layer.style.highlight.zIndex, Infinity, 'Highlight zIndex should be Infinity');
+      }
+
+      // Test theme handling
+      if (layer.style.themes) {
+        Object.values(layer.style.themes).forEach(theme => {
+          codi.assertTrue(theme.hasOwnProperty('title'), 'Theme should have title');
+          codi.assertTrue(theme.hasOwnProperty('key'), 'Theme should have key');
+
+          if (theme.type === 'graduated') {
+            // Check graduated_breaks default
+            if (!theme.graduated_breaks) {
+              codi.assertEqual(theme.graduated_breaks, 'less_than', 'Graduated theme should default to less_than breaks');
+            }
+
+            // Verify all values are numbers
+            theme.categories.forEach(cat => {
+              codi.assertTrue(typeof cat.value === 'number', 'Graduated theme category values should be numbers');
+            });
+
+            // Check ordering
+            const isOrdered = theme.categories.every((cat, i) => {
+              if (i === 0) return true;
+              const prev = theme.categories[i - 1].value;
+              const curr = cat.value;
+
+              if (theme.graduated_breaks === 'less_than') {
+                return prev <= curr;
+              } else {
+                return prev >= curr;
+              }
+            });
+
+            codi.assertTrue(isOrdered, `Categories should be ordered ${theme.graduated_breaks === 'less_than' ? 'ascending' : 'descending'}`);
+          }
+
+          if (theme.categories) {
+            theme.categories.forEach(category => {
+              codi.assertTrue(category.hasOwnProperty('label'), 'Category should have label');
+              codi.assertTrue(category.hasOwnProperty('value'), 'Category should have value');
+              if (category.style?.icon) {
+                codi.assertFalse(category.hasOwnProperty('icon'), 'Category should not have direct icon property');
+              }
+            });
+          }
+        });
+      }
+
+      // Test hover configuration
+      if (layer.style.hovers) {
+        Object.values(layer.style.hovers).forEach(hover => {
+          codi.assertTrue(hover.hasOwnProperty('title'), 'Hover should have title');
+          codi.assertTrue(hover.hasOwnProperty('key'), 'Hover should have key');
+        });
+      }
+
+      // Test label configuration
+      if (layer.style.labels) {
+        Object.values(layer.style.labels).forEach(label => {
+          codi.assertTrue(label.hasOwnProperty('title'), 'Label should have title');
+          codi.assertTrue(label.hasOwnProperty('key'), 'Label should have key');
+        });
+      }
+
+    });
+
   });
 }


### PR DESCRIPTION
Reversing the order for graduated theme categories was a terrible idea. This causes the order to be reversed multiple times if a theme is parsed multiple times.

The graduated_breaks check should not warn and always be correct. "less_than" order is assumed.

The categories are ordered according to their numeric values and direction, eg. less_than / greater_than.

Themes can be ammended and parsed multiple times with the order always being correct.

The styleParser method has multiple nested methods which have been moved to the module root and documented.

The styleObject method has been renamed to catStyle to indicate what the method actually does.