### PR TITLE
Ensure that flex growth container is scrollable on mobile

### DIFF
--- a/public/views/_default.html
+++ b/public/views/_default.html
@@ -159,7 +159,7 @@
         }
 
         #Map {
-          height: calc(100% - 50px);
+          height: calc(100% - 40px);
           width: 100%;
         }
 
@@ -172,6 +172,8 @@
           width: 100%;
           height: 100%;
           position: relative;
+          display: flex;
+          flex-direction: column;
         }
       }
     </style>


### PR DESCRIPTION
The flex growth can only work for the panel in the ctrls element if the parent has a display flex property with the column direction.

The height of the mobile #Map element has been adjusted to take the smaller icons into account.