### PR TITLE
Geom must allow a string property

### DIFF
--- a/lib/utils/queryParams.mjs
+++ b/lib/utils/queryParams.mjs
@@ -39,89 +39,89 @@ The queryParams method is particularly useful for calculating the current [viewp
 @returns {object} A params object to create a params string.
 */
 function queryParams(_this) {
-	// If queryparams is not an object, return.
-	if (typeof _this.queryparams !== "object") {
-		console.warn("queryparams must be an object");
-		return;
-	}
+  // If queryparams is not an object, return.
+  if (typeof _this.queryparams !== 'object') {
+    console.warn('queryparams must be an object');
+    return;
+  }
 
-	const layer = _this.layer || _this.location?.layer;
+  const layer = _this.layer || _this.location?.layer;
 
-	// Assign table from layer JSON or layer.tableCurrent() method.
-	_this.queryparams.table &&=
-		typeof _this.queryparams.table === "string"
-			? _this.queryparams.table
-			: getTable(_this);
+  // Assign table from layer JSON or layer.tableCurrent() method.
+  _this.queryparams.table &&=
+    typeof _this.queryparams.table === 'string'
+      ? _this.queryparams.table
+      : getTable(_this);
 
-	// Get bounds from mapview.
-	const bounds = _this.viewport && _this.layer.mapview.getBounds();
+  // Get bounds from mapview.
+  const bounds = _this.viewport && _this.layer.mapview.getBounds();
 
-	const geom =
-		typeof _this.queryparams.geom === "string"
-			? _this.queryparams.geom
-			: getGeom(_this);
+  const geom =
+    typeof _this.queryparams.geom === 'string'
+      ? _this.queryparams.geom
+      : getGeom(_this);
 
-	// Get center from mapview.
-	const center =
-		_this.queryparams.center &&
-		ol.proj.transform(
-			_this.layer.mapview.Map.getView().getCenter(),
-			`EPSG:${_this.layer.mapview.srid}`,
-			`EPSG:4326`,
-		);
+  // Get center from mapview.
+  const center =
+    _this.queryparams.center &&
+    ol.proj.transform(
+      _this.layer.mapview.Map.getView().getCenter(),
+      `EPSG:${_this.layer.mapview.srid}`,
+      `EPSG:4326`,
+    );
 
-	// Queries will fail if the template can not be accessed in workspace.
-	const template =
-		_this.queryparams.template || encodeURIComponent(_this.query);
+  // Queries will fail if the template can not be accessed in workspace.
+  const template =
+    _this.queryparams.template || encodeURIComponent(_this.query);
 
-	// Layer filter can only be applied if the layer is provided as reference to a layer object in the layers list.
-	const filter = _this.queryparams.filter ? layer?.filter?.current : undefined;
+  // Layer filter can only be applied if the layer is provided as reference to a layer object in the layers list.
+  const filter = _this.queryparams.filter ? layer?.filter?.current : undefined;
 
-	// Locale param is only required for layer lookups.
-	const locale =
-		layer?.mapview?.locale.key || _this.location?.locale || undefined;
+  // Locale param is only required for layer lookups.
+  const locale =
+    layer?.mapview?.locale.key || _this.location?.locale || undefined;
 
-	// ID will be taken if a location object is provided with the params.
-	const id = _this.queryparams.id ? _this.location?.id : undefined;
+  // ID will be taken if a location object is provided with the params.
+  const id = _this.queryparams.id ? _this.location?.id : undefined;
 
-	// qID will be taken if a location object is provided with the params.
-	const qID = _this.queryparams.qID ? _this.location?.layer?.qID : undefined;
+  // qID will be taken if a location object is provided with the params.
+  const qID = _this.queryparams.qID ? _this.location?.layer?.qID : undefined;
 
-	// queryparams.email is a boolean property.
-	const email = _this.queryparams.email ? mapp.user.email : undefined;
+  // queryparams.email is a boolean property.
+  const email = _this.queryparams.email ? mapp.user.email : undefined;
 
-	// lat lng must be explicit or the center flag param must be set.
-	const lat = center?.[1];
-	const lng = center?.[0];
+  // lat lng must be explicit or the center flag param must be set.
+  const lat = center?.[1];
+  const lng = center?.[0];
 
-	// z will be generated if the z flag is set in the params.
-	const z = _this.queryparams?.z && layer.mapview.Map.getView().getZoom();
+  // z will be generated if the z flag is set in the params.
+  const z = _this.queryparams?.z && layer.mapview.Map.getView().getZoom();
 
-	// Viewport will only be generated if the viewport flag is set on the params.
-	const viewport = bounds && [
-		bounds.west,
-		bounds.south,
-		bounds.east,
-		bounds.north,
-		layer.mapview.srid,
-	];
+  // Viewport will only be generated if the viewport flag is set on the params.
+  const viewport = bounds && [
+    bounds.west,
+    bounds.south,
+    bounds.east,
+    bounds.north,
+    layer.mapview.srid,
+  ];
 
-	return {
-		..._this.queryparams,
-		email,
-		fieldValues: undefined,
-		filter,
-		geom,
-		id,
-		lat,
-		layer: layer?.key,
-		lng,
-		locale,
-		qID,
-		template,
-		viewport,
-		z, // The fieldValues array entries should not be part of the url params.
-	};
+  return {
+    ..._this.queryparams,
+    email,
+    fieldValues: undefined,
+    filter,
+    geom,
+    id,
+    lat,
+    layer: layer?.key,
+    lng,
+    locale,
+    qID,
+    template,
+    viewport,
+    z, // The fieldValues array entries should not be part of the url params.
+  };
 }
 
 /**
@@ -138,17 +138,17 @@ Returns the current table associated with a layer or location.layer which maybe 
 @returns {string} Table name
 */
 function getTable(_this) {
-	return (
-		_this.location?.layer?.table ||
-		_this.layer?.table ||
-		_this.location?.layer?.tableCurrent?.() ||
-		_this.layer?.tableCurrent?.() ||
-		_this.location?.layer?.tableCurrent?.() ||
-		(_this.layer?.tables &&
-			Object.values(_this.layer.tables).find((table) => !!table)) ||
-		(_this.location?.layer?.tables &&
-			Object.values(_this.location?.layer.tables).find((table) => !!table))
-	);
+  return (
+    _this.location?.layer?.table ||
+    _this.layer?.table ||
+    _this.location?.layer?.tableCurrent?.() ||
+    _this.layer?.tableCurrent?.() ||
+    _this.location?.layer?.tableCurrent?.() ||
+    (_this.layer?.tables &&
+      Object.values(_this.layer.tables).find((table) => !!table)) ||
+    (_this.location?.layer?.tables &&
+      Object.values(_this.location?.layer.tables).find((table) => !!table))
+  );
 }
 
 /**
@@ -164,5 +164,5 @@ Returns the current geometry associated with a layer or location.layer which may
 @returns {string} Table name
 */
 function getGeom(_this) {
-	return _this.viewport ? _this.layer.geomCurrent() : undefined;
+  return _this.viewport ? _this.layer.geomCurrent() : undefined;
 }

--- a/lib/utils/queryParams.mjs
+++ b/lib/utils/queryParams.mjs
@@ -56,7 +56,9 @@ function queryParams(_this) {
   // Get bounds from mapview.
   const bounds = _this.viewport && _this.layer.mapview.getBounds();
 
-  const geom = _this.viewport ? _this.layer.geomCurrent() : undefined;
+  const geom =   
+  typeof _this.queryparams.geom === 'string' 
+  ? _this.queryparams.geom : getGeom(_this); 
 
   // Get center from mapview.
   const center =
@@ -145,5 +147,23 @@ function getTable(_this) {
       Object.values(_this.layer.tables).find((table) => !!table)) ||
     (_this.location?.layer?.tables &&
       Object.values(_this.location?.layer.tables).find((table) => !!table))
+  );
+}
+
+/**
+@function getGeom
+
+@description
+Returns the current geometry associated with a layer or location.layer which maybe dependent on the mapview zoom level.
+
+@param {Object} _this Object from which the query originates, eg. layer, dataview entry.
+@property {location} [_this.viewport] The viewport flag is set on the params.
+@property {layer} [_this.layer] A mapp layer associated with _this object.
+
+@returns {string} Table name
+*/
+function getGeom(_this) {
+  return (
+    _this.viewport ? _this.layer.geomCurrent() : undefined
   );
 }

--- a/lib/utils/queryParams.mjs
+++ b/lib/utils/queryParams.mjs
@@ -39,88 +39,89 @@ The queryParams method is particularly useful for calculating the current [viewp
 @returns {object} A params object to create a params string.
 */
 function queryParams(_this) {
-  // If queryparams is not an object, return.
-  if (typeof _this.queryparams !== 'object') {
-    console.warn('queryparams must be an object');
-    return;
-  }
+	// If queryparams is not an object, return.
+	if (typeof _this.queryparams !== "object") {
+		console.warn("queryparams must be an object");
+		return;
+	}
 
-  const layer = _this.layer || _this.location?.layer;
+	const layer = _this.layer || _this.location?.layer;
 
-  // Assign table from layer JSON or layer.tableCurrent() method.
-  _this.queryparams.table &&=
-    typeof _this.queryparams.table === 'string'
-      ? _this.queryparams.table
-      : getTable(_this);
+	// Assign table from layer JSON or layer.tableCurrent() method.
+	_this.queryparams.table &&=
+		typeof _this.queryparams.table === "string"
+			? _this.queryparams.table
+			: getTable(_this);
 
-  // Get bounds from mapview.
-  const bounds = _this.viewport && _this.layer.mapview.getBounds();
+	// Get bounds from mapview.
+	const bounds = _this.viewport && _this.layer.mapview.getBounds();
 
-  const geom =   
-  typeof _this.queryparams.geom === 'string' 
-  ? _this.queryparams.geom : getGeom(_this); 
+	const geom =
+		typeof _this.queryparams.geom === "string"
+			? _this.queryparams.geom
+			: getGeom(_this);
 
-  // Get center from mapview.
-  const center =
-    _this.queryparams.center &&
-    ol.proj.transform(
-      _this.layer.mapview.Map.getView().getCenter(),
-      `EPSG:${_this.layer.mapview.srid}`,
-      `EPSG:4326`,
-    );
+	// Get center from mapview.
+	const center =
+		_this.queryparams.center &&
+		ol.proj.transform(
+			_this.layer.mapview.Map.getView().getCenter(),
+			`EPSG:${_this.layer.mapview.srid}`,
+			`EPSG:4326`,
+		);
 
-  // Queries will fail if the template can not be accessed in workspace.
-  const template =
-    _this.queryparams.template || encodeURIComponent(_this.query);
+	// Queries will fail if the template can not be accessed in workspace.
+	const template =
+		_this.queryparams.template || encodeURIComponent(_this.query);
 
-  // Layer filter can only be applied if the layer is provided as reference to a layer object in the layers list.
-  const filter = _this.queryparams.filter ? layer?.filter?.current : undefined;
+	// Layer filter can only be applied if the layer is provided as reference to a layer object in the layers list.
+	const filter = _this.queryparams.filter ? layer?.filter?.current : undefined;
 
-  // Locale param is only required for layer lookups.
-  const locale =
-    layer?.mapview?.locale.key || _this.location?.locale || undefined;
+	// Locale param is only required for layer lookups.
+	const locale =
+		layer?.mapview?.locale.key || _this.location?.locale || undefined;
 
-  // ID will be taken if a location object is provided with the params.
-  const id = _this.queryparams.id ? _this.location?.id : undefined;
+	// ID will be taken if a location object is provided with the params.
+	const id = _this.queryparams.id ? _this.location?.id : undefined;
 
-  // qID will be taken if a location object is provided with the params.
-  const qID = _this.queryparams.qID ? _this.location?.layer?.qID : undefined;
+	// qID will be taken if a location object is provided with the params.
+	const qID = _this.queryparams.qID ? _this.location?.layer?.qID : undefined;
 
-  // queryparams.email is a boolean property.
-  const email = _this.queryparams.email ? mapp.user.email : undefined;
+	// queryparams.email is a boolean property.
+	const email = _this.queryparams.email ? mapp.user.email : undefined;
 
-  // lat lng must be explicit or the center flag param must be set.
-  const lat = center?.[1];
-  const lng = center?.[0];
+	// lat lng must be explicit or the center flag param must be set.
+	const lat = center?.[1];
+	const lng = center?.[0];
 
-  // z will be generated if the z flag is set in the params.
-  const z = _this.queryparams?.z && layer.mapview.Map.getView().getZoom();
+	// z will be generated if the z flag is set in the params.
+	const z = _this.queryparams?.z && layer.mapview.Map.getView().getZoom();
 
-  // Viewport will only be generated if the viewport flag is set on the params.
-  const viewport = bounds && [
-    bounds.west,
-    bounds.south,
-    bounds.east,
-    bounds.north,
-    layer.mapview.srid,
-  ];
+	// Viewport will only be generated if the viewport flag is set on the params.
+	const viewport = bounds && [
+		bounds.west,
+		bounds.south,
+		bounds.east,
+		bounds.north,
+		layer.mapview.srid,
+	];
 
-  return {
-    ..._this.queryparams,
-    email,
-    fieldValues: undefined,
-    filter,
-    geom,
-    id,
-    lat,
-    layer: layer?.key,
-    lng,
-    locale,
-    qID,
-    template,
-    viewport,
-    z, // The fieldValues array entries should not be part of the url params.
-  };
+	return {
+		..._this.queryparams,
+		email,
+		fieldValues: undefined,
+		filter,
+		geom,
+		id,
+		lat,
+		layer: layer?.key,
+		lng,
+		locale,
+		qID,
+		template,
+		viewport,
+		z, // The fieldValues array entries should not be part of the url params.
+	};
 }
 
 /**
@@ -137,17 +138,17 @@ Returns the current table associated with a layer or location.layer which maybe 
 @returns {string} Table name
 */
 function getTable(_this) {
-  return (
-    _this.location?.layer?.table ||
-    _this.layer?.table ||
-    _this.location?.layer?.tableCurrent?.() ||
-    _this.layer?.tableCurrent?.() ||
-    _this.location?.layer?.tableCurrent?.() ||
-    (_this.layer?.tables &&
-      Object.values(_this.layer.tables).find((table) => !!table)) ||
-    (_this.location?.layer?.tables &&
-      Object.values(_this.location?.layer.tables).find((table) => !!table))
-  );
+	return (
+		_this.location?.layer?.table ||
+		_this.layer?.table ||
+		_this.location?.layer?.tableCurrent?.() ||
+		_this.layer?.tableCurrent?.() ||
+		_this.location?.layer?.tableCurrent?.() ||
+		(_this.layer?.tables &&
+			Object.values(_this.layer.tables).find((table) => !!table)) ||
+		(_this.location?.layer?.tables &&
+			Object.values(_this.location?.layer.tables).find((table) => !!table))
+	);
 }
 
 /**
@@ -163,7 +164,5 @@ Returns the current geometry associated with a layer or location.layer which may
 @returns {string} Table name
 */
 function getGeom(_this) {
-  return (
-    _this.viewport ? _this.layer.geomCurrent() : undefined
-  );
+	return _this.viewport ? _this.layer.geomCurrent() : undefined;
 }

--- a/tests/lib/utils/queryParams.test.mjs
+++ b/tests/lib/utils/queryParams.test.mjs
@@ -37,7 +37,7 @@ export async function queryParams(mapview) {
         async () => {
           const layer_params = geojsonLayerDefault;
           const expected = {
-            geom: 'geometry',
+            geom: 'different_geom',
             id: '1234',
             layer: 'queryParamsLayer',
             locale: 'locale',
@@ -61,6 +61,7 @@ export async function queryParams(mapview) {
             queryparams: {
               email: 'test@email.com',
               filter: true,
+              geom: 'different_geom',
               id: 1234,
               table: 'different_table',
               template: 'another_template',


### PR DESCRIPTION
Allow string property for geom to ensure that its not overwritten when defined manually. 
`"geom": "geometry"` 