### PR TITLE
check entry.value type in date module

### DIFF
--- a/lib/ui/locations/entries/date.mjs
+++ b/lib/ui/locations/entries/date.mjs
@@ -43,7 +43,7 @@ function date(entry) {
       console.warn(`${entry.type} field: ${entry.field} should be an integer.`);
     }
 
-    const value = mapp.utils.temporal[entry.type](parseInt(timestamp))
+    const value = mapp.utils.temporal[entry.type](parseInt(timestamp));
 
     // return date/time input
     return mapp.utils.html.node`<input

--- a/lib/ui/locations/entries/date.mjs
+++ b/lib/ui/locations/entries/date.mjs
@@ -37,7 +37,13 @@ function date(entry) {
       );
     }
 
-    const value = mapp.utils.temporal[entry.type](entry);
+    const timestamp = entry.newValue || entry.value;
+
+    if (typeof timestamp === 'string') {
+      console.warn(`${entry.type} field: ${entry.field} should be an integer.`);
+    }
+
+    const value = mapp.utils.temporal[entry.type](parseInt(timestamp))
 
     // return date/time input
     return mapp.utils.html.node`<input

--- a/lib/utils/temporal.mjs
+++ b/lib/utils/temporal.mjs
@@ -62,13 +62,10 @@ function dateToUnixEpoch(dateStr) {
 
 /**
 Formats Unix timestamp to ISO datetime string (YYYY-MM-DDThh:mm:ss)
-@param {Object} params Input parameters
-@property {number} params.value Unix timestamp in seconds
-@property {number} [params.newValue] Updated timestamp value
+@param {integer} timestamp Unix timestamp in seconds
 @returns {string} ISO datetime string without timezone
 */
-function datetime(params) {
-  const timestamp = parseInt(params.newValue || params.value);
+function datetime(timestamp) {
   if (!timestamp) return;
   const date = toJSDate(timestamp);
   return date.toISOString().split('.')[0];
@@ -76,13 +73,10 @@ function datetime(params) {
 
 /**
 Formats Unix timestamp to ISO date string (YYYY-MM-DD)
-@param {Object} params Input parameters
-@property {number} params.value Unix timestamp in seconds
-@property {number} [params.newValue] Updated timestamp value
+@param {integer} timestamp Unix timestamp in seconds
 @returns {string} ISO date string
 */
-function date(params) {
-  const timestamp = params.newValue || params.value;
+function date(timestamp) {
   if (!timestamp) return;
   const date = toJSDate(timestamp);
   return date.toISOString().split('T')[0];

--- a/tests/lib/utils/temporal.test.mjs
+++ b/tests/lib/utils/temporal.test.mjs
@@ -132,7 +132,7 @@ export function temporal() {
         },
         () => {
           const epoch = 1704067200;
-          const datetime = mapp.utils.temporal.datetime({ value: epoch });
+          const datetime = mapp.utils.temporal.datetime(epoch);
 
           codi.assertEqual(
             datetime,
@@ -153,7 +153,7 @@ export function temporal() {
         },
         () => {
           const epoch = 1704067200;
-          const datetime = mapp.utils.temporal.date({ value: epoch });
+          const datetime = mapp.utils.temporal.date(epoch);
 
           codi.assertEqual(
             datetime,

--- a/tests/lib/utils/temporal.test.mjs
+++ b/tests/lib/utils/temporal.test.mjs
@@ -137,7 +137,7 @@ export function temporal() {
           codi.assertEqual(
             datetime,
             '2024-01-01T00:00:00',
-            'The datetime should b be the 1st of January 2024',
+            'The datetime should be the 1st of January 2024',
           );
         },
       );
@@ -158,7 +158,7 @@ export function temporal() {
           codi.assertEqual(
             datetime,
             '2024-01-01',
-            'The datetime should b be the 1st of January 2024',
+            'The datetime should be the 1st of January 2024',
           );
         },
       );


### PR DESCRIPTION
The temporal.date and temporal.datetime method should receive an integer as specified in the documentation.

The params [entry] object for the newValue check is unnecessary.

Date and datetime entry fields will work with string fields but an integer stored in a string field can not work with date[time] range filter.

This PR adds a check on the timestamp type which is either the entry.newValue or entry.value property in the entry.edit condition.