### PR TITLE
Featurehover table check

### DIFF
--- a/lib/layer/featureHover.mjs
+++ b/lib/layer/featureHover.mjs
@@ -13,6 +13,10 @@ export default function (feature, layer) {
 
   if (!featureKey) return;
 
+  const table = layer.tableCurrent();
+
+  if (!table) return;
+
   const paramString = mapp.utils.paramString({
     locale: layer.mapview.locale.key,
     layer: layer.key,
@@ -21,7 +25,7 @@ export default function (feature, layer) {
     template: layer.style.hover.query || 'infotip',
     qID: layer.qID,
     id: feature.properties.id,
-    table: layer.tableCurrent(),
+    table,
     geom: layer.geom,
     field: layer.style.hover.field,
     coords:

--- a/lib/layer/featureHover.mjs
+++ b/lib/layer/featureHover.mjs
@@ -4,7 +4,16 @@
 @module /layer/featureHover
 */
 
-export default function (feature, layer) {
+/**
+@function featureHover
+
+@description
+The featureHover method will send an xhr request for the provided feature argument. The returned string value will be displayed in an infotip element in the feature layer mapview.
+
+@param {object} feature 
+@param {layer} layer A decorated mapp layer object.
+*/
+export default function featureHover(feature, layer) {
   // The hover method must only execute if the display flag is set.
   if (!layer.style.hover.display) return;
 


### PR DESCRIPTION
The featureHover method should shortcircuit if no current table value is available.