### PR TITLE
The temporal utility mod must not throw an error to take down infoj p…

### DIFF
--- a/lib/utils/temporal.mjs
+++ b/lib/utils/temporal.mjs
@@ -15,7 +15,8 @@ Safely converts Unix timestamp to JavaScript Date object
 */
 function toJSDate(unixTimestamp) {
   if (!Number.isInteger(unixTimestamp)) {
-    throw new Error('Invalid timestamp: must be an integer');
+    console.error('unixTimestamp must be integer for Date conversion');
+    return;
   }
 
   return new Date(unixTimestamp * MILLISECONDS_IN_SECOND);
@@ -34,11 +35,9 @@ Formats a Unix timestamp into a localized date string. If not explicit in the pa
 function dateString(params) {
   params.locale ??= mapp.user?.language || DEFAULT_LOCALE;
 
-  if (!params.value && !params.newValue) {
-    throw new Error('Either value or newValue must be provided');
-  }
+  // The timestamp must be parsed as Integer.
+  const timestamp = parseInt(params.newValue || params.value);
 
-  const timestamp = params.newValue || params.value;
   const date = toJSDate(timestamp);
 
   return new Intl.DateTimeFormat(params.locale, params.options).format(date);
@@ -54,7 +53,8 @@ function dateToUnixEpoch(dateStr) {
   const date = dateStr ? new Date(dateStr) : new Date();
 
   if (isNaN(date.getTime())) {
-    throw new Error('Invalid date string provided');
+    console.error('Invalid date string provided');
+    return;
   }
 
   return Math.floor(date.getTime() / MILLISECONDS_IN_SECOND);


### PR DESCRIPTION
The temporal utility module should be able to handle null, undefined, or string values (including empty).

The integer value required for the Date generation should be parsed from entry value (or newValue).

An error should be logged instead of thrown with the method returning and not crashing the infoj process.
