### PR TITLE
Get Last Location - Remove Order by & Rename to Get Random Location

### DIFF
--- a/mod/workspace/templates/_queries.js
+++ b/mod/workspace/templates/_queries.js
@@ -13,8 +13,8 @@ import fieldStats from './field_stats.js';
 // Import all templates and renders
 import gazQuery from './gaz_query.js';
 import geojson from './geojson.js';
-import getRandomLocation from './get_random_location.js';
 import getNnearest from './get_nnearest.js';
+import getRandomLocation from './get_random_location.js';
 import infotip from './infotip.js';
 import layerExtent from './layer_extent.js';
 import locationCount from './location_count.js';

--- a/mod/workspace/templates/_queries.js
+++ b/mod/workspace/templates/_queries.js
@@ -13,7 +13,7 @@ import fieldStats from './field_stats.js';
 // Import all templates and renders
 import gazQuery from './gaz_query.js';
 import geojson from './geojson.js';
-import getLastLocation from './get_last_location.js';
+import getRandomLocation from './get_random_location.js';
 import getNnearest from './get_nnearest.js';
 import infotip from './infotip.js';
 import layerExtent from './layer_extent.js';
@@ -68,9 +68,9 @@ export default {
     layer: true,
     render: geojson,
   },
-  get_last_location: {
+  get_random_location: {
     layer: true,
-    render: getLastLocation,
+    render: getRandomLocation,
   },
   get_nnearest: {
     render: getNnearest,

--- a/mod/workspace/templates/get_last_location.js
+++ b/mod/workspace/templates/get_last_location.js
@@ -1,7 +1,9 @@
 /**
 ### /workspace/templates/get_last_location
 
-The get_last_location layer query template returns the last id from layer table in a descending order.
+The get_last_location layer query template returns a single feature from the specified layer that meets the criteria. 
+The criteria include the presence of a geometry and a unique identifier (ID) for the feature.
+The filter will also be applied to the query if provided.
 
 @module /workspace/templates/get_last_location
 */
@@ -17,6 +19,5 @@ export default (_) => {
     ${_.layer.qID} as id
     FROM ${table}
     WHERE ${geom} IS NOT NULL AND ${_.layer.qID} IS NOT NULL \${filter}
-    ORDER BY ${_.layer.qID} DESC
     LIMIT 1`;
 };

--- a/mod/workspace/templates/get_random_location.js
+++ b/mod/workspace/templates/get_random_location.js
@@ -1,11 +1,11 @@
 /**
-### /workspace/templates/get_last_location
+### /workspace/templates/get_random_location
 
-The get_last_location layer query template returns a single feature from the specified layer that meets the criteria. 
+The get_random_location layer query template returns a single feature from the specified layer that meets the criteria. 
 The criteria include the presence of a geometry and a unique identifier (ID) for the feature.
 The filter will also be applied to the query if provided.
 
-@module /workspace/templates/get_last_location
+@module /workspace/templates/get_random_location
 */
 export default (_) => {
   const table =

--- a/tests/browser/integrity/layer.test.mjs
+++ b/tests/browser/integrity/layer.test.mjs
@@ -17,7 +17,7 @@ export async function layerTest(mapview) {
             if (layer.infoj) {
               const lastLocation = await mapp.utils.xhr(
                 `${mapp.host}/api/query?${mapp.utils.paramString({
-                  template: 'get_last_location',
+                  template: 'get_random_location',
                   locale: layer.mapview.locale.key,
                   layer: layer.key,
                   filter: layer.filter?.current,


### PR DESCRIPTION
The Get Last Location query is only used in the `integrity` tests, it is designed to get a feature that meets the specified criteria to select a feature for testing. 
We don't need the last location, just a location so this order by is unnecessary and causes speed issues.

The `order by ID DESC` section was causing the query to run really slowly for large datasets. 
A test global dataset was running for >3 minutes with the order by included, I didn't wait for the full execution but it was very slow. 
Removing the order by, the query completes in <1 second. 
