### PR TITLE
CSS colour classes - cleanup;

### DIFF
--- a/lib/plugins/login.mjs
+++ b/lib/plugins/login.mjs
@@ -29,7 +29,7 @@ export function login(plugin, mapview) {
   const iconName = `${mapp.user ? 'logout' : 'lock_open'}`;
 
   const iconClass =
-    'material-symbols-outlined' + (mapp.user ? ' no-colour' : '');
+    'material-symbols-outlined' + (mapp.user ? ' danger' : '');
 
   btnColumn.appendChild(mapp.utils.html.node`
     <a

--- a/lib/plugins/login.mjs
+++ b/lib/plugins/login.mjs
@@ -28,7 +28,7 @@ export function login(plugin, mapview) {
 
   const iconName = `${mapp.user ? 'logout' : 'lock_open'}`;
 
-  const iconClass = 'material-symbols-outlined' + (mapp.user ? ' danger' : '');
+  const iconClass = 'material-symbols-outlined' + (mapp.user ? ' color-danger' : '');
 
   btnColumn.appendChild(mapp.utils.html.node`
     <a

--- a/lib/plugins/login.mjs
+++ b/lib/plugins/login.mjs
@@ -28,7 +28,8 @@ export function login(plugin, mapview) {
 
   const iconName = `${mapp.user ? 'logout' : 'lock_open'}`;
 
-  const iconClass = 'material-symbols-outlined' + (mapp.user ? ' color-danger' : '');
+  const iconClass =
+    'material-symbols-outlined' + (mapp.user ? ' color-danger' : '');
 
   btnColumn.appendChild(mapp.utils.html.node`
     <a

--- a/lib/plugins/login.mjs
+++ b/lib/plugins/login.mjs
@@ -28,8 +28,7 @@ export function login(plugin, mapview) {
 
   const iconName = `${mapp.user ? 'logout' : 'lock_open'}`;
 
-  const iconClass =
-    'material-symbols-outlined' + (mapp.user ? ' danger' : '');
+  const iconClass = 'material-symbols-outlined' + (mapp.user ? ' danger' : '');
 
   btnColumn.appendChild(mapp.utils.html.node`
     <a

--- a/lib/ui/elements/card.mjs
+++ b/lib/ui/elements/card.mjs
@@ -27,7 +27,7 @@ export default function card(params) {
     <header class="header bold">
       <span>${params.header}</span>
       <button
-        class="material-symbols-outlined"
+        class="material-symbols-outlined color-font-mid"
         onclick=${(e) => {
           e.target.closest('.drawer').remove();
           if (typeof params.close === 'function') {

--- a/lib/ui/layers/view.mjs
+++ b/lib/ui/layers/view.mjs
@@ -65,7 +65,7 @@ export default function layerView(layer) {
 
   // The displayToggle element should be on if the layer is displayed or should be displayed in zoom range.
   const displayToggleClass = `material-symbols-outlined toggle ${
-    layer.zoomDisplay || layer.display ? 'on' : ''
+    layer.zoomDisplay || layer.display ? 'toggle-on' : ''
   }`;
 
   // Create layer.displayToggle button for header.
@@ -76,7 +76,7 @@ export default function layerView(layer) {
       title=${mapp.dictionary.layer_visibility}
       class=${displayToggleClass}
       onclick=${(e) => {
-        const toggle = e.target.classList.toggle('on');
+        const toggle = e.target.classList.toggle('toggle-on');
         toggle ? layer.show() : layer.hide();
       }}>`;
 
@@ -91,12 +91,12 @@ export default function layerView(layer) {
 
   // Add on callback for toggle button.
   layer.showCallbacks.push(() => {
-    layer.displayToggle.classList.add('on');
+    layer.displayToggle.classList.add('toggle-on');
   });
 
   // Remove on callback for toggle button.
   layer.hideCallbacks.push(() => {
-    !layer.zoomDisplay && layer.displayToggle.classList.remove('on');
+    !layer.zoomDisplay && layer.displayToggle.classList.remove('toggle-on');
   });
 
   const header = mapp.utils.html`

--- a/lib/ui/locations/entries/cloudinary.mjs
+++ b/lib/ui/locations/entries/cloudinary.mjs
@@ -38,7 +38,7 @@ function image(entry) {
       entry.edit &&
       mapp.utils.html`<button 
       title="${mapp.dictionary.delete}"
-      class="material-symbols-outlined no-colour delete"
+      class="material-symbols-outlined danger delete"
       data-name=${entry.value.replace(/^.*\//, '').replace(/\.([\w-]{3})/, '')}
       data-src=${entry.value}
       onclick=${(e) => trash(e, entry, mapp.dictionary.remove_image_confirm)}>delete`;
@@ -85,7 +85,7 @@ function images(entry) {
     const trashBtn =
       entry.edit &&
       mapp.utils.html`<button title="${mapp.dictionary.delete}"
-      class="material-symbols-outlined no-colour delete"
+      class="material-symbols-outlined danger delete"
       data-name=${image.replace(/^.*\//, '').replace(/\.([\w-]{3})/, '')}
       data-src=${image}
       onclick=${(e) => trash(e, entry, mapp.dictionary.remove_image_confirm)}>delete`;
@@ -137,7 +137,7 @@ function documents(entry) {
       entry.edit &&
       mapp.utils.html`<button 
       title="${mapp.dictionary.delete}"
-      class="material-symbols-outlined no-colour delete"
+      class="material-symbols-outlined danger delete"
       data-name=${doc.replace(/^.*\//, '').replace(/\.([\w-]{3})/, '')}
       data-href=${doc}
       onclick=${(e) => trash(e, entry, mapp.dictionary.remove_document_confirm)}>delete`;

--- a/lib/ui/locations/entries/cloudinary.mjs
+++ b/lib/ui/locations/entries/cloudinary.mjs
@@ -38,7 +38,7 @@ function image(entry) {
       entry.edit &&
       mapp.utils.html`<button 
       title="${mapp.dictionary.delete}"
-      class="material-symbols-outlined danger delete"
+      class="material-symbols-outlined color-danger delete"
       data-name=${entry.value.replace(/^.*\//, '').replace(/\.([\w-]{3})/, '')}
       data-src=${entry.value}
       onclick=${(e) => trash(e, entry, mapp.dictionary.remove_image_confirm)}>delete`;
@@ -85,7 +85,7 @@ function images(entry) {
     const trashBtn =
       entry.edit &&
       mapp.utils.html`<button title="${mapp.dictionary.delete}"
-      class="material-symbols-outlined danger delete"
+      class="material-symbols-outlined color-danger delete"
       data-name=${image.replace(/^.*\//, '').replace(/\.([\w-]{3})/, '')}
       data-src=${image}
       onclick=${(e) => trash(e, entry, mapp.dictionary.remove_image_confirm)}>delete`;
@@ -137,7 +137,7 @@ function documents(entry) {
       entry.edit &&
       mapp.utils.html`<button 
       title="${mapp.dictionary.delete}"
-      class="material-symbols-outlined danger delete"
+      class="material-symbols-outlined color-danger delete"
       data-name=${doc.replace(/^.*\//, '').replace(/\.([\w-]{3})/, '')}
       data-href=${doc}
       onclick=${(e) => trash(e, entry, mapp.dictionary.remove_document_confirm)}>delete`;

--- a/lib/ui/locations/entries/geometry.mjs
+++ b/lib/ui/locations/entries/geometry.mjs
@@ -205,7 +205,7 @@ function edit(entry) {
   if (entry.field !== entry.location.layer.geomCurrent())
     entry.elements.push(mapp.utils.html`
     <button
-      class="flat wide danger"
+      class="flat wide color-danger"
       onclick=${() => {
         // Set value to null and update.
         entry.display = false;

--- a/lib/ui/locations/entries/geometry.mjs
+++ b/lib/ui/locations/entries/geometry.mjs
@@ -205,7 +205,7 @@ function edit(entry) {
   if (entry.field !== entry.location.layer.geomCurrent())
     entry.elements.push(mapp.utils.html`
     <button
-      class="flat wide no-colour"
+      class="flat wide danger"
       onclick=${() => {
         // Set value to null and update.
         entry.display = false;

--- a/lib/ui/locations/view.mjs
+++ b/lib/ui/locations/view.mjs
@@ -74,7 +74,7 @@ export default function view(location) {
   if (location.layer?.edit?.delete || location.layer?.deleteLocation) {
     header.push(mapp.utils.html`<button
       title=${mapp.dictionary.location_delete}
-      class="material-symbols-outlined danger"
+      class="material-symbols-outlined color-danger"
       onclick = ${() => location.trash()}>delete`);
   }
 

--- a/lib/ui/locations/view.mjs
+++ b/lib/ui/locations/view.mjs
@@ -58,7 +58,7 @@ export default function view(location) {
   // Update icon.
   header.push(mapp.utils.html`<button
     title=${mapp.dictionary.location_save}
-    class="btn-save material-symbols-outlined info"
+    class="btn-save material-symbols-outlined color-info"
     style="display: none;"
     onclick = ${() => {
       location.view.classList.add('disabled');

--- a/lib/ui/locations/view.mjs
+++ b/lib/ui/locations/view.mjs
@@ -58,7 +58,7 @@ export default function view(location) {
   // Update icon.
   header.push(mapp.utils.html`<button
     title=${mapp.dictionary.location_save}
-    class="btn-save material-symbols-outlined ok-colour"
+    class="btn-save material-symbols-outlined info"
     style="display: none;"
     onclick = ${() => {
       location.view.classList.add('disabled');
@@ -74,7 +74,7 @@ export default function view(location) {
   if (location.layer?.edit?.delete || location.layer?.deleteLocation) {
     header.push(mapp.utils.html`<button
       title=${mapp.dictionary.location_delete}
-      class="material-symbols-outlined no-colour"
+      class="material-symbols-outlined danger"
       onclick = ${() => location.trash()}>delete`);
   }
 

--- a/lib/ui/locations/view.mjs
+++ b/lib/ui/locations/view.mjs
@@ -132,7 +132,7 @@ export default function view(location) {
 
     // Location has toggle editing.
     if (location.editToggle) {
-      location.editToggle.classList.remove('on');
+      location.editToggle.classList.remove('edit-toggle-on');
 
       // Remove edits from infoj entries.
       location.removeEdits();
@@ -184,7 +184,7 @@ function toggleLocationViewEdits(location) {
   // Create edit toggle button.
   location.editToggle = mapp.utils.html.node`<button
     title="Enable edits"
-    class=${`material-symbols-outlined ${(location.new && 'on') || ''}`}
+    class=${`material-symbols-outlined ${(location.new && 'edit-toggle-on') || ''}`}
     onclick=${onClickEditToggle}>edit`;
 
   /**
@@ -223,7 +223,7 @@ function toggleLocationViewEdits(location) {
         // The update may err due to invalid entries.
         if (update instanceof Error) return;
       }
-    } else if (e.target.classList.toggle('on')) {
+    } else if (e.target.classList.toggle('edit-toggle-on')) {
       // Button is toggled on.
       location.restoreEdits();
     } else {

--- a/public/css/base/_colours.css
+++ b/public/css/base/_colours.css
@@ -35,10 +35,19 @@ body {
   transition-property: background-color;
 }
 
+
 .active {
   color: var(--color-active);
 }
 
 .color-danger {
   color: var(--color-danger);
+}
+
+.color-info {
+  color: var(--color-info);
+}
+
+.color-font-mid {
+  color: var(--color-font-mid);
 }

--- a/public/css/base/_colours.css
+++ b/public/css/base/_colours.css
@@ -43,11 +43,6 @@ body {
   }
 }
 
-.primary-background {
-  color: var(--color-font-contrast);
-  background-color: var(--color-primary);
-}
-
 .off-black {
   color: var(--color-font);
 }

--- a/public/css/base/_colours.css
+++ b/public/css/base/_colours.css
@@ -35,7 +35,6 @@ body {
   transition-property: background-color;
 }
 
-
 .active {
   color: var(--color-active);
 }

--- a/public/css/base/_colours.css
+++ b/public/css/base/_colours.css
@@ -39,7 +39,7 @@ body {
   color: var(--color-font);
 }
 
-.on-colour {
+.active {
   color: var(--color-active);
 }
 

--- a/public/css/base/_colours.css
+++ b/public/css/base/_colours.css
@@ -35,14 +35,6 @@ body {
   transition-property: background-color;
 }
 
-.primary-colour {
-  color: var(--color-primary);
-
-  &.active {
-    color: var(--color-active);
-  }
-}
-
 .off-black {
   color: var(--color-font);
 }

--- a/public/css/base/_colours.css
+++ b/public/css/base/_colours.css
@@ -39,6 +39,6 @@ body {
   color: var(--color-active);
 }
 
-.danger {
+.color-danger {
   color: var(--color-danger);
 }

--- a/public/css/base/_colours.css
+++ b/public/css/base/_colours.css
@@ -35,10 +35,6 @@ body {
   transition-property: background-color;
 }
 
-.off-black {
-  color: var(--color-font);
-}
-
 .active {
   color: var(--color-active);
 }

--- a/public/css/base/_colours.css
+++ b/public/css/base/_colours.css
@@ -34,19 +34,3 @@ body {
   transition: 0.2s ease-in-out;
   transition-property: background-color;
 }
-
-.active {
-  color: var(--color-active);
-}
-
-.color-danger {
-  color: var(--color-danger);
-}
-
-.color-info {
-  color: var(--color-info);
-}
-
-.color-font-mid {
-  color: var(--color-font-mid);
-}

--- a/public/css/base/_colours.css
+++ b/public/css/base/_colours.css
@@ -48,27 +48,14 @@ body {
   background-color: var(--color-primary);
 }
 
-.light-background {
-  background-color: var(--color-base-tertiary);
-}
-
-.light-colour {
-  color: var(--color-base-tertiary);
-}
-
 .off-black {
   color: var(--color-font);
-}
-
-.off-black-background {
-  color: var(--color-base-tertiary);
-  background-color: var(--color-font);
 }
 
 .on-colour {
   color: var(--color-active);
 }
 
-.no-colour {
+.danger {
   color: var(--color-danger);
 }

--- a/public/css/base/_inputs.css
+++ b/public/css/base/_inputs.css
@@ -57,7 +57,7 @@ input[type='time'],
 input[type='datetime-local'] {
   background-color: var(--color-base);
   border: 1px solid var(--color-border);
-  color: var(--color-primary);
+  color: var(--color-font);
   padding: 5px;
   border-radius: 3px;
 
@@ -71,7 +71,7 @@ input[type='number'] {
   padding: 5px;
   border: none;
   background-color: var(--color-base);
-  color: var(--color-primary);
+  color: var(--color-font);
   border-bottom: 1px dotted var(--color-border);
   display: inline-block;
   width: 100%;

--- a/public/css/base/_material_icons.css
+++ b/public/css/base/_material_icons.css
@@ -15,11 +15,11 @@
     color: var(--color-active);
   }
 
-  &.no-colour {
+  &.danger {
     color: var(--color-danger);
   }
 
-  &.ok-colour {
+  &.info {
     color: var(--color-info);
   }
 

--- a/public/css/base/_material_icons.css
+++ b/public/css/base/_material_icons.css
@@ -10,11 +10,15 @@
     color: var(--color-active);
   }
 
-  &.info {
+  &.color-info {
     color: var(--color-info);
   }
 
-  &.primary-light-colour {
+  &.color-danger {
+    color: var(--color-danger);
+  }
+
+  &.color-font-mid {
     color: var(--color-font-mid);
   }
 

--- a/public/css/base/_material_icons.css
+++ b/public/css/base/_material_icons.css
@@ -10,11 +10,6 @@
     color: var(--color-active);
   }
 
-  &.on-colour,
-  &.on {
-    color: var(--color-active);
-  }
-
   &.danger {
     color: var(--color-danger);
   }
@@ -38,7 +33,7 @@
     content: 'toggle_off';
   }
 
-  &.on::after {
+  &.toggle-on::after {
     content: 'toggle_on';
     color: var(--color-active);
   }

--- a/public/css/base/_material_icons.css
+++ b/public/css/base/_material_icons.css
@@ -22,7 +22,7 @@
     color: var(--color-font-mid);
   }
 
-  &.close:after {
+  &.close::after {
     content: 'close';
     color: var(--color-font-mid);
   }

--- a/public/css/base/_material_icons.css
+++ b/public/css/base/_material_icons.css
@@ -10,9 +10,7 @@
     color: var(--color-active);
   }
 
-  &.danger {
-    color: var(--color-danger);
-  }
+
 
   &.info {
     color: var(--color-info);

--- a/public/css/base/_material_icons.css
+++ b/public/css/base/_material_icons.css
@@ -10,8 +10,6 @@
     color: var(--color-active);
   }
 
-
-
   &.info {
     color: var(--color-info);
   }

--- a/public/css/base/_material_icons.css
+++ b/public/css/base/_material_icons.css
@@ -28,7 +28,7 @@
   }
 }
 
-.toogle-on {
+.toggle-on {
   color: var(--color-active);
 }
 

--- a/public/css/layout/_locationview.css
+++ b/public/css/layout/_locationview.css
@@ -2,6 +2,10 @@
   margin-top: 5px;
   border-radius: 5px;
   background-color: var(--color-base-tertiary);
+
+  .edit-toggle-on {
+    color: var(--color-active);
+  }
 }
 
 .location-view-grid {

--- a/public/css/mapp.css
+++ b/public/css/mapp.css
@@ -21,13 +21,10 @@ body {
   transition: 0.2s ease-in-out;
   transition-property: background-color;
 }
-.off-black {
-  color: var(--color-font);
-}
 .active {
   color: var(--color-active);
 }
-.danger {
+.color-danger {
   color: var(--color-danger);
 }
 

--- a/public/css/mapp.css
+++ b/public/css/mapp.css
@@ -27,10 +27,6 @@ body {
     color: var(--color-active);
   }
 }
-.primary-background {
-  color: var(--color-font-contrast);
-  background-color: var(--color-primary);
-}
 .off-black {
   color: var(--color-font);
 }

--- a/public/css/mapp.css
+++ b/public/css/mapp.css
@@ -21,12 +21,6 @@ body {
   transition: 0.2s ease-in-out;
   transition-property: background-color;
 }
-.primary-colour {
-  color: var(--color-primary);
-  &.active {
-    color: var(--color-active);
-  }
-}
 .off-black {
   color: var(--color-font);
 }

--- a/public/css/mapp.css
+++ b/public/css/mapp.css
@@ -21,18 +21,6 @@ body {
   transition: 0.2s ease-in-out;
   transition-property: background-color;
 }
-.active {
-  color: var(--color-active);
-}
-.color-danger {
-  color: var(--color-danger);
-}
-.color-info {
-  color: var(--color-info);
-}
-.color-font-mid {
-  color: var(--color-font-mid);
-}
 
 /* public/css/layout/_ol.css */
 .ol-scale-line {

--- a/public/css/mapp.css
+++ b/public/css/mapp.css
@@ -27,6 +27,12 @@ body {
 .color-danger {
   color: var(--color-danger);
 }
+.color-info {
+  color: var(--color-info);
+}
+.color-font-mid {
+  color: var(--color-font-mid);
+}
 
 /* public/css/layout/_ol.css */
 .ol-scale-line {

--- a/public/css/mapp.css
+++ b/public/css/mapp.css
@@ -24,7 +24,7 @@ body {
 .off-black {
   color: var(--color-font);
 }
-.on-colour {
+.active {
   color: var(--color-active);
 }
 .danger {

--- a/public/css/mapp.css
+++ b/public/css/mapp.css
@@ -31,23 +31,13 @@ body {
   color: var(--color-font-contrast);
   background-color: var(--color-primary);
 }
-.light-background {
-  background-color: var(--color-base-tertiary);
-}
-.light-colour {
-  color: var(--color-base-tertiary);
-}
 .off-black {
   color: var(--color-font);
-}
-.off-black-background {
-  color: var(--color-base-tertiary);
-  background-color: var(--color-font);
 }
 .on-colour {
   color: var(--color-active);
 }
-.no-colour {
+.danger {
   color: var(--color-danger);
 }
 

--- a/public/css/ui.css
+++ b/public/css/ui.css
@@ -27,7 +27,7 @@ body {
 .active {
   color: var(--color-active);
 }
-.danger {
+.color-danger {
   color: var(--color-danger);
 }
 
@@ -288,9 +288,6 @@ input[type=search]::-webkit-search-cancel-button:hover {
   color: var(--color-primary);
   &.active {
     color: var(--color-active);
-  }
-  &.danger {
-    color: var(--color-danger);
   }
   &.info {
     color: var(--color-info);

--- a/public/css/ui.css
+++ b/public/css/ui.css
@@ -292,7 +292,7 @@ input[type=search]::-webkit-search-cancel-button:hover {
   &.color-font-mid {
     color: var(--color-font-mid);
   }
-  &.close:after {
+  &.close::after {
     content: "close";
     color: var(--color-font-mid);
   }

--- a/public/css/ui.css
+++ b/public/css/ui.css
@@ -24,18 +24,6 @@ body {
   transition: 0.2s ease-in-out;
   transition-property: background-color;
 }
-.active {
-  color: var(--color-active);
-}
-.color-danger {
-  color: var(--color-danger);
-}
-.color-info {
-  color: var(--color-info);
-}
-.color-font-mid {
-  color: var(--color-font-mid);
-}
 
 /* public/css/base/_common.css */
 .display-none {

--- a/public/css/ui.css
+++ b/public/css/ui.css
@@ -34,23 +34,13 @@ body {
   color: var(--color-font-contrast);
   background-color: var(--color-primary);
 }
-.light-background {
-  background-color: var(--color-base-tertiary);
-}
-.light-colour {
-  color: var(--color-base-tertiary);
-}
 .off-black {
   color: var(--color-font);
-}
-.off-black-background {
-  color: var(--color-base-tertiary);
-  background-color: var(--color-font);
 }
 .on-colour {
   color: var(--color-active);
 }
-.no-colour {
+.danger {
   color: var(--color-danger);
 }
 
@@ -316,10 +306,10 @@ input[type=search]::-webkit-search-cancel-button:hover {
   &.on {
     color: var(--color-active);
   }
-  &.no-colour {
+  &.danger {
     color: var(--color-danger);
   }
-  &.ok-colour {
+  &.info {
     color: var(--color-info);
   }
   &.primary-light-colour {

--- a/public/css/ui.css
+++ b/public/css/ui.css
@@ -24,9 +24,6 @@ body {
   transition: 0.2s ease-in-out;
   transition-property: background-color;
 }
-.off-black {
-  color: var(--color-font);
-}
 .active {
   color: var(--color-active);
 }

--- a/public/css/ui.css
+++ b/public/css/ui.css
@@ -27,7 +27,7 @@ body {
 .off-black {
   color: var(--color-font);
 }
-.on-colour {
+.active {
   color: var(--color-active);
 }
 .danger {
@@ -292,10 +292,6 @@ input[type=search]::-webkit-search-cancel-button:hover {
   &.active {
     color: var(--color-active);
   }
-  &.on-colour,
-  &.on {
-    color: var(--color-active);
-  }
   &.danger {
     color: var(--color-danger);
   }
@@ -314,7 +310,7 @@ input[type=search]::-webkit-search-cancel-button:hover {
   &::after {
     content: "toggle_off";
   }
-  &.on::after {
+  &.toggle-on::after {
     content: "toggle_on";
     color: var(--color-active);
   }
@@ -1089,6 +1085,9 @@ dialog {
   margin-top: 5px;
   border-radius: 5px;
   background-color: var(--color-base-tertiary);
+  .edit-toggle-on {
+    color: var(--color-active);
+  }
 }
 .location-view-grid {
   display: grid;

--- a/public/css/ui.css
+++ b/public/css/ui.css
@@ -30,6 +30,12 @@ body {
 .color-danger {
   color: var(--color-danger);
 }
+.color-info {
+  color: var(--color-info);
+}
+.color-font-mid {
+  color: var(--color-font-mid);
+}
 
 /* public/css/base/_common.css */
 .display-none {
@@ -289,10 +295,13 @@ input[type=search]::-webkit-search-cancel-button:hover {
   &.active {
     color: var(--color-active);
   }
-  &.info {
+  &.color-info {
     color: var(--color-info);
   }
-  &.primary-light-colour {
+  &.color-danger {
+    color: var(--color-danger);
+  }
+  &.color-font-mid {
     color: var(--color-font-mid);
   }
   &.close:after {

--- a/public/css/ui.css
+++ b/public/css/ui.css
@@ -30,10 +30,6 @@ body {
     color: var(--color-active);
   }
 }
-.primary-background {
-  color: var(--color-font-contrast);
-  background-color: var(--color-primary);
-}
 .off-black {
   color: var(--color-font);
 }

--- a/public/css/ui.css
+++ b/public/css/ui.css
@@ -297,7 +297,7 @@ input[type=search]::-webkit-search-cancel-button:hover {
     color: var(--color-font-mid);
   }
 }
-.toogle-on {
+.toggle-on {
   color: var(--color-active);
 }
 .toggle {

--- a/public/css/ui.css
+++ b/public/css/ui.css
@@ -24,12 +24,6 @@ body {
   transition: 0.2s ease-in-out;
   transition-property: background-color;
 }
-.primary-colour {
-  color: var(--color-primary);
-  &.active {
-    color: var(--color-active);
-  }
-}
 .off-black {
   color: var(--color-font);
 }
@@ -252,7 +246,7 @@ input[type=time],
 input[type=datetime-local] {
   background-color: var(--color-base);
   border: 1px solid var(--color-border);
-  color: var(--color-primary);
+  color: var(--color-font);
   padding: 5px;
   border-radius: 3px;
   &:focus {
@@ -264,7 +258,7 @@ input[type=number] {
   padding: 5px;
   border: none;
   background-color: var(--color-base);
-  color: var(--color-primary);
+  color: var(--color-font);
   border-bottom: 1px dotted var(--color-border);
   display: inline-block;
   width: 100%;


### PR DESCRIPTION
**Removed classes:**
- light-background ➡️  unused
- light-colour ➡️  unused
- off-black-background ➡️  unused
- primary-background ➡️  unused
- primary-colour 
⬆️
This styling is now inherited by button component.
This class has been used with buttons.

- off-black ➡️ Unused. **_Plugins use only the colour variable which can have a fallback colour if necessary._**

**Renamed classes:**

no-color ➡️ danger
ok-color ➡️ info

**Changed classes**

* on
⬆️
Eradicated .on class which was used in 2 cases and was impossible to find.
Now:
on for display toggle is toggle-on
on for location edit is edit-toggle-on

In plugins on-colour was used only once and not in line with new colour scheme so no loss here.


Also: text input and textarea text colour now basic. Otherwise it's a spiral of making everything 'primary' and therefore at risk of poor readability.
