### PR TITLE
A numeric value only may not be returned from the query module.

### DIFF
--- a/mod/query.js
+++ b/mod/query.js
@@ -389,7 +389,14 @@ function sendRows(req, res, template, rows) {
 
   if (req.params.value_only || template?.value_only) {
 
-    return res.send(Object.values(rows[0])[0])
+    const value = Object.values(rows[0])[0]
+
+    // Numeric values may not be returned with the res.send() method.
+    if (typeof value === 'number') {
+      return res.send(value.toString())
+    }
+
+    return res.send(value)
   }
 
   // Send the infoj object with values back to the client.


### PR DESCRIPTION
A single numeric value_only query response can not be sent from the response object.

```json
    "select_num_value": {
      "dbs": "NEON",
      "value_only": true,
      "template": "select 123;"
    },
```

The numeric value must returned as a string.