### PR TITLE
syncFields array and documentation

### DIFF
--- a/lib/location/decorate.mjs
+++ b/lib/location/decorate.mjs
@@ -190,6 +190,7 @@ async function update() {
 
       // Update entry.values with newValues.
       entry.value = entry.newValue;
+
       // Remove newValue
       delete entry.newValue;
 
@@ -222,7 +223,23 @@ async function update() {
   this.updateCallbacks?.forEach(fn => typeof fn === 'function' && fn(this))
 }
 
+/**
+@function syncFields
+@async
+
+@description
+The syncFields method sends a parameterised query to the location_get query template. The fields parameter will be populated from the fields params argument.
+
+Values of the location [this] infoj entry matching the fields will be updated with values from the query response.
+
+@param {array} fields
+*/
 async function syncFields(fields) {
+
+  // fields must be an array
+  if (!Array.isArray(fields)) {
+    fields = [fields]
+  }
 
   const response = await mapp.utils.xhr(
     `${this.layer.mapview.host}/api/query?` +
@@ -238,13 +255,12 @@ async function syncFields(fields) {
   // Return if response is falsy or error.
   if (!response || response instanceof Error) {
     console.warn('No data returned from location_get request using ID:', this.id)
-    return
-  }
-  // Check if the response is an array.
-  else if (Array.isArray(response)) {
+    return;
+
+  } else if (Array.isArray(response)) {
     console.warn(`Location response returned more than one record for Layer: ${this.layer.key}.`)
     console.log('Location Get Response:', response)
-    return
+    return;
   }
 
   this.infoj


### PR DESCRIPTION
The dependents array defined as a string for geometry entries would throw an error since the syncFields method expects a fields array as params argument.

The method has now been documented and the fields param is turned into an array if not provided as an array.
