### PR TITLE
Entry Dataviews Refresh

### DIFF
--- a/lib/ui/Dataview.mjs
+++ b/lib/ui/Dataview.mjs
@@ -106,22 +106,6 @@ export default async function Dataview(_this) {
 
   _this.hide ??= hide
 
-  // Create checkbox if a label is provided.
-  _this.chkbox = _this.label && mapp.ui.elements.chkbox({
-    data_id: _this.key,
-    label: _this.label,
-    checked: !!_this.display,
-    disabled: _this.disabled,
-    onchange: (checked) => {
-
-      _this.display = checked
-
-      _this.display
-        ? _this.show()
-        : _this.hide()
-    }
-  })
-
   // Create dataview toolbar
   dataviewToolbar(_this)
  

--- a/lib/ui/Tabview.mjs
+++ b/lib/ui/Tabview.mjs
@@ -73,8 +73,8 @@ The decorator method will add `show()` and `hide()` methods for the tab.
 */
 function addTab(entry) {
 
-  // The entry already has a tab.
-  if (entry.tab) return;
+  // The entry already has a tab, and is not flagged as dynamic.
+  if (entry.tab && !entry.dynamic) return;
 
   const tabview = this
 

--- a/lib/ui/Tabview.mjs
+++ b/lib/ui/Tabview.mjs
@@ -71,7 +71,7 @@ The decorator method will add `show()` and `hide()` methods for the tab.
 @property {string} [entry.label] The title to be displayed in the tab element.
 @property {HTMLElement} [entry.panel] The node element which will be displayed if the tab is active.
 */
-function addTab() {
+function addTab(entry) {
 
   // The entry already has a tab, and is not flagged as dynamic.
   if (entry.tab && !entry.dynamic) return;

--- a/lib/ui/Tabview.mjs
+++ b/lib/ui/Tabview.mjs
@@ -83,7 +83,7 @@ function addTab(entry) {
   if (entry.location) {
 
     // The tabview should be removed if the location is removed.
-    entry.location.removeCallbacks.push(() => entry.remove())
+    entry.location.removeCallbacks.push(() => entry.remove(entry))
 
   } else if (entry.layer) {
 
@@ -91,12 +91,12 @@ function addTab(entry) {
     entry.layer.showCallbacks.push(() => {
 
       // Entry must have display flag.
-      entry.display && entry.show()
+      entry.display && entry.show(entry)
     })
 
     // Hide tab when layer is hidden.
     entry.layer.hideCallbacks.push(() => {
-      entry.remove()
+      entry.remove(entry)
     })
   }
 
@@ -108,7 +108,7 @@ function addTab(entry) {
         .disabled=${entry.disabled}
         class="header"
         style="${entry.tab_style || ''}"
-        onclick=${showTab}>${entry.label}`
+        onclick=${()=>showTab(entry)}>${entry.label}`
 
   entry.panel ??= entry.target || mapp.utils.html.node`
     <div class="${`panel ${entry.class || ''}`}">`
@@ -128,7 +128,7 @@ function addTab(entry) {
 
   The dataview may have an associated toolbar [btnRow element] which must be displayed.
   */
-  function activateTab() {
+  function activateTab(entry) {
 
     if (entry.create === undefined) {
 
@@ -164,7 +164,7 @@ function addTab(entry) {
 
   The showTab method is debounced by 500ms to execute only for the last tab to be added when multiple tabs are added in quick succession.
   */
-  function showTab() {
+  function showTab(entry) {
 
     // Render entry.panel into tabview.panel
     mapp.utils.render(tabview.panel, entry.panel)
@@ -182,7 +182,7 @@ function addTab(entry) {
     // This prevents each tab to activate when multiple tabs are added in quick succession.
     tabview.timer && window.clearTimeout(tabview.timer)
 
-    tabview.timer = window.setTimeout(entry.activate, 500)
+    tabview.timer = window.setTimeout(()=>entry.activate(entry), 500)
 
     if (tabview.showTab instanceof Function) {
 
@@ -203,7 +203,7 @@ function addTab(entry) {
 
   The removeLastTab() method of the tabview will be executed if the last tab object is removed from a tabview.
   */
-  function removeTab() {
+  function removeTab(entry) {
 
     // A tab without parent element cannot be in the tab bar.
     if (!entry.tab.parentElement) return

--- a/lib/ui/Tabview.mjs
+++ b/lib/ui/Tabview.mjs
@@ -71,7 +71,7 @@ The decorator method will add `show()` and `hide()` methods for the tab.
 @property {string} [entry.label] The title to be displayed in the tab element.
 @property {HTMLElement} [entry.panel] The node element which will be displayed if the tab is active.
 */
-function addTab(entry) {
+function addTab() {
 
   // The entry already has a tab, and is not flagged as dynamic.
   if (entry.tab && !entry.dynamic) return;

--- a/lib/ui/Tabview.mjs
+++ b/lib/ui/Tabview.mjs
@@ -83,7 +83,7 @@ function addTab(entry) {
   if (entry.location) {
 
     // The tabview should be removed if the location is removed.
-    entry.location.removeCallbacks.push(() => entry.remove(entry))
+    entry.location.removeCallbacks.push(() => entry.remove())
 
   } else if (entry.layer) {
 
@@ -91,12 +91,12 @@ function addTab(entry) {
     entry.layer.showCallbacks.push(() => {
 
       // Entry must have display flag.
-      entry.display && entry.show(entry)
+      entry.display && entry.show()
     })
 
     // Hide tab when layer is hidden.
     entry.layer.hideCallbacks.push(() => {
-      entry.remove(entry)
+      entry.remove()
     })
   }
 
@@ -108,7 +108,7 @@ function addTab(entry) {
         .disabled=${entry.disabled}
         class="header"
         style="${entry.tab_style || ''}"
-        onclick=${()=>showTab(entry)}>${entry.label}`
+        onclick=${showTab}>${entry.label}`
 
   entry.panel ??= entry.target || mapp.utils.html.node`
     <div class="${`panel ${entry.class || ''}`}">`
@@ -128,7 +128,7 @@ function addTab(entry) {
 
   The dataview may have an associated toolbar [btnRow element] which must be displayed.
   */
-  function activateTab(entry) {
+  function activateTab() {
 
     if (entry.create === undefined) {
 
@@ -164,7 +164,7 @@ function addTab(entry) {
 
   The showTab method is debounced by 500ms to execute only for the last tab to be added when multiple tabs are added in quick succession.
   */
-  function showTab(entry) {
+  function showTab() {
 
     // Render entry.panel into tabview.panel
     mapp.utils.render(tabview.panel, entry.panel)
@@ -182,12 +182,12 @@ function addTab(entry) {
     // This prevents each tab to activate when multiple tabs are added in quick succession.
     tabview.timer && window.clearTimeout(tabview.timer)
 
-    tabview.timer = window.setTimeout(()=>entry.activate(entry), 500)
+    tabview.timer = window.setTimeout(()=>entry.activate(), 500)
 
     if (tabview.showTab instanceof Function) {
 
       // Execute tabview method to show a tab.
-      tabview.showTab(entry)
+      tabview.showTab()
     }
   }
 
@@ -203,7 +203,7 @@ function addTab(entry) {
 
   The removeLastTab() method of the tabview will be executed if the last tab object is removed from a tabview.
   */
-  function removeTab(entry) {
+  function removeTab() {
 
     // A tab without parent element cannot be in the tab bar.
     if (!entry.tab.parentElement) return

--- a/lib/ui/layers/panels/dataviews.mjs
+++ b/lib/ui/layers/panels/dataviews.mjs
@@ -109,6 +109,22 @@ export default function dataviews(layer) {
       dataview.remove()
     }
 
+    // Create checkbox control for dataview.
+    dataview.chkbox = mapp.ui.elements.chkbox({
+      data_id: dataview.key,
+      label: dataview.label,
+      checked: !!dataview.display,
+      disabled: dataview.disabled,
+      onchange: (checked) => {
+
+        dataview.display = checked
+
+        dataview.display
+          ? dataview.show()
+          : dataview.hide()
+      }
+    })
+
     if (mapp.ui.Dataview(dataview) instanceof Error) return;
 
     // Display dataview if layer and dv have display flag.

--- a/lib/ui/locations/entries/dataview.mjs
+++ b/lib/ui/locations/entries/dataview.mjs
@@ -86,7 +86,7 @@ export default function dataview(entry) {
       disabled: entry.data === null,
       onchange: (checked) => {
         entry.display = checked;
-        entry.display ? entry.show(entry) : entry.hide(entry);
+        entry.display ? entry.show() : entry.hide();
       },
     });
   }

--- a/lib/ui/locations/entries/dataview.mjs
+++ b/lib/ui/locations/entries/dataview.mjs
@@ -56,7 +56,7 @@ The dataview checkbox and locationViewTarget elements will be returned if availa
 
 export default function dataview(entry) {
 
-  entry.data ??= entry.value
+  if (entry.value !== undefined) entry.data = entry.value;
 
   if (entry.data === null) {
 
@@ -71,18 +71,6 @@ export default function dataview(entry) {
     entry.display ??= entry._display
 
     delete entry.disabled
-
-    // The chkbox may also be disabled, if it exists - then we need to set it to enabled.
-    if (entry.chkbox) {
-      entry.chkbox.querySelector('input').disabled = false
-      // If display is true, the checkbox needs to be checked.
-      if (entry.display) entry.chkbox.querySelector('input').checked = true
-    }
-
-    // If entry.tab exists, it may be disabled so we need to enable it.
-    if (entry.tab) {
-      if (entry.display) delete entry.tab.querySelector('button').disabled
-    }
 
   }
 

--- a/lib/ui/locations/entries/dataview.mjs
+++ b/lib/ui/locations/entries/dataview.mjs
@@ -55,6 +55,7 @@ The dataview checkbox and locationViewTarget elements will be returned if availa
 */
 
 export default function dataview(entry) {
+
   if (entry.value !== undefined) entry.data = entry.value;
 
   if (entry.data === null) {
@@ -64,6 +65,7 @@ export default function dataview(entry) {
     entry._display = entry.display;
     delete entry.display;
     entry.disabled = true;
+
   } else {
     entry.display ??= entry._display;
     delete entry.disabled;
@@ -104,13 +106,6 @@ export default function dataview(entry) {
     return;
   }
 
-  // Dataview is dependent on other field entries.
-  if (entry.dependents) {
-    console.warn(
-      `The dataview type entry key:${entry.key} may be dependent on other entries but has no dependents.`
-    );
-  }
-
   // Dataview has already been created. e.g. after the location (view) is updated, and it is not dynamic.
   if (entry.update && !entry.dynamic) {
 
@@ -126,7 +121,7 @@ export default function dataview(entry) {
     typeof entry.target === 'string' &&
     document.querySelector(`[data-id=${entry.target}]`)
   ) {
-    
+
     // Tabview entries return empty on mobile.
     if (mapp.utils.mobile()) return;
 

--- a/lib/ui/locations/entries/dataview.mjs
+++ b/lib/ui/locations/entries/dataview.mjs
@@ -56,6 +56,7 @@ The dataview checkbox and locationViewTarget elements will be returned if availa
 
 export default function dataview(entry) {
 
+
   if (entry.value !== undefined) entry.data = entry.value;
 
   if (entry.data === null) {
@@ -73,6 +74,22 @@ export default function dataview(entry) {
     delete entry.disabled
 
   }
+
+  // Create checkbox if a label is provided.
+  entry.chkbox = entry.label && mapp.ui.elements.chkbox({
+    data_id: entry.key,
+    label: entry.label,
+    checked: !!entry.display,
+    disabled: entry.disabled,
+    onchange: (checked) => {
+
+      entry.display = checked
+
+      entry.display
+        ? entry.show()
+        : entry.hide()
+    }
+  })
 
   // Dataview queries may require the layer and host to be defined on the entry.
   entry.layer ??= entry.location.layer
@@ -98,8 +115,8 @@ export default function dataview(entry) {
     console.warn(`The dataview type entry key:${entry.key} may be dependent on other entries but has no dependents.`)
   }
 
-  // Dataview has already been created. e.g. after the location (view) is updated.
-  if (entry.update) {
+  // Dataview has already been created. e.g. after the location (view) is updated, and it is not dynamic.
+  if (entry.update && !entry.dynamic) {
 
     if (entry.display) entry.show?.()
 

--- a/lib/ui/locations/entries/dataview.mjs
+++ b/lib/ui/locations/entries/dataview.mjs
@@ -147,8 +147,10 @@ export default function dataview(entry) {
   } else {
 
     // Dataview will be rendered into location view.
+    const location_class = `location ${entry.key || entry.query}`;
+
     entry.locationViewTarget = mapp.utils.html.node`
-      <div class="${`location ${entry.key || entry.query}`}">`
+      <div class="${location_class}">`
 
     entry.target = entry.locationViewTarget
   }

--- a/lib/ui/locations/entries/dataview.mjs
+++ b/lib/ui/locations/entries/dataview.mjs
@@ -122,16 +122,20 @@ export default function dataview(entry) {
       ${entry.locationViewTarget || ''}`;
   }
 
-  // Find tabview element from data-id attribute.
-  entry.tabview ??=
+  if (
     typeof entry.target === 'string' &&
-    document.querySelector(`[data-id=${entry.target}]`);
+    document.querySelector(`[data-id=${entry.target}]`)
+  ) {
+    
+    // Tabview entries return empty on mobile.
+    if (mapp.utils.mobile()) return;
+
+    // Assign tabview element from queryselector
+    entry.tabview ??= document.querySelector(`[data-id=${entry.target}]`);
+  }
 
   // Dataview will be rendered into a tabview panel.
   if (entry.tabview) {
-
-    // Tabview entries return empty on mobile.
-    if (mapp.utils.mobile()) return;
 
     // Assign border style based on the location view record (from list)
     entry.tab_style ??= `border-bottom: 3px solid ${
@@ -150,7 +154,7 @@ export default function dataview(entry) {
     );
 
   } else {
-    
+
     // Dataview will be rendered into location view.
     const location_class = `location ${entry.key || entry.query}`;
 

--- a/lib/ui/locations/entries/dataview.mjs
+++ b/lib/ui/locations/entries/dataview.mjs
@@ -68,7 +68,7 @@ export default function dataview(entry) {
 
   } else {
 
-    entry.display = entry._display
+    entry.display ??= entry._display
 
     delete entry.disabled
 
@@ -79,9 +79,9 @@ export default function dataview(entry) {
       if (entry.display) entry.chkbox.querySelector('input').checked = true
     }
 
-    // If entry.tab exists, it may be disabled.
+    // If entry.tab exists, it may be disabled so we need to enable it.
     if (entry.tab) {
-      if (entry.display) entry.tab.querySelector('button').disabled = false
+      if (entry.display) delete entry.tab.querySelector('button').disabled
     }
 
   }

--- a/lib/ui/locations/entries/dataview.mjs
+++ b/lib/ui/locations/entries/dataview.mjs
@@ -71,11 +71,9 @@ export default function dataview(entry) {
     // This is to prevent the query running over and over again getting the same result.
     entry._display ??= entry.display;
     delete entry.display;
-    entry.disabled = true;
-
+    
   } else {
     entry.display ??= entry._display;
-    delete entry.disabled;
   }
 
   if (entry.label) {
@@ -85,7 +83,7 @@ export default function dataview(entry) {
       data_id: entry.key,
       label: entry.label,
       checked: !!entry.display,
-      disabled: entry.disabled,
+      disabled: entry.data === null,
       onchange: (checked) => {
         entry.display = checked;
         entry.display ? entry.show(entry) : entry.hide(entry);

--- a/lib/ui/locations/entries/dataview.mjs
+++ b/lib/ui/locations/entries/dataview.mjs
@@ -55,80 +55,77 @@ The dataview checkbox and locationViewTarget elements will be returned if availa
 */
 
 export default function dataview(entry) {
-
-
   if (entry.value !== undefined) entry.data = entry.value;
 
   if (entry.data === null) {
 
     // The entry must be disabled if the query has run with querycheck:true and the data is null.
     // This is to prevent the query running over and over again getting the same result.
-    entry._display = entry.display
-    delete entry.display
-    entry.disabled = true
-
+    entry._display = entry.display;
+    delete entry.display;
+    entry.disabled = true;
   } else {
-
-    entry.display ??= entry._display
-
-    delete entry.disabled
-
+    entry.display ??= entry._display;
+    delete entry.disabled;
   }
 
-  // Create checkbox if a label is provided.
-  entry.chkbox = entry.label && mapp.ui.elements.chkbox({
-    data_id: entry.key,
-    label: entry.label,
-    checked: !!entry.display,
-    disabled: entry.disabled,
-    onchange: (checked) => {
+  if (entry.label) {
 
-      entry.display = checked
-
-      entry.display
-        ? entry.show()
-        : entry.hide()
-    }
-  })
+    // Create checkbox if a label is provided.
+    entry.chkbox = mapp.ui.elements.chkbox({
+      data_id: entry.key,
+      label: entry.label,
+      checked: !!entry.display,
+      disabled: entry.disabled,
+      onchange: (checked) => {
+        entry.display = checked;
+        entry.display ? entry.show() : entry.hide();
+      },
+    });
+  }
 
   // Dataview queries may require the layer and host to be defined on the entry.
-  entry.layer ??= entry.location.layer
-  entry.host ??= entry.layer.mapview.host
+  entry.layer ??= entry.location.layer;
+  entry.host ??= entry.layer.mapview.host;
 
   // Dataview will be rendered into target identified by ID.
-  if (typeof entry.target === 'string' && document.getElementById(entry.target)) {
+  if (
+    typeof entry.target === 'string' &&
+    document.getElementById(entry.target)
+  ) {
 
     // Assign element by ID as target.
-    entry.target = document.getElementById(entry.target)
+    entry.target = document.getElementById(entry.target);
 
     // Create and update the dataview.
     if (mapp.ui.Dataview(entry) instanceof Error) return;
 
-    entry.update()
-
+    entry.update();
     return;
   }
 
   // Dataview is dependent on other field entries.
   if (entry.dependents) {
-
-    console.warn(`The dataview type entry key:${entry.key} may be dependent on other entries but has no dependents.`)
+    console.warn(
+      `The dataview type entry key:${entry.key} may be dependent on other entries but has no dependents.`
+    );
   }
 
   // Dataview has already been created. e.g. after the location (view) is updated, and it is not dynamic.
   if (entry.update && !entry.dynamic) {
 
-    if (entry.display) entry.show?.()
+    if (entry.display) entry.show?.();
 
     // Return elements to location view.
     return mapp.utils.html.node`
       ${entry.chkbox || ''}
-      ${entry.locationViewTarget || ''}`
+      ${entry.locationViewTarget || ''}`;
   }
 
   // Find tabview element from data-id attribute.
-  entry.tabview ??= typeof entry.target === 'string'
-    && document.querySelector(`[data-id=${entry.target}]`)
+  entry.tabview ??=
+    typeof entry.target === 'string' &&
+    document.querySelector(`[data-id=${entry.target}]`);
 
   // Dataview will be rendered into a tabview panel.
   if (entry.tabview) {
@@ -137,37 +134,40 @@ export default function dataview(entry) {
     if (mapp.utils.mobile()) return;
 
     // Assign border style based on the location view record (from list)
-    entry.tab_style ??= `border-bottom: 3px solid ${entry.location.style?.strokeColor || 'var(--color-primary)'}`
+    entry.tab_style ??= `border-bottom: 3px solid ${
+      entry.location.style?.strokeColor || 'var(--color-primary)'
+    }`;
 
     // Assign target html element for dataview.
     entry.target = mapp.utils.html.node`
-      <div class="dataview-target">`
-
+      <div class="dataview-target">`;
 
     // Create tab after dataview creation is complete.
-    entry.tabview.dispatchEvent(new CustomEvent('addTab', {
-      detail: entry
-    }))
+    entry.tabview.dispatchEvent(
+      new CustomEvent('addTab', {
+        detail: entry,
+      })
+    );
 
   } else {
-
+    
     // Dataview will be rendered into location view.
     const location_class = `location ${entry.key || entry.query}`;
 
     entry.locationViewTarget = mapp.utils.html.node`
-      <div class="${location_class}">`
+      <div class="${location_class}">`;
 
-    entry.target = entry.locationViewTarget
+    entry.target = entry.locationViewTarget;
   }
 
   // Decorate the dataview entry.
   if (mapp.ui.Dataview(entry) instanceof Error) return;
 
   // Dataview should be displayed.
-  entry.display && entry.show?.()
+  entry.display && entry.show?.();
 
   // Return elements to location view.
   return mapp.utils.html.node`
     ${entry.chkbox || ''}
-    ${entry.locationViewTarget || ''}`
+    ${entry.locationViewTarget || ''}`;
 }

--- a/lib/ui/locations/entries/dataview.mjs
+++ b/lib/ui/locations/entries/dataview.mjs
@@ -56,13 +56,20 @@ The dataview checkbox and locationViewTarget elements will be returned if availa
 
 export default function dataview(entry) {
 
-  if (entry.value !== undefined) entry.data = entry.value;
+  if (entry.value !== undefined) {
+    entry.data = entry.value
+
+    if (entry.data?.length === 0) {
+
+      entry.data = null
+    }
+  } 
 
   if (entry.data === null) {
 
     // The entry must be disabled if the query has run with querycheck:true and the data is null.
     // This is to prevent the query running over and over again getting the same result.
-    entry._display = entry.display;
+    entry._display ??= entry.display;
     delete entry.display;
     entry.disabled = true;
 
@@ -81,7 +88,7 @@ export default function dataview(entry) {
       disabled: entry.disabled,
       onchange: (checked) => {
         entry.display = checked;
-        entry.display ? entry.show() : entry.hide();
+        entry.display ? entry.show(entry) : entry.hide(entry);
       },
     });
   }
@@ -109,7 +116,7 @@ export default function dataview(entry) {
   // Dataview has already been created. e.g. after the location (view) is updated, and it is not dynamic.
   if (entry.update && !entry.dynamic) {
 
-    if (entry.display) entry.show?.();
+    if (entry.display) entry.show?.(entry);
 
     // Return elements to location view.
     return mapp.utils.html.node`
@@ -121,16 +128,11 @@ export default function dataview(entry) {
     typeof entry.target === 'string' &&
     document.querySelector(`[data-id=${entry.target}]`)
   ) {
-
     // Tabview entries return empty on mobile.
     if (mapp.utils.mobile()) return;
 
     // Assign tabview element from queryselector
     entry.tabview ??= document.querySelector(`[data-id=${entry.target}]`);
-  }
-
-  // Dataview will be rendered into a tabview panel.
-  if (entry.tabview) {
 
     // Assign border style based on the location view record (from list)
     entry.tab_style ??= `border-bottom: 3px solid ${
@@ -147,8 +149,7 @@ export default function dataview(entry) {
         detail: entry,
       })
     );
-
-  } else {
+  } else if (!entry.tabview) {
 
     // Dataview will be rendered into location view.
     const location_class = `location ${entry.key || entry.query}`;
@@ -163,7 +164,7 @@ export default function dataview(entry) {
   if (mapp.ui.Dataview(entry) instanceof Error) return;
 
   // Dataview should be displayed.
-  entry.display && entry.show?.();
+  entry.display && entry.show?.(entry);
 
   // Return elements to location view.
   return mapp.utils.html.node`

--- a/lib/ui/locations/entries/dataview.mjs
+++ b/lib/ui/locations/entries/dataview.mjs
@@ -114,7 +114,7 @@ export default function dataview(entry) {
   // Dataview has already been created. e.g. after the location (view) is updated, and it is not dynamic.
   if (entry.update && !entry.dynamic) {
 
-    if (entry.display) entry.show?.(entry);
+    if (entry.display) entry.show?.();
 
     // Return elements to location view.
     return mapp.utils.html.node`
@@ -162,7 +162,7 @@ export default function dataview(entry) {
   if (mapp.ui.Dataview(entry) instanceof Error) return;
 
   // Dataview should be displayed.
-  entry.display && entry.show?.(entry);
+  entry.display && entry.show?.();
 
   // Return elements to location view.
   return mapp.utils.html.node`

--- a/lib/ui/locations/entries/dataview.mjs
+++ b/lib/ui/locations/entries/dataview.mjs
@@ -62,12 +62,28 @@ export default function dataview(entry) {
 
     // The entry must be disabled if the query has run with querycheck:true and the data is null.
     // This is to prevent the query running over and over again getting the same result.
+    entry._display = entry.display
     delete entry.display
     entry.disabled = true
 
   } else {
 
+    entry.display = entry._display
+
     delete entry.disabled
+
+    // The chkbox may also be disabled, if it exists - then we need to set it to enabled.
+    if (entry.chkbox) {
+      entry.chkbox.querySelector('input').disabled = false
+      // If display is true, the checkbox needs to be checked.
+      if (entry.display) entry.chkbox.querySelector('input').checked = true
+    }
+
+    // If entry.tab exists, it may be disabled.
+    if (entry.tab) {
+      if (entry.display) entry.tab.querySelector('button').disabled = false
+    }
+
   }
 
   // Dataview queries may require the layer and host to be defined on the entry.
@@ -132,7 +148,7 @@ export default function dataview(entry) {
 
     // Dataview will be rendered into location view.
     entry.locationViewTarget = mapp.utils.html.node`
-      <div class="${`location ${entry.class}`}">`
+      <div class="${`location ${entry.key || entry.query}`}">`
 
     entry.target = entry.locationViewTarget
   }

--- a/lib/ui/locations/listview.mjs
+++ b/lib/ui/locations/listview.mjs
@@ -231,7 +231,7 @@ export default function listview(params) {
     // Assign record to the location.
     location.record = record
 
-    location.style = locale.locations.style
+    location.style = structuredClone(locale.locations.style)
 
     // Assign stroke and filleColor from record.
     if (record.colour) {

--- a/lib/ui/utils/jsonDataview.mjs
+++ b/lib/ui/utils/jsonDataview.mjs
@@ -22,10 +22,16 @@ export default {
 The create method for json dataviews assigns the setData method to the dataview object.
 
 @param {dataview} dataview Dataview object.
+@property {object} dataview.data A JSON data object to be assigned as data to the Json dataview.
 */
 function create(dataview) {
 
   dataview.setData = setData
+  
+  if (dataview.data) {
+
+    dataview.setData(dataview.data)
+  }
 }
 
 /**


### PR DESCRIPTION
## Description
When calling the `location.update()` method, this subsequently calls the `renderLocationView` method which rebuilds the `location.infoj` in the `location` panel. 
However, `dataviews` are not being refreshed properly. 
 
In `entries/dataview.mjs`: 
1. We remove the `entry.display` flag when the data is null - however if this data is subsequently provided, say via a db update on the back-end, the display flag is gone. This should be stored as a temporary variable so it can be reset if required. 
2. An `entry` may have a `chkbox` associated with it for display of the `dataview`. This needs to be enabled when the `disabled` flag is removed if data is present. 
3. An `entry` may have a `chkbox` associated with it for display of the `dataview`. This needs to be set to checked if the `display` flag is set to true. 
4. An `entry` may have a `tab` associated with it (displaying in the `tabview`). This needs to be enabled when the `disabled` flag is removed if the data is present.
5. `entry.locationViewTarget` is set to `location ${entry.class}`. Most entries don't have a class, so this should use `entry.key` or `entry.query` to avoid creating `location undefined`. 

**The checkbox creation method has been moved into the `entry` or `layer` methods - this is to ensure that when a dynamic dataview is provided, the whole UI and dataview are rebuilt.** 

## GitHub Issue
#1784 

## Type of Change
Please delete options that are not relevant, and select all options that apply. 

- ✅ Bug fix (non-breaking change which fixes an issue)

## Testing Checklist 
Please delete options that are not relevant, and select all options that apply. 

- ✅ Existing Tests still pass
- ✅ Ran locally on my machine

## Code Quality Checklist
Please delete options that are not relevant, and select all options that apply. 

- ✅ My code follows the guidelines of XYZ
- ✅ My code has been commented
- ✅ Documentation has been updated
- ✅ New and existing unit tests pass locally with my changes
- ✅ Main has been merged into this PR