### PR TITLE
Delete geometry should not finish an interaction, as no interaction h…

### DIFF
--- a/lib/ui/locations/entries/geometry.mjs
+++ b/lib/ui/locations/entries/geometry.mjs
@@ -243,7 +243,6 @@ function edit(entry) {
       class="flat wide no-colour"
       onclick=${() => {
         // Set value to null and update.
-        entry.location.layer.mapview.interaction.finish();
         entry.display = false;
         entry.value = null;
         update(entry);


### PR DESCRIPTION


## Description

Delete geometry should not finish an interaction, as no interaction has been called.
This was causing issues with being unable to select other locations from the `location.layer`. 

## GitHub Issue
#1907 

## Type of Change
Please delete options that are not relevant, and select all options that apply. 

- ✅ Bug fix (non-breaking change which fixes an issue)

## Testing Checklist 
Please delete options that are not relevant, and select all options that apply. 

- ✅ Existing Tests still pass
- ✅ Ran locally on my machine

## Code Quality Checklist
Please delete options that are not relevant, and select all options that apply. 

- ✅ My code follows the guidelines of XYZ
- ✅ My code has been commented
- ✅ Documentation has been updated
- ✅ New and existing unit tests pass locally with my changes