### PR TITLE
Temporal Fix

### DIFF
--- a/lib/utils/numericFormatter.mjs
+++ b/lib/utils/numericFormatter.mjs
@@ -53,7 +53,6 @@ export function formatNumericValue(params) {
     // Assign numericValue as string if formatterParams are null.
     params.localeString = numericValue.toString();
   } else if (!isNaN(numericValue)) {
-    
     // Assign the browser language as locale if not provided in formatterParams, otherwise use mapp.language.
     params.formatterParams.locale ??= navigator.language || mapp.language;
 

--- a/lib/utils/numericFormatter.mjs
+++ b/lib/utils/numericFormatter.mjs
@@ -53,8 +53,9 @@ export function formatNumericValue(params) {
     // Assign numericValue as string if formatterParams are null.
     params.localeString = numericValue.toString();
   } else if (!isNaN(numericValue)) {
-    // Assign mapp.language as default locale.
-    params.formatterParams.locale ??= mapp.language;
+    
+    // Assign the browser language as locale if not provided in formatterParams, otherwise use mapp.language.
+    params.formatterParams.locale ??= navigator.language || mapp.language;
 
     params.formatterParams.options ??= {};
 

--- a/lib/utils/temporal.mjs
+++ b/lib/utils/temporal.mjs
@@ -33,7 +33,22 @@ Formats a Unix timestamp into a localized date string. If not explicit in the pa
 @see {@link https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/DateTimeFormat|Intl.DateTimeFormat}
 */
 function dateString(params) {
-  params.locale ??= mapp.user?.language || DEFAULT_LOCALE;
+
+  const localeMap = {
+    en: 'en-GB',     // British English (DD/MM/YYYY)
+    de: 'de-DE',     // German (DD.MM.YYYY)
+    fr: 'fr-FR',     // French (DD/MM/YYYY)
+    pl: 'pl-PL',     // Polish (DD.MM.YYYY)
+    ja: 'ja-JP',     // Japanese (YYYY/MM/DD)
+    zh: 'zh-CN',     // Simplified Chinese
+    zh_tw: 'zh-TW',  // Traditional Chinese
+    es: 'es-ES',     // Spanish (DD/MM/YYYY)
+    it: 'it-IT',     // Italian (DD/MM/YYYY)
+    tr: 'tr-TR',     // Turkish (DD.MM.YYYY)
+    th: 'th-TH',     // Thai (DD/MM/YYYY)
+  };
+  
+  params.locale ??= localeMap[mapp.user?.language] || DEFAULT_LOCALE;
 
   // The timestamp must be parsed as Integer.
   const timestamp = parseInt(params.newValue || params.value);

--- a/lib/utils/temporal.mjs
+++ b/lib/utils/temporal.mjs
@@ -33,21 +33,9 @@ Formats a Unix timestamp into a localized date string. If not explicit in the pa
 @see {@link https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/DateTimeFormat|Intl.DateTimeFormat}
 */
 function dateString(params) {
-  const localeMap = {
-    en: 'en-GB', // British English (DD/MM/YYYY)
-    de: 'de-DE', // German (DD.MM.YYYY)
-    fr: 'fr-FR', // French (DD/MM/YYYY)
-    pl: 'pl-PL', // Polish (DD.MM.YYYY)
-    ja: 'ja-JP', // Japanese (YYYY/MM/DD)
-    zh: 'zh-CN', // Simplified Chinese
-    zh_tw: 'zh-TW', // Traditional Chinese
-    es: 'es-ES', // Spanish (DD/MM/YYYY)
-    it: 'it-IT', // Italian (DD/MM/YYYY)
-    tr: 'tr-TR', // Turkish (DD.MM.YYYY)
-    th: 'th-TH', // Thai (DD/MM/YYYY)
-  };
 
-  params.locale ??= localeMap[mapp.user?.language] || DEFAULT_LOCALE;
+  // Set the locale to the browser language if not provided, or fallback to the default of 'en-GB'.
+  params.locale ??= navigator.language || DEFAULT_LOCALE;
 
   // The timestamp must be parsed as Integer.
   const timestamp = parseInt(params.newValue || params.value);

--- a/lib/utils/temporal.mjs
+++ b/lib/utils/temporal.mjs
@@ -33,7 +33,6 @@ Formats a Unix timestamp into a localized date string. If not explicit in the pa
 @see {@link https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/DateTimeFormat|Intl.DateTimeFormat}
 */
 function dateString(params) {
-
   // Set the locale to the browser language if not provided, or fallback to the default of 'en-GB'.
   params.locale ??= navigator.language || DEFAULT_LOCALE;
 

--- a/lib/utils/temporal.mjs
+++ b/lib/utils/temporal.mjs
@@ -33,21 +33,20 @@ Formats a Unix timestamp into a localized date string. If not explicit in the pa
 @see {@link https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/DateTimeFormat|Intl.DateTimeFormat}
 */
 function dateString(params) {
-
   const localeMap = {
-    en: 'en-GB',     // British English (DD/MM/YYYY)
-    de: 'de-DE',     // German (DD.MM.YYYY)
-    fr: 'fr-FR',     // French (DD/MM/YYYY)
-    pl: 'pl-PL',     // Polish (DD.MM.YYYY)
-    ja: 'ja-JP',     // Japanese (YYYY/MM/DD)
-    zh: 'zh-CN',     // Simplified Chinese
-    zh_tw: 'zh-TW',  // Traditional Chinese
-    es: 'es-ES',     // Spanish (DD/MM/YYYY)
-    it: 'it-IT',     // Italian (DD/MM/YYYY)
-    tr: 'tr-TR',     // Turkish (DD.MM.YYYY)
-    th: 'th-TH',     // Thai (DD/MM/YYYY)
+    en: 'en-GB', // British English (DD/MM/YYYY)
+    de: 'de-DE', // German (DD.MM.YYYY)
+    fr: 'fr-FR', // French (DD/MM/YYYY)
+    pl: 'pl-PL', // Polish (DD.MM.YYYY)
+    ja: 'ja-JP', // Japanese (YYYY/MM/DD)
+    zh: 'zh-CN', // Simplified Chinese
+    zh_tw: 'zh-TW', // Traditional Chinese
+    es: 'es-ES', // Spanish (DD/MM/YYYY)
+    it: 'it-IT', // Italian (DD/MM/YYYY)
+    tr: 'tr-TR', // Turkish (DD.MM.YYYY)
+    th: 'th-TH', // Thai (DD/MM/YYYY)
   };
-  
+
   params.locale ??= localeMap[mapp.user?.language] || DEFAULT_LOCALE;
 
   // The timestamp must be parsed as Integer.

--- a/tests/lib/utils/temporal.test.mjs
+++ b/tests/lib/utils/temporal.test.mjs
@@ -44,6 +44,41 @@ export function temporal() {
       );
 
       /**
+       * ### Should format en-GB locale Date/Time
+       * @function it
+       */
+      codi.it(
+        {
+          name: 'Should format correctly to en-GB when using mapp.user.language of en',
+          parentId: 'utils_datetime',
+        },
+        () => {
+
+          const params = {
+            value: 1702483200, // December 13, 2023
+            locale: 'en', // This is how the locale is defined when setting to mapp.user.language
+            options: {
+              year: 'numeric',
+              month: 'long',
+              day: 'numeric',
+              hour: '2-digit',
+              minute: '2-digit',
+            },
+          };
+
+          
+          const expectedDate = '13 December 2023 at 18:00';
+          const date = mapp.utils.temporal.dateString(params);
+
+          codi.assertEqual(
+            date,
+            expectedDate,
+            'We expect the date to be the exact string',
+          );
+        },
+      );
+
+      /**
        * ### Should convert date string to Unix timestamp
        * @function it
        */

--- a/tests/lib/utils/temporal.test.mjs
+++ b/tests/lib/utils/temporal.test.mjs
@@ -65,13 +65,13 @@ export function temporal() {
             },
           };
 
-          const expectedDate = '13 December 2023 at 18:00';
+          const expectedDate = 'December 13, 2023 at 06:00 PM';
           const date = mapp.utils.temporal.dateString(params);
 
           codi.assertEqual(
             date,
             expectedDate,
-            'We expect the date to be the exact string',
+            `We expect ${date} to be the exact string: ${expectedDate}`,
           );
         },
       );

--- a/tests/lib/utils/temporal.test.mjs
+++ b/tests/lib/utils/temporal.test.mjs
@@ -53,7 +53,6 @@ export function temporal() {
           parentId: 'utils_datetime',
         },
         () => {
-
           const params = {
             value: 1702483200, // December 13, 2023
             locale: 'en', // This is how the locale is defined when setting to mapp.user.language
@@ -66,7 +65,6 @@ export function temporal() {
             },
           };
 
-          
           const expectedDate = '13 December 2023 at 18:00';
           const date = mapp.utils.temporal.dateString(params);
 

--- a/tests/lib/utils/temporal.test.mjs
+++ b/tests/lib/utils/temporal.test.mjs
@@ -44,39 +44,6 @@ export function temporal() {
       );
 
       /**
-       * ### Should format en-GB locale Date/Time
-       * @function it
-       */
-      codi.it(
-        {
-          name: 'Should format correctly to en-GB when using mapp.user.language of en',
-          parentId: 'utils_datetime',
-        },
-        () => {
-          const params = {
-            value: 1702483200, // December 13, 2023
-            locale: 'en', // This is how the locale is defined when setting to mapp.user.language
-            options: {
-              year: 'numeric',
-              month: 'long',
-              day: 'numeric',
-              hour: '2-digit',
-              minute: '2-digit',
-            },
-          };
-
-          const expectedDate = 'December 13, 2023 at 06:00 PM';
-          const date = mapp.utils.temporal.dateString(params);
-
-          codi.assertEqual(
-            date,
-            expectedDate,
-            `We expect ${date} to be the exact string: ${expectedDate}`,
-          );
-        },
-      );
-
-      /**
        * ### Should convert date string to Unix timestamp
        * @function it
        */


### PR DESCRIPTION
## Description

If the locale is set by using mapp.user.language - we must have an object to Map this to the correct formatter
Otherwise, a value of `mapp.user.language = 'en'` will default to using `en-US` which is incorrect. It should default to `en-GB`. 
The tests have been updated to explicitly look for this. 

## GitHub Issue

https://github.com/GEOLYTIX/xyz/issues/2057

## Type of Change

Please delete options that are not relevant, and select all options that apply.

- ✅ Bug fix (non-breaking change which fixes an issue)
- ✅ Documentation
- ✅ Testing

## How have you tested this?

If the locale is set by using mapp.user.language - we must have an object to Map this to the correct formatter
Otherwise, a value of `mapp.user.language = 'en'` will default to using `en-US` which is incorrect. It should default to `en-GB`. 
The tests have been updated to explicitly look for this. 

## Testing Checklist

Please delete options that are not relevant, and select all options that apply.

- ✅ Existing Tests still pass
- ✅ Updated Existing Tests
- ✅ New Tests Added
- ✅ Ran locally on my machine

## Code Quality Checklist

Please delete options that are not relevant, and select all options that apply.

- ✅ My code follows the guidelines of XYZ
- ✅ My code has been commented
- ✅ Documentation has been updated
- ✅ New and existing unit tests pass locally with my changes
- ✅ Main has been merged into this PR
