### PR TITLE
Check roles in template merge

### DIFF
--- a/mod/workspace/getLayer.js
+++ b/mod/workspace/getLayer.js
@@ -78,8 +78,6 @@ export default async function getLayer(params, locale) {
   // Assign key value as key on layer object.
   layer.key ??= params.layer;
 
-  layer = await mergeTemplates(layer);
-
   if (locale.layer) {
     layer = merge(structuredClone(locale.layer), layer);
   }
@@ -88,7 +86,9 @@ export default async function getLayer(params, locale) {
     return new Error('Role access denied.');
   }
 
-  layer = Roles.objMerge(layer, params.user?.roles);
+  layer = Roles.objMerge(layer, params.user?.roles);  
+
+  layer = await mergeTemplates(layer, params.user?.roles);
 
   // Assign layer key as name with no existing name on layer object.
   layer.name ??= layer.key;

--- a/mod/workspace/getLocale.js
+++ b/mod/workspace/getLocale.js
@@ -79,13 +79,13 @@ export default async function getLocale(params, parentLocale) {
     return new Error(locale.message);
   }
 
-  locale = await mergeTemplates(locale);
-
   if (!Roles.check(locale, params.user?.roles)) {
     return new Error('Role access denied.');
   }
 
   locale = Roles.objMerge(locale, params.user?.roles);
+
+  locale = await mergeTemplates(locale, params.user?.roles);
 
   locale.workspace = workspace.key;
 

--- a/mod/workspace/mergeTemplates.js
+++ b/mod/workspace/mergeTemplates.js
@@ -3,6 +3,7 @@
 
 The workspace is cached in the module scope to allow for the mergeObjectTemplates(layer) method to assign template objects defined in a JSON layer to the workspace.templates{}.
 
+@requires /utils/roles
 @requires /utils/merge
 @requires /utils/envReplace
 @requires /workspace/getTemplate
@@ -13,6 +14,7 @@ The workspace is cached in the module scope to allow for the mergeObjectTemplate
 
 import envReplace from '../utils/envReplace.js';
 import merge from '../utils/merge.js';
+import * as Roles from '../utils/roles.js';
 import workspaceCache from './cache.js';
 import getTemplate from './getTemplate.js';
 
@@ -32,6 +34,7 @@ The method will check for a template matching the obj.key string property if obj
 An array of templates can be defined as obj.templates[]. The templates will be merged into the obj in the order the template keys are in the templates[] array.
 
 @param {Object} obj 
+@param {array} roles An array of user roles from request params. 
 
 @property {string} [obj.template] Key of template for the object.
 @property {string} obj.key Fallback for lookup of template if not an implicit property.
@@ -39,61 +42,18 @@ An array of templates can be defined as obj.templates[]. The templates will be m
 
 @returns {Promise} The layer or locale provided as obj param.
 */
-export default async function mergeTemplates(obj) {
+export default async function mergeTemplates(obj, roles) {
   // Cache workspace in module scope for template assignment.
   workspace = await workspaceCache();
 
   // The object has an implicit template to merge into.
-  if (typeof obj.template === 'string') {
-    const template = await getTemplate(obj.template);
-
-    // Failed to get template matching obj.template from template.src!
-    if (template instanceof Error) {
-      obj.err ??= [];
-      obj.err.push(template.message);
-      return obj;
-    } else {
-      // Merge obj --> template
-      // Template must be cloned to prevent cross polination and array aggregation.
-      obj = merge(structuredClone(template), obj);
-    }
-  }
-
-  // The object has a template object to merge into.
-  if (obj.template instanceof Object) {
-    const template = await getTemplate(obj.template);
-
-    // Failed to get template matching obj.template from template.src!
-    if (template instanceof Error) {
-      obj.err ??= [];
-      obj.err.push(template.message);
-      return obj;
-    } else {
-      // Merge obj --> template
-      // Template must be cloned to prevent cross pollination and array aggregation.
-      obj = merge(structuredClone(template), obj);
-    }
+  if (typeof obj.template === 'string' || obj.template instanceof Object) {
+    await objTemplate(obj, obj.template, roles);
   }
 
   // The _template can be a string or object [with src]
   for (const _template of obj.templates || []) {
-    const template = await getTemplate(_template);
-
-    // Failed to retrieve template matching template_key
-    if (template instanceof Error) {
-      obj.err ??= [];
-      obj.err.push(template.message);
-      return obj;
-    } else {
-      //The object key must not be overwritten by a template key.
-      delete template.key;
-
-      //The object template must not be overwritten by a templates template.
-      delete template.template;
-
-      // Merge template --> obj
-      obj = merge(obj, template);
-    }
+    await objTemplate(obj, _template, roles, true);
   }
 
   // Substitute ${SRC_*} in object string.
@@ -106,6 +66,55 @@ export default async function mergeTemplates(obj) {
   obj.dbs ??= workspace.dbs;
 
   return obj;
+}
+
+/**
+@function objTemplate
+@async
+
+@description
+The method will request a template object from the getTemplate module method.
+
+The template will be checked against the request user roles.
+
+The method will shortcircuit if roles restrict access to the template object.
+
+Otherwise the obj will be merged into the template.
+
+The template will be merged into the obj with the reverse flag.
+
+@param {Object} obj 
+@param {Object} template The template maybe an object with a src property or a string. 
+@param {array} roles An array of user roles from request params. 
+@param {boolean} reverse Whether template should be merged into the obj, not the other way around.
+*/
+async function objTemplate(obj, template, roles, reverse) {
+  template = await getTemplate(template);
+
+  // Failed to get template matching obj.template from template.src!
+  if (template instanceof Error) {
+    obj.err ??= [];
+    obj.err.push(template.message);
+  } else if (Roles.check(template, roles)) {
+    template = structuredClone(template);
+
+    template = Roles.objMerge(template, roles);
+
+    if (reverse) {
+      //The object key must not be overwritten by a template key.
+      delete template.key;
+
+      //The object template must not be overwritten by a templates template.
+      delete template.template;
+
+      // Merge template --> obj
+      obj = merge(obj, template);
+    } else {
+      // Merge obj --> template
+      // Template must be cloned to prevent cross polination and array aggregation.
+      obj = merge(template, obj);
+    }
+  }
 }
 
 /**


### PR DESCRIPTION
roles will be provided as optional argument to the mergeTemplates method.

The objTemplate method will check whether role restriction permit access to a template before the template is merged into the object [eg locale, layer].
