### PR TITLE
The btnRow should be set to 'flex' not 'block'

### DIFF
--- a/lib/ui/Dataview.mjs
+++ b/lib/ui/Dataview.mjs
@@ -154,7 +154,7 @@ function show() {
   }
 
   //Show toolbar buttons if there are any
-  this.btnRow?.style.setProperty('display','block')
+  this.btnRow?.style.setProperty('display','flex')
 
   this.target.style.display = 'block'
 }

--- a/lib/ui/Tabview.mjs
+++ b/lib/ui/Tabview.mjs
@@ -153,7 +153,7 @@ function addTab(entry) {
     }
 
     //Show toolbar buttons if there are any
-    entry.btnRow?.style.setProperty('display', 'block')
+    entry.btnRow?.style.setProperty('display', 'flex')
   }
 
   /**

--- a/tests/lib/ui/Dataview.test.mjs
+++ b/tests/lib/ui/Dataview.test.mjs
@@ -34,7 +34,7 @@ export async function DataviewTest(mapview) {
         await codi.it('dataview btnRow should be display true when show method called', async () => {
 
             entry.show();
-            codi.assertEqual(entry.btnRow.style.display, 'block', 'The dataview entry btnRow should be display block.');
+            codi.assertEqual(entry.btnRow.style.display, 'flex', 'The dataview entry btnRow should be display flex.');
 
         });
 


### PR DESCRIPTION
We were incorrectly setting the `btnRow` to be `display:block` when it should be `display:flex`. 
This was messing with the styling of the `btnRow`, and was overwriting the `ui.css` stylesheet incorrectly. 

![image](https://github.com/user-attachments/assets/e4394eef-2782-4283-b007-9208bd82024a)

This PR simply changes the references from `flex` to `block` to resolve it.