### PR TITLE
remove locale.layer merge from addlayer method

### DIFF
--- a/lib/mapview/addLayer.mjs
+++ b/lib/mapview/addLayer.mjs
@@ -14,8 +14,6 @@ A single or an array of JSON layer can be added to the mapview with the addLayer
 
 A default zIndex is assigned to layer without an implicit zIndex.
 
-A structuredClone of the JSON layer will be merged into a clone of the locale.layer template to be decorated and assigned to the mapview [this] layers.
-
 The mapview [this] to which the addLayer method is bound will be assigned to the layer object.
 
 A layer with a valid format property will be decorated and added to the mapview.layers{} object.
@@ -36,44 +34,30 @@ export default async function addLayer(layers) {
   }
 
   // A set of the layers is required in order to control the display based on URL params [hooks]
-  const layersSet = this.hooks && new Set(mapp.hooks.current.layers);
+  const currentLayers = this.hooks && new Set(mapp.hooks.current.layers);
 
-  const decoratedLayers = [];
+  // Create clone layers NOT to modify the original JSON layer.
+  layers = structuredClone(layers);
 
-  for (let i = 0; i < layers.length; i++) {
-    // The JSON layer is merged into the locale.layer
-    const layer = mapp.utils.merge(
-      {},
-      structuredClone(this.locale.layer || {}),
-      structuredClone(layers[i]),
-    );
+  let zIndex = 0;
 
+  for (const layer of layers) {
     // The layer.err is an array of errors from failing to retrieve templates asscoiated with a layer.
     layer.err && console.error(layer.err);
 
-    // A default zIndex is assigned from the loop index to ensure layers are drawn in the order without an implicit zIndex.
-    layer.zIndex ??= i;
+    // An increasing zIndex is assigned to layer without implicit zIndex to ensure that layers added later are drawn on top.
+    layer.zIndex ??= zIndex++;
 
     layer.mapview = this;
 
-    // Only the layers in the layerset should be displayed.
-    // Will override the layer.display setting from the workspace
-    if (layersSet?.size) {
-      layer.display = layersSet.has(layer.key);
+    // currentLayers as defined through the layers array URL parameter will be displayed.
+    if (currentLayers?.size) {
+      layer.display = currentLayers.has(layer.key);
     }
-
-    // Layer without format should not be decorated.
-    if (!layer.format) continue;
-
-    // Assign default key if not explicit in layer JSON.
-    layer.key ??= `${layer.format}-${i}`;
 
     await mapp.layer.decorate(layer);
 
     if (!layer.L) continue;
-
-    // Assign layer to array returned from method.
-    decoratedLayers.push(layer);
 
     this.layers[layer.key] = layer;
 
@@ -85,5 +69,5 @@ export default async function addLayer(layers) {
     this.Map.once('rendercomplete', resolve);
   });
 
-  return decoratedLayers;
+  return layers;
 }


### PR DESCRIPTION
The locale.layer default object is already merged in the getLayer module of the Workspace API.

The locale.layer, layer.template, and layer.templates properties will no longer be returned in Workspace API responses in the future.

The iteration of layers can be simplified with a for of loop.

The layers array can be cloned as a whole, the decoratedLayers object is not required with this.

zIndex can increase itself with ++

Layer objects will always have a key, this is provided by the Workspace API methods.

The decorate layer method checks for the format anyways, no additional check is required.
