### PR TITLE
Jenks must only parseFloat valid numbers 

### DIFF
--- a/lib/layer/featureFields.mjs
+++ b/lib/layer/featureFields.mjs
@@ -23,20 +23,17 @@ featureFields.reset(layer) method will reset the layer.featureFields{} object an
 @property {Array} params.fields Array of strings for feature property fields.
 */
 export function reset(layer) {
-
   if (!layer.params.fields) return;
 
   // Create featureFields object if nullish.
   layer.featureFields ??= {};
 
-  layer.params.fields.forEach(field => {
-
+  layer.params.fields.forEach((field) => {
     // Set empty values array.
     layer.featureFields[field] = {
-      values: []
+      values: [],
     };
-
-  })
+  });
 }
 
 /**
@@ -51,29 +48,28 @@ The featureFields.process(layer) method will calculate the distribution of featu
 @property {Object} style.theme The current theme to style features according to their properties.
 */
 export function process(layer) {
-
   if (layer.style.icon_scaling?.field) {
+    const numbers = layer.featureFields[layer.style.icon_scaling?.field].values
+      .map(Number)
+      .filter((n) => !isNaN(n));
 
-    const numbers = layer.featureFields[layer.style.icon_scaling?.field].values.map(Number).filter(n => !isNaN(n))
-
-    layer.style.icon_scaling.max = Math.max(...numbers)
+    layer.style.icon_scaling.max = Math.max(...numbers);
   }
 
   // Check if the distribution method is defined in the distribution object.
   if (Object.hasOwn(distribution, layer.style?.theme?.distribution)) {
-
     // Call the corresponding distribution function.
     distribution[layer.style.theme.distribution](layer);
 
     // The legend method renders into the layer.style.legend
-    mapp.ui.layers.legends[layer.style.theme.type](layer)
+    mapp.ui.layers.legends[layer.style.theme.type](layer);
   }
 }
 
 export const distribution = {
   jenks,
-  count
-}
+  count,
+};
 
 /**
 @function jenks
@@ -86,21 +82,31 @@ The jenks distribution method requires the stats.jenks utility method to calcula
 function jenks(layer) {
   const theme = layer.style.theme;
 
-  const n = Math.min(layer.featureFields[theme.field].values.length, theme.categories.length);
+  const n = Math.min(
+    layer.featureFields[theme.field].values.length,
+    theme.categories.length,
+  );
 
- // Parse array values as float.
-  // First remove null values from the array to avoid NaN errors.
-  layer.featureFields[theme.field].values = layer.featureFields[theme.field].values.filter(v => v !== null);
-  layer.featureFields[theme.field].values = layer.featureFields[theme.field].values.map(parseFloat);
-  
+  // Filter null values and parse filtered values as float to featureFields field array.
+  layer.featureFields[theme.field].values = layer.featureFields[
+    theme.field
+  ].values
+    .filter((v) => v !== null)
+    .map(parseFloat);
+
   // Compute Jenks natural breaks.
-  layer.featureFields[theme.field].jenks =
-    mapp.utils.stats.jenks(layer.featureFields[theme.field].values, n);
+  layer.featureFields[theme.field].jenks = mapp.utils.stats.jenks(
+    layer.featureFields[theme.field].values,
+    n,
+  );
 
   let val;
 
   theme.categories.forEach((cat, i) => {
-    val = val === layer.featureFields[theme.field].jenks[i] ? undefined : layer.featureFields[theme.field].jenks[i];
+    val =
+      val === layer.featureFields[theme.field].jenks[i]
+        ? undefined
+        : layer.featureFields[theme.field].jenks[i];
     cat.value = val;
     cat.label = val;
   });
@@ -117,8 +123,7 @@ The count distribution method counts values in the `featureFields.values[]` arra
 function count(layer) {
   const theme = layer.style.theme;
 
-  layer.featureFields[theme.field].values.forEach(val => {
-
+  layer.featureFields[theme.field].values.forEach((val) => {
     // Increment count for each value.
     layer.featureFields[theme.field][val] ??= 0;
     layer.featureFields[theme.field][val]++;
@@ -137,18 +142,19 @@ An array without duplicates or undefined fields is returned from the Set.
 @returns {array} Array of feature fields.
 */
 export function fieldsArray(layer) {
-
   const fieldsSet = new Set([
     layer.params.default_fields,
     layer.style.theme?.field,
     layer.style.label?.field,
     layer.style.icon_scaling?.field,
     layer.cluster?.label,
-  ])
+  ]);
 
   if (Array.isArray(layer.style.theme?.fields)) {
-    layer.style.theme.fields.forEach(fieldsSet.add, fieldsSet)
+    layer.style.theme.fields.forEach(fieldsSet.add, fieldsSet);
   }
 
-  return Array.from(fieldsSet).flat().filter(field => !!field)
+  return Array.from(fieldsSet)
+    .flat()
+    .filter((field) => !!field);
 }

--- a/lib/layer/featureFields.mjs
+++ b/lib/layer/featureFields.mjs
@@ -88,9 +88,11 @@ function jenks(layer) {
 
   const n = Math.min(layer.featureFields[theme.field].values.length, theme.categories.length);
 
-  // Parse array values as float.
+ // Parse array values as float.
+  // First remove null values from the array to avoid NaN errors.
+  layer.featureFields[theme.field].values = layer.featureFields[theme.field].values.filter(v => v !== null);
   layer.featureFields[theme.field].values = layer.featureFields[theme.field].values.map(parseFloat);
-
+  
   // Compute Jenks natural breaks.
   layer.featureFields[theme.field].jenks =
     mapp.utils.stats.jenks(layer.featureFields[theme.field].values, n);


### PR DESCRIPTION
Addresses issue as we must first filter out any features with a field value of null. This ensures that we don't crash the parse float process