### PR TITLE
disabled nested elements in view changeend method.

### DIFF
--- a/lib/ui/layers/view.mjs
+++ b/lib/ui/layers/view.mjs
@@ -292,17 +292,21 @@ Layer with a tables object maybe zoom restricted.
 
 The [layer.tableCurrent()]{@link module:/layer/decorate~tableCurrent} method is called to determine whether the layer has a table configured for the current zoom level.
 
+Nested elements will be disabled if a layer can not be displayed.
+
 @param {layer} layer A decorated mapp layer.
 @property {HTMLElement} layer.view The layer view element.
+@property {HTMLElement} layer.drawer The layer view drawer element.
 @property {HTMLElement} layer.displayToggle A button element which toggles the layer.display.
 @property {HTMLElement} layer.zoomBtn A button element which sets the mapview into the visible zoom range for the layer.
 */
 function changeEnd(layer) {
-  // Get array of drawer in layer.drawer
-  const drawerArray = Array.from(
-    layer.drawer.querySelectorAll(':scope > .drawer'),
+  // Get array of nested elements excluding the .header element.
+  const nestedElements = Array.from(
+    layer.drawer.querySelectorAll(':scope > :not(.header)'),
   );
 
+  // Check whether the layer can be displayed at current zoom.
   if (layer.tableCurrent()) {
     // The zoomBtn is hidden if the layer is in range.
     layer.zoomBtn instanceof HTMLElement &&
@@ -313,7 +317,10 @@ function changeEnd(layer) {
       layer.displayToggle.classList.remove('disabled');
 
     // Enable all drawer elements in array.
-    drawerArray.forEach((el) => el.classList.remove('disabled'));
+    nestedElements.forEach((el) => {
+      el.disabled = false;
+      el.classList.remove('disabled');
+    });
   } else {
     // The zoomBtn is displayed outside if the layer is out of range.
     layer.zoomBtn instanceof HTMLElement &&
@@ -327,6 +334,9 @@ function changeEnd(layer) {
       layer.displayToggle.classList.add('disabled');
 
     // Disable all drawer elements in array.
-    drawerArray.forEach((el) => el.classList.add('disabled'));
+    nestedElements.forEach((el) => {
+      el.disabled = true;
+      el.classList.add('disabled');
+    });
   }
 }


### PR DESCRIPTION
Instead of just the nested drawer elements all elements but the .header class element in the drawer scope should be handled by the changeend event method to ensure that button in the drawer are disabled or enabled according to the layer being zoom range.