### PR TITLE
Xhr Utility: Onload and abort functionality

### DIFF
--- a/lib/layer/format/mvt.mjs
+++ b/lib/layer/format/mvt.mjs
@@ -235,8 +235,6 @@ Finally the layer.L.changed() method is called to trigger the [layer.featureStyl
 @param {layer} layer A decorated format:mvt mapp layer.
 */
 function wktPropertiesLoad(layer) {
-  layer.xhr?.abort();
-
   const table = layer.tableCurrent();
 
   if (!table || !layer.display) {
@@ -261,11 +259,7 @@ function wktPropertiesLoad(layer) {
   // Assign current viewport if queryparam is truthy.
   const z = layer.mapview.Map.getView().getZoom();
 
-  layer.xhr = new XMLHttpRequest();
-
-  layer.xhr.responseType = 'json';
-
-  layer.xhr.onload = (e) => {
+  layer.onLoad = (e) => {
     layer.featuresObject = {};
 
     if (!e.target?.response) {
@@ -280,21 +274,20 @@ function wktPropertiesLoad(layer) {
     layer.L.changed();
   };
 
-  layer.xhr.open(
-    'GET',
-    `${layer.mapview.host}/api/query?${mapp.utils.paramString({
-      template: 'wkt',
-      locale: layer.mapview.locale.key,
-      layer: layer.key,
-      table,
-      geom,
-      no_geom: true,
-      viewport,
-      z,
-      filter: layer.filter?.current,
-      ...layer.params,
-    })}`,
-  );
+  const paramString = mapp.utils.paramString({
+    template: 'wkt',
+    locale: layer.mapview.locale.key,
+    layer: layer.key,
+    table,
+    geom,
+    no_geom: true,
+    viewport,
+    z,
+    filter: layer.filter?.current,
+    ...layer.params,
+  });
 
-  layer.xhr.send();
+  layer.url = `${layer.mapview.host}/api/query?${paramString}`;
+
+  mapp.utils.xhr(layer);
 }

--- a/lib/ui/utils/idleLogout.mjs
+++ b/lib/ui/utils/idleLogout.mjs
@@ -8,7 +8,7 @@ const idle = {
   idle: 600,
 };
 
-export default (params) => {
+export default function idleLogout(params) {
   Object.assign(idle, params);
 
   if (idle.idle === 0) return;
@@ -22,7 +22,7 @@ export default (params) => {
   window.onkeypress = resetTimer;
   resetTimer();
   renewToken();
-};
+}
 
 // Reset idle timeout
 function resetTimer() {
@@ -41,30 +41,30 @@ function lock() {
   idle.renew && clearTimeout(idle.renew);
 
   // Destroy cookie.
-  const xhr = new XMLHttpRequest();
-  xhr.open('GET', `${idle.host}/api/user/cookie?destroy=true`);
+  const params = { url: `${idle.host}/api/user/cookie?destroy=true` };
 
   // Reload location once cookie has been removed.
-  xhr.onload = (e) => location.reload();
-  xhr.send();
+  params.onLoad = (e) => location.reload();
+
+  mapp.utils.xhr(params);
 }
 
 // Renew cookie
 function renewToken() {
   // Renew token after idle minus 20 seconds.
   idle.renew = setTimeout(cookie, (idle.idle - 20) * 1000);
+}
 
-  function cookie() {
-    const xhr = new XMLHttpRequest();
-    xhr.open('GET', `${idle.host}/api/user/cookie?renew=true`);
-    xhr.onload = (e) => {
-      // Lock interface if cookie renewal fails.
-      if (e.target.status === 401) return lock();
+function cookie() {
+  const params = { url: `${idle.host}/api/user/cookie?renew=true` };
 
-      // Re-call method to renew token.
-      renewToken();
-    };
+  params.onLoad = (e) => {
+    // Lock interface if cookie renewal fails.
+    if (e.target.status === 401) return lock();
 
-    xhr.send();
-  }
+    // Re-call method to renew token.
+    renewToken();
+  };
+
+  mapp.utils.xhr(params);
 }

--- a/lib/ui/utils/idleLogout.mjs
+++ b/lib/ui/utils/idleLogout.mjs
@@ -8,6 +8,31 @@ const idle = {
   idle: 600,
 };
 
+/**
+@function idleLogout
+
+@description
+A function for logging out inactive users. Inactivity is determined by no action occuring on the view within a certain amouint of time.
+
+The host and the amount of seconds can be specified in the params:
+
+```
+  {
+    idle: 600,
+    host: example.com
+  }
+```
+
+-Idle is the duration in seconds
+-Host the calling url
+
+The logout is achieved by deleting the session cookie.
+
+@param {Object} params configuration options for the the idle state.
+@property {Number} [params.idle] The length of time in seconds that establishes the idle state.
+@property {String} [params.host] The url host to be logged out of.
+
+*/
 export default function idleLogout(params) {
   Object.assign(idle, params);
 
@@ -24,7 +49,12 @@ export default function idleLogout(params) {
   renewToken();
 }
 
-// Reset idle timeout
+/**
+@function resetTimer
+
+@description
+function for resetting the timeout in instances where an action occurs on the view.
+*/
 function resetTimer() {
   if (idle.locked) return;
 
@@ -33,7 +63,12 @@ function resetTimer() {
   idle.timeout = setTimeout(lock, idle.idle * 1000);
 }
 
-// Lock interface
+/**
+@function lock
+
+@description
+Function which logs the user out of the view by deleting the cookie and reloading the location.
+*/
 function lock() {
   idle.locked = true;
 
@@ -49,12 +84,23 @@ function lock() {
   mapp.utils.xhr(params);
 }
 
-// Renew cookie
+/**
+@function renewToken
+
+@description
+Function for getting a new token if some action has taken place on the view.
+*/
 function renewToken() {
   // Renew token after idle minus 20 seconds.
   idle.renew = setTimeout(cookie, (idle.idle - 20) * 1000);
 }
 
+/**
+@function cookie
+
+@description
+Timeout function for renewing the access token used in {@link module:/ui/utils/idleLogout~renewToken}.
+*/
 function cookie() {
   const params = { url: `${idle.host}/api/user/cookie?renew=true` };
 

--- a/lib/ui/utils/idleLogout.mjs
+++ b/lib/ui/utils/idleLogout.mjs
@@ -12,7 +12,7 @@ const idle = {
 @function idleLogout
 
 @description
-A function for logging out inactive users. Inactivity is determined by no action occuring on the view within a certain amouint of time.
+A function for logging out inactive users. Inactivity is determined by no action occuring on the view within a certain amount of time.
 
 The host and the amount of seconds can be specified in the params:
 

--- a/lib/utils/gazetteer.mjs
+++ b/lib/utils/gazetteer.mjs
@@ -13,18 +13,18 @@ export function datasets(term, gazetteer) {
   if (!gazetteer.provider) {
     // The default gazetteer config is for a dataset search.
     // Abort current dataset query. Onload will not be called.
-    gazetteer.xhr?.abort();
-    gazetteer.xhr = new XMLHttpRequest();
+    // gazetteer.xhr?.abort();
+    // gazetteer.xhr = new XMLHttpRequest();
     gazetteer.qterm && search(term, gazetteer);
   }
 
   // Search additional datasets.
   gazetteer.datasets?.forEach((dataset) => {
     // Abort current dataset query. Onload will not be called.
-    dataset.xhr?.abort();
-    dataset.xhr = new XMLHttpRequest();
+    // dataset.xhr?.abort();
+    // dataset.xhr = new XMLHttpRequest();
 
-    search(term, {
+    Object.assign(dataset, {
       ...gazetteer,
       layer: gazetteer.layer,
       table: gazetteer.table,
@@ -37,12 +37,14 @@ export function datasets(term, gazetteer) {
       leading_wildcard: gazetteer.leading_wildcard,
       callback: gazetteer.callback,
       maxZoom: gazetteer.maxZoom,
-      ...dataset,
     });
+
+    search(term, dataset);
   });
 }
 
 function search(term, dataset) {
+  console.log(dataset);
   const layer = dataset.mapview.layers[dataset.layer];
 
   // Skip if layer defined in datasets is not added to the mapview
@@ -57,28 +59,43 @@ function search(term, dataset) {
     return;
   }
 
-  dataset.xhr.open(
-    'GET',
-    dataset.mapview.host +
-      '/api/query?' +
-      mapp.utils.paramString({
-        template: dataset.query || 'gaz_query',
-        label: dataset.label || dataset.qterm,
-        qterm: dataset.qterm,
-        qID: layer.qID,
-        locale: dataset.mapview.locale.key,
-        layer: layer.key,
-        filter: layer.filter?.current,
-        table: dataset.table || layer.table,
-        wildcard: '*',
-        term: `${dataset.leading_wildcard ? '*' : ''}${term}*`,
-        limit: dataset.limit || 10,
-      }),
-  );
+  const paramString = mapp.utils.paramString({
+    template: dataset.query || 'gaz_query',
+    label: dataset.label || dataset.qterm,
+    qterm: dataset.qterm,
+    qID: layer.qID,
+    locale: dataset.mapview.locale.key,
+    layer: layer.key,
+    filter: layer.filter?.current,
+    table: dataset.table || layer.table,
+    wildcard: '*',
+    term: `${dataset.leading_wildcard ? '*' : ''}${term}*`,
+    limit: dataset.limit || 10,
+  });
 
-  dataset.xhr.setRequestHeader('Content-Type', 'application/json');
-  dataset.xhr.responseType = 'json';
-  dataset.xhr.onload = (e) => {
+  dataset.url = `${dataset.mapview.host}/api/query?${paramString}`;
+  // dataset.xhr.open(
+  //   'GET',
+  //   dataset.mapview.host +
+  //     '/api/query?' +
+  //     mapp.utils.paramString({
+  //       template: dataset.query || 'gaz_query',
+  //       label: dataset.label || dataset.qterm,
+  //       qterm: dataset.qterm,
+  //       qID: layer.qID,
+  //       locale: dataset.mapview.locale.key,
+  //       layer: layer.key,
+  //       filter: layer.filter?.current,
+  //       table: dataset.table || layer.table,
+  //       wildcard: '*',
+  //       term: `${dataset.leading_wildcard ? '*' : ''}${term}*`,
+  //       limit: dataset.limit || 10,
+  //     }),
+  // );
+
+  // dataset.xhr.setRequestHeader('Content-Type', 'application/json');
+  // dataset.xhr.responseType = 'json';
+  dataset.onLoad = (e) => {
     // The gazetteer input may have been cleared prior to the onload event.
     if (!dataset.input.value.length) return;
 
@@ -98,7 +115,8 @@ function search(term, dataset) {
     [e.target.response].flat().forEach((row) => addRow(dataset, layer, row));
   };
 
-  dataset.xhr.send();
+  mapp.utils.xhr(dataset);
+  //dataset.xhr.send();
 }
 
 function addRow(dataset, layer, row) {

--- a/lib/utils/gazetteer.mjs
+++ b/lib/utils/gazetteer.mjs
@@ -1,6 +1,45 @@
 /**
 ## mapp.utils.gazetteer{}
 
+The gazetteer is used to search for locations via a provider or by searching for matching terms in a database.
+
+A provider can be suplpied to search e.g. Google
+```
+{
+  "provider": "GOOGLE",
+  "maxZoom": 10,
+  "streetview": {
+    "key": "xxxxxxxxxxxxxxxxxxxx"
+  },
+  "options": {
+    "componentRestrictions": {
+      "country": "country code"
+    }
+  }
+}
+```
+
+This search will use google services and not interact with the database, if `datasets` are provided the search
+will also look through the database:
+```
+"datasets": [
+  {
+    "qterm": "postcode",
+    "title": "Postcode",
+    "layer": "retailpoints"
+  }
+]
+```
+
+To search only the database only a smaller config can be provided:
+```
+"gazetteer": {
+  "layer": "scratch",
+  "qterm": "store_name",
+  "table": "scratch"
+},
+```
+
 Dictionary entries:
 - no_results
 - invalid_lat_lon
@@ -9,6 +48,17 @@ Dictionary entries:
 @module /utils/gazetteer
 */
 
+/**
+@function datasets
+
+@description
+Calls the search function in cases where the gazetteer was not provided with datasets. 
+
+@param {string} term The search term from the input
+@param {Object} gazetteer gazetteer configuration object.
+@property {String} [gazetteer.provider] Provider for the search e.g. Google.
+@property {String} [gazetteer.qterm] A database field to search for the term.
+*/
 export function datasets(term, gazetteer) {
   if (!gazetteer.provider) {
     gazetteer.qterm && search(term, gazetteer);
@@ -35,6 +85,17 @@ export function datasets(term, gazetteer) {
   });
 }
 
+/**
+@function search
+
+@description
+Performs the search using the provided dataset and term.
+
+Provides a custom onLoad function for xhr utils which adds the found rows to the result set shown in the view.
+
+@param {string} term The search term from the input
+@param {Object} dataset The parameters for the search.
+*/
 function search(term, dataset) {
   const layer = dataset.mapview.layers[dataset.layer];
 
@@ -89,6 +150,19 @@ function search(term, dataset) {
   mapp.utils.xhr(dataset);
 }
 
+/**
+@function addRow
+
+@description
+Adds any search results to a lsit to be displayed in the view.
+
+Uses {@link module:/location/get} to add a location to search results so they can be
+shown on click.
+
+@param {Object} dataset The configuraion object from which the search is bening conducted.
+@param {Object} layer The layer on which the result is found.
+@param {Object} row the returned data.
+*/
 function addRow(dataset, layer, row) {
   const listRow = mapp.utils.html.node`<li 
     onclick=${(e) => {
@@ -107,6 +181,21 @@ function addRow(dataset, layer, row) {
   dataset.list.append(listRow);
 }
 
+/**
+@function getLocation
+
+@description
+Turns latitude and longitude parameters into a location.
+
+Will display a warning if the returned location is outsiode the extent.
+
+@param {Object} location The configuraion object from which the search is bening conducted.
+@property {Number} location.lng The longitude of the location.
+@property {Number} location.lat The latitude of the location.
+@property {Function} location.flyTo {@link module:/location/flyTo} is used to go to a location.
+@param {Object} gazetteer The layer on which the result is found.
+
+*/
 export function getLocation(location, gazetteer) {
   if (typeof gazetteer.callback === 'function') {
     gazetteer.callback(location);

--- a/lib/utils/gazetteer.mjs
+++ b/lib/utils/gazetteer.mjs
@@ -3,7 +3,7 @@
 
 The gazetteer is used to search for locations via a provider or by searching for matching terms in a database.
 
-A provider can be suplpied to search e.g. Google
+A provider can be supplied to search e.g. Google
 ```
 {
   "provider": "GOOGLE",
@@ -154,12 +154,12 @@ function search(term, dataset) {
 @function addRow
 
 @description
-Adds any search results to a lsit to be displayed in the view.
+Adds any search results to a list to be displayed in the view.
 
 Uses {@link module:/location/get} to add a location to search results so they can be
 shown on click.
 
-@param {Object} dataset The configuraion object from which the search is bening conducted.
+@param {Object} dataset The configuraion object from which the search is being conducted.
 @param {Object} layer The layer on which the result is found.
 @param {Object} row the returned data.
 */
@@ -187,9 +187,9 @@ function addRow(dataset, layer, row) {
 @description
 Turns latitude and longitude parameters into a location.
 
-Will display a warning if the returned location is outsiode the extent.
+Will display a warning if the returned location is outside the extent.
 
-@param {Object} location The configuraion object from which the search is bening conducted.
+@param {Object} location The configuraion object from which the search is being conducted.
 @property {Number} location.lng The longitude of the location.
 @property {Number} location.lat The latitude of the location.
 @property {Function} location.flyTo {@link module:/location/flyTo} is used to go to a location.

--- a/lib/utils/gazetteer.mjs
+++ b/lib/utils/gazetteer.mjs
@@ -11,19 +11,11 @@ Dictionary entries:
 
 export function datasets(term, gazetteer) {
   if (!gazetteer.provider) {
-    // The default gazetteer config is for a dataset search.
-    // Abort current dataset query. Onload will not be called.
-    // gazetteer.xhr?.abort();
-    // gazetteer.xhr = new XMLHttpRequest();
     gazetteer.qterm && search(term, gazetteer);
   }
 
   // Search additional datasets.
   gazetteer.datasets?.forEach((dataset) => {
-    // Abort current dataset query. Onload will not be called.
-    // dataset.xhr?.abort();
-    // dataset.xhr = new XMLHttpRequest();
-
     Object.assign(dataset, {
       ...gazetteer,
       layer: gazetteer.layer,
@@ -44,7 +36,6 @@ export function datasets(term, gazetteer) {
 }
 
 function search(term, dataset) {
-  console.log(dataset);
   const layer = dataset.mapview.layers[dataset.layer];
 
   // Skip if layer defined in datasets is not added to the mapview
@@ -74,27 +65,7 @@ function search(term, dataset) {
   });
 
   dataset.url = `${dataset.mapview.host}/api/query?${paramString}`;
-  // dataset.xhr.open(
-  //   'GET',
-  //   dataset.mapview.host +
-  //     '/api/query?' +
-  //     mapp.utils.paramString({
-  //       template: dataset.query || 'gaz_query',
-  //       label: dataset.label || dataset.qterm,
-  //       qterm: dataset.qterm,
-  //       qID: layer.qID,
-  //       locale: dataset.mapview.locale.key,
-  //       layer: layer.key,
-  //       filter: layer.filter?.current,
-  //       table: dataset.table || layer.table,
-  //       wildcard: '*',
-  //       term: `${dataset.leading_wildcard ? '*' : ''}${term}*`,
-  //       limit: dataset.limit || 10,
-  //     }),
-  // );
 
-  // dataset.xhr.setRequestHeader('Content-Type', 'application/json');
-  // dataset.xhr.responseType = 'json';
   dataset.onLoad = (e) => {
     // The gazetteer input may have been cleared prior to the onload event.
     if (!dataset.input.value.length) return;
@@ -116,7 +87,6 @@ function search(term, dataset) {
   };
 
   mapp.utils.xhr(dataset);
-  //dataset.xhr.send();
 }
 
 function addRow(dataset, layer, row) {

--- a/lib/utils/xhr.mjs
+++ b/lib/utils/xhr.mjs
@@ -32,12 +32,19 @@ The method is assumed to be 'POST' if a params.body is provided.
 const requestMap = new Map();
 
 export function xhr(params) {
+  console.log(params.body);
+  console.log(params.xhr);
   return new Promise((resolve) => {
     // Return if params are falsy.
     if (!params) {
       console.error(`xhr params are falsy.`);
       return;
     }
+
+    // if (params.xhr) {
+    //   params.xhr.abort();
+    //   return;
+    // }
 
     // Set params as object with url from string.
     params = typeof params === 'string' ? { url: params } : params;
@@ -55,9 +62,9 @@ export function xhr(params) {
     // Assign 'GET' as default method if no body is provided.
     params.method ??= params.body ? 'POST' : 'GET';
 
-    const xhr = new XMLHttpRequest();
+    params.xhr = new XMLHttpRequest();
 
-    xhr.open(params.method, params.url);
+    params.xhr.open(params.method, params.url);
 
     // Use requestHeader: null to prevent assignment of requestHeader.
     if (params.requestHeader !== null) {
@@ -68,13 +75,15 @@ export function xhr(params) {
       };
 
       Object.entries(requestHeader).forEach((entry) =>
-        xhr.setRequestHeader(...entry),
+        params.xhr.setRequestHeader(...entry),
       );
     }
 
-    xhr.responseType = params.responseType || 'json';
+    params.xhr.responseType = params.responseType || 'json';
 
-    xhr.onload = (e) => {
+    params.xhr.onload = (e) => {
+      if (params?.onLoad) return params.onLoad?.(e);
+
       if (e.target.status >= 400) {
         resolve(new Error(e.target.status));
         return;
@@ -86,8 +95,8 @@ export function xhr(params) {
       resolve(params.resolveTarget ? e.target : e.target.response);
     };
 
-    xhr.onerror = (e) => resolve(new Error(e));
+    params.xhr.onerror = (e) => resolve(new Error(e));
 
-    xhr.send(params.body);
+    params.xhr.send(params.body);
   });
 }

--- a/lib/utils/xhr.mjs
+++ b/lib/utils/xhr.mjs
@@ -32,19 +32,19 @@ The method is assumed to be 'POST' if a params.body is provided.
 const requestMap = new Map();
 
 export function xhr(params) {
-  console.log(params.body);
-  console.log(params.xhr);
   return new Promise((resolve) => {
+    console.log(params.body);
+    console.log(params.xhr);
     // Return if params are falsy.
     if (!params) {
       console.error(`xhr params are falsy.`);
       return;
     }
 
-    // if (params.xhr) {
-    //   params.xhr.abort();
-    //   return;
-    // }
+    if (params.xhr) {
+      params.xhr.abort();
+      return;
+    }
 
     // Set params as object with url from string.
     params = typeof params === 'string' ? { url: params } : params;

--- a/lib/utils/xhr.mjs
+++ b/lib/utils/xhr.mjs
@@ -33,18 +33,13 @@ const requestMap = new Map();
 
 export function xhr(params) {
   return new Promise((resolve) => {
-    console.log(params.body);
-    console.log(params.xhr);
     // Return if params are falsy.
     if (!params) {
       console.error(`xhr params are falsy.`);
       return;
     }
 
-    if (params.xhr) {
-      params.xhr.abort();
-      return;
-    }
+    params.xhr?.abort();
 
     // Set params as object with url from string.
     params = typeof params === 'string' ? { url: params } : params;
@@ -62,7 +57,7 @@ export function xhr(params) {
     // Assign 'GET' as default method if no body is provided.
     params.method ??= params.body ? 'POST' : 'GET';
 
-    params.xhr = new XMLHttpRequest();
+    params.xhr ??= new XMLHttpRequest();
 
     params.xhr.open(params.method, params.url);
 


### PR DESCRIPTION
## Description
The xhr object is now assigned to the calling parameters. An onLoad function can be provided in the calling parameters to provide a custom function to be called. 

```Javascript
 params = {
 url: 'www.url.com'
 onLoad: (e) => console.log('my onload function)
 }
```

If a xhr request is repeated with the same parameters it will be aborted. 

## GitHub Issue
[1602](https://github.com/GEOLYTIX/xyz/issues/1602)

## Type of Change
- ✅ New feature (non-breaking change which adds functionality)
- ✅ Documentation

## How have you tested this?
Can be tested on any instance. Gazetteer testing can be tried on `bugs_testing/plugins/gazetteers.json`.
idleLogout can be tested on `bugs_testing/ui_elements/workspace.json` on the report input layer there is a report, 
upon opening the report waiting for 40 seconds should log you out. 

## Testing Checklist

Please delete options that are not relevant, and select all options that apply.
- ✅ Existing Tests still pass
- ✅ Ran locally on my machine

## Code Quality Checklist
- ✅ My code follows the guidelines of XYZ
- ✅ My code has been commented
- ✅ Documentation has been updated
- ✅ New and existing unit tests pass locally with my changes
- ✅ Main has been merged into this PR
