### PR TITLE
CSV Download

### DIFF
--- a/lib/utils/csvDownload.mjs
+++ b/lib/utils/csvDownload.mjs
@@ -33,7 +33,12 @@ export default function csvDownload(data, params = {}) {
     rows.unshift(params.fields.map((field) => field.title || field.field));
   }
 
-  const blob = new Blob([rows.join(params.join)], { type: params.type });
+  // Prepend UTF-8 BOM
+  // This is done to ensure that language-specific characters are displayed correctly.
+  const BOM = '\uFEFF';
+  const csvContent = BOM + rows.join(params.join);
+
+  const blob = new Blob([csvContent], { type: params.type });
 
   const link = document.createElement('a');
 


### PR DESCRIPTION
# CSV Download Character Fix

## Description

This PR updates the csvDownload function to correctly handle special characters (e.g., Ł, ę, ż) in CSV exports by adding a UTF-8 Byte Order Mark (BOM). 
This ensures compatibility with Microsoft Excel and other programs that expect a BOM for proper UTF-8 detection.

Previously, the function attempted to export CSV files using:
``` js
type: 'text/csv;charset=windows-1250'
```

The Blob API does not actually encode content as windows-1250.
As a result, the file was still UTF-8 encoded, but mislabeled.
This caused character mismatch (e.g., MÄ™Å¼czyzna instead of Mężczyzna).


## Type of Change

Please delete options that are not relevant, and select all options that apply.

- ✅ Bug fix (non-breaking change which fixes an issue)

## Code Quality Checklist

Please delete options that are not relevant, and select all options that apply.

- ✅ My code follows the guidelines of XYZ
- ✅ My code has been commented
- ✅ Documentation has been updated
- ✅ New and existing unit tests pass locally with my changes
- ✅ Main has been merged into this PR
