### PR TITLE
update layer.draw in decorator

### DIFF
--- a/lib/layer/decorate.mjs
+++ b/lib/layer/decorate.mjs
@@ -55,18 +55,6 @@ export default async function decorate(layer) {
     zoomToExtent,
   });
 
-  // Warn if outdated layer.edit configuration is used.
-  // Set layer.draw to layer.edit if it exists.
-  if (layer.edit) {
-    console.warn(
-      `Layer: ${layer.key}, please update edit:{} to use draw:{} as layer.edit has been superseeded with layer.draw to be in line with the OL drawing interaction.`,
-    );
-    layer.draw = Object.assign(layer.draw || {}, layer.edit);
-  }
-
-  // Layer must have an empty draw config to allow for role-based assignment of drawing methods.
-  layer.draw ??= {};
-
   // Warn if outdated layer.draw.delete configuration is used.
   if (layer.draw?.delete) {
     console.warn(


### PR DESCRIPTION
Not every layer should get an empty draw object property assigned. The draw property indicates that it should be possible to draw on the layer.

The comment ` // Layer must have an empty draw config to allow for role-based assignment of drawing methods.` doesn't really mean anything to me. I would need to see an example configuration for this.

The `layer.edit` property has long been retired. There shouldn't been a check and warning on this anymore. If used you will not see the drawing elements and won't be able to draw on the layer. No need to warn on this and assign the draw property keeping outdated configuration in place if they even exist.
