### PR TITLE
Fix saml import logic

### DIFF
--- a/mod/user/saml.js
+++ b/mod/user/saml.js
@@ -165,7 +165,6 @@ const getModule = async () => {
 The SAML service has not been configured correctly.
 */
 function saml_not_configured(req, res) {
-
   res.status(405).send('SAML not configured');
 }
 

--- a/mod/user/saml.js
+++ b/mod/user/saml.js
@@ -156,9 +156,18 @@ const getModule = async () => {
     if (samlKeys.length > 0) {
       console.log('SAML2 module is not available.');
     }
-    return null;
+    return saml_not_configured;
   }
 };
+
+/**
+@function saml_not_configured
+The SAML service has not been configured correctly.
+*/
+function saml_not_configured(req, res) {
+
+  res.status(405).send('SAML not configured');
+}
 
 const exportedModule = await getModule();
 

--- a/mod/user/saml.js
+++ b/mod/user/saml.js
@@ -108,7 +108,7 @@ let samlStrat, samlConfig;
 
 const getModule = async () => {
   try {
-    const SAML = await import('@node-saml/node-saml');
+    const { SAML } = await import('@node-saml/node-saml');
     // Initialize SAML configuration
     samlConfig = {
       callbackUrl: xyzEnv.SAML_ACS,
@@ -160,7 +160,7 @@ const getModule = async () => {
   }
 };
 
-const exportedModule = getModule();
+const exportedModule = await getModule();
 
 export default exportedModule;
 


### PR DESCRIPTION
To resolve this issue, I made two key changes for correct SAML usage:

1. Used destructuring to import the `SAML` class directly from the module.
2. Ensured the `getModule` function is properly awaited.

```diff
- const SAML = await import("@node-saml/node-saml");
+ const { SAML } = await import("@node-saml/node-saml");

// ...rest of the SAML config

samlStrat = new SAML(samlConfig);
```

```diff
- const exportedModule = getModule();
+ const exportedModule = await getModule();
```

These changes ensure that `SAML` is correctly imported as a class and that asynchronous module loading works as expected.
