### PR TITLE
express v5 migration

### DIFF
--- a/express.js
+++ b/express.js
@@ -84,10 +84,10 @@ app.use(xyzEnv.DIR, express.static('tests'));
 
 app.use(cookieParser());
 
-app.get(`${xyzEnv.DIR}/api/provider/{:provider}`, api);
+app.get(`${xyzEnv.DIR}/api/provider{/:provider}`, api);
 
 app.post(
-  `${xyzEnv.DIR}/api/provider/{:provider}`,
+  `${xyzEnv.DIR}/api/provider{/:provider}`,
   express.json({ limit: '5mb' }),
   api,
 );

--- a/express.js
+++ b/express.js
@@ -84,30 +84,30 @@ app.use(xyzEnv.DIR, express.static('tests'));
 
 app.use(cookieParser());
 
-app.get(`${xyzEnv.DIR}/api/provider/:provider?`, api);
+app.get(`${xyzEnv.DIR}/api/provider/{:provider}`, api);
 
 app.post(
-  `${xyzEnv.DIR}/api/provider/:provider?`,
+  `${xyzEnv.DIR}/api/provider/{:provider}`,
   express.json({ limit: '5mb' }),
   api,
 );
 
-app.get(`${xyzEnv.DIR || ''}/api/sign/:signer?`, api);
+app.get(`${xyzEnv.DIR || ''}/api/sign{/:signer}`, api);
 
-app.get(`${xyzEnv.DIR}/api/query/:template?`, api);
+app.get(`${xyzEnv.DIR}/api/query{/:template}`, api);
 
 app.post(
-  `${xyzEnv.DIR}/api/query/:template?`,
+  `${xyzEnv.DIR}/api/query{/:template}`,
   express.json({ limit: '5mb' }),
   api,
 );
 
-app.get(`${xyzEnv.DIR}/api/workspace/:key?`, api);
+app.get(`${xyzEnv.DIR}/api/workspace{/:key}`, api);
 
-app.get(`${xyzEnv.DIR}/api/user/:method?/:key?`, api);
+app.get(`${xyzEnv.DIR}/api/user{/:method}{/:key}`, api);
 
 app.post(
-  `${xyzEnv.DIR}/api/user/:method?`,
+  `${xyzEnv.DIR}/api/user{/:method}`,
   [express.urlencoded({ extended: true }), express.json({ limit: '5mb' })],
   api,
 );
@@ -120,9 +120,9 @@ app.get(`${xyzEnv.DIR}/saml/login`, api);
 
 app.post(`${xyzEnv.DIR}/saml/acs`, express.urlencoded({ extended: true }), api);
 
-app.get(`${xyzEnv.DIR}/view/:template?`, api);
+app.get(`${xyzEnv.DIR}/view{/:template}`, api);
 
-app.get(`${xyzEnv.DIR}/:locale?`, api);
+app.get(`${xyzEnv.DIR}{/:locale}`, api);
 
 app.get(`/`, api);
 

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "cookie-parser": "^1.4.5",
     "dotenv": "^16.4.5",
     "esbuild": "^0.25.0",
-    "express": "^4.18.3",
+    "express": "^5.1.0",
     "express-rate-limit": "^7.5.0",
     "nodemon": "^3.1.7"
   }


### PR DESCRIPTION
# express-v5

Express migration from v4 to v5

There are a few changes from v4 to v5 with express.

The main impact of our current server is the path route matching syntax.

The optional character '?' is no longer supported and has been replace with '{}'

```diff
-- app.get(`${xyzEnv.DIR}/api/provider/:provider?`, api);
++ app.get(`${xyzEnv.DIR}/api/provider{/:provider}`, api);
```
