### PR TITLE
Assign mapview.extent in viewExtent method

### DIFF
--- a/lib/mapview/_mapview.mjs
+++ b/lib/mapview/_mapview.mjs
@@ -263,6 +263,9 @@ function viewExtent(mapview) {
       `EPSG:${mapview.srid}`,
     );
   }
+
+  // Assign extent for gazetteer check.
+  mapview.extent = mapview.view.extent;
 }
 
 /**


### PR DESCRIPTION
The extent required for the Map view decorator was removed from the mapview object when the mapview module was reviewed.

This property is required for a gazetteer extent check.

This PR assigns the mapview.extent property from the mapview.view in the mapview decorator viewExtent method.