### PR TITLE
Locale without layers should not crash the process

### DIFF
--- a/mod/workspace/getLocale.js
+++ b/mod/workspace/getLocale.js
@@ -62,5 +62,7 @@ module.exports = async function getLocale(params) {
 
   locale = Roles.objMerge(locale, params.user?.roles);
 
+  locale.layers ??= {};
+
   return locale;
 };


### PR DESCRIPTION
An empty layers object should be assigned to a locale without layers.

This workspace would crash the _workspace module otherwise.

```js
{
  "locale": {}
}
```

The mapp library would also fall over on the layers length being undefined rather than 0.