### PR TITLE
Link Button: allow locale to be passed as flag

### DIFF
--- a/lib/plugins/link_button.mjs
+++ b/lib/plugins/link_button.mjs
@@ -31,16 +31,16 @@ The link_button method will call the addButton method for each link_button objec
 let mapButton;
 export function link_button(link_button, mapview) {
   mapButton = document.getElementById('mapButton');
-  const locale_key = mapview.locale.key;
+  const localeKey = mapview.locale.key;
 
   if (!mapButton) return;
 
   if (!link_button) return;
 
   if (Array.isArray(link_button)) {
-    link_button.forEach((link) => addButton(link, locale_key));
+    link_button.forEach((link) => addButton(link, localeKey));
   } else {
-    addButton(link_button, locale_key);
+    addButton(link_button, localeKey);
   }
 }
 
@@ -50,7 +50,7 @@ export function link_button(link_button, mapview) {
 The addButton method creates a link element and appends the element to the mapButton.
 
 @param {Object} link The link object.
-@param {string} locale_key The key of the current mapview locale.
+@param {string} localeKey The key of the current mapview locale.
 @property {string} link.href The link URL.
 @property {string} link.title The link title, defaults to "Link".
 @property {string} link.target The link target, defaults to "_blank".
@@ -58,14 +58,14 @@ The addButton method creates a link element and appends the element to the mapBu
 @property {string} link.css_style The style for the div.
 @property {boolean} [link.locale] Whether to append the locale to the href.
 */
-function addButton(link, locale_key) {
+function addButton(link, localeKey) {
   if (!link?.href) {
     console.warn(`You must provide a href for the link_button plugin.`);
     return;
   }
 
   if (link.locale) {
-    link.href = `${link.href}?locale=${locale_key}`;
+    link.href = `${link.href}?locale=${localeKey}`;
   }
 
   link.target ??= '_blank';

--- a/lib/plugins/link_button.mjs
+++ b/lib/plugins/link_button.mjs
@@ -28,24 +28,21 @@ The link_button method will call the addButton method for each link_button objec
 @param {Object} link_button The link_button config, can be an array of objects.
 @param {mapview} mapview The mapview object.
 */
-let mapButton
+let mapButton;
 export function link_button(link_button, mapview) {
-
   mapButton = document.getElementById('mapButton');
-  const locale_key = mapview.locale.key
+  const locale_key = mapview.locale.key;
 
   if (!mapButton) return;
 
   if (!link_button) return;
 
   if (Array.isArray(link_button)) {
-
-    link_button.forEach((link) => addButton(link, locale_key))
+    link_button.forEach((link) => addButton(link, locale_key));
   } else {
-
-    addButton(link_button, locale_key)
+    addButton(link_button, locale_key);
   }
-};
+}
 
 /**
 @function addButton
@@ -62,21 +59,20 @@ The addButton method creates a link element and appends the element to the mapBu
 @property {boolean} [link.locale] Whether to append the locale to the href.
 */
 function addButton(link, locale_key) {
-
   if (!link?.href) {
     console.warn(`You must provide a href for the link_button plugin.`);
     return;
   }
 
   if (link.locale) {
-    link.href = `${link.href}?locale=${locale_key}`
+    link.href = `${link.href}?locale=${locale_key}`;
   }
 
-  link.target ??= '_blank'
+  link.target ??= '_blank';
 
-  link.css_class ??= 'mask-icon'
+  link.css_class ??= 'mask-icon';
 
-  link.title ??= mapp.dictionary.link
+  link.title ??= mapp.dictionary.link;
 
   const node = mapp.utils.html.node`
     <a

--- a/lib/plugins/link_button.mjs
+++ b/lib/plugins/link_button.mjs
@@ -26,9 +26,10 @@ The link_button locale property is provided as the link_button function argument
 The link_button method will call the addButton method for each link_button object.
 
 @param {Object} link_button The link_button config, can be an array of objects.
+@param {mapview} mapview The mapview object.
 */
 let mapButton
-export function link_button(link_button) {
+export function link_button(link_button, mapview) {
 
   mapButton = document.getElementById('mapButton');
 
@@ -38,10 +39,10 @@ export function link_button(link_button) {
 
   if (Array.isArray(link_button)) {
 
-    link_button.forEach(addButton)
+    link_button.forEach((link) => addButton(link, mapview))
   } else {
 
-    addButton(link_button)
+    addButton(link_button, mapview)
   }
 };
 
@@ -51,17 +52,23 @@ export function link_button(link_button) {
 The addButton method creates a link element and appends the element to the mapButton.
 
 @param {Object} link The link object.
+@param {mapview} mapview the mapview object.
 @property {string} link.href The link URL.
 @property {string} link.title The link title, defaults to "Link".
 @property {string} link.target The link target, defaults to "_blank".
 @property {string} link.css_class The class for the div, defaults to "mask-icon".
 @property {string} link.css_style The style for the div.
+@property {boolean} link.locale Whether to append the locale to the href.
 */
-function addButton(link) {
+function addButton(link, mapview) {
 
   if (!link?.href) {
     console.warn(`You must provide a href for the link_button plugin.`);
     return;
+  }
+
+  if (link.locale) {
+    link.href = `${link.href}?locale=${mapview.locale.key}`
   }
 
   link.target ??= '_blank'

--- a/lib/plugins/link_button.mjs
+++ b/lib/plugins/link_button.mjs
@@ -32,6 +32,7 @@ let mapButton
 export function link_button(link_button, mapview) {
 
   mapButton = document.getElementById('mapButton');
+  const locale_key = mapview.locale.key
 
   if (!mapButton) return;
 
@@ -39,10 +40,10 @@ export function link_button(link_button, mapview) {
 
   if (Array.isArray(link_button)) {
 
-    link_button.forEach((link) => addButton(link, mapview))
+    link_button.forEach((link) => addButton(link, locale_key))
   } else {
 
-    addButton(link_button, mapview)
+    addButton(link_button, locale_key)
   }
 };
 
@@ -52,7 +53,7 @@ export function link_button(link_button, mapview) {
 The addButton method creates a link element and appends the element to the mapButton.
 
 @param {Object} link The link object.
-@param {mapview} mapview the mapview object.
+@param {string} locale_key The key of the current mapview locale.
 @property {string} link.href The link URL.
 @property {string} link.title The link title, defaults to "Link".
 @property {string} link.target The link target, defaults to "_blank".
@@ -60,7 +61,7 @@ The addButton method creates a link element and appends the element to the mapBu
 @property {string} link.css_style The style for the div.
 @property {boolean} [link.locale] Whether to append the locale to the href.
 */
-function addButton(link, mapview) {
+function addButton(link, locale_key) {
 
   if (!link?.href) {
     console.warn(`You must provide a href for the link_button plugin.`);
@@ -68,7 +69,7 @@ function addButton(link, mapview) {
   }
 
   if (link.locale) {
-    link.href = `${link.href}?locale=${mapview.locale.key}`
+    link.href = `${link.href}?locale=${locale_key}`
   }
 
   link.target ??= '_blank'

--- a/lib/plugins/link_button.mjs
+++ b/lib/plugins/link_button.mjs
@@ -19,7 +19,8 @@ The link_button locale property is provided as the link_button function argument
   },
   {
     "href": "/foo",
-    "title": "Foo"
+    "title": "Foo",
+    "locale": true
   }
 ]
 ```

--- a/lib/plugins/link_button.mjs
+++ b/lib/plugins/link_button.mjs
@@ -58,7 +58,7 @@ The addButton method creates a link element and appends the element to the mapBu
 @property {string} link.target The link target, defaults to "_blank".
 @property {string} link.css_class The class for the div, defaults to "mask-icon".
 @property {string} link.css_style The style for the div.
-@property {boolean} link.locale Whether to append the locale to the href.
+@property {boolean} [link.locale] Whether to append the locale to the href.
 */
 function addButton(link, mapview) {
 

--- a/tests/browser/local.test.mjs
+++ b/tests/browser/local.test.mjs
@@ -9,7 +9,7 @@ export async function coreTest() {
     // Run the dictionary Tests
     await runAllTests(_mappTest.dictionaryTest, mapview);
     //Plugins Tests
-    await runAllTests(_mappTest.pluginsTest);
+    await runAllTests(_mappTest.pluginsTest, mapview);
     //Layer Tests
     await runAllTests(_mappTest.layerTest, mapview);
     //Location Tests

--- a/tests/browser/local.test.mjs
+++ b/tests/browser/local.test.mjs
@@ -1,51 +1,53 @@
 export async function coreTest() {
-    //API Tests
-    await runAllTests(_mappTest.workspaceSuite);
-    await _mappTest.queryTest();
-    const mapview = await _mappTest.base();
-    await runAllTests(_mappTest.userTest);
-    //Run Map Object test
-    await runAllTests(_mappTest.mappTest);
-    // Run the dictionary Tests
-    await runAllTests(_mappTest.dictionaryTest, mapview);
-    //Plugins Tests
-    await runAllTests(_mappTest.pluginsTest, mapview);
-    //Layer Tests
-    await runAllTests(_mappTest.layerTest, mapview);
-    //Location Tests
-    await runAllTests(_mappTest.locationTest, mapview);
-    //Mapview Tests
-    await runAllTests(_mappTest.mapviewTest, mapview);
-    //UI Elements Tests
-    await runAllTests(_mappTest.ui_elementsTest, mapview);
-    //Entries Tests
-    await runAllTests(_mappTest.entriesTest, mapview);
-    //UI Layers Tests
-    await runAllTests(_mappTest.ui_layers, mapview);
-    //UI tests
-    await runAllTests(_mappTest.uiTest, mapview);
-    //Format Tests
-    await runAllTests(_mappTest.formatTest, mapview);
-    //UI Locations Tests
-    await runAllTests(_mappTest.ui_locations, mapview);
-    //Utils Tests
-    await runAllTests(_mappTest.utilsTest, mapview);
+  //API Tests
+  await runAllTests(_mappTest.workspaceSuite);
+  await _mappTest.queryTest();
+  const mapview = await _mappTest.base();
+  await runAllTests(_mappTest.userTest);
+  //Run Map Object test
+  await runAllTests(_mappTest.mappTest);
+  // Run the dictionary Tests
+  await runAllTests(_mappTest.dictionaryTest, mapview);
+  //Plugins Tests
+  await runAllTests(_mappTest.pluginsTest, mapview);
+  //Layer Tests
+  await runAllTests(_mappTest.layerTest, mapview);
+  //Location Tests
+  await runAllTests(_mappTest.locationTest, mapview);
+  //Mapview Tests
+  await runAllTests(_mappTest.mapviewTest, mapview);
+  //UI Elements Tests
+  await runAllTests(_mappTest.ui_elementsTest, mapview);
+  //Entries Tests
+  await runAllTests(_mappTest.entriesTest, mapview);
+  //UI Layers Tests
+  await runAllTests(_mappTest.ui_layers, mapview);
+  //UI tests
+  await runAllTests(_mappTest.uiTest, mapview);
+  //Format Tests
+  await runAllTests(_mappTest.formatTest, mapview);
+  //UI Locations Tests
+  await runAllTests(_mappTest.ui_locations, mapview);
+  //Utils Tests
+  await runAllTests(_mappTest.utilsTest, mapview);
 }
 
 /**
- * This function is used to execute all the test functions on the exported test object. 
+ * This function is used to execute all the test functions on the exported test object.
  * @function runAllTests
- * @param {object} tests 
- * @param {object} mapview 
+ * @param {object} tests
+ * @param {object} mapview
  */
 async function runAllTests(tests, mapview) {
-    const testFunctions = Object.values(tests).filter(item => typeof item === 'function');
+  const testFunctions = Object.values(tests).filter(
+    (item) => typeof item === 'function',
+  );
 
-    for (const testFn of testFunctions) {
-        try {
-            await testFn(mapview);
-        } catch (error) {
-            console.error(`Error in test ${testFn.name}:`, error);
-        }
+  for (const testFn of testFunctions) {
+    try {
+      await testFn(mapview);
+    } catch (error) {
+      console.error(`Error in test ${testFn.name}:`, error);
     }
+  }
 }

--- a/tests/plugins/link_button.test.mjs
+++ b/tests/plugins/link_button.test.mjs
@@ -3,7 +3,41 @@
  * This test is used to see if the link_button plugin is working as expected.
  * @function linkButtonTest
  */
-export function linkButtonTest() {
+export function linkButtonTest(mapview) {
+
+    const links = [
+        {
+            'href': '/url/url',
+            'title': 'TITLE HERE',
+            'target': '_blank',
+            'css_class': 'mask-icon',
+            'css_style': 'mask-image: url(https://geolytix.github.io/MapIcons/services/component_exchange.svg); -webkit-mask-image: url(https://geolytix.github.io/MapIcons/services/component_exchange.svg);'
+        },
+        {
+            'title': 'WILL NOT BE ADDED AS NO HREF',
+            'target': '_blank',
+            'css_class': 'mask-icon',
+            'css_style': 'mask-image: url(https://geolytix.github.io/MapIcons/services/component_exchange.svg); -webkit-mask-image: url(https://geolytix.github.io/MapIcons/services/component_exchange.svg);'
+        },
+        {
+            'title': 'WILL BE ADDED AS HREF',
+            'href': '/url/url2',
+            'target': '_blank',
+            'css_class': 'mask-icon',
+            'css_style': 'mask-image: url(https://geolytix.github.io/MapIcons/services/component_exchange.svg); -webkit-mask-image: url(https://geolytix.github.io/MapIcons/services/component_exchange.svg);'
+        },
+        {
+            'title': 'Locale HREF',
+            'href': '/url/url3',
+            'target': '_blank',
+            'css_class': 'mask-icon',
+            'css_style': 'mask-image: url(https://geolytix.github.io/MapIcons/services/component_exchange.svg); -webkit-mask-image: url(https://geolytix.github.io/MapIcons/services/component_exchange.svg);',
+            'locale': true
+        }
+    ]
+
+    mapp.plugins.link_button(links, mapview)
+
     codi.describe('Link Button Test', () => {
         codi.it('Should add a link button to the mapButton panel', () => {
             // Get the mapButton element

--- a/tests/plugins/link_button.test.mjs
+++ b/tests/plugins/link_button.test.mjs
@@ -1,89 +1,96 @@
-
 /**
  * This test is used to see if the link_button plugin is working as expected.
  * @function linkButtonTest
  */
 export function linkButtonTest(mapview) {
+  const links = [
+    {
+      href: '/url/url',
+      title: 'TITLE HERE',
+      target: '_blank',
+      css_class: 'mask-icon',
+      css_style:
+        'mask-image: url(https://geolytix.github.io/MapIcons/services/component_exchange.svg); -webkit-mask-image: url(https://geolytix.github.io/MapIcons/services/component_exchange.svg);',
+    },
+    {
+      title: 'WILL NOT BE ADDED AS NO HREF',
+      target: '_blank',
+      css_class: 'mask-icon',
+      css_style:
+        'mask-image: url(https://geolytix.github.io/MapIcons/services/component_exchange.svg); -webkit-mask-image: url(https://geolytix.github.io/MapIcons/services/component_exchange.svg);',
+    },
+    {
+      title: 'WILL BE ADDED AS HREF',
+      href: '/url/url2',
+      target: '_blank',
+      css_class: 'mask-icon',
+      css_style:
+        'mask-image: url(https://geolytix.github.io/MapIcons/services/component_exchange.svg); -webkit-mask-image: url(https://geolytix.github.io/MapIcons/services/component_exchange.svg);',
+    },
+    {
+      title: 'Locale HREF',
+      href: '/url/url3',
+      target: '_blank',
+      css_class: 'mask-icon',
+      css_style:
+        'mask-image: url(https://geolytix.github.io/MapIcons/services/component_exchange.svg); -webkit-mask-image: url(https://geolytix.github.io/MapIcons/services/component_exchange.svg);',
+      locale: true,
+    },
+  ];
 
-    const links = [
-        {
-            'href': '/url/url',
-            'title': 'TITLE HERE',
-            'target': '_blank',
-            'css_class': 'mask-icon',
-            'css_style': 'mask-image: url(https://geolytix.github.io/MapIcons/services/component_exchange.svg); -webkit-mask-image: url(https://geolytix.github.io/MapIcons/services/component_exchange.svg);'
-        },
-        {
-            'title': 'WILL NOT BE ADDED AS NO HREF',
-            'target': '_blank',
-            'css_class': 'mask-icon',
-            'css_style': 'mask-image: url(https://geolytix.github.io/MapIcons/services/component_exchange.svg); -webkit-mask-image: url(https://geolytix.github.io/MapIcons/services/component_exchange.svg);'
-        },
-        {
-            'title': 'WILL BE ADDED AS HREF',
-            'href': '/url/url2',
-            'target': '_blank',
-            'css_class': 'mask-icon',
-            'css_style': 'mask-image: url(https://geolytix.github.io/MapIcons/services/component_exchange.svg); -webkit-mask-image: url(https://geolytix.github.io/MapIcons/services/component_exchange.svg);'
-        },
-        {
-            'title': 'Locale HREF',
-            'href': '/url/url3',
-            'target': '_blank',
-            'css_class': 'mask-icon',
-            'css_style': 'mask-image: url(https://geolytix.github.io/MapIcons/services/component_exchange.svg); -webkit-mask-image: url(https://geolytix.github.io/MapIcons/services/component_exchange.svg);',
-            'locale': true
-        }
-    ]
+  mapp.plugins.link_button(links, mapview);
 
-    mapp.plugins.link_button(links, mapview)
+  codi.describe('Link Button Test', () => {
+    codi.it('Should add a link button to the mapButton panel', () => {
+      // Get the mapButton element
+      const mapButton = document.getElementById('mapButton');
+      // Get the link_button from the mapButton (a tag with the title="TITLE HERE")
+      const linkButton = mapButton.querySelector('a[title="TITLE HERE"]');
 
-    codi.describe('Link Button Test', () => {
-        codi.it('Should add a link button to the mapButton panel', () => {
-            // Get the mapButton element
-            const mapButton = document.getElementById('mapButton');
-            // Get the link_button from the mapButton (a tag with the title="TITLE HERE")
-            const linkButton = mapButton.querySelector('a[title="TITLE HERE"]');
-
-            // Check if the linkButton has the correct href
-            codi.assertEqual(linkButton.getAttribute('href'), '/url/url');
-        });
-
-        codi.it('Should not add a button if no href is provided', () => {
-            // Get the mapButton element
-            const mapButton = document.getElementById('mapButton');
-            // Get the link_button from the mapButton (a tag with the title="SHOULD NOT BE ADDED AS NO HREF")
-            const linkButton = mapButton.querySelector('a[title="SHOULD NOT BE ADDED AS NO HREF"]');
-
-            // Check if the linkButton does not exist
-            codi.assertTrue(!linkButton);
-        });
-
-        codi.it('Should add multiple buttons if the link_button config is an array', () => {
-            // Get the mapButton element
-            const mapButton = document.getElementById('mapButton');
-            // Get the link_button from the mapButton (a tag with the title="TITLE HERE")
-            const linkButton = mapButton.querySelector('a[title="TITLE HERE"]');
-
-            const linkButton2 = mapButton.querySelector('a[title="WILL BE ADDED AS HREF"]');
-
-            // Check if the linkButton has the correct href
-            codi.assertEqual(linkButton.getAttribute('href'), '/url/url');
-
-            // Check if the linkButton2 has the correct href
-            codi.assertEqual(linkButton2.getAttribute('href'), '/url/url2');
-        });
-
-        codi.it('Should add a link with the locale added to the href', () => {
-            // Get the mapButton element
-            const mapButton = document.getElementById('mapButton');
-            // Get the link_button from the mapButton (a tag with the title="TITLE HERE")
-            const linkButton = mapButton.querySelector('a[title="Locale HREF"]');
-
-            // Check if the linkButton has the correct href
-            codi.assertTrue(linkButton.getAttribute('href').includes('locale='));
-
-        });
-
+      // Check if the linkButton has the correct href
+      codi.assertEqual(linkButton.getAttribute('href'), '/url/url');
     });
+
+    codi.it('Should not add a button if no href is provided', () => {
+      // Get the mapButton element
+      const mapButton = document.getElementById('mapButton');
+      // Get the link_button from the mapButton (a tag with the title="SHOULD NOT BE ADDED AS NO HREF")
+      const linkButton = mapButton.querySelector(
+        'a[title="SHOULD NOT BE ADDED AS NO HREF"]',
+      );
+
+      // Check if the linkButton does not exist
+      codi.assertTrue(!linkButton);
+    });
+
+    codi.it(
+      'Should add multiple buttons if the link_button config is an array',
+      () => {
+        // Get the mapButton element
+        const mapButton = document.getElementById('mapButton');
+        // Get the link_button from the mapButton (a tag with the title="TITLE HERE")
+        const linkButton = mapButton.querySelector('a[title="TITLE HERE"]');
+
+        const linkButton2 = mapButton.querySelector(
+          'a[title="WILL BE ADDED AS HREF"]',
+        );
+
+        // Check if the linkButton has the correct href
+        codi.assertEqual(linkButton.getAttribute('href'), '/url/url');
+
+        // Check if the linkButton2 has the correct href
+        codi.assertEqual(linkButton2.getAttribute('href'), '/url/url2');
+      },
+    );
+
+    codi.it('Should add a link with the locale added to the href', () => {
+      // Get the mapButton element
+      const mapButton = document.getElementById('mapButton');
+      // Get the link_button from the mapButton (a tag with the title="TITLE HERE")
+      const linkButton = mapButton.querySelector('a[title="Locale HREF"]');
+
+      // Check if the linkButton has the correct href
+      codi.assertTrue(linkButton.getAttribute('href').includes('locale='));
+    });
+  });
 }

--- a/tests/plugins/link_button.test.mjs
+++ b/tests/plugins/link_button.test.mjs
@@ -40,5 +40,16 @@ export function linkButtonTest() {
             codi.assertEqual(linkButton2.getAttribute('href'), '/url/url2');
         });
 
+        codi.it('Should add a link with the locale added to the href', () => {
+            // Get the mapButton element
+            const mapButton = document.getElementById('mapButton');
+            // Get the link_button from the mapButton (a tag with the title="TITLE HERE")
+            const linkButton = mapButton.querySelector('a[title="Locale HREF"]');
+
+            // Check if the linkButton has the correct href
+            codi.assertTrue(linkButton.getAttribute('href').includes('locale='));
+
+        });
+
     });
 }

--- a/tests/workspace.json
+++ b/tests/workspace.json
@@ -96,6 +96,14 @@
                 "target": "_blank",
                 "css_class": "mask-icon",
                 "css_style": "mask-image: url(https://geolytix.github.io/MapIcons/services/component_exchange.svg); -webkit-mask-image: url(https://geolytix.github.io/MapIcons/services/component_exchange.svg);"
+            },
+            {
+                "title": "Locale HREF",
+                "href": "/url/url3",
+                "target": "_blank",
+                "css_class": "mask-icon",
+                "css_style": "mask-image: url(https://geolytix.github.io/MapIcons/services/component_exchange.svg); -webkit-mask-image: url(https://geolytix.github.io/MapIcons/services/component_exchange.svg);",
+                "locale": true
             }
         ],
         "assignMapview": {},

--- a/tests/workspace.json
+++ b/tests/workspace.json
@@ -1,395 +1,376 @@
 {
-    "dbs": "NEON",
-    "roles": {
-        "A": "Text about A",
-        "B": "Text about B",
-        "*": null
+  "dbs": "NEON",
+  "roles": {
+    "A": "Text about A",
+    "B": "Text about B",
+    "*": null
+  },
+  "templates": {
+    "template_test_temp": {
+      "src": "file:/tests/assets/layers/template_test/layer.json"
     },
-    "templates": {
-        "template_test_temp": {
-            "src": "file:/tests/assets/layers/template_test/layer.json"
-        },
-        "mvt_test_temp": {
-            "src": "file:/tests/assets/layers/mvt/layer.json"
-        },
-        "module_test": {
-            "type": "module",
-            "src": "file:/tests/assets/queries/foo.js"
-        },
-        "template_1": {
-            "src": "file:/tests/assets/infoj/template_infoj.json"
-        },
-        "template_2": {
-            "src": "file:/tests/assets/styles/template_style.json"
-        },
-        "icon_scaling_scratch": {
-            "src": "file:/tests/assets/queries/icon_scaling_scratch.sql"
-        },
-        "get_location_mock": {
-            "src": "file:/tests/assets/queries/get_location_mock.sql"
-        },
-        "minmax_query": {
-            "src": "file:/tests/assets/queries/minmax_mock.sql"
-        },
-        "data_array": {
-            "src": "file:/tests/assets/queries/data_array.sql",
-            "value_only": true
-        },
-        "bogus_data_array": {
-            "src": "file:/tests/assets/queries/data_array.sql",
-            "dbs": "bogus"
-        },
-        "merge_into": {
-            "name": "merge_into",
-            "roles": {
-                "merge_into": null
-            }
-        }
+    "mvt_test_temp": {
+      "src": "file:/tests/assets/layers/mvt/layer.json"
     },
-    "locale": {
-        "roles": {
-            "A": null,
-            "B": null,
-            "C": null,
-            "*": null
-        },
-        "mapviewControls": [
-            "Zoom"
-        ],
-        "plugins": [
-            "${PLUGINS}v4.8.0/coordinates.js",
-            "${PLUGINS}v4.8.0/chartjs.js",
-            "/test/api/provider/file?content_type=application/javascript&url=./tests/assets/plugins/assignMapview.js"
-        ],
-        "syncPlugins": [
-            "zoomBtn",
-            "zoomToArea",
-            "coordinates",
-            "admin",
-            "login"
-        ],
-        "svg_templates": {
-            "dot_test": "https://geolytix.github.io/MapIcons/templates/dot_10px.svg",
-            "target_test": "https://geolytix.github.io/MapIcons/templates/target.svg",
-            "square_test": "https://geolytix.github.io/MapIcons/templates/square_10px.svg",
-            "diamond_test": "https://geolytix.github.io/MapIcons/templates/diamond_10px.svg",
-            "triangle_test": "https://geolytix.github.io/MapIcons/templates/triangle_10px.svg",
-            "template_pin_test": "https://geolytix.github.io/MapIcons/pins/pink_master_pin.svg"
-        },
-        "assignMapview": {},
-        "keyvalue_dictionary": [
-            {
-                "key": "name",
-                "value": "OpenStreetMap",
-                "default": "OpenStreetMap KeyValue Dictionary"
-            },
-            {
-                "key": "title",
-                "value": "textarea",
-                "default": "TextArea KeyValue Dictionary"
-            },
-            {
-                "key": "test_array",
-                "value": "TEST KEYVALUE",
-                "default": "WILL NOT BE SEEN AS ARRAY CANNOT BE UPDATED"
-            }
-        ],
-        "coordinates": {},
-        "layers": {
-            "OSM": {
-                "name": "OpenStreetMap",
-                "display": true,
-                "format": "tiles",
-                "URI": "https://{a-c}.tile.openstreetmap.org/{z}/{x}/{y}.png",
-                "style": {
-                    "contextFilter": "grayscale(100%)"
-                },
-                "attribution": {
-                    "© OpenStreetMap": "http://www.openstreetmap.org/copyright"
-                }
-            },
-            "changeEnd": {
-                "display": true,
-                "templates": [
-                    {
-                        "src": "file:/tests/assets/layers/scratch/layer.json"
-                    },
-                    {
-                        "src": "file:/tests/assets/layers/scratch/infoj.json"
-                    },
-                    {
-                        "src": "file:/tests/assets/layers/scratch/style.json"
-                    }
-                ],
-                "tables": {
-                    "5": null,
-                    "6": "test.scratch"
-                },
-                "test_array": [
-                    "TEST KEYVALUE"
-                ]
-            },
-            "decorate": {
-                "display": false,
-                "templates": [
-                    {
-                        "src": "file:/tests/assets/layers/scratch/layer.json"
-                    },
-                    {
-                        "src": "file:/tests/assets/layers/scratch/infoj.json"
-                    },
-                    {
-                        "src": "file:/tests/assets/layers/scratch/style.json"
-                    }
-                ],
-                "draw": {
-                    "circle_2pt": true,
-                    "circle": {
-                        "roles": {
-                            "test": null,
-                            "super_test": null
-                        },
-                        "hidePanel": true
-                    },
-                    "polygon": true,
-                    "point": true
-                },
-                "infoj": [
-                    {
-                        "label": "check",
-                        "field": "bool_field",
-                        "edit": true,
-                        "inline": true,
-                        "type": "boolean",
-                        "dependents": [
-                            "integer_field"
-                        ]
-                    },
-                    {
-                        "title": "minutes",
-                        "field": "integer_field",
-                        "value": null,
-                        "edit": "true",
-                        "inline": true
-                    }
-                ],
-                "infoj_skip": [
-                    "textarea"
-                ]
-            },
-            "fade": {
-                "display": true,
-                "templates": [
-                    {
-                        "src": "file:/tests/assets/layers/scratch/layer.json"
-                    },
-                    {
-                        "src": "file:/tests/assets/layers/scratch/infoj.json"
-                    },
-                    {
-                        "src": "file:/tests/assets/layers/scratch/style.json"
-                    }
-                ]
-            },
-            "styleParser": {
-                "templates": [
-                    {
-                        "src": "file:/tests/assets/layers/uk_geometries/layer.json"
-                    },
-                    {
-                        "src": "file:/tests/assets/layers/uk_geometries/infoj.json"
-                    }
-                ]
-            },
-            "input_slider": {
-                "display": true,
-                "group": "ui_elements",
-                "templates": [
-                    {
-                        "src": "file:/tests/assets/layers/scratch/layer.json"
-                    },
-                    {
-                        "src": "file:/tests/assets/layers/scratch/infoj.json"
-                    },
-                    {
-                        "src": "file:/tests/assets/layers/scratch/style.json"
-                    }
-                ],
-                "infoj": [
-                    {
-                        "title": "int",
-                        "field": "integer_field",
-                        "type": "integer",
-                        "formatterParams": null,
-                        "default": 0,
-                        "edit": {
-                            "range": true
-                        },
-                        "min": -100000,
-                        "max": 10000,
-                        "prefix": "£",
-                        "filter": {
-                            "type": "integer"
-                        }
-                    }
-                ]
-            },
-            "pin": {
-                "display": true,
-                "group": "ui_elements",
-                "templates": [
-                    {
-                        "src": "file:/tests/assets/layers/scratch/layer.json"
-                    },
-                    {
-                        "src": "file:/tests/assets/layers/scratch/infoj.json"
-                    },
-                    {
-                        "src": "file:/tests/assets/layers/scratch/style.json"
-                    }
-                ]
-            },
-            "icon_scaling": {
-                "display": true,
-                "templates": [
-                    {
-                        "src": "file:/tests/assets/layers/scratch/layer.json"
-                    },
-                    {
-                        "src": "file:/tests/assets/layers/scratch/infoj.json"
-                    },
-                    {
-                        "src": "file:/tests/assets/layers/scratch/style.json"
-                    },
-                    {
-                        "src": "file:/tests/assets/layers/scratch/style_icon_scaling.json"
-                    }
-                ],
-                "infoj": [
-                    {
-                        "title": "icon_scale",
-                        "field": "icon_scale",
-                        "type": "integer",
-                        "edit": {
-                            "range": true
-                        },
-                        "min": 1,
-                        "max": 10000
-                    }
-                ]
-            },
-            "template_test": {
-                "display": true,
-                "template": "template_test_temp",
-                "templates": [
-                    {
-                        "key": "template_infoj",
-                        "src": "file:/tests/assets/infoj/template_infoj.json"
-                    },
-                    {
-                        "key": "chart_queryparams",
-                        "src": "file:/tests/assets/infoj/chart_queryparams.json"
-                    },
-                    {
-                        "key": "bogus_file",
-                        "src": "file:/tests/assets/styles/bogus_file.json"
-                    },
-                    {
-                        "key": "dataviews_json",
-                        "src": "file:/tests/assets/dataviews/dataviews_json.json"
-                    }
-                ]
-            },
-            "template_foo": {
-                "template": "foo",
-                "display": true
-            },
-            "template_test_vanilla": {
-                "hidden": true,
-                "template": "template_test_temp",
-                "templates": [
-                    "template_1",
-                    "template_2"
-                ]
-            },
-            "location_get_test": {
-                "hidden": true,
-                "templates": [
-                    {
-                        "src": "file:/tests/assets/layers/location_mock/layer.json"
-                    },
-                    {
-                        "src": "file:/tests/assets/layers/location_mock/infoj.json"
-                    }
-                ]
-            },
-            "location_get_test_no_infoj": {
-                "hidden": true,
-                "templates": [
-                    {
-                        "src": "file:/tests/assets/layers/location_mock/layer.json"
-                    }
-                ]
-            },
-            "query_params_layer": {
-                "hidden": true,
-                "templates": [
-                    {
-                        "src": "file:/tests/assets/layers/location_mock/layer.json"
-                    },
-                    {
-                        "src": "file:/tests/assets/layers/location_mock/infoj.json"
-                    }
-                ]
-            },
-            "cluster_test": {},
-            "mvt_test": {
-                "template": "mvt_test_temp"
-            },
-            "entry_layer": {
-                "display": true,
-                "template": "template_test_temp",
-                "infoj": [
-                    {
-                        "type": "pin",
-                        "label": "ST_PointOnSurface",
-                        "field": "pin",
-                        "fieldfx": "ARRAY[ST_X(ST_PointOnSurface(geom_3857)),ST_Y(ST_PointOnSurface(geom_3857))]"
-                    },
-                    {
-                        "key": "test_mvt_clone",
-                        "label": "entry_mvt_clone",
-                        "type": "mvt_clone",
-                        "display": "true",
-                        "name": "mvt clone",
-                        "layer": "mvt_test",
-                        "query": "mvt_lookup",
-                        "template": {
-                            "key": "mvt_lookup",
-                            "template": "select id, numeric_field from test.mvt_test"
-                        }
-                    },
-                    {
-                        "key": "test_layer",
-                        "label": "entry_layer",
-                        "type": "layer",
-                        "display": "true",
-                        "name": "layer entry",
-                        "layer": "mvt_test",
-                        "query": "mvt_lookup"
-                    }
-                ]
-            },
-            "roles_test": {
-                "name": "You should not see me",
-                "template": "mvt_test_temp",
-                "templates": [
-                    "merge_into"
-                ],
-                "roles": {
-                    "roles_test": null
-                }
-            }
-        }
+    "module_test": {
+      "type": "module",
+      "src": "file:/tests/assets/queries/foo.js"
+    },
+    "template_1": {
+      "src": "file:/tests/assets/infoj/template_infoj.json"
+    },
+    "template_2": {
+      "src": "file:/tests/assets/styles/template_style.json"
+    },
+    "icon_scaling_scratch": {
+      "src": "file:/tests/assets/queries/icon_scaling_scratch.sql"
+    },
+    "get_location_mock": {
+      "src": "file:/tests/assets/queries/get_location_mock.sql"
+    },
+    "minmax_query": {
+      "src": "file:/tests/assets/queries/minmax_mock.sql"
+    },
+    "data_array": {
+      "src": "file:/tests/assets/queries/data_array.sql",
+      "value_only": true
+    },
+    "bogus_data_array": {
+      "src": "file:/tests/assets/queries/data_array.sql",
+      "dbs": "bogus"
+    },
+    "merge_into": {
+      "name": "merge_into",
+      "roles": {
+        "merge_into": null
+      }
     }
+  },
+  "locale": {
+    "roles": {
+      "A": null,
+      "B": null,
+      "C": null,
+      "*": null
+    },
+    "mapviewControls": ["Zoom"],
+    "plugins": [
+      "${PLUGINS}v4.8.0/coordinates.js",
+      "${PLUGINS}v4.8.0/chartjs.js",
+      "/test/api/provider/file?content_type=application/javascript&url=./tests/assets/plugins/assignMapview.js"
+    ],
+    "syncPlugins": ["zoomBtn", "zoomToArea", "coordinates", "admin", "login"],
+    "svg_templates": {
+      "dot_test": "https://geolytix.github.io/MapIcons/templates/dot_10px.svg",
+      "target_test": "https://geolytix.github.io/MapIcons/templates/target.svg",
+      "square_test": "https://geolytix.github.io/MapIcons/templates/square_10px.svg",
+      "diamond_test": "https://geolytix.github.io/MapIcons/templates/diamond_10px.svg",
+      "triangle_test": "https://geolytix.github.io/MapIcons/templates/triangle_10px.svg",
+      "template_pin_test": "https://geolytix.github.io/MapIcons/pins/pink_master_pin.svg"
+    },
+    "assignMapview": {},
+    "keyvalue_dictionary": [
+      {
+        "key": "name",
+        "value": "OpenStreetMap",
+        "default": "OpenStreetMap KeyValue Dictionary"
+      },
+      {
+        "key": "title",
+        "value": "textarea",
+        "default": "TextArea KeyValue Dictionary"
+      },
+      {
+        "key": "test_array",
+        "value": "TEST KEYVALUE",
+        "default": "WILL NOT BE SEEN AS ARRAY CANNOT BE UPDATED"
+      }
+    ],
+    "coordinates": {},
+    "layers": {
+      "OSM": {
+        "name": "OpenStreetMap",
+        "display": true,
+        "format": "tiles",
+        "URI": "https://{a-c}.tile.openstreetmap.org/{z}/{x}/{y}.png",
+        "style": {
+          "contextFilter": "grayscale(100%)"
+        },
+        "attribution": {
+          "© OpenStreetMap": "http://www.openstreetmap.org/copyright"
+        }
+      },
+      "changeEnd": {
+        "display": true,
+        "templates": [
+          {
+            "src": "file:/tests/assets/layers/scratch/layer.json"
+          },
+          {
+            "src": "file:/tests/assets/layers/scratch/infoj.json"
+          },
+          {
+            "src": "file:/tests/assets/layers/scratch/style.json"
+          }
+        ],
+        "tables": {
+          "5": null,
+          "6": "test.scratch"
+        },
+        "test_array": ["TEST KEYVALUE"]
+      },
+      "decorate": {
+        "display": false,
+        "templates": [
+          {
+            "src": "file:/tests/assets/layers/scratch/layer.json"
+          },
+          {
+            "src": "file:/tests/assets/layers/scratch/infoj.json"
+          },
+          {
+            "src": "file:/tests/assets/layers/scratch/style.json"
+          }
+        ],
+        "draw": {
+          "circle_2pt": true,
+          "circle": {
+            "roles": {
+              "test": null,
+              "super_test": null
+            },
+            "hidePanel": true
+          },
+          "polygon": true,
+          "point": true
+        },
+        "infoj": [
+          {
+            "label": "check",
+            "field": "bool_field",
+            "edit": true,
+            "inline": true,
+            "type": "boolean",
+            "dependents": ["integer_field"]
+          },
+          {
+            "title": "minutes",
+            "field": "integer_field",
+            "value": null,
+            "edit": "true",
+            "inline": true
+          }
+        ],
+        "infoj_skip": ["textarea"]
+      },
+      "fade": {
+        "display": true,
+        "templates": [
+          {
+            "src": "file:/tests/assets/layers/scratch/layer.json"
+          },
+          {
+            "src": "file:/tests/assets/layers/scratch/infoj.json"
+          },
+          {
+            "src": "file:/tests/assets/layers/scratch/style.json"
+          }
+        ]
+      },
+      "styleParser": {
+        "templates": [
+          {
+            "src": "file:/tests/assets/layers/uk_geometries/layer.json"
+          },
+          {
+            "src": "file:/tests/assets/layers/uk_geometries/infoj.json"
+          }
+        ]
+      },
+      "input_slider": {
+        "display": true,
+        "group": "ui_elements",
+        "templates": [
+          {
+            "src": "file:/tests/assets/layers/scratch/layer.json"
+          },
+          {
+            "src": "file:/tests/assets/layers/scratch/infoj.json"
+          },
+          {
+            "src": "file:/tests/assets/layers/scratch/style.json"
+          }
+        ],
+        "infoj": [
+          {
+            "title": "int",
+            "field": "integer_field",
+            "type": "integer",
+            "formatterParams": null,
+            "default": 0,
+            "edit": {
+              "range": true
+            },
+            "min": -100000,
+            "max": 10000,
+            "prefix": "£",
+            "filter": {
+              "type": "integer"
+            }
+          }
+        ]
+      },
+      "pin": {
+        "display": true,
+        "group": "ui_elements",
+        "templates": [
+          {
+            "src": "file:/tests/assets/layers/scratch/layer.json"
+          },
+          {
+            "src": "file:/tests/assets/layers/scratch/infoj.json"
+          },
+          {
+            "src": "file:/tests/assets/layers/scratch/style.json"
+          }
+        ]
+      },
+      "icon_scaling": {
+        "display": true,
+        "templates": [
+          {
+            "src": "file:/tests/assets/layers/scratch/layer.json"
+          },
+          {
+            "src": "file:/tests/assets/layers/scratch/infoj.json"
+          },
+          {
+            "src": "file:/tests/assets/layers/scratch/style.json"
+          },
+          {
+            "src": "file:/tests/assets/layers/scratch/style_icon_scaling.json"
+          }
+        ],
+        "infoj": [
+          {
+            "title": "icon_scale",
+            "field": "icon_scale",
+            "type": "integer",
+            "edit": {
+              "range": true
+            },
+            "min": 1,
+            "max": 10000
+          }
+        ]
+      },
+      "template_test": {
+        "display": true,
+        "template": "template_test_temp",
+        "templates": [
+          {
+            "key": "template_infoj",
+            "src": "file:/tests/assets/infoj/template_infoj.json"
+          },
+          {
+            "key": "chart_queryparams",
+            "src": "file:/tests/assets/infoj/chart_queryparams.json"
+          },
+          {
+            "key": "bogus_file",
+            "src": "file:/tests/assets/styles/bogus_file.json"
+          },
+          {
+            "key": "dataviews_json",
+            "src": "file:/tests/assets/dataviews/dataviews_json.json"
+          }
+        ]
+      },
+      "template_foo": {
+        "template": "foo",
+        "display": true
+      },
+      "template_test_vanilla": {
+        "hidden": true,
+        "template": "template_test_temp",
+        "templates": ["template_1", "template_2"]
+      },
+      "location_get_test": {
+        "hidden": true,
+        "templates": [
+          {
+            "src": "file:/tests/assets/layers/location_mock/layer.json"
+          },
+          {
+            "src": "file:/tests/assets/layers/location_mock/infoj.json"
+          }
+        ]
+      },
+      "location_get_test_no_infoj": {
+        "hidden": true,
+        "templates": [
+          {
+            "src": "file:/tests/assets/layers/location_mock/layer.json"
+          }
+        ]
+      },
+      "query_params_layer": {
+        "hidden": true,
+        "templates": [
+          {
+            "src": "file:/tests/assets/layers/location_mock/layer.json"
+          },
+          {
+            "src": "file:/tests/assets/layers/location_mock/infoj.json"
+          }
+        ]
+      },
+      "cluster_test": {},
+      "mvt_test": {
+        "template": "mvt_test_temp"
+      },
+      "entry_layer": {
+        "display": true,
+        "template": "template_test_temp",
+        "infoj": [
+          {
+            "type": "pin",
+            "label": "ST_PointOnSurface",
+            "field": "pin",
+            "fieldfx": "ARRAY[ST_X(ST_PointOnSurface(geom_3857)),ST_Y(ST_PointOnSurface(geom_3857))]"
+          },
+          {
+            "key": "test_mvt_clone",
+            "label": "entry_mvt_clone",
+            "type": "mvt_clone",
+            "display": "true",
+            "name": "mvt clone",
+            "layer": "mvt_test",
+            "query": "mvt_lookup",
+            "template": {
+              "key": "mvt_lookup",
+              "template": "select id, numeric_field from test.mvt_test"
+            }
+          },
+          {
+            "key": "test_layer",
+            "label": "entry_layer",
+            "type": "layer",
+            "display": "true",
+            "name": "layer entry",
+            "layer": "mvt_test",
+            "query": "mvt_lookup"
+          }
+        ]
+      },
+      "roles_test": {
+        "name": "You should not see me",
+        "template": "mvt_test_temp",
+        "templates": ["merge_into"],
+        "roles": {
+          "roles_test": null
+        }
+      }
+    }
+  }
 }

--- a/tests/workspace.json
+++ b/tests/workspace.json
@@ -76,36 +76,6 @@
             "triangle_test": "https://geolytix.github.io/MapIcons/templates/triangle_10px.svg",
             "template_pin_test": "https://geolytix.github.io/MapIcons/pins/pink_master_pin.svg"
         },
-        "link_button": [
-            {
-                "href": "/url/url",
-                "title": "TITLE HERE",
-                "target": "_blank",
-                "css_class": "mask-icon",
-                "css_style": "mask-image: url(https://geolytix.github.io/MapIcons/services/component_exchange.svg); -webkit-mask-image: url(https://geolytix.github.io/MapIcons/services/component_exchange.svg);"
-            },
-            {
-                "title": "WILL NOT BE ADDED AS NO HREF",
-                "target": "_blank",
-                "css_class": "mask-icon",
-                "css_style": "mask-image: url(https://geolytix.github.io/MapIcons/services/component_exchange.svg); -webkit-mask-image: url(https://geolytix.github.io/MapIcons/services/component_exchange.svg);"
-            },
-            {
-                "title": "WILL BE ADDED AS HREF",
-                "href": "/url/url2",
-                "target": "_blank",
-                "css_class": "mask-icon",
-                "css_style": "mask-image: url(https://geolytix.github.io/MapIcons/services/component_exchange.svg); -webkit-mask-image: url(https://geolytix.github.io/MapIcons/services/component_exchange.svg);"
-            },
-            {
-                "title": "Locale HREF",
-                "href": "/url/url3",
-                "target": "_blank",
-                "css_class": "mask-icon",
-                "css_style": "mask-image: url(https://geolytix.github.io/MapIcons/services/component_exchange.svg); -webkit-mask-image: url(https://geolytix.github.io/MapIcons/services/component_exchange.svg);",
-                "locale": true
-            }
-        ],
         "assignMapview": {},
         "keyvalue_dictionary": [
             {


### PR DESCRIPTION
## Description
This PR adds the ability to pass a locale to the `link_buton` plugin.

## GitHub Issue
[1825](https://github.com/GEOLYTIX/xyz/issues/1825)

## Type of Change
- ✅ New feature (non-breaking change which adds functionality)
- ✅ Documentation

## How have you tested this? 
Locally, `bugs_testing\plugins\link_button.js` and click on this:
![Screenshot 2025-01-21 094232](https://github.com/user-attachments/assets/3218b49a-e159-48c0-b897-00a075637edd)
in the btnColumn

## Testing Checklist 
- ✅ Existing Tests still pass
- ✅ Ran locally on my machine
- ✅ Added new test

## Code Quality Checklist
- ✅ My code follows the guidelines of XYZ
- ✅ My code has been commented
- ✅ Documentation has been updated
- ✅ New and existing unit tests pass locally with my changes
- ✅ Main has been merged into this PR