### PR TITLE
Only reload layers with viewport that should be displayed.

### DIFF
--- a/lib/layer/decorate.mjs
+++ b/lib/layer/decorate.mjs
@@ -286,6 +286,16 @@ async function zoomToExtent(params) {
   return true;
 }
 
+/**
+@function changeEnd
+
+@description
+The layer decorator method assigns an event listener to the layer mapview map object for layers with a tables or viewport param property.
+
+The changeEnd method checks whether the layer should be displayed and requests a layer reload if necessary.
+
+@param {layer} layer A decorated mapp layer.
+*/
 function changeEnd(layer) {
   // Layer is out of zoom range.
   if (!layer.tableCurrent()) {
@@ -307,6 +317,6 @@ function changeEnd(layer) {
   }
 
   if (layer.params.viewport) {
-    layer.reload();
+    layer.display && layer.reload();
   }
 }


### PR DESCRIPTION
This PR fixes an issue where layers with a viewport parameter requested a reload on changeend even if the layer display was toggled off (through zoom level restrictions or otherwise).