### PR TITLE
Automatic Code Formatting husky/lint-stage/prettier 🐶🧹💅

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,1 +1,4 @@
+#!/usr/bin/env sh
+. "$(dirname -- "$0")/_/husky.sh"
+
 npx lint-staged

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,4 +1,1 @@
-#!/usr/bin/env sh
-. "$(dirname -- "$0")/_/husky.sh"
-
 npx lint-staged

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,0 +1,1 @@
+npx lint-staged

--- a/package.json
+++ b/package.json
@@ -8,6 +8,11 @@
   "engines": {
     "node": ">=18.x"
   },
+  "lint-staged": {
+    "*.{js,mjs,json,css,md}": [
+      "prettier --write"
+    ]
+  },
   "scripts": {
     "test": "codi tests",
     "_build": "node esbuild.config.mjs",
@@ -17,7 +22,8 @@
     "generate-docs": "jsdoc --configure jsdoc_mapp.json --verbose && jsdoc --configure jsdoc_xyz.json --verbose && jsdoc --configure jsdoc_test.json --verbose",
     "mapp-docs": "jsdoc --configure jsdoc_mapp.json --verbose",
     "xyz-docs": "jsdoc --configure jsdoc_xyz.json --verbose",
-    "test-docs": "jsdoc --configure jsdoc_test.json --verbose"
+    "test-docs": "jsdoc --configure jsdoc_test.json --verbose",
+    "prepare": "husky"
   },
   "license": "MIT",
   "dependencies": {
@@ -40,8 +46,11 @@
     "esbuild": "^0.19.11",
     "eslint": "^9.13.0",
     "express": "^4.18.3",
+    "express-rate-limit": "^7.5.0",
+    "husky": "^9.1.7",
+    "lint-staged": "^15.4.1",
     "nodemon": "^3.1.7",
-    "uhtml": "^3.1.0",
-    "express-rate-limit": "^7.5.0"
+    "prettier": "^3.4.2",
+    "uhtml": "^3.1.0"
   }
 }

--- a/tests/mod/query.test.mjs
+++ b/tests/mod/query.test.mjs
@@ -1,3 +1,4 @@
+
 /**
  * ## queryTest()
  * @module mod/query
@@ -5,80 +6,52 @@
 
 /**
  * This function is used to test the query API endpoint
- * @function querytest
- * @param {Object} mapview
- */
+ * @function querytest 
+ * @param {Object} mapview 
+*/
 export async function queryTest() {
-  await codi.describe('Query: Testing Query API', async () => {
-    /**
-     * @description Query: Testing Query defined on infoj entry
-     * @function it
-     */
-    await codi.it('Query: Testing Query defined on infoj entry', async () => {
-      const expected_result = [1, 2, 5, 3, 4];
-      const results = await mapp.utils.xhr(
-        `/test/api/query?template=data_array`,
-      );
-      codi.assertEqual(
-        results,
-        expected_result,
-        'We should be able to just call the template even if its not part of the workspace.templates object in configuration',
-      );
-    });
-    /**
-     * @description Query: Testing Module defined in templates
-     * @function it
-     */
-    await codi.it('Query: Testing Module defined in templates', async () => {
-      const expected_result = {
-        bar: 'foo',
-      };
-      const results = await mapp.utils.xhr(
-        `/test/api/query?template=module_test`,
-      );
-      codi.assertEqual(
-        results,
-        expected_result,
-        'The Module should return the basic query',
-      );
-    });
 
-    /**
-     * @description Query: Testing a query with a bogus dbs string via the req params
-     * @function it
-     */
-    await codi.it(
-      'Query: Testing a query with a bogus dbs string via the req params',
-      async () => {
-        const expected_result = {
-          bar: 'foo',
-        };
-        const results = await mapp.utils.xhr(
-          `/test/api/query?template=module_test&dbs=bogus`,
-        );
-        codi.assertEqual(
-          results,
-          expected_result,
-          'The Module should return the basic query',
-        );
-      },
-    );
+    await codi.describe('Query: Testing Query API', async () => {
+        /**
+         * @description Query: Testing Query defined on infoj entry
+         * @function it 
+         */
+        await codi.it('Query: Testing Query defined on infoj entry', async () => {
+            const expected_result = [1, 2, 5, 3, 4];
+            const results = await mapp.utils.xhr(`/test/api/query?template=data_array`);
+            codi.assertEqual(results, expected_result, 'We should be able to just call the template even if its not part of the workspace.templates object in configuration');
+        });
+        /**
+         * @description Query: Testing Module defined in templates
+         * @function it 
+         */
+        await codi.it('Query: Testing Module defined in templates', async () => {
+            const expected_result = {
+                'bar': 'foo'
+            }
+            const results = await mapp.utils.xhr(`/test/api/query?template=module_test`);
+            codi.assertEqual(results, expected_result, 'The Module should return the basic query');
+        });
 
-    /**
-     * @description Query: Testing a query with a bogus dbs on the template
-     * @function it
-     */
-    await codi.it(
-      'Query: Testing a query with a bogus dbs on the template',
-      async () => {
-        const results = await mapp.utils.xhr(
-          `/test/api/query?template=bogus_data_array`,
-        );
-        codi.assertTrue(
-          results instanceof Error,
-          'We should return an error for a bogus DBS connection',
-        );
-      },
-    );
-  });
+        /**
+         * @description Query: Testing a query with a bogus dbs string via the req params
+         * @function it 
+         */
+        await codi.it('Query: Testing a query with a bogus dbs string via the req params', async () => {
+            const expected_result = {
+                'bar': 'foo'
+            }
+            const results = await mapp.utils.xhr(`/test/api/query?template=module_test&dbs=bogus`);
+            codi.assertEqual(results, expected_result, 'The Module should return the basic query');
+        });
+
+        /**
+         * @description Query: Testing a query with a bogus dbs on the template
+         * @function it 
+         */
+        await codi.it('Query: Testing a query with a bogus dbs on the template', async () => {
+            const results = await mapp.utils.xhr(`/test/api/query?template=bogus_data_array`);
+            codi.assertTrue(results instanceof Error, 'We should return an error for a bogus DBS connection');
+        });
+    });
 }

--- a/tests/mod/query.test.mjs
+++ b/tests/mod/query.test.mjs
@@ -1,4 +1,3 @@
-
 /**
  * ## queryTest()
  * @module mod/query
@@ -6,52 +5,80 @@
 
 /**
  * This function is used to test the query API endpoint
- * @function querytest 
- * @param {Object} mapview 
-*/
+ * @function querytest
+ * @param {Object} mapview
+ */
 export async function queryTest() {
-
-    await codi.describe('Query: Testing Query API', async () => {
-        /**
-         * @description Query: Testing Query defined on infoj entry
-         * @function it 
-         */
-        await codi.it('Query: Testing Query defined on infoj entry', async () => {
-            const expected_result = [1, 2, 5, 3, 4];
-            const results = await mapp.utils.xhr(`/test/api/query?template=data_array`);
-            codi.assertEqual(results, expected_result, 'We should be able to just call the template even if its not part of the workspace.templates object in configuration');
-        });
-        /**
-         * @description Query: Testing Module defined in templates
-         * @function it 
-         */
-        await codi.it('Query: Testing Module defined in templates', async () => {
-            const expected_result = {
-                'bar': 'foo'
-            }
-            const results = await mapp.utils.xhr(`/test/api/query?template=module_test`);
-            codi.assertEqual(results, expected_result, 'The Module should return the basic query');
-        });
-
-        /**
-         * @description Query: Testing a query with a bogus dbs string via the req params
-         * @function it 
-         */
-        await codi.it('Query: Testing a query with a bogus dbs string via the req params', async () => {
-            const expected_result = {
-                'bar': 'foo'
-            }
-            const results = await mapp.utils.xhr(`/test/api/query?template=module_test&dbs=bogus`);
-            codi.assertEqual(results, expected_result, 'The Module should return the basic query');
-        });
-
-        /**
-         * @description Query: Testing a query with a bogus dbs on the template
-         * @function it 
-         */
-        await codi.it('Query: Testing a query with a bogus dbs on the template', async () => {
-            const results = await mapp.utils.xhr(`/test/api/query?template=bogus_data_array`);
-            codi.assertTrue(results instanceof Error, 'We should return an error for a bogus DBS connection');
-        });
+  await codi.describe('Query: Testing Query API', async () => {
+    /**
+     * @description Query: Testing Query defined on infoj entry
+     * @function it
+     */
+    await codi.it('Query: Testing Query defined on infoj entry', async () => {
+      const expected_result = [1, 2, 5, 3, 4];
+      const results = await mapp.utils.xhr(
+        `/test/api/query?template=data_array`,
+      );
+      codi.assertEqual(
+        results,
+        expected_result,
+        'We should be able to just call the template even if its not part of the workspace.templates object in configuration',
+      );
     });
+    /**
+     * @description Query: Testing Module defined in templates
+     * @function it
+     */
+    await codi.it('Query: Testing Module defined in templates', async () => {
+      const expected_result = {
+        bar: 'foo',
+      };
+      const results = await mapp.utils.xhr(
+        `/test/api/query?template=module_test`,
+      );
+      codi.assertEqual(
+        results,
+        expected_result,
+        'The Module should return the basic query',
+      );
+    });
+
+    /**
+     * @description Query: Testing a query with a bogus dbs string via the req params
+     * @function it
+     */
+    await codi.it(
+      'Query: Testing a query with a bogus dbs string via the req params',
+      async () => {
+        const expected_result = {
+          bar: 'foo',
+        };
+        const results = await mapp.utils.xhr(
+          `/test/api/query?template=module_test&dbs=bogus`,
+        );
+        codi.assertEqual(
+          results,
+          expected_result,
+          'The Module should return the basic query',
+        );
+      },
+    );
+
+    /**
+     * @description Query: Testing a query with a bogus dbs on the template
+     * @function it
+     */
+    await codi.it(
+      'Query: Testing a query with a bogus dbs on the template',
+      async () => {
+        const results = await mapp.utils.xhr(
+          `/test/api/query?template=bogus_data_array`,
+        );
+        codi.assertTrue(
+          results instanceof Error,
+          'We should return an error for a bogus DBS connection',
+        );
+      },
+    );
+  });
 }

--- a/tests/workspace.json
+++ b/tests/workspace.json
@@ -1,398 +1,417 @@
 {
-  "dbs": "NEON",
-  "roles": {
-    "A": "Text about A",
-    "B": "Text about B",
-    "*": null
-  },
-  "templates": {
-    "template_test_temp": {
-      "src": "file:/tests/assets/layers/template_test/layer.json"
-    },
-    "mvt_test_temp": {
-      "src": "file:/tests/assets/layers/mvt/layer.json"
-    },
-    "module_test": {
-      "type": "module",
-      "src": "file:/tests/assets/queries/foo.js"
-    },
-    "template_1": {
-      "src": "file:/tests/assets/infoj/template_infoj.json"
-    },
-    "template_2": {
-      "src": "file:/tests/assets/styles/template_style.json"
-    },
-    "icon_scaling_scratch": {
-      "src": "file:/tests/assets/queries/icon_scaling_scratch.sql"
-    },
-    "get_location_mock": {
-      "src": "file:/tests/assets/queries/get_location_mock.sql"
-    },
-    "minmax_query": {
-      "src": "file:/tests/assets/queries/minmax_mock.sql"
-    },
-    "data_array": {
-      "src": "file:/tests/assets/queries/data_array.sql",
-      "value_only": true
-    },
-    "bogus_data_array": {
-      "src": "file:/tests/assets/queries/data_array.sql",
-      "dbs": "bogus"
-    },
-    "merge_into": {
-      "name": "merge_into",
-      "roles": {
-        "merge_into": null
-      }
-    }
-  },
-  "locale": {
+    "dbs": "NEON",
     "roles": {
-      "A": null,
-      "B": null,
-      "C": null,
-      "*": null
+        "A": "Text about A",
+        "B": "Text about B",
+        "*": null
     },
-    "mapviewControls": ["Zoom"],
-    "plugins": [
-      "${PLUGINS}v4.8.0/coordinates.js",
-      "${PLUGINS}v4.8.0/chartjs.js",
-      "/test/api/provider/file?content_type=application/javascript&url=./tests/assets/plugins/assignMapview.js"
-    ],
-    "syncPlugins": ["zoomBtn", "zoomToArea", "coordinates", "admin", "login"],
-    "svg_templates": {
-      "dot_test": "https://geolytix.github.io/MapIcons/templates/dot_10px.svg",
-      "target_test": "https://geolytix.github.io/MapIcons/templates/target.svg",
-      "square_test": "https://geolytix.github.io/MapIcons/templates/square_10px.svg",
-      "diamond_test": "https://geolytix.github.io/MapIcons/templates/diamond_10px.svg",
-      "triangle_test": "https://geolytix.github.io/MapIcons/templates/triangle_10px.svg",
-      "template_pin_test": "https://geolytix.github.io/MapIcons/pins/pink_master_pin.svg"
-    },
-    "link_button": [
-      {
-        "href": "/url/url",
-        "title": "TITLE HERE",
-        "target": "_blank",
-        "css_class": "mask-icon",
-        "css_style": "mask-image: url(https://geolytix.github.io/MapIcons/services/component_exchange.svg); -webkit-mask-image: url(https://geolytix.github.io/MapIcons/services/component_exchange.svg);"
-      },
-      {
-        "title": "WILL NOT BE ADDED AS NO HREF",
-        "target": "_blank",
-        "css_class": "mask-icon",
-        "css_style": "mask-image: url(https://geolytix.github.io/MapIcons/services/component_exchange.svg); -webkit-mask-image: url(https://geolytix.github.io/MapIcons/services/component_exchange.svg);"
-      },
-      {
-        "title": "WILL BE ADDED AS HREF",
-        "href": "/url/url2",
-        "target": "_blank",
-        "css_class": "mask-icon",
-        "css_style": "mask-image: url(https://geolytix.github.io/MapIcons/services/component_exchange.svg); -webkit-mask-image: url(https://geolytix.github.io/MapIcons/services/component_exchange.svg);"
-      }
-    ],
-    "assignMapview": {},
-    "keyvalue_dictionary": [
-      {
-        "key": "name",
-        "value": "OpenStreetMap",
-        "default": "OpenStreetMap KeyValue Dictionary"
-      },
-      {
-        "key": "title",
-        "value": "textarea",
-        "default": "TextArea KeyValue Dictionary"
-      },
-      {
-        "key": "test_array",
-        "value": "TEST KEYVALUE",
-        "default": "WILL NOT BE SEEN AS ARRAY CANNOT BE UPDATED"
-      }
-    ],
-    "coordinates": {},
-    "layers": {
-      "OSM": {
-        "name": "OpenStreetMap",
-        "display": true,
-        "format": "tiles",
-        "URI": "https://{a-c}.tile.openstreetmap.org/{z}/{x}/{y}.png",
-        "style": {
-          "contextFilter": "grayscale(100%)"
+    "templates": {
+        "template_test_temp": {
+            "src": "file:/tests/assets/layers/template_test/layer.json"
         },
-        "attribution": {
-          "© OpenStreetMap": "http://www.openstreetmap.org/copyright"
-        }
-      },
-      "changeEnd": {
-        "display": true,
-        "templates": [
-          {
-            "src": "file:/tests/assets/layers/scratch/layer.json"
-          },
-          {
-            "src": "file:/tests/assets/layers/scratch/infoj.json"
-          },
-          {
-            "src": "file:/tests/assets/layers/scratch/style.json"
-          }
-        ],
-        "tables": {
-          "5": null,
-          "6": "test.scratch"
+        "mvt_test_temp": {
+            "src": "file:/tests/assets/layers/mvt/layer.json"
         },
-        "test_array": ["TEST KEYVALUE"]
-      },
-      "decorate": {
-        "display": false,
-        "templates": [
-          {
-            "src": "file:/tests/assets/layers/scratch/layer.json"
-          },
-          {
-            "src": "file:/tests/assets/layers/scratch/infoj.json"
-          },
-          {
-            "src": "file:/tests/assets/layers/scratch/style.json"
-          }
-        ],
-        "draw": {
-          "circle_2pt": true,
-          "circle": {
-            "roles": {
-              "test": null,
-              "super_test": null
-            },
-            "hidePanel": true
-          },
-          "polygon": true,
-          "point": true
+        "module_test": {
+            "type": "module",
+            "src": "file:/tests/assets/queries/foo.js"
         },
-        "infoj": [
-          {
-            "label": "check",
-            "field": "bool_field",
-            "edit": true,
-            "inline": true,
-            "type": "boolean",
-            "dependents": ["integer_field"]
-          },
-          {
-            "title": "minutes",
-            "field": "integer_field",
-            "value": null,
-            "edit": "true",
-            "inline": true
-          }
-        ],
-        "infoj_skip": ["textarea"]
-      },
-      "fade": {
-        "display": true,
-        "templates": [
-          {
-            "src": "file:/tests/assets/layers/scratch/layer.json"
-          },
-          {
-            "src": "file:/tests/assets/layers/scratch/infoj.json"
-          },
-          {
-            "src": "file:/tests/assets/layers/scratch/style.json"
-          }
-        ]
-      },
-      "styleParser": {
-        "templates": [
-          {
-            "src": "file:/tests/assets/layers/uk_geometries/layer.json"
-          },
-          {
-            "src": "file:/tests/assets/layers/uk_geometries/infoj.json"
-          }
-        ]
-      },
-      "input_slider": {
-        "display": true,
-        "group": "ui_elements",
-        "templates": [
-          {
-            "src": "file:/tests/assets/layers/scratch/layer.json"
-          },
-          {
-            "src": "file:/tests/assets/layers/scratch/infoj.json"
-          },
-          {
-            "src": "file:/tests/assets/layers/scratch/style.json"
-          }
-        ],
-        "infoj": [
-          {
-            "title": "int",
-            "field": "integer_field",
-            "type": "integer",
-            "formatterParams": null,
-            "default": 0,
-            "edit": {
-              "range": true
-            },
-            "min": -100000,
-            "max": 10000,
-            "prefix": "£",
-            "filter": {
-              "type": "integer"
-            }
-          }
-        ]
-      },
-      "pin": {
-        "display": true,
-        "group": "ui_elements",
-        "templates": [
-          {
-            "src": "file:/tests/assets/layers/scratch/layer.json"
-          },
-          {
-            "src": "file:/tests/assets/layers/scratch/infoj.json"
-          },
-          {
-            "src": "file:/tests/assets/layers/scratch/style.json"
-          }
-        ]
-      },
-      "icon_scaling": {
-        "display": true,
-        "templates": [
-          {
-            "src": "file:/tests/assets/layers/scratch/layer.json"
-          },
-          {
-            "src": "file:/tests/assets/layers/scratch/infoj.json"
-          },
-          {
-            "src": "file:/tests/assets/layers/scratch/style.json"
-          },
-          {
-            "src": "file:/tests/assets/layers/scratch/style_icon_scaling.json"
-          }
-        ],
-        "infoj": [
-          {
-            "title": "icon_scale",
-            "field": "icon_scale",
-            "type": "integer",
-            "edit": {
-              "range": true
-            },
-            "min": 1,
-            "max": 10000
-          }
-        ]
-      },
-      "template_test": {
-        "display": true,
-        "template": "template_test_temp",
-        "templates": [
-          {
-            "key": "template_infoj",
+        "template_1": {
             "src": "file:/tests/assets/infoj/template_infoj.json"
-          },
-          {
-            "key": "chart_queryparams",
-            "src": "file:/tests/assets/infoj/chart_queryparams.json"
-          },
-          {
-            "key": "bogus_file",
-            "src": "file:/tests/assets/styles/bogus_file.json"
-          },
-          {
-            "key": "dataviews_json",
-            "src": "file:/tests/assets/dataviews/dataviews_json.json"
-          }
-        ]
-      },
-      "template_foo": {
-        "template": "foo",
-        "display": true
-      },
-      "template_test_vanilla": {
-        "hidden": true,
-        "template": "template_test_temp",
-        "templates": ["template_1", "template_2"]
-      },
-      "location_get_test": {
-        "hidden": true,
-        "templates": [
-          {
-            "src": "file:/tests/assets/layers/location_mock/layer.json"
-          },
-          {
-            "src": "file:/tests/assets/layers/location_mock/infoj.json"
-          }
-        ]
-      },
-      "location_get_test_no_infoj": {
-        "hidden": true,
-        "templates": [
-          {
-            "src": "file:/tests/assets/layers/location_mock/layer.json"
-          }
-        ]
-      },
-      "query_params_layer": {
-        "hidden": true,
-        "templates": [
-          {
-            "src": "file:/tests/assets/layers/location_mock/layer.json"
-          },
-          {
-            "src": "file:/tests/assets/layers/location_mock/infoj.json"
-          }
-        ]
-      },
-      "cluster_test": {},
-      "mvt_test": {
-        "template": "mvt_test_temp"
-      },
-      "entry_layer": {
-        "display": true,
-        "template": "template_test_temp",
-        "infoj": [
-          {
-            "type": "pin",
-            "label": "ST_PointOnSurface",
-            "field": "pin",
-            "fieldfx": "ARRAY[ST_X(ST_PointOnSurface(geom_3857)),ST_Y(ST_PointOnSurface(geom_3857))]"
-          },
-          {
-            "key": "test_mvt_clone",
-            "label": "entry_mvt_clone",
-            "type": "mvt_clone",
-            "display": "true",
-            "name": "mvt clone",
-            "layer": "mvt_test",
-            "query": "mvt_lookup",
-            "template": {
-              "key": "mvt_lookup",
-              "template": "select id, numeric_field from test.mvt_test"
+        },
+        "template_2": {
+            "src": "file:/tests/assets/styles/template_style.json"
+        },
+        "icon_scaling_scratch": {
+            "src": "file:/tests/assets/queries/icon_scaling_scratch.sql"
+        },
+        "get_location_mock": {
+            "src": "file:/tests/assets/queries/get_location_mock.sql"
+        },
+        "minmax_query": {
+            "src": "file:/tests/assets/queries/minmax_mock.sql"
+        },
+        "data_array": {
+            "src": "file:/tests/assets/queries/data_array.sql",
+            "value_only": true
+        },
+        "bogus_data_array": {
+            "src": "file:/tests/assets/queries/data_array.sql",
+            "dbs": "bogus"
+        },
+        "merge_into": {
+            "name": "merge_into",
+            "roles": {
+                "merge_into": null
             }
-          },
-          {
-            "key": "test_layer",
-            "label": "entry_layer",
-            "type": "layer",
-            "display": "true",
-            "name": "layer entry",
-            "layer": "mvt_test",
-            "query": "mvt_lookup"
-          }
-        ]
-      },
-      "roles_test": {
-        "name": "You should not see me",
-        "template": "mvt_test_temp",
-        "templates": ["merge_into"],
-        "roles": {
-          "roles_test": null
         }
-      }
+    },
+    "locale": {
+        "roles": {
+            "A": null,
+            "B": null,
+            "C": null,
+            "*": null
+        },
+        "mapviewControls": [
+            "Zoom"
+        ],
+        "plugins": [
+            "${PLUGINS}v4.8.0/coordinates.js",
+            "${PLUGINS}v4.8.0/chartjs.js",
+            "/test/api/provider/file?content_type=application/javascript&url=./tests/assets/plugins/assignMapview.js"
+        ],
+        "syncPlugins": [
+            "zoomBtn",
+            "zoomToArea",
+            "coordinates",
+            "admin",
+            "login"
+        ],
+        "svg_templates": {
+            "dot_test": "https://geolytix.github.io/MapIcons/templates/dot_10px.svg",
+            "target_test": "https://geolytix.github.io/MapIcons/templates/target.svg",
+            "square_test": "https://geolytix.github.io/MapIcons/templates/square_10px.svg",
+            "diamond_test": "https://geolytix.github.io/MapIcons/templates/diamond_10px.svg",
+            "triangle_test": "https://geolytix.github.io/MapIcons/templates/triangle_10px.svg",
+            "template_pin_test": "https://geolytix.github.io/MapIcons/pins/pink_master_pin.svg"
+        },
+        "link_button": [
+            {
+                "href": "/url/url",
+                "title": "TITLE HERE",
+                "target": "_blank",
+                "css_class": "mask-icon",
+                "css_style": "mask-image: url(https://geolytix.github.io/MapIcons/services/component_exchange.svg); -webkit-mask-image: url(https://geolytix.github.io/MapIcons/services/component_exchange.svg);"
+            },
+            {
+                "title": "WILL NOT BE ADDED AS NO HREF",
+                "target": "_blank",
+                "css_class": "mask-icon",
+                "css_style": "mask-image: url(https://geolytix.github.io/MapIcons/services/component_exchange.svg); -webkit-mask-image: url(https://geolytix.github.io/MapIcons/services/component_exchange.svg);"
+            },
+            {
+                "title": "WILL BE ADDED AS HREF",
+                "href": "/url/url2",
+                "target": "_blank",
+                "css_class": "mask-icon",
+                "css_style": "mask-image: url(https://geolytix.github.io/MapIcons/services/component_exchange.svg); -webkit-mask-image: url(https://geolytix.github.io/MapIcons/services/component_exchange.svg);"
+            }
+        ],
+        "assignMapview": {},
+        "keyvalue_dictionary": [
+            {
+                "key": "name",
+                "value": "OpenStreetMap",
+                "default": "OpenStreetMap KeyValue Dictionary"
+            },
+            {
+                "key": "title",
+                "value": "textarea",
+                "default": "TextArea KeyValue Dictionary"
+            },
+            {
+                "key": "test_array",
+                "value": "TEST KEYVALUE",
+                "default": "WILL NOT BE SEEN AS ARRAY CANNOT BE UPDATED"
+            }
+        ],
+        "coordinates": {},
+        "layers": {
+            "OSM": {
+                "name": "OpenStreetMap",
+                "display": true,
+                "format": "tiles",
+                "URI": "https://{a-c}.tile.openstreetmap.org/{z}/{x}/{y}.png",
+                "style": {
+                    "contextFilter": "grayscale(100%)"
+                },
+                "attribution": {
+                    "© OpenStreetMap": "http://www.openstreetmap.org/copyright"
+                }
+            },
+            "changeEnd": {
+                "display": true,
+                "templates": [
+                    {
+                        "src": "file:/tests/assets/layers/scratch/layer.json"
+                    },
+                    {
+                        "src": "file:/tests/assets/layers/scratch/infoj.json"
+                    },
+                    {
+                        "src": "file:/tests/assets/layers/scratch/style.json"
+                    }
+                ],
+                "tables": {
+                    "5": null,
+                    "6": "test.scratch"
+                },
+                "test_array": [
+                    "TEST KEYVALUE"
+                ]
+            },
+            "decorate": {
+                "display": false,
+                "templates": [
+                    {
+                        "src": "file:/tests/assets/layers/scratch/layer.json"
+                    },
+                    {
+                        "src": "file:/tests/assets/layers/scratch/infoj.json"
+                    },
+                    {
+                        "src": "file:/tests/assets/layers/scratch/style.json"
+                    }
+                ],
+                "draw": {
+                    "circle_2pt": true,
+                    "circle": {
+                        "roles": {
+                            "test": null,
+                            "super_test": null
+                        },
+                        "hidePanel": true
+                    },
+                    "polygon": true,
+                    "point": true
+                },
+                "infoj": [
+                    {
+                        "label": "check",
+                        "field": "bool_field",
+                        "edit": true,
+                        "inline": true,
+                        "type": "boolean",
+                        "dependents": [
+                            "integer_field"
+                        ]
+                    },
+                    {
+                        "title": "minutes",
+                        "field": "integer_field",
+                        "value": null,
+                        "edit": "true",
+                        "inline": true
+                    }
+                ],
+                "infoj_skip": [
+                    "textarea"
+                ]
+            },
+            "fade": {
+                "display": true,
+                "templates": [
+                    {
+                        "src": "file:/tests/assets/layers/scratch/layer.json"
+                    },
+                    {
+                        "src": "file:/tests/assets/layers/scratch/infoj.json"
+                    },
+                    {
+                        "src": "file:/tests/assets/layers/scratch/style.json"
+                    }
+                ]
+            },
+            "styleParser": {
+                "templates": [
+                    {
+                        "src": "file:/tests/assets/layers/uk_geometries/layer.json"
+                    },
+                    {
+                        "src": "file:/tests/assets/layers/uk_geometries/infoj.json"
+                    }
+                ]
+            },
+            "input_slider": {
+                "display": true,
+                "group": "ui_elements",
+                "templates": [
+                    {
+                        "src": "file:/tests/assets/layers/scratch/layer.json"
+                    },
+                    {
+                        "src": "file:/tests/assets/layers/scratch/infoj.json"
+                    },
+                    {
+                        "src": "file:/tests/assets/layers/scratch/style.json"
+                    }
+                ],
+                "infoj": [
+                    {
+                        "title": "int",
+                        "field": "integer_field",
+                        "type": "integer",
+                        "formatterParams": null,
+                        "default": 0,
+                        "edit": {
+                            "range": true
+                        },
+                        "min": -100000,
+                        "max": 10000,
+                        "prefix": "£",
+                        "filter": {
+                            "type": "integer"
+                        }
+                    }
+                ]
+            },
+            "pin": {
+                "display": true,
+                "group": "ui_elements",
+                "templates": [
+                    {
+                        "src": "file:/tests/assets/layers/scratch/layer.json"
+                    },
+                    {
+                        "src": "file:/tests/assets/layers/scratch/infoj.json"
+                    },
+                    {
+                        "src": "file:/tests/assets/layers/scratch/style.json"
+                    }
+                ]
+            },
+            "icon_scaling": {
+                "display": true,
+                "templates": [
+                    {
+                        "src": "file:/tests/assets/layers/scratch/layer.json"
+                    },
+                    {
+                        "src": "file:/tests/assets/layers/scratch/infoj.json"
+                    },
+                    {
+                        "src": "file:/tests/assets/layers/scratch/style.json"
+                    },
+                    {
+                        "src": "file:/tests/assets/layers/scratch/style_icon_scaling.json"
+                    }
+                ],
+                "infoj": [
+                    {
+                        "title": "icon_scale",
+                        "field": "icon_scale",
+                        "type": "integer",
+                        "edit": {
+                            "range": true
+                        },
+                        "min": 1,
+                        "max": 10000
+                    }
+                ]
+            },
+            "template_test": {
+                "display": true,
+                "template": "template_test_temp",
+                "templates": [
+                    {
+                        "key": "template_infoj",
+                        "src": "file:/tests/assets/infoj/template_infoj.json"
+                    },
+                    {
+                        "key": "chart_queryparams",
+                        "src": "file:/tests/assets/infoj/chart_queryparams.json"
+                    },
+                    {
+                        "key": "bogus_file",
+                        "src": "file:/tests/assets/styles/bogus_file.json"
+                    },
+                    {
+                        "key": "dataviews_json",
+                        "src": "file:/tests/assets/dataviews/dataviews_json.json"
+                    }
+                ]
+            },
+            "template_foo": {
+                "template": "foo",
+                "display": true
+            },
+            "template_test_vanilla": {
+                "hidden": true,
+                "template": "template_test_temp",
+                "templates": [
+                    "template_1",
+                    "template_2"
+                ]
+            },
+            "location_get_test": {
+                "hidden": true,
+                "templates": [
+                    {
+                        "src": "file:/tests/assets/layers/location_mock/layer.json"
+                    },
+                    {
+                        "src": "file:/tests/assets/layers/location_mock/infoj.json"
+                    }
+                ]
+            },
+            "location_get_test_no_infoj": {
+                "hidden": true,
+                "templates": [
+                    {
+                        "src": "file:/tests/assets/layers/location_mock/layer.json"
+                    }
+                ]
+            },
+            "query_params_layer": {
+                "hidden": true,
+                "templates": [
+                    {
+                        "src": "file:/tests/assets/layers/location_mock/layer.json"
+                    },
+                    {
+                        "src": "file:/tests/assets/layers/location_mock/infoj.json"
+                    }
+                ]
+            },
+            "cluster_test": {},
+            "mvt_test": {
+                "template": "mvt_test_temp"
+            },
+            "entry_layer": {
+                "display": true,
+                "template": "template_test_temp",
+                "infoj": [
+                    {
+                        "type": "pin",
+                        "label": "ST_PointOnSurface",
+                        "field": "pin",
+                        "fieldfx": "ARRAY[ST_X(ST_PointOnSurface(geom_3857)),ST_Y(ST_PointOnSurface(geom_3857))]"
+                    },
+                    {
+                        "key": "test_mvt_clone",
+                        "label": "entry_mvt_clone",
+                        "type": "mvt_clone",
+                        "display": "true",
+                        "name": "mvt clone",
+                        "layer": "mvt_test",
+                        "query": "mvt_lookup",
+                        "template": {
+                            "key": "mvt_lookup",
+                            "template": "select id, numeric_field from test.mvt_test"
+                        }
+                    },
+                    {
+                        "key": "test_layer",
+                        "label": "entry_layer",
+                        "type": "layer",
+                        "display": "true",
+                        "name": "layer entry",
+                        "layer": "mvt_test",
+                        "query": "mvt_lookup"
+                    }
+                ]
+            },
+            "roles_test": {
+                "name": "You should not see me",
+                "template": "mvt_test_temp",
+                "templates": [
+                    "merge_into"
+                ],
+                "roles": {
+                    "roles_test": null
+                }
+            }
+        }
     }
-  }
 }

--- a/tests/workspace.json
+++ b/tests/workspace.json
@@ -1,417 +1,398 @@
 {
-    "dbs": "NEON",
-    "roles": {
-        "A": "Text about A",
-        "B": "Text about B",
-        "*": null
+  "dbs": "NEON",
+  "roles": {
+    "A": "Text about A",
+    "B": "Text about B",
+    "*": null
+  },
+  "templates": {
+    "template_test_temp": {
+      "src": "file:/tests/assets/layers/template_test/layer.json"
     },
-    "templates": {
-        "template_test_temp": {
-            "src": "file:/tests/assets/layers/template_test/layer.json"
-        },
-        "mvt_test_temp": {
-            "src": "file:/tests/assets/layers/mvt/layer.json"
-        },
-        "module_test": {
-            "type": "module",
-            "src": "file:/tests/assets/queries/foo.js"
-        },
-        "template_1": {
-            "src": "file:/tests/assets/infoj/template_infoj.json"
-        },
-        "template_2": {
-            "src": "file:/tests/assets/styles/template_style.json"
-        },
-        "icon_scaling_scratch": {
-            "src": "file:/tests/assets/queries/icon_scaling_scratch.sql"
-        },
-        "get_location_mock": {
-            "src": "file:/tests/assets/queries/get_location_mock.sql"
-        },
-        "minmax_query": {
-            "src": "file:/tests/assets/queries/minmax_mock.sql"
-        },
-        "data_array": {
-            "src": "file:/tests/assets/queries/data_array.sql",
-            "value_only": true
-        },
-        "bogus_data_array": {
-            "src": "file:/tests/assets/queries/data_array.sql",
-            "dbs": "bogus"
-        },
-        "merge_into": {
-            "name": "merge_into",
-            "roles": {
-                "merge_into": null
-            }
-        }
+    "mvt_test_temp": {
+      "src": "file:/tests/assets/layers/mvt/layer.json"
     },
-    "locale": {
-        "roles": {
-            "A": null,
-            "B": null,
-            "C": null,
-            "*": null
-        },
-        "mapviewControls": [
-            "Zoom"
-        ],
-        "plugins": [
-            "${PLUGINS}v4.8.0/coordinates.js",
-            "${PLUGINS}v4.8.0/chartjs.js",
-            "/test/api/provider/file?content_type=application/javascript&url=./tests/assets/plugins/assignMapview.js"
-        ],
-        "syncPlugins": [
-            "zoomBtn",
-            "zoomToArea",
-            "coordinates",
-            "admin",
-            "login"
-        ],
-        "svg_templates": {
-            "dot_test": "https://geolytix.github.io/MapIcons/templates/dot_10px.svg",
-            "target_test": "https://geolytix.github.io/MapIcons/templates/target.svg",
-            "square_test": "https://geolytix.github.io/MapIcons/templates/square_10px.svg",
-            "diamond_test": "https://geolytix.github.io/MapIcons/templates/diamond_10px.svg",
-            "triangle_test": "https://geolytix.github.io/MapIcons/templates/triangle_10px.svg",
-            "template_pin_test": "https://geolytix.github.io/MapIcons/pins/pink_master_pin.svg"
-        },
-        "link_button": [
-            {
-                "href": "/url/url",
-                "title": "TITLE HERE",
-                "target": "_blank",
-                "css_class": "mask-icon",
-                "css_style": "mask-image: url(https://geolytix.github.io/MapIcons/services/component_exchange.svg); -webkit-mask-image: url(https://geolytix.github.io/MapIcons/services/component_exchange.svg);"
-            },
-            {
-                "title": "WILL NOT BE ADDED AS NO HREF",
-                "target": "_blank",
-                "css_class": "mask-icon",
-                "css_style": "mask-image: url(https://geolytix.github.io/MapIcons/services/component_exchange.svg); -webkit-mask-image: url(https://geolytix.github.io/MapIcons/services/component_exchange.svg);"
-            },
-            {
-                "title": "WILL BE ADDED AS HREF",
-                "href": "/url/url2",
-                "target": "_blank",
-                "css_class": "mask-icon",
-                "css_style": "mask-image: url(https://geolytix.github.io/MapIcons/services/component_exchange.svg); -webkit-mask-image: url(https://geolytix.github.io/MapIcons/services/component_exchange.svg);"
-            }
-        ],
-        "assignMapview": {},
-        "keyvalue_dictionary": [
-            {
-                "key": "name",
-                "value": "OpenStreetMap",
-                "default": "OpenStreetMap KeyValue Dictionary"
-            },
-            {
-                "key": "title",
-                "value": "textarea",
-                "default": "TextArea KeyValue Dictionary"
-            },
-            {
-                "key": "test_array",
-                "value": "TEST KEYVALUE",
-                "default": "WILL NOT BE SEEN AS ARRAY CANNOT BE UPDATED"
-            }
-        ],
-        "coordinates": {},
-        "layers": {
-            "OSM": {
-                "name": "OpenStreetMap",
-                "display": true,
-                "format": "tiles",
-                "URI": "https://{a-c}.tile.openstreetmap.org/{z}/{x}/{y}.png",
-                "style": {
-                    "contextFilter": "grayscale(100%)"
-                },
-                "attribution": {
-                    "© OpenStreetMap": "http://www.openstreetmap.org/copyright"
-                }
-            },
-            "changeEnd": {
-                "display": true,
-                "templates": [
-                    {
-                        "src": "file:/tests/assets/layers/scratch/layer.json"
-                    },
-                    {
-                        "src": "file:/tests/assets/layers/scratch/infoj.json"
-                    },
-                    {
-                        "src": "file:/tests/assets/layers/scratch/style.json"
-                    }
-                ],
-                "tables": {
-                    "5": null,
-                    "6": "test.scratch"
-                },
-                "test_array": [
-                    "TEST KEYVALUE"
-                ]
-            },
-            "decorate": {
-                "display": false,
-                "templates": [
-                    {
-                        "src": "file:/tests/assets/layers/scratch/layer.json"
-                    },
-                    {
-                        "src": "file:/tests/assets/layers/scratch/infoj.json"
-                    },
-                    {
-                        "src": "file:/tests/assets/layers/scratch/style.json"
-                    }
-                ],
-                "draw": {
-                    "circle_2pt": true,
-                    "circle": {
-                        "roles": {
-                            "test": null,
-                            "super_test": null
-                        },
-                        "hidePanel": true
-                    },
-                    "polygon": true,
-                    "point": true
-                },
-                "infoj": [
-                    {
-                        "label": "check",
-                        "field": "bool_field",
-                        "edit": true,
-                        "inline": true,
-                        "type": "boolean",
-                        "dependents": [
-                            "integer_field"
-                        ]
-                    },
-                    {
-                        "title": "minutes",
-                        "field": "integer_field",
-                        "value": null,
-                        "edit": "true",
-                        "inline": true
-                    }
-                ],
-                "infoj_skip": [
-                    "textarea"
-                ]
-            },
-            "fade": {
-                "display": true,
-                "templates": [
-                    {
-                        "src": "file:/tests/assets/layers/scratch/layer.json"
-                    },
-                    {
-                        "src": "file:/tests/assets/layers/scratch/infoj.json"
-                    },
-                    {
-                        "src": "file:/tests/assets/layers/scratch/style.json"
-                    }
-                ]
-            },
-            "styleParser": {
-                "templates": [
-                    {
-                        "src": "file:/tests/assets/layers/uk_geometries/layer.json"
-                    },
-                    {
-                        "src": "file:/tests/assets/layers/uk_geometries/infoj.json"
-                    }
-                ]
-            },
-            "input_slider": {
-                "display": true,
-                "group": "ui_elements",
-                "templates": [
-                    {
-                        "src": "file:/tests/assets/layers/scratch/layer.json"
-                    },
-                    {
-                        "src": "file:/tests/assets/layers/scratch/infoj.json"
-                    },
-                    {
-                        "src": "file:/tests/assets/layers/scratch/style.json"
-                    }
-                ],
-                "infoj": [
-                    {
-                        "title": "int",
-                        "field": "integer_field",
-                        "type": "integer",
-                        "formatterParams": null,
-                        "default": 0,
-                        "edit": {
-                            "range": true
-                        },
-                        "min": -100000,
-                        "max": 10000,
-                        "prefix": "£",
-                        "filter": {
-                            "type": "integer"
-                        }
-                    }
-                ]
-            },
-            "pin": {
-                "display": true,
-                "group": "ui_elements",
-                "templates": [
-                    {
-                        "src": "file:/tests/assets/layers/scratch/layer.json"
-                    },
-                    {
-                        "src": "file:/tests/assets/layers/scratch/infoj.json"
-                    },
-                    {
-                        "src": "file:/tests/assets/layers/scratch/style.json"
-                    }
-                ]
-            },
-            "icon_scaling": {
-                "display": true,
-                "templates": [
-                    {
-                        "src": "file:/tests/assets/layers/scratch/layer.json"
-                    },
-                    {
-                        "src": "file:/tests/assets/layers/scratch/infoj.json"
-                    },
-                    {
-                        "src": "file:/tests/assets/layers/scratch/style.json"
-                    },
-                    {
-                        "src": "file:/tests/assets/layers/scratch/style_icon_scaling.json"
-                    }
-                ],
-                "infoj": [
-                    {
-                        "title": "icon_scale",
-                        "field": "icon_scale",
-                        "type": "integer",
-                        "edit": {
-                            "range": true
-                        },
-                        "min": 1,
-                        "max": 10000
-                    }
-                ]
-            },
-            "template_test": {
-                "display": true,
-                "template": "template_test_temp",
-                "templates": [
-                    {
-                        "key": "template_infoj",
-                        "src": "file:/tests/assets/infoj/template_infoj.json"
-                    },
-                    {
-                        "key": "chart_queryparams",
-                        "src": "file:/tests/assets/infoj/chart_queryparams.json"
-                    },
-                    {
-                        "key": "bogus_file",
-                        "src": "file:/tests/assets/styles/bogus_file.json"
-                    },
-                    {
-                        "key": "dataviews_json",
-                        "src": "file:/tests/assets/dataviews/dataviews_json.json"
-                    }
-                ]
-            },
-            "template_foo": {
-                "template": "foo",
-                "display": true
-            },
-            "template_test_vanilla": {
-                "hidden": true,
-                "template": "template_test_temp",
-                "templates": [
-                    "template_1",
-                    "template_2"
-                ]
-            },
-            "location_get_test": {
-                "hidden": true,
-                "templates": [
-                    {
-                        "src": "file:/tests/assets/layers/location_mock/layer.json"
-                    },
-                    {
-                        "src": "file:/tests/assets/layers/location_mock/infoj.json"
-                    }
-                ]
-            },
-            "location_get_test_no_infoj": {
-                "hidden": true,
-                "templates": [
-                    {
-                        "src": "file:/tests/assets/layers/location_mock/layer.json"
-                    }
-                ]
-            },
-            "query_params_layer": {
-                "hidden": true,
-                "templates": [
-                    {
-                        "src": "file:/tests/assets/layers/location_mock/layer.json"
-                    },
-                    {
-                        "src": "file:/tests/assets/layers/location_mock/infoj.json"
-                    }
-                ]
-            },
-            "cluster_test": {},
-            "mvt_test": {
-                "template": "mvt_test_temp"
-            },
-            "entry_layer": {
-                "display": true,
-                "template": "template_test_temp",
-                "infoj": [
-                    {
-                        "type": "pin",
-                        "label": "ST_PointOnSurface",
-                        "field": "pin",
-                        "fieldfx": "ARRAY[ST_X(ST_PointOnSurface(geom_3857)),ST_Y(ST_PointOnSurface(geom_3857))]"
-                    },
-                    {
-                        "key": "test_mvt_clone",
-                        "label": "entry_mvt_clone",
-                        "type": "mvt_clone",
-                        "display": "true",
-                        "name": "mvt clone",
-                        "layer": "mvt_test",
-                        "query": "mvt_lookup",
-                        "template": {
-                            "key": "mvt_lookup",
-                            "template": "select id, numeric_field from test.mvt_test"
-                        }
-                    },
-                    {
-                        "key": "test_layer",
-                        "label": "entry_layer",
-                        "type": "layer",
-                        "display": "true",
-                        "name": "layer entry",
-                        "layer": "mvt_test",
-                        "query": "mvt_lookup"
-                    }
-                ]
-            },
-            "roles_test": {
-                "name": "You should not see me",
-                "template": "mvt_test_temp",
-                "templates": [
-                    "merge_into"
-                ],
-                "roles": {
-                    "roles_test": null
-                }
-            }
-        }
+    "module_test": {
+      "type": "module",
+      "src": "file:/tests/assets/queries/foo.js"
+    },
+    "template_1": {
+      "src": "file:/tests/assets/infoj/template_infoj.json"
+    },
+    "template_2": {
+      "src": "file:/tests/assets/styles/template_style.json"
+    },
+    "icon_scaling_scratch": {
+      "src": "file:/tests/assets/queries/icon_scaling_scratch.sql"
+    },
+    "get_location_mock": {
+      "src": "file:/tests/assets/queries/get_location_mock.sql"
+    },
+    "minmax_query": {
+      "src": "file:/tests/assets/queries/minmax_mock.sql"
+    },
+    "data_array": {
+      "src": "file:/tests/assets/queries/data_array.sql",
+      "value_only": true
+    },
+    "bogus_data_array": {
+      "src": "file:/tests/assets/queries/data_array.sql",
+      "dbs": "bogus"
+    },
+    "merge_into": {
+      "name": "merge_into",
+      "roles": {
+        "merge_into": null
+      }
     }
+  },
+  "locale": {
+    "roles": {
+      "A": null,
+      "B": null,
+      "C": null,
+      "*": null
+    },
+    "mapviewControls": ["Zoom"],
+    "plugins": [
+      "${PLUGINS}v4.8.0/coordinates.js",
+      "${PLUGINS}v4.8.0/chartjs.js",
+      "/test/api/provider/file?content_type=application/javascript&url=./tests/assets/plugins/assignMapview.js"
+    ],
+    "syncPlugins": ["zoomBtn", "zoomToArea", "coordinates", "admin", "login"],
+    "svg_templates": {
+      "dot_test": "https://geolytix.github.io/MapIcons/templates/dot_10px.svg",
+      "target_test": "https://geolytix.github.io/MapIcons/templates/target.svg",
+      "square_test": "https://geolytix.github.io/MapIcons/templates/square_10px.svg",
+      "diamond_test": "https://geolytix.github.io/MapIcons/templates/diamond_10px.svg",
+      "triangle_test": "https://geolytix.github.io/MapIcons/templates/triangle_10px.svg",
+      "template_pin_test": "https://geolytix.github.io/MapIcons/pins/pink_master_pin.svg"
+    },
+    "link_button": [
+      {
+        "href": "/url/url",
+        "title": "TITLE HERE",
+        "target": "_blank",
+        "css_class": "mask-icon",
+        "css_style": "mask-image: url(https://geolytix.github.io/MapIcons/services/component_exchange.svg); -webkit-mask-image: url(https://geolytix.github.io/MapIcons/services/component_exchange.svg);"
+      },
+      {
+        "title": "WILL NOT BE ADDED AS NO HREF",
+        "target": "_blank",
+        "css_class": "mask-icon",
+        "css_style": "mask-image: url(https://geolytix.github.io/MapIcons/services/component_exchange.svg); -webkit-mask-image: url(https://geolytix.github.io/MapIcons/services/component_exchange.svg);"
+      },
+      {
+        "title": "WILL BE ADDED AS HREF",
+        "href": "/url/url2",
+        "target": "_blank",
+        "css_class": "mask-icon",
+        "css_style": "mask-image: url(https://geolytix.github.io/MapIcons/services/component_exchange.svg); -webkit-mask-image: url(https://geolytix.github.io/MapIcons/services/component_exchange.svg);"
+      }
+    ],
+    "assignMapview": {},
+    "keyvalue_dictionary": [
+      {
+        "key": "name",
+        "value": "OpenStreetMap",
+        "default": "OpenStreetMap KeyValue Dictionary"
+      },
+      {
+        "key": "title",
+        "value": "textarea",
+        "default": "TextArea KeyValue Dictionary"
+      },
+      {
+        "key": "test_array",
+        "value": "TEST KEYVALUE",
+        "default": "WILL NOT BE SEEN AS ARRAY CANNOT BE UPDATED"
+      }
+    ],
+    "coordinates": {},
+    "layers": {
+      "OSM": {
+        "name": "OpenStreetMap",
+        "display": true,
+        "format": "tiles",
+        "URI": "https://{a-c}.tile.openstreetmap.org/{z}/{x}/{y}.png",
+        "style": {
+          "contextFilter": "grayscale(100%)"
+        },
+        "attribution": {
+          "© OpenStreetMap": "http://www.openstreetmap.org/copyright"
+        }
+      },
+      "changeEnd": {
+        "display": true,
+        "templates": [
+          {
+            "src": "file:/tests/assets/layers/scratch/layer.json"
+          },
+          {
+            "src": "file:/tests/assets/layers/scratch/infoj.json"
+          },
+          {
+            "src": "file:/tests/assets/layers/scratch/style.json"
+          }
+        ],
+        "tables": {
+          "5": null,
+          "6": "test.scratch"
+        },
+        "test_array": ["TEST KEYVALUE"]
+      },
+      "decorate": {
+        "display": false,
+        "templates": [
+          {
+            "src": "file:/tests/assets/layers/scratch/layer.json"
+          },
+          {
+            "src": "file:/tests/assets/layers/scratch/infoj.json"
+          },
+          {
+            "src": "file:/tests/assets/layers/scratch/style.json"
+          }
+        ],
+        "draw": {
+          "circle_2pt": true,
+          "circle": {
+            "roles": {
+              "test": null,
+              "super_test": null
+            },
+            "hidePanel": true
+          },
+          "polygon": true,
+          "point": true
+        },
+        "infoj": [
+          {
+            "label": "check",
+            "field": "bool_field",
+            "edit": true,
+            "inline": true,
+            "type": "boolean",
+            "dependents": ["integer_field"]
+          },
+          {
+            "title": "minutes",
+            "field": "integer_field",
+            "value": null,
+            "edit": "true",
+            "inline": true
+          }
+        ],
+        "infoj_skip": ["textarea"]
+      },
+      "fade": {
+        "display": true,
+        "templates": [
+          {
+            "src": "file:/tests/assets/layers/scratch/layer.json"
+          },
+          {
+            "src": "file:/tests/assets/layers/scratch/infoj.json"
+          },
+          {
+            "src": "file:/tests/assets/layers/scratch/style.json"
+          }
+        ]
+      },
+      "styleParser": {
+        "templates": [
+          {
+            "src": "file:/tests/assets/layers/uk_geometries/layer.json"
+          },
+          {
+            "src": "file:/tests/assets/layers/uk_geometries/infoj.json"
+          }
+        ]
+      },
+      "input_slider": {
+        "display": true,
+        "group": "ui_elements",
+        "templates": [
+          {
+            "src": "file:/tests/assets/layers/scratch/layer.json"
+          },
+          {
+            "src": "file:/tests/assets/layers/scratch/infoj.json"
+          },
+          {
+            "src": "file:/tests/assets/layers/scratch/style.json"
+          }
+        ],
+        "infoj": [
+          {
+            "title": "int",
+            "field": "integer_field",
+            "type": "integer",
+            "formatterParams": null,
+            "default": 0,
+            "edit": {
+              "range": true
+            },
+            "min": -100000,
+            "max": 10000,
+            "prefix": "£",
+            "filter": {
+              "type": "integer"
+            }
+          }
+        ]
+      },
+      "pin": {
+        "display": true,
+        "group": "ui_elements",
+        "templates": [
+          {
+            "src": "file:/tests/assets/layers/scratch/layer.json"
+          },
+          {
+            "src": "file:/tests/assets/layers/scratch/infoj.json"
+          },
+          {
+            "src": "file:/tests/assets/layers/scratch/style.json"
+          }
+        ]
+      },
+      "icon_scaling": {
+        "display": true,
+        "templates": [
+          {
+            "src": "file:/tests/assets/layers/scratch/layer.json"
+          },
+          {
+            "src": "file:/tests/assets/layers/scratch/infoj.json"
+          },
+          {
+            "src": "file:/tests/assets/layers/scratch/style.json"
+          },
+          {
+            "src": "file:/tests/assets/layers/scratch/style_icon_scaling.json"
+          }
+        ],
+        "infoj": [
+          {
+            "title": "icon_scale",
+            "field": "icon_scale",
+            "type": "integer",
+            "edit": {
+              "range": true
+            },
+            "min": 1,
+            "max": 10000
+          }
+        ]
+      },
+      "template_test": {
+        "display": true,
+        "template": "template_test_temp",
+        "templates": [
+          {
+            "key": "template_infoj",
+            "src": "file:/tests/assets/infoj/template_infoj.json"
+          },
+          {
+            "key": "chart_queryparams",
+            "src": "file:/tests/assets/infoj/chart_queryparams.json"
+          },
+          {
+            "key": "bogus_file",
+            "src": "file:/tests/assets/styles/bogus_file.json"
+          },
+          {
+            "key": "dataviews_json",
+            "src": "file:/tests/assets/dataviews/dataviews_json.json"
+          }
+        ]
+      },
+      "template_foo": {
+        "template": "foo",
+        "display": true
+      },
+      "template_test_vanilla": {
+        "hidden": true,
+        "template": "template_test_temp",
+        "templates": ["template_1", "template_2"]
+      },
+      "location_get_test": {
+        "hidden": true,
+        "templates": [
+          {
+            "src": "file:/tests/assets/layers/location_mock/layer.json"
+          },
+          {
+            "src": "file:/tests/assets/layers/location_mock/infoj.json"
+          }
+        ]
+      },
+      "location_get_test_no_infoj": {
+        "hidden": true,
+        "templates": [
+          {
+            "src": "file:/tests/assets/layers/location_mock/layer.json"
+          }
+        ]
+      },
+      "query_params_layer": {
+        "hidden": true,
+        "templates": [
+          {
+            "src": "file:/tests/assets/layers/location_mock/layer.json"
+          },
+          {
+            "src": "file:/tests/assets/layers/location_mock/infoj.json"
+          }
+        ]
+      },
+      "cluster_test": {},
+      "mvt_test": {
+        "template": "mvt_test_temp"
+      },
+      "entry_layer": {
+        "display": true,
+        "template": "template_test_temp",
+        "infoj": [
+          {
+            "type": "pin",
+            "label": "ST_PointOnSurface",
+            "field": "pin",
+            "fieldfx": "ARRAY[ST_X(ST_PointOnSurface(geom_3857)),ST_Y(ST_PointOnSurface(geom_3857))]"
+          },
+          {
+            "key": "test_mvt_clone",
+            "label": "entry_mvt_clone",
+            "type": "mvt_clone",
+            "display": "true",
+            "name": "mvt clone",
+            "layer": "mvt_test",
+            "query": "mvt_lookup",
+            "template": {
+              "key": "mvt_lookup",
+              "template": "select id, numeric_field from test.mvt_test"
+            }
+          },
+          {
+            "key": "test_layer",
+            "label": "entry_layer",
+            "type": "layer",
+            "display": "true",
+            "name": "layer entry",
+            "layer": "mvt_test",
+            "query": "mvt_lookup"
+          }
+        ]
+      },
+      "roles_test": {
+        "name": "You should not see me",
+        "template": "mvt_test_temp",
+        "templates": ["merge_into"],
+        "roles": {
+          "roles_test": null
+        }
+      }
+    }
+  }
 }


### PR DESCRIPTION
# Automatic Code Formatting husky/lint-stage/prettier 🐶🧹💅

## Changes

- Add pre-commit hooks using [husky](https://typicode.github.io/husky/)
- Configure [lint-staged](https://github.com/lint-staged/lint-staged) to run Prettier on staged files

## Dependencies Added

- husky
- lint-staged

## Details

- Adds pre-commit hook to automatically format code using existing Prettier config
- Formats staged files of type: js, mjs, json, css, md

## Setup Required

After pulling these changes, dev's should run:

```bash
npm install
```

## How to Test

1. Make changes to any supported file type
2. Stage the changes (`git add .`)
3. Commit the changes (`git commit -m "test"`)
4. Verify that files are automatically formatted before commit

## Impact

- Ensures consistent formatting across the codebase
- Prevents unformatted code from being committed
- Reduces manual formatting overhead