### PR TITLE
KeyValue Dictionary Map and Key Value Dictionary from Layer

### DIFF
--- a/lib/layer/_layer.mjs
+++ b/lib/layer/_layer.mjs
@@ -34,6 +34,7 @@ import basic from './themes/basic.mjs';
 import categorized from './themes/categorized.mjs';
 import distributed from './themes/distributed.mjs';
 import graduated from './themes/graduated.mjs';
+import { parseObject } from '../plugins/keyvalue_dictionary.mjs';
 
 export default {
   decorate,
@@ -43,6 +44,7 @@ export default {
   featureHover,
   featureStyle,
   fade,
+  keyvalue_dictionary,
   styleParser,
   Style,
   themes: {
@@ -64,10 +66,29 @@ The deprecated `mapp.layer.Style()` method will warn if used and return the `fea
 
 @return {Function} featureStyle
 */
-
 function Style(layer) {
   console.warn(
     `The mapp.layer.Style() method has been superseeded by the mapp.layer.featureStyle() method.`,
   );
   return featureStyle(layer);
+}
+
+/**
+@function keyvalue_dictionary
+
+@description
+Replaces key-value pairs in the layer object with dictionary entries. Will be executed instead of the keyvalue_dictionary plugin method from the layer decorator.
+
+@param {layer} layer.keyvalue_dictionary The keyvalue dictionary.
+@property {Object} layer.locale.keyvalue_dictionaryMap The locale keyvalue dictionary map.
+*/
+export function keyvalue_dictionary(layer) {
+  if (!layer?.keyvalue_dictionary) return;
+
+  layer.keyvalue_dictionary.forEach((entry) => {
+    const compositeKey = `${entry.key}:${entry.value}`;
+    layer.mapview.locale.keyvalue_dictionaryMap.set(compositeKey, entry);
+  });
+
+  parseObject(layer, layer.mapview.locale.keyvalue_dictionaryMap);
 }

--- a/lib/layer/_layer.mjs
+++ b/lib/layer/_layer.mjs
@@ -85,10 +85,13 @@ Replaces key-value pairs in the layer object with dictionary entries. Will be ex
 export function keyvalue_dictionary(layer) {
   if (!layer?.keyvalue_dictionary) return;
 
+  // Create a Map from dictionary object.
+  const keyvalue_dictionaryMap = new Map();
+
   layer.keyvalue_dictionary.forEach((entry) => {
     const compositeKey = `${entry.key}:${entry.value}`;
-    layer.mapview.locale.keyvalue_dictionaryMap.set(compositeKey, entry);
+    keyvalue_dictionaryMap.set(compositeKey, entry);
   });
 
-  parseObject(layer, layer.mapview.locale.keyvalue_dictionaryMap);
+  parseObject(layer, keyvalue_dictionaryMap);
 }

--- a/lib/plugins/keyvalue_dictionary.mjs
+++ b/lib/plugins/keyvalue_dictionary.mjs
@@ -27,9 +27,17 @@ Replaces key-value pairs in the mapview locale object with dictionary entries.
 @property {Object} mapview.locale The locale object of the mapview.
 */
 export function keyvalue_dictionary(keyvalue_dictionary, mapview) {
-  if (!mapview.locale) return;
+  if (!mapview?.locale) return;
 
-  parseObject(mapview.locale, keyvalue_dictionary);
+  // Create a new Map on the locale.
+  mapview.locale.keyvalue_dictionaryMap = new Map();
+
+  keyvalue_dictionary.forEach((entry) => {
+    const compositeKey = `${entry.key}:${entry.value}`;
+    mapview.locale.keyvalue_dictionaryMap.set(compositeKey, entry);
+  });
+
+  parseObject(mapview.locale, mapview.locale.keyvalue_dictionaryMap);
 }
 
 /**
@@ -41,7 +49,7 @@ Parses an object and replaces its string values with dictionary entries.
 @param {Object} obj The object to parse.
 @param {Array} dictionary An array of dictionary entries.
 */
-function parseObject(obj, dictionary) {
+export function parseObject(obj, dictionary) {
   for (const [key, value] of Object.entries(obj)) {
     // Prevents crash where the mapview with the locale itself maybe nested in a locale plugin object.
     if (key === 'mapview') continue;
@@ -84,14 +92,12 @@ Replaces a key-value pair in an object with a dictionary entry.
 @param {Array} dictionary An array of dictionary entries.
 */
 function replaceKeyValue(obj, key, value, dictionary) {
-  // Find dictionary entry matching key and value.
-  const entry = dictionary
-    .filter((entry) => entry.key === key)
-    .findLast((entry) => entry.value === value);
+  const compositeKey = `${key}:${value}`;
 
-  if (!entry) return;
+  if (!dictionary.has(compositeKey)) return;
 
-  // Replace object key value with entry language lookup or default.
+  const entry = dictionary.get(compositeKey);
+
   obj[key] =
     entry[mapp?.user?.language || mapp.language] || entry.default || value;
 }

--- a/lib/plugins/keyvalue_dictionary.mjs
+++ b/lib/plugins/keyvalue_dictionary.mjs
@@ -29,15 +29,15 @@ Replaces key-value pairs in the mapview locale object with dictionary entries.
 export function keyvalue_dictionary(keyvalue_dictionary, mapview) {
   if (!mapview?.locale) return;
 
-  // Create a new Map on the locale.
-  mapview.locale.keyvalue_dictionaryMap = new Map();
+  // Create a Map from dictionary object.
+  const keyvalue_dictionaryMap = new Map();
 
   keyvalue_dictionary.forEach((entry) => {
     const compositeKey = `${entry.key}:${entry.value}`;
-    mapview.locale.keyvalue_dictionaryMap.set(compositeKey, entry);
+    keyvalue_dictionaryMap.set(compositeKey, entry);
   });
 
-  parseObject(mapview.locale, mapview.locale.keyvalue_dictionaryMap);
+  parseObject(mapview.locale, keyvalue_dictionaryMap);
 }
 
 /**


### PR DESCRIPTION
## Description

Converted the `weakMap` used previously to improve performance into a `Map` .
WeakMap keys must be objects, while we need string-based lookup. 
Created a composite key made up of `key:value` to retrieve dictionary entries. 
Add the `Map` dictionary to the locale as `locale.keyvalue_dictionaryMap` this is done to allow for layer-based translations too, as everything remains on the locale, that a layer can access. 

This was previously done on minor (but doesn't work) - https://github.com/GEOLYTIX/xyz/pull/1887
It has been moved to Patch as lots of clients are flagging the speed issues. 

This PR also introduces the ability to define a `keyvalue_dictionary` array on a layer, and it will be added to the overall dictionary. 
So this will work: 
1. Convert name: OSM to OpenStreetMAP DEFAULT on the locale.
2. Convert name: OpenStreetMAP DEFAULT to OpenStreetMap_layer from the layer. 
3. Convert name: OpenStreetMAP DEFAULT to OpenStreetMap_en from the layer only if the user language is English.


## GitHub Issue
#1945 
#1946 

## Type of Change

Please delete options that are not relevant, and select all options that apply.

- ✅ Bug fix (non-breaking change which fixes an issue)
- ✅ New feature (non-breaking change which adds functionality)

## Testing Checklist

Please delete options that are not relevant, and select all options that apply.

- ✅ Existing Tests still pass
- ✅ Ran locally on my machine

## Code Quality Checklist

Please delete options that are not relevant, and select all options that apply.

- ✅ My code follows the guidelines of XYZ
- ✅ My code has been commented
- ✅ Documentation has been updated
- ✅ New and existing unit tests pass locally with my changes
- ✅ Main has been merged into this PR
