### PR TITLE
Turn keyvalue_dictionary plugin into a utility.

### DIFF
--- a/lib/layer/_layer.mjs
+++ b/lib/layer/_layer.mjs
@@ -34,7 +34,6 @@ import basic from './themes/basic.mjs';
 import categorized from './themes/categorized.mjs';
 import distributed from './themes/distributed.mjs';
 import graduated from './themes/graduated.mjs';
-import { parseObject } from '../plugins/keyvalue_dictionary.mjs';
 
 export default {
   decorate,
@@ -44,7 +43,6 @@ export default {
   featureHover,
   featureStyle,
   fade,
-  keyvalue_dictionary,
   styleParser,
   Style,
   themes: {
@@ -71,19 +69,4 @@ function Style(layer) {
     `The mapp.layer.Style() method has been superseeded by the mapp.layer.featureStyle() method.`,
   );
   return featureStyle(layer);
-}
-
-/**
-@function keyvalue_dictionary
-
-@description
-Replaces key-value pairs in the layer object with dictionary entries. Will be executed instead of the keyvalue_dictionary plugin method from the layer decorator.
-
-@param {layer} layer A decorated layer object.
-@property {Object} layer.keyvalue_dictionary The keyvalue dictionary.
-*/
-export function keyvalue_dictionary(layer) {
-  if (!layer?.keyvalue_dictionary) return;
-
-  parseObject(layer, layer.keyvalue_dictionary);
 }

--- a/lib/layer/decorate.mjs
+++ b/lib/layer/decorate.mjs
@@ -16,6 +16,8 @@ Any plugins matching layer keys will be executed with the layer being passed as 
 
 The layer object is returned from the decorator.
 
+@requires /utils/keyvalue_dictionary
+
 @module /layer/decorate
 */
 
@@ -32,6 +34,9 @@ The layer decorator method create mapp-layer typedef object from a json-layer.
 @returns {layer} Decorated Mapp Layer.
 */
 export default async function decorate(layer) {
+  // Replace keyvalue_dictionary entries if required.
+  mapp.utils.keyvalue_dictionary(layer);
+
   // Check layer format.
   if (!Object.hasOwn(mapp.layer.formats, layer.format)) {
     console.warn(`Layer: ${layer.key}; ${layer.format} format unavailable.`);
@@ -313,4 +318,19 @@ function changeEnd(layer) {
   if (layer.params.viewport) {
     layer.display && layer.reload();
   }
+}
+
+/**
+@function keyvalue_dictionary
+
+@description
+Replaces key-value pairs in the layer object with dictionary entries. Will be executed instead of the keyvalue_dictionary plugin method from the layer decorator.
+
+@param {layer} layer A decorated layer object.
+@property {Object} layer.keyvalue_dictionary The keyvalue dictionary.
+*/
+export function keyvalue_dictionary(layer) {
+  if (!layer?.keyvalue_dictionary) return;
+
+  parseObject(layer, layer.keyvalue_dictionary);
 }

--- a/lib/mapview/_mapview.mjs
+++ b/lib/mapview/_mapview.mjs
@@ -63,6 +63,14 @@ The mapview decorator may return the async mapviewPromise method which must be a
 @returns {mapview} Decorated Mapview.
 */
 export default function decorate(mapview) {
+  if (!mapview.locale) {
+    console.warn(`A locale property is required to decorare a mapview object.`);
+    return;
+  }
+
+  // Replace keyvalue_dictionary entries if required.
+  mapp.utils.keyvalue_dictionary(mapview.locale);
+
   // Assign host from mapp if not implicit.
   mapview.host ??= mapp.host;
 

--- a/lib/plugins/_plugins.mjs
+++ b/lib/plugins/_plugins.mjs
@@ -8,7 +8,6 @@ The module exports a collection of core mapp plugins.
 @requires module:/plugins/admin
 @requires module:/plugins/feature_info
 @requires module:/plugins/fullscreen
-@requires module:/plugins/keyvalue_dictionary
 @requires module:/plugins/link_button
 @requires module:/plugins/locator
 @requires module:/plugins/login
@@ -23,7 +22,6 @@ import { admin } from './admin.mjs';
 import { dark_mode } from './dark_mode.mjs';
 import { feature_info } from './feature_info.mjs';
 import { fullscreen } from './fullscreen.mjs';
-import { keyvalue_dictionary } from './keyvalue_dictionary.mjs';
 import { link_button } from './link_button.mjs';
 import { locator } from './locator.mjs';
 import { login } from './login.mjs';
@@ -38,7 +36,6 @@ const plugins = {
   dark_mode,
   feature_info,
   fullscreen,
-  keyvalue_dictionary,
   link_button,
   locator,
   login,

--- a/lib/utils/_utils.mjs
+++ b/lib/utils/_utils.mjs
@@ -33,6 +33,8 @@ import { default as hexa } from './hexa.mjs';
 
 import jsonParser from './jsonParser.mjs';
 
+import { keyvalue_dictionary } from './keyvalue_dictionary.mjs';
+
 import loadPlugins from './loadPlugins.mjs';
 
 import getCurrentPosition from './getCurrentPosition.mjs';
@@ -96,6 +98,7 @@ export default {
   getCurrentPosition,
   hexa,
   jsonParser,
+  keyvalue_dictionary,
   loadPlugins,
   merge,
   mobile,

--- a/lib/utils/keyvalue_dictionary.mjs
+++ b/lib/utils/keyvalue_dictionary.mjs
@@ -1,7 +1,9 @@
 /**
-### /plugins/keyvalue_dictionary
+### /utils/keyvalue_dictionary
 
-A keyvalue_dictionary can be configured in the locale. The keyvalue_dictionary plugin method will parse the mapview.locale for properties with key/value pairs matching entries in the dictionary. The property value will be replaced with a language lookup in the dictionary or the default value.
+The keyvalue_dictionary utility method will parse a JSON object for properties with key/value pairs matching entries a provided dictionary.
+
+The property value will be replaced with a language lookup in the dictionary or the default value.
 
 ```js
 "keyvalue_dictionary": [
@@ -13,7 +15,7 @@ A keyvalue_dictionary can be configured in the locale. The keyvalue_dictionary p
   }
 ]
 ```
-@module /plugins/keyvalue_dictionary
+@module /utils/keyvalue_dictionary
 */
 
 /**
@@ -26,16 +28,16 @@ Replaces key-value pairs in the mapview locale object with dictionary entries.
 @param {mapview} mapview The mapview object.
 @property {Object} mapview.locale The locale object of the mapview.
 */
-export function keyvalue_dictionary(keyvalue_dictionary, mapview) {
-  if (!mapview?.locale) return;
+export function keyvalue_dictionary(obj) {
+  if (!obj.keyvalue_dictionary) return;
 
   const dictionary = new WeakMap();
 
-  keyvalue_dictionary.forEach((entry) => {
+  obj.keyvalue_dictionary.forEach((entry) => {
     dictionary.set([entry.key, entry.value], entry);
   });
 
-  parseObject(mapview.locale, dictionary);
+  parseObject(obj, dictionary);
 }
 
 /**
@@ -47,11 +49,9 @@ Parses an object and replaces its string values with dictionary entries.
 @param {Object} obj The object to parse.
 @param {Array} dictionary An array of dictionary entries.
 */
-export function parseObject(obj, dictionary) {
+function parseObject(obj, dictionary) {
   for (const [key, value] of Object.entries(obj)) {
-    // Prevents crash where the mapview with the locale itself maybe nested in a locale plugin object.
     if (key === 'mapview') continue;
-
     if (isArrayObject(value, dictionary)) continue;
     if (typeof value === 'string') replaceKeyValue(obj, key, value, dictionary);
   }


### PR DESCRIPTION
The keyvalue_dictionary module must be a utlity, not a plugin.

This resolves the issue of the parseObject having to be exported and imported into the layer methods.

The keyvalue_dictionary must not be run on a decorated object with complex method.

A dataview object for example can have self references.

The keyvalue_dictionary utils can be run at the beginning of the mapview, and layer decorator methods.