### PR TITLE
Change the lookup for a layer theme field

### DIFF
--- a/mod/query.js
+++ b/mod/query.js
@@ -298,7 +298,7 @@ async function fieldsMap(req, res) {
     if (Object.hasOwn(req.params.workspace.templates, field)) {
       const fieldTemplate = await getTemplate(field);
 
-      value = fieldTemplate.template || '';
+      value = fieldTemplate.field  || field;
     }
 
     req.params.fieldsMap.set(field, value);


### PR DESCRIPTION
A layer with a field defined in the theme that matches to a template in `workspace.templates` will error. 

``` json
  "themes": {
      "a": {
        "title": "Theme A",
        "type": "categorized",
        "field": "theme_field"
   }
}
```

If there's a layer of the name `theme_field` - the thematic will fail. 

**Solution**
- Change the lookup from fieldTemplate.template to fieldTemplate.field
``` js 
 if (Object.hasOwn(req.params.workspace.templates, field)) {
      const fieldTemplate = await getTemplate(field);

    // Previously 
    value = fieldTemplate.template || ''; 
   // New
      value = fieldTemplate.field  || field;
    }
```

This will mean that the lookup requires a template that contains a field key - which is the SQL for the calculated field for the theme. Also, by setting the || to field, it means that if this is not found - the original field is used. 