### PR TITLE
Ping Promise

### DIFF
--- a/lib/utils/ping.mjs
+++ b/lib/utils/ping.mjs
@@ -53,51 +53,60 @@ export default function ping(params) {
 
   params.url = `${mapp.host}/api/query?${paramString}`;
 
-  pingQuery(params);
+  return pingQuery(params);
 }
 
-/**
+/** 
 @function pingQuery 
-@async
   
 @description
 The pingQuery method will call itself with a timeout until a condition is met.
 
-The method will shortcircuit if the query fails.
+The method will reject if the response is an error.
 
-The method will shortcircuit if the callback property is set to false.
+The method will resolve if the response matches either the failCondition or the successCondition.
+
+The method will resolve if the callback property is set to false.
 
 If the callback property is a function it will be called with the response and the params object itself as arguments.
-
-The method will shortcircuit if the reponse matches either the failCondition or the successCondition.
 
 @param {Object} params The parameters object.
 @property {string} params.responseType The expected responseType form the ping query.
 @property {string} params.url The request url for the ping query.
 @property {function} params.callback Method to be executed with the response and params object as arguments.
-*/
-async function pingQuery(params) {
-  const response = await mapp.utils.xhr(params);
+@property {string} params.successCondition The expected response for a successful ping query.
+@property {string} params.failCondition The expected response for a failed ping query.
+@property {number} params.interval The interval in milliseconds between ping queries.
+@returns {Promise} A promise that resolves with the response or rejects with an error.
+*/ 
+function pingQuery(params) {
+  return new Promise((resolve, reject) => {
+    const pingPromise = async () => {
+      const response = await mapp.utils.xhr(params);
 
-  if (response instanceof Error) {
-    return;
-  }
+      if (response instanceof Error) {
+        return reject(response);
+      }
 
-  if (params.callback instanceof Function) {
-    params.callback(response, params);
-  }
+      if (params.callback instanceof Function) {
+        params.callback(response, params);
+      }
 
-  if (params.callback === false) {
-    return;
-  }
+      if (params.callback === false) {
+        return resolve(response);
+      }
 
-  if (params.failCondition === response) {
-    return;
-  }
+      if (params.failCondition === response) {
+        return resolve(response);
+      }
 
-  if (params.successCondition === response) {
-    return;
-  }
+      if (params.successCondition === response) {
+        return resolve(response);
+      }
 
-  setTimeout(() => pingQuery(params), params.interval);
+      setTimeout(pingPromise, params.interval);
+    };
+
+    pingPromise();
+  });
 }

--- a/lib/utils/ping.mjs
+++ b/lib/utils/ping.mjs
@@ -78,7 +78,7 @@ If the callback property is a function it will be called with the response and t
 @property {string} params.failCondition The expected response for a failed ping query.
 @property {number} params.interval The interval in milliseconds between ping queries.
 @returns {Promise} A promise that resolves with the response or rejects with an error.
-*/ 
+*/
 function pingQuery(params) {
   return new Promise((resolve, reject) => {
     const pingPromise = async () => {


### PR DESCRIPTION
**Summary**
This PR updates the /utils/ping module to return a Promise, allowing it to be await-ed. This enables cleaner asynchronous control flow when running the query repeatedly until a condition is met. You can just await the resolution of the promise.

**Changes**
ping() now returns the Promise from pingQuery().