### PR TITLE
bump esbuild to v0.25

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "concurrently": "^9.1.0",
     "cookie-parser": "^1.4.5",
     "dotenv": "^16.4.5",
-    "esbuild": "^0.19.11",
+    "esbuild": "^0.25.0",
     "eslint": "^9.13.0",
     "express": "^4.18.3",
     "express-rate-limit": "^7.5.0",


### PR DESCRIPTION
In order to address the dependabot in regards to esbuild I have bumped the version to 0.25

https://github.com/GEOLYTIX/xyz/security/dependabot/22