### PR TITLE
Template parameter check

### DIFF
--- a/mod/workspace/getTemplate.js
+++ b/mod/workspace/getTemplate.js
@@ -127,7 +127,7 @@ An error exception will be returned if the template object lookup from the works
 async function getTemplateObject(template) {
   if (typeof template === 'string') {
     // The template param must not include non whitelisted character.
-    if (/[^a-zA-Z\d\s:_-]/.exec(template)) {
+    if (/[^a-zA-Z0-9 :_-]/.exec(template)) {
       return new Error(
         `Template param may only include whitelisted character.`,
       );

--- a/mod/workspace/getTemplate.js
+++ b/mod/workspace/getTemplate.js
@@ -47,6 +47,13 @@ Module templates will be constructed before being returned.
 */
 module.exports = async function getTemplate(template) {
   if (typeof template === 'string') {
+    // The template param must not include non whitelisted character.
+    if (template.match(/[^a-zA-Z\d\s:_-]/)) {
+      return new Error(
+        `Template param may only include whitelisted character.`,
+      );
+    }
+
     const workspace = await workspaceCache();
 
     if (workspace instanceof Error) {

--- a/mod/workspace/getTemplate.js
+++ b/mod/workspace/getTemplate.js
@@ -127,7 +127,7 @@ An error exception will be returned if the template object lookup from the works
 async function getTemplateObject(template) {
   if (typeof template === 'string') {
     // The template param must not include non whitelisted character.
-    if (RegExp('[^a-zA-Z\d\s:_-]').exec(template)) {
+    if (/[^a-zA-Z\d\s:_-]/.exec(template)) {
       return new Error(
         `Template param may only include whitelisted character.`,
       );

--- a/mod/workspace/getTemplate.js
+++ b/mod/workspace/getTemplate.js
@@ -33,38 +33,23 @@ const envReplace = require('../utils/envReplace');
 @async
 
 @description
-The workspace will checked and cached by the [Workspace API checkWorkspaceCache]{@link module:/workspace/cache~checkWorkspaceCache} method.
+A JSON template object will be requested from the getTemplateObject method.
 
-A template object matching the template_key param in the workspace.templates{} object will be returned from the getTemplate method.
+An error will be returned if the lookup failed.
 
-The template will be retrieved from its src if not cached.
+A template will be requested from source if the template has not been cached.
 
-Module templates will be constructed before being returned.
+Template modules will be constructed.
 
 @param {string} template 
 
 @returns {Promise<Object|Error>} JSON Template
 */
 module.exports = async function getTemplate(template) {
-  if (typeof template === 'string') {
-    // The template param must not include non whitelisted character.
-    if (template.match(/[^a-zA-Z\d\s:_-]/)) {
-      return new Error(
-        `Template param may only include whitelisted character.`,
-      );
-    }
+  template = await getTemplateObject(template);
 
-    const workspace = await workspaceCache();
-
-    if (workspace instanceof Error) {
-      return workspace;
-    }
-
-    if (!Object.hasOwn(workspace.templates, template)) {
-      return new Error(`Template: ${template} not found.`);
-    }
-
-    template = workspace.templates[template];
+  if (template instanceof Error) {
+    return template;
   }
 
   if (!template.src) {
@@ -121,3 +106,45 @@ module.exports = async function getTemplate(template) {
 
   return template;
 };
+
+/**
+@function getTemplateObject
+@async
+
+@description
+The workspace will checked and cached by the [Workspace API checkWorkspaceCache]{@link module:/workspace/cache~checkWorkspaceCache} method.
+
+A template object matching the template_key param in the workspace.templates{} object will be returned.
+
+The template string will be checked to include only whitelisted character.
+
+An error exception will be returned if the template object lookup from the workspace failed.
+
+@param {string} template 
+
+@returns {Promise<Object|Error>} JSON Template
+*/
+async function getTemplateObject(template) {
+  if (typeof template === 'string') {
+    // The template param must not include non whitelisted character.
+    if (RegExp('[^a-zA-Z\d\s:_-]').exec(template)) {
+      return new Error(
+        `Template param may only include whitelisted character.`,
+      );
+    }
+
+    const workspace = await workspaceCache();
+
+    if (workspace instanceof Error) {
+      return workspace;
+    }
+
+    if (!Object.hasOwn(workspace.templates, template)) {
+      return new Error(`Template: ${template} not found.`);
+    }
+
+    template = workspace.templates[template];
+  }
+
+  return template;
+}


### PR DESCRIPTION
The template parameter is used to lookup templates in the workspace.

The template parameter is returned in an error message if a template is not found. This is required in order to know which template is missing in a workspace or inaccesible due to role restrictions.

An error message must be protected against cross site scripting.

A template key/parameter should only include whitelisted character.

The getTemplate module method should check whether the template parameter does include character which are not whitelisted and return an respective error message.

The regex for the non whitelisted character check is `[^a-zA-Z\d\s:_-]`