### PR TITLE
node-saml v5.0.1 bump

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "@aws-sdk/client-s3": "^3.691.0",
     "@aws-sdk/cloudfront-signer": "^3.621.0",
     "@aws-sdk/s3-request-presigner": "^3.691.0",
-    "@node-saml/node-saml": "^5.0.0"
+    "@node-saml/node-saml": "^5.0.1"
   },
   "dependencies": {
     "jsonwebtoken": "^9.0.2",


### PR DESCRIPTION
The fix should be on minor since I believe that the minor saml has been updated in the 4.13 release.