### PR TITLE
Avoid nullish assignment of entry.featureLookup on type layer 

### DIFF
--- a/lib/ui/locations/entries/layer.mjs
+++ b/lib/ui/locations/entries/layer.mjs
@@ -27,9 +27,6 @@ export default function layer(entry) {
 
   entry.mapview ??= entry.location.layer.mapview
 
-  //An entry needs to have a featureLookup array as it's used in the show method,
-  entry.featureLookup ??= []
-
   // The layer lookup is optional. An entry maybe defined as a layer.
   if (entry.layer) {
 
@@ -186,7 +183,7 @@ async function showLayer() {
     delete entry.featureLookup
     entry.featureSet = new Set(entry.data)
 
-  } else {
+  } else if (entry.featureLookup) {
 
     // featureLookup on layer must be arrays
     entry.featureLookup = Array.isArray(entry.data) ? entry.data : [entry.data]


### PR DESCRIPTION
When nullish assigning `entry.featureLookup` to an empty array, it meant that the layer entry was not working correctly. 
This PR addresses the issue, ensuring that we don't assign this always, and converts an `else` to an `else if featureLookup` to ensure that the logic works for the 3 options. 

See PR https://github.com/GEOLYTIX/xyz/pull/1793 for the available options - layer, featureSet and featureLookup. All of these should be tested to ensure everything is working as expected. 