### PR TITLE
Fix jsdocs return statement for csvUpload

### DIFF
--- a/lib/utils/csvUpload.mjs
+++ b/lib/utils/csvUpload.mjs
@@ -27,7 +27,7 @@ This function uploads a CSV file to a database store.
 @property {Boolean} [params.async] If set to true, the data is uploaded asynchronously. Default is false.
 @property {Boolean} [params.header] If set to true, the first row is treated as a header row and not uploaded.
 
-@returns {<Promise>} The outcome object and any messages returned by the database.
+@returns {Promise<Object|Error>} The outcome object and any messages returned by the database.
 */
 export default async function csvUpload(file, params = {}) {
   if (!params.query) {
@@ -181,7 +181,7 @@ The method returns a parameterised query object from the XHR utility method.
 
 @param {Array} data Data for the post request body.
 @param {Object} params Parameters for the post query.
-@returns {<Promise>} Returns promise from XHR query utility.
+@returns {Promise<Object|Error>} Returns promise from XHR query utility.
 */
 function postRequestData(data, params) {
   params.queryparams ??= {};


### PR DESCRIPTION
The return statement for twoi functions was wrong which breaks the compilation if the jsdoc pages for the module.