### PR TITLE
Store view params on mapview.locale.view

### DIFF
--- a/lib/mapview/_mapview.mjs
+++ b/lib/mapview/_mapview.mjs
@@ -210,16 +210,16 @@ function viewConfig(mapview) {
 
   mapview.view.projection = `EPSG:${mapview.srid}`;
 
-  mapview.view.minZoom = mapview.locale.minZoom;
+  mapview.view.minZoom = mapview.locale.minZoom || 0;
 
   mapview.view.maxZoom = mapview.locale.maxZoom;
 
   mapview.view.zoom =
-    mapp.hooks?.current?.z || mapview.view.z || mapview.view.minZoom || 0;
+    mapp.hooks?.current?.z || mapview.locale?.view.z || mapview.view.minZoom;
 
   mapview.view.center = ol.proj.fromLonLat([
-    parseFloat(mapp.hooks?.current?.lng || mapview.view.lng || 0),
-    parseFloat(mapp.hooks?.current?.lat || mapview.view.lat || 0),
+    parseFloat(mapp.hooks?.current?.lng || mapview.locale.view?.lng || 0),
+    parseFloat(mapp.hooks?.current?.lat || mapview.locale.view?.lat || 0),
   ]);
 
   viewExtent(mapview);
@@ -378,15 +378,16 @@ function viewMask(mapview) {
 @description
 The changeEnd method assigned to the mapview [this] will be triggered by the Openlayers mapview.Map moveend event.
 
-The method assigns the current zoom level (rounded to 2 decimal) as mapview.z before checking whether the lat, lng, z hooks (url parameter) should be updated.
+The changeEnd method stores the current view parameters lat, lng, z in the locale view.
+
+The view parameters will also be set as url params with hooks option priovided to the mapview decorator.
 */
 function changeEnd() {
-  // Assign the Map.view z to the mapview object.
-  this.z =
-    Math.round((this.Map.getView().getZoom() + Number.EPSILON) * 100) / 100;
+  this.view = {};
 
-  // Update URL params if enabled on mapview
-  if (!this.hooks) return;
+  // Assign the Map.view z to the mapview object.
+  this.view.z =
+    Math.round((this.Map.getView().getZoom() + Number.EPSILON) * 100) / 100;
 
   // Get center from Map.View
   const center = ol.proj.transform(
@@ -395,12 +396,16 @@ function changeEnd() {
     `EPSG:4326`,
   );
 
+  this.view.lat = Math.round((center[1] + Number.EPSILON) * 100000) / 100000;
+  this.view.lng = Math.round((center[0] + Number.EPSILON) * 100000) / 100000;
+
+  this.locale.view = this.view;
+
+  // Update URL params if enabled on mapview
+  if (!this.hooks) return;
+
   // Set lat, lng, z URL params.
-  mapp.hooks.set({
-    lat: Math.round((center[1] + Number.EPSILON) * 100000) / 100000,
-    lng: Math.round((center[0] + Number.EPSILON) * 100000) / 100000,
-    z: this.z,
-  });
+  mapp.hooks.set(this.view);
 }
 
 /**


### PR DESCRIPTION
The current view params are now stored in the locale view allowing the parameter to be stored in a userLocale.

I noticed that view currently not correctly assigned.

I fixed this in the mapview module viewConfig method.