### PR TITLE
Correct merging of gazetteer with individual datasets

### DIFF
--- a/lib/utils/gazetteer.mjs
+++ b/lib/utils/gazetteer.mjs
@@ -66,14 +66,13 @@ export function datasets(term, gazetteer) {
 
   // Search additional datasets.
   gazetteer.datasets?.forEach((dataset) => {
-
     const mergeddataset = {
       // Merge the gazetteer and dataset objects
       // Ensuring that the dataset takes precedence over the gazetteer
       ...gazetteer,
-      ...dataset, 
+      ...dataset,
     };
-  
+
     search(term, mergeddataset);
   });
 }

--- a/lib/utils/gazetteer.mjs
+++ b/lib/utils/gazetteer.mjs
@@ -43,7 +43,7 @@ To search only the database only a smaller config can be provided:
 Dictionary entries:
 - no_results
 - invalid_lat_lon
-@requires /dictionary 
+@requires /dictionary
 
 @module /utils/gazetteer
 */
@@ -52,7 +52,7 @@ Dictionary entries:
 @function datasets
 
 @description
-Calls the search function in cases where the gazetteer was not provided with datasets. 
+Calls the search function in cases where the gazetteer was not provided with datasets.
 
 @param {string} term The search term from the input
 @param {Object} gazetteer gazetteer configuration object.
@@ -156,7 +156,7 @@ shown on click.
 @param {Object} row the returned data.
 */
 function addRow(dataset, layer, row) {
-  const listRow = mapp.utils.html.node`<li 
+  const listRow = mapp.utils.html.node`<li
     onclick=${(e) => {
       if (dataset.callback) return dataset.callback(row, dataset);
 

--- a/lib/utils/gazetteer.mjs
+++ b/lib/utils/gazetteer.mjs
@@ -66,22 +66,15 @@ export function datasets(term, gazetteer) {
 
   // Search additional datasets.
   gazetteer.datasets?.forEach((dataset) => {
-    Object.assign(dataset, {
-      ...gazetteer,
-      callback: gazetteer.callback,
-      label: gazetteer.label,
-      layer: gazetteer.layer,
-      leading_wildcard: gazetteer.leading_wildcard,
-      limit: gazetteer.limit,
-      maxZoom: gazetteer.maxZoom,
-      no_result: gazetteer.no_result,
-      qterm: gazetteer.qterm,
-      query: gazetteer.query,
-      table: gazetteer.table,
-      title: gazetteer.title,
-    });
 
-    search(term, dataset);
+    const mergeddataset = {
+      // Merge the gazetteer and dataset objects
+      // Ensuring that the dataset takes precedence over the gazetteer
+      ...gazetteer,
+      ...dataset, 
+    };
+  
+    search(term, mergeddataset);
   });
 }
 


### PR DESCRIPTION
Correct the merging / over-assignment of a dataset from the gazetteer. 
The dataset should take precedence and be merged over the gazetteer so you get keys from both if required. 

``` js
  // Search additional datasets.
  gazetteer.datasets?.forEach((dataset) => {
    const mergeddataset = {
      // Merge the gazetteer and dataset objects
      // Ensuring that the dataset takes precedence over the gazetteer
      ...gazetteer,
      ...dataset,
    };

    search(term, mergeddataset);
```