### PR TITLE
The string value of like filter must be decoded.

### DIFF
--- a/mod/utils/sqlFilter.js
+++ b/mod/utils/sqlFilter.js
@@ -24,12 +24,16 @@ const filterTypes = {
 
   in: (col, val) => `"${col}" = ANY (\$${addValues([val], 'array')})`,
 
-  like: (col, val) =>
-    `(${val
+  like: (col, val) => {
+    // The val string must be decoded.
+    val = decodeURIComponent(val);
+
+    return `(${val
       .split(',')
       .filter((val) => val.length > 0)
       .map((val) => `"${col}" ILIKE \$${addValues(`${val}%`, 'string')}`)
-      .join(' OR ')})`,
+      .join(' OR ')})`;
+  },
 
   match: (col, val) => `"${col}"::text = \$${addValues(val, 'string')}`,
 };


### PR DESCRIPTION
A string value provided as argument to the ILIKE SQL filter condition will not be matched with encoded values, eg. `%20` for spaces.