### PR TITLE
fix material icons bundle size

### DIFF
--- a/lib/mapp.mjs
+++ b/lib/mapp.mjs
@@ -57,7 +57,7 @@ globalThis.mapp = {
 
   version: '4.13.0-beta',
 
-  hash: '4b06387c1ea48b00c947299b8788954010841edd',
+  hash: '39c2d7abe9bb012cc6b1ecae251c6fb1f5b6e11c',
 
   host: document.head?.dataset?.dir || '',
 

--- a/public/css/base/_material_icons.css
+++ b/public/css/base/_material_icons.css
@@ -1,4 +1,4 @@
-@import url(https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined:opsz,wght,FILL,GRAD@20..48,100..700,0..1,-50..200);
+@import url(https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined:opsz,wght,FILL,GRAD@24,300,0,0);
 
 .material-symbols-outlined {
   font-variation-settings:

--- a/public/css/ui.css
+++ b/public/css/ui.css
@@ -1,5 +1,5 @@
 @import "https://fonts.googleapis.com/css2?family=Titillium+Web:ital,wght@0,300;0,400;0,600;1,200;1,300&display=swap";
-@import "https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined:opsz,wght,FILL,GRAD@20..48,100..700,0..1,-50..200";
+@import "https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined:opsz,wght,FILL,GRAD@24,300,0,0";
 
 /* public/css/base/_colours.css */
 :root {


### PR DESCRIPTION
# Material Icon Library reduction

The material icons library without any axes configurations was coming in at
3.3mb which is far too large for what we need.

The following axes configuration is what we need and now only comes in at 280kb
This is a 98% reduction in size.

- `opsz` (Optical Size): 24px - Controls how the icons are optimized for display at specific sizes
- `wght` (Weight): 300 - Sets the thickness/weight of the icons (300 is a light weight)
- `FILL` (Fill): 0 - Determines if icons are filled (1) or outlined (0)
- `GRAD` (Grade): 0 - Adjusts the relative thickness of the icons without affecting layout

```javascript
@import url(https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined:opsz,wght,FILL,GRAD@24,300,0,0);
```
