### PR TITLE
Opacity Slider Fix

### DIFF
--- a/lib/ui/layers/panels/style.mjs
+++ b/lib/ui/layers/panels/style.mjs
@@ -161,6 +161,7 @@ export default function stylePanel(layer) {
     'themes',
     'theme',
     'icon_scaling',
+    'opacitySlider'
   ];
 
   // Request style.panel element as content for drawer.


### PR DESCRIPTION
# Pull Request Template

## Description

We need to ensure that `opacitySlider` is provided in the nullish assignment to `layer.style.elements` to ensure that the slider can be seen when `style.opacitySlider = true` is set. 

## GitHub Issue

https://github.com/GEOLYTIX/xyz/issues/1898

## Type of Change
Please delete options that are not relevant, and select all options that apply. 

- ✅ Bug fix (non-breaking change which fixes an issue)

## Testing Checklist 
Please delete options that are not relevant, and select all options that apply. 

- ✅ Existing Tests still pass

## Code Quality Checklist
Please delete options that are not relevant, and select all options that apply. 

- ✅ My code follows the guidelines of XYZ
- ✅ My code has been commented
- ✅ Documentation has been updated
- ✅ New and existing unit tests pass locally with my changes