### PR TITLE
Pg v8.13.1 semver install

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
   },
   "dependencies": {
     "jsonwebtoken": "^9.0.2",
-    "pg": "8.13.1"
+    "pg": "~8.15.1"
   },
   "devDependencies": {
     "@biomejs/biome": "1.9.4",

--- a/tests/mod/user/acl.test.mjs
+++ b/tests/mod/user/acl.test.mjs
@@ -6,7 +6,7 @@ const mockPgConnectFn = codi.mock.fn();
 const mockPgQueryFn = codi.mock.fn();
 
 const mockPg = codi.mock.module('pg', {
-  namedExports: {
+  defaultExport: {
     Pool: class Pool {
       constructor() {
         this.connect = mockPgConnectFn;


### PR DESCRIPTION
## pg v8.15.1

There is unexpected behaviour after installing pg with the current semver setup in the package.json

```json
{
  "dependencies": {
    "pg": "^8.13.1"
  }
}
```

There seems to be a export change in this latest release of pg v8.15.1

https://github.com/brianc/node-postgres/releases/tag/pg%408.15.1

I have changed the version in the package.json to '~8.15.1' as this will install the latest version and any new patch versions going forward.

```diff
{
  "dependencies": {
-    "pg": "^8.13.1"
+    "pg": "~8.15.1"
  }
}
```

With this change I also needed to correct the pg mock in the acl.test.mjs module.

There is no longer a named export but default.

```diff
const mockPg = codi.mock.module('pg', {
-   namedExports: {
+   defaultExport: {
    Pool: class Pool {
      constructor() {
        this.connect = mockPgConnectFn;
      }
    },
  },
});
```
