### PR TITLE
Bump OL to 10.3.1 to include clear cache fix.

### DIFF
--- a/lib/layer/format/mvt.mjs
+++ b/lib/layer/format/mvt.mjs
@@ -84,8 +84,6 @@ export default function MVT(layer) {
     layer.source.clear()
     layer.source.refresh()
 
-    // Reset source tiles to force refresh.
-    layer.source.sourceTiles_ = {};
     layer.featureSource.refresh()
 
     if (callback instanceof Function) callback(layer)

--- a/lib/mapp.mjs
+++ b/lib/mapp.mjs
@@ -34,7 +34,7 @@ import plugins from './plugins/_plugins.mjs'
 hooks.parse();
 
 const _ol = {
-  current: '10.2.1'
+  current: '10.3.1'
 }
 
 if (window.ol === undefined) {

--- a/lib/utils/olScript.mjs
+++ b/lib/utils/olScript.mjs
@@ -23,12 +23,12 @@ export default async function olScript() {
 
     script.type = 'application/javascript'
 
-    script.src = 'https://cdn.jsdelivr.net/npm/ol@v10.2.1/dist/ol.js'
+    script.src = 'https://cdn.jsdelivr.net/npm/ol@v10.3.1/dist/ol.js'
 
     script.onload = resolve
 
     document.head.append(script)
 
-    console.warn('Openlayers v10.2.1 loaded from script tag.')
+    console.warn('Openlayers v10.3.1 loaded from script tag.')
   })
 }

--- a/public/views/_default.html
+++ b/public/views/_default.html
@@ -9,7 +9,7 @@
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
 
-  <script src="https://cdn.jsdelivr.net/npm/ol@v10.2.1/dist/ol.js" defer></script>
+  <script src="https://cdn.jsdelivr.net/npm/ol@v10.3.1/dist/ol.js" defer></script>
 
   <!-- Load XYZ / MAPP stylesheet and library. -->
   <link rel="stylesheet" href="{{dir}}/public/css/mapp.css" />

--- a/public/views/_test.html
+++ b/public/views/_test.html
@@ -9,7 +9,7 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
 
-    <script src="https://cdn.jsdelivr.net/npm/ol@v10.2.1/dist/ol.js" defer></script>
+    <script src="https://cdn.jsdelivr.net/npm/ol@v10.3.1/dist/ol.js" defer></script>
 
     <!-- Load XYZ / MAPP stylesheet and library. -->
     <link rel="stylesheet" href="{{dir}}/public/css/mapp.css" />

--- a/tests/lib/layer/format/mvt.test.mjs
+++ b/tests/lib/layer/format/mvt.test.mjs
@@ -18,16 +18,5 @@ export function mvtTest(mapview, layer) {
             codi.assertTrue(Object.hasOwn(layer, 'L'), 'The mvt layer needs to have an openlayer object')
         });
 
-        /**
-         * @description MVT: Reload should remove sourceTiles
-         * @function it
-         */
-        codi.it('MVT: Reload should remove sourceTiles', () => {
-            mapp.layer.formats[layer.format]?.(layer);
-
-            layer.source.sourceTiles_ = { tile: 'foo' };
-            layer.reload();
-            codi.assertEqual(layer.source.sourceTiles_, {}, 'The sourceTiles needs to be cleared');
-        });
     });
 }


### PR DESCRIPTION
This patch PR upgrades OL to 10.3.1 which includes a fix to clear the LRU cache properly. 

https://github.com/openlayers/openlayers/pull/16328

The workaround setting the OL source property manually has been removed. OL properties should never be directly modified but only through the OL api.

The associated test has been removed since it is meaningless. The test set a property to foo before calling a method which sets the property to an empty object and then checking whether the property is set to an empty object. The test did not actually look at the tile cache and associated trigger.