### PR TITLE
add a user filter to the sqlfilter module

### DIFF
--- a/mod/query.js
+++ b/mod/query.js
@@ -182,10 +182,10 @@ async function layerQuery(req, res) {
   // Create filter condition for SQL query.
   req.params.filter = [
     (req.params.layer.filter?.default &&
-      `AND ${sqlFilter(req.params.layer.filter.default, req.params.SQL)}`) ||
+      `AND ${sqlFilter(req.params.layer.filter.default, req)}`) ||
       '',
     (req.params.filter &&
-      `AND ${sqlFilter(JSON.parse(req.params.filter), req.params.SQL)}`) ||
+      `AND ${sqlFilter(JSON.parse(req.params.filter), req)}`) ||
       '',
   ].join(' ');
 
@@ -402,7 +402,7 @@ function getQueryFromTemplate(req, template) {
     if (req.params.sqlFilter) {
       req.params.filter =
         req.params.filter ||
-        `AND ${sqlFilter(JSON.parse(req.params.sqlFilter), req.params.SQL)}`;
+        `AND ${sqlFilter(JSON.parse(req.params.sqlFilter), req)}`;
     }
 
     // Returns -1 if ${filter} not found in template

--- a/mod/utils/sqlFilter.js
+++ b/mod/utils/sqlFilter.js
@@ -49,11 +49,7 @@ const filterTypes = {
       .join(' OR ')})`;
   },
 
-  match: (col, val) => {
-    console.log(val);
-
-    return `"${col}"::text = \$${addValues(val, 'string')}`;
-  },
+  match: (col, val) => `"${col}"::text = \$${addValues(val, 'string')}`,
 };
 
 let SQLparams;


### PR DESCRIPTION
A default filter can add SQL filter statement for the user.email of the request.

```json
"filter": {
  "default": {
    "char_field": {
      "user": true
    }
  }
}
```

The default filter can not be modified by the client.

The documentation for the sqlfilter module has been updated with typedef for filterTypes and typeCheckers objects.

The deeply nested array methods in the mapFilterEntries method has been replaced with an easier to read `for (const [field, value] of Object.entries(filter))` loop.
