### PR TITLE
Entry layer tweak

### DIFF
--- a/lib/ui/locations/entries/layer.mjs
+++ b/lib/ui/locations/entries/layer.mjs
@@ -131,6 +131,12 @@ async function decorateLayer(entry) {
   // Request style.panel element as content for drawer.
   entry.style.panel = mapp.ui.elements.layerStyle.panel(entry)
 
+  if (entry.style.default) {
+
+    // Assign the location style to the default style.
+    entry.style.default = {...entry.location?.style, ...entry.style.default}
+  }
+  
   // Append style panel to layer panel, if style is available.
   entry.style.panel && entry.panel.append(entry.style.panel)
 

--- a/lib/ui/locations/entries/layer.mjs
+++ b/lib/ui/locations/entries/layer.mjs
@@ -96,6 +96,7 @@ async function decorateLayer(entry) {
     }
   })
 
+
   // The layer may be zoom level restricted.
   if (entry.tables) {
 
@@ -109,14 +110,20 @@ async function decorateLayer(entry) {
     })
   }
 
+  // Append display_toggle to panel.
   entry.panel.append(entry.display_toggle)
 
+  // Append meta panel to layer panel, if meta is available.
+  entry.meta && entry.panel.append(mapp.ui.layers.panels.meta(entry));
+
+  // Nullish assign style elements to entry.
   entry.style.elements ??= [
     'labels',
     'label',
     'hovers',
     'hover',
     'icon_scaling',
+    'opacitySlider',
     'themes',
     'theme',
   ]
@@ -124,6 +131,7 @@ async function decorateLayer(entry) {
   // Request style.panel element as content for drawer.
   entry.style.panel = mapp.ui.elements.layerStyle.panel(entry)
 
+  // Append style panel to layer panel, if style is available.
   entry.style.panel && entry.panel.append(entry.style.panel)
 
   entry.location.removeCallbacks.push(() => {


### PR DESCRIPTION
## Description

1. Updated the `entry.style.elements` nullish assignment to include defining `opacitySlider` - which is one of the default panel options so should be there. 
2. Updated the `entry.panel` to support providing a `meta` flag via the `infoj` `entry`. 
3. The `location` styling is now spread, meaning that as before the colour of the location (A= blue, B = orange) can be used for the styling. 
![image](https://github.com/user-attachments/assets/90cf21ac-ec75-4114-be10-ac6f51049854)


I haven't updated the tests as @RobAndrewHurst  is rewriting all of these, and we should revisit this test once we resolve the vector layer into this method, and the UI/UX of this entry.


## GitHub Issue
#1787 

## Type of Change
Please delete options that are not relevant, and select all options that apply. 

- ✅ Bug fix (non-breaking change which fixes an issue)

## Testing Checklist 
Please delete options that are not relevant, and select all options that apply. 

- ✅ Existing Tests still pass
- ✅ Ran locally on my machine

## Code Quality Checklist
Please delete options that are not relevant, and select all options that apply. 

- ✅ My code follows the guidelines of XYZ
- ✅ My code has been commented
- ✅ Documentation has been updated
- ✅ New and existing unit tests pass locally with my changes
- ✅ Main has been merged into this PR