### PR TITLE
Cookie module should return null without an ACL configured.

### DIFF
--- a/mod/user/cookie.js
+++ b/mod/user/cookie.js
@@ -43,7 +43,7 @@ The token user will be sent back to the client.
 export default async function cookie(req, res) {
   // acl module will export an empty require object without the ACL being configured.
   if (acl === null) {
-    return res.status(500).send('ACL unavailable.');
+    return res.send(null);
   }
 
   if (req.params.create) {


### PR DESCRIPTION
This prevents an Error on a public instance without an ACL.

You will still see a login button which is a default syncPlugin.

Either set the syncPlugins to empty array or just the zoomBtn to not see the login.

```json
"syncPlugins": [],
```

![image](https://github.com/user-attachments/assets/ee4c29ec-7b41-4b48-8e06-e1c7a9558487)
