### PR TITLE
Categorized Themes & Initial Filter Current

### DIFF
--- a/lib/ui/layers/legends/categorized.mjs
+++ b/lib/ui/layers/legends/categorized.mjs
@@ -151,6 +151,10 @@ function catToggle(e, layer, cat) {
 
     filterRemove(layer, cat);
 
+    // If the filter is defined in the config for initial display of just a subset of catergories, _style may not yet exist.
+    cat._style ??= cat.style;
+
+    // Set the style to _style that is a stored style.
     cat.style = cat._style;
 
     delete cat._style;


### PR DESCRIPTION
Addresses Issue #1869  


This PR simply nullish assigns `cat._style` in the `catToggle` method so that it always exists, fixing the problem when you have a `filter.current` applied in the configuration initially to subset the initial display of information.  

This should be tested on a layer with a `categorized` theme and no `filter.current` and also with a `filter.current` to ensure it works in both scenarios. 