### PR TITLE
Replace [vector] layer.properties warning with layer.qID warning.

### DIFF
--- a/lib/layer/format/vector.mjs
+++ b/lib/layer/format/vector.mjs
@@ -41,14 +41,13 @@ export default function vector(layer) {
     return;
   }
 
+  if (!layer.qID) {
+    console.warn(`Vector Layer: ${layer.key} missing qID property.`);
+    return;
+  }
+
   // Update feature style config.
   mapp.layer.styleParser(layer);
-
-  if (layer.properties) {
-    console.warn(
-      `Layer: ${layer.key}, layer.properties{} are no longer required for wkt & geojson datasets.`,
-    );
-  }
 
   // Set default layer params if nullish.
   layer.params ??= { fields: [] };


### PR DESCRIPTION
The layer.properties warning shouldn't be required anymore. A layer with the properties property will work it is just not required hence there shouldn't be a warning.

A vector layer without a qID however can not load data. This layer should not be added to the mapview, hence a warning is required.
