### PR TITLE
Display check for viewport param reload on changeEnd.

### DIFF
--- a/lib/layer/decorate.mjs
+++ b/lib/layer/decorate.mjs
@@ -31,7 +31,6 @@ The layer decorator method create mapp-layer typedef object from a json-layer.
 @returns {layer} Decorated Mapp Layer.
 */
 export default async function decorate(layer) {
-
   // Decorate layer format methods.
   await mapp.layer.formats[layer.format]?.(layer);
 
@@ -40,8 +39,9 @@ export default async function decorate(layer) {
 
   // The layer may be zoom level restricted.
   if (layer.tables || layer.params?.viewport) {
-    layer.mapview.Map.getTargetElement()
-      .addEventListener('changeEnd', () => changeEnd(layer))
+    layer.mapview.Map.getTargetElement().addEventListener('changeEnd', () =>
+      changeEnd(layer),
+    );
   }
 
   // Assign show, hide, and other methods to the layer object.
@@ -58,7 +58,9 @@ export default async function decorate(layer) {
   // Warn if outdated layer.edit configuration is used.
   // Set layer.draw to layer.edit if it exists.
   if (layer.edit) {
-    console.warn(`Layer: ${layer.key}, please update edit:{} to use draw:{} as layer.edit has been superseeded with layer.draw to be in line with the OL drawing interaction.`);
+    console.warn(
+      `Layer: ${layer.key}, please update edit:{} to use draw:{} as layer.edit has been superseeded with layer.draw to be in line with the OL drawing interaction.`,
+    );
     layer.draw = Object.assign(layer.draw || {}, layer.edit);
   }
 
@@ -67,34 +69,32 @@ export default async function decorate(layer) {
 
   // Warn if outdated layer.draw.delete configuration is used.
   if (layer.draw?.delete) {
-    console.warn(`Layer: ${layer.key}, please move draw.delete to use layer.deleteLocation:true.`);
+    console.warn(
+      `Layer: ${layer.key}, please move draw.delete to use layer.deleteLocation:true.`,
+    );
   }
 
   // Set layer filter.
   layer.filter = {
     current: {},
-    ...layer.filter
-  }
+    ...layer.filter,
+  };
 
   // Set layer opacity from style.
   layer.L.setOpacity(layer.style?.opacity || 1);
 
   // Check which infoj entries should be skipped.
   if (Array.isArray(layer.infoj_skip)) {
-
     layer.infoj
-      .filter(entry => [
-        entry.key,
-        entry.field,
-        entry.query,
-        entry.type,
-        entry.group]
+      .filter((entry) =>
+        [entry.key, entry.field, entry.query, entry.type, entry.group]
 
-        // Some object property value is included in infoj_skip array.
-        .some(val => layer.infoj_skip.includes(val)))
+          // Some object property value is included in infoj_skip array.
+          .some((val) => layer.infoj_skip.includes(val)),
+      )
 
       // Set skipEntry flag if some entry property is included in infoj_skip array.
-      .forEach(entry => entry.skipEntry = true)
+      .forEach((entry) => (entry.skipEntry = true));
   }
 
   // Call layer and/or plugin methods.
@@ -113,14 +113,12 @@ export default async function decorate(layer) {
 Shows the layer on the map.
 */
 function show() {
-
   // Push the layer into the layers hook array.
   this.mapview.hooks && mapp.hooks.push('layers', this.key);
 
   this.display = true;
 
   try {
-
     // Add layer to map
     this.mapview.Map.addLayer(this.L);
   } catch {
@@ -134,7 +132,7 @@ function show() {
   this.mapview.attribution?.check();
 
   // Execute showCallbacks
-  this.showCallbacks?.forEach(fn => fn instanceof Function && fn(this));
+  this.showCallbacks?.forEach((fn) => fn instanceof Function && fn(this));
 }
 
 /**
@@ -144,7 +142,6 @@ function show() {
 Hides the layer from the map.
 */
 function hide() {
-
   this.display = false;
 
   // Remove OL layer from mapview.
@@ -159,7 +156,7 @@ function hide() {
   }
 
   // Execute hideCallbacks
-  this.hideCallbacks?.forEach(fn => fn instanceof Function && fn(this));
+  this.hideCallbacks?.forEach((fn) => fn instanceof Function && fn(this));
 }
 
 /**
@@ -171,7 +168,6 @@ Returns the current table associated with the layer.
 @returns {string} The current table associated with the layer.
 */
 function tableCurrent() {
-
   // Return the current table if it exists.
   if (!this.tables) return this.table;
 
@@ -249,16 +245,21 @@ async function zoomToExtent(params) {
   // Zooms to a specific extent.
 
   // XMLHttpRequest to layer extent endpoint
-  const response = await mapp.utils.xhr(`${this.mapview.host}/api/query/layer_extent?` +
-    mapp.utils.paramString({ // build query string for the url
-      locale: this.mapview.locale.key,
-      layer: this.key,
-      table: this.table || Object.values(this.tables)[0] || Object.values(this.tables)[1],
-      geom: this.geom,
-      proj: this.srid,
-      srid: this.mapview.srid,
-      filter: this.filter.current
-    })
+  const response = await mapp.utils.xhr(
+    `${this.mapview.host}/api/query/layer_extent?` +
+      mapp.utils.paramString({
+        // build query string for the url
+        locale: this.mapview.locale.key,
+        layer: this.key,
+        table:
+          this.table ||
+          Object.values(this.tables)[0] ||
+          Object.values(this.tables)[1],
+        geom: this.geom,
+        proj: this.srid,
+        srid: this.mapview.srid,
+        filter: this.filter.current,
+      }),
   );
 
   // If failed to fetch response
@@ -269,42 +270,49 @@ async function zoomToExtent(params) {
   // re matches text in parentheses
   const bounds = /\((.*?)\)/.exec(response.box2d)[1].replace(/ /g, ',');
 
-  this.mapview.fitView( // fit the map view within bounds 
-    bounds.split(',').map( // get a float array of bounds
-      coords => parseFloat(coords)
+  this.mapview.fitView(
+    // fit the map view within bounds
+    bounds.split(',').map(
+      // get a float array of bounds
+      (coords) => parseFloat(coords),
     ),
-    params
+    params,
   );
 
   return true;
 }
 
-function changeEnd(layer) {
+/**
+@function changeEnd
 
+@description
+The layer decorator method assigns an event listener to the layer mapview map object for layers with a tables or viewport param property.
+
+The changeEnd method checks whether the layer should be displayed and requests a layer reload if necessary.
+
+@param {layer} layer A decorated mapp layer.
+*/
+function changeEnd(layer) {
   // Layer is out of zoom range.
   if (!layer.tableCurrent()) {
-
     if (layer.display) {
-
       // Layer should be shown if possible.
-      layer.zoomDisplay = true
-      layer.hide()
+      layer.zoomDisplay = true;
+      layer.hide();
     }
 
     return;
   }
 
   if (layer.zoomDisplay) {
-
     // Prevents layer.show() being fired on zoom change within range.
-    delete layer.zoomDisplay
+    delete layer.zoomDisplay;
 
     // Show layer if within zoomDisplay range.
-    layer.show()
+    layer.show();
   }
 
   if (layer.params.viewport) {
-
-    layer.reload()
+    layer.display && layer.reload();
   }
 }


### PR DESCRIPTION
This PR fixes an issue where layers with a viewport parameter requested a reload on changeend even if the layer display was toggled off (through zoom level restrictions or otherwise).
