### PR TITLE
Return dropdown node without pills container.

### DIFF
--- a/lib/ui/elements/dropdown.mjs
+++ b/lib/ui/elements/dropdown.mjs
@@ -92,8 +92,7 @@ export default function dropdown(params) {
   }
 
   if (params.pills?.container) {
-
-    params.node = mapp.utils.html.node`${params.pills.container}${params.node}`
+    params.node = mapp.utils.html.node`${params.pills.container}${params.node}`;
   }
 
   return params.node;

--- a/lib/ui/elements/dropdown.mjs
+++ b/lib/ui/elements/dropdown.mjs
@@ -65,8 +65,7 @@ export default function dropdown(params) {
       params.placeholder;
 
   if (params.dropdown_search) {
-    params.node = mapp.utils.html`
-    ${params.pills?.container}
+    params.node = mapp.utils.html.node`
       <div class="dropdown" onclick=${(e) => params.headerOnClick(e)}>
         <input
           type="text"
@@ -81,8 +80,7 @@ export default function dropdown(params) {
         ${params.ul}
       </div>`;
   } else {
-    params.node = mapp.utils.html`
-    ${params.pills?.container}
+    params.node = mapp.utils.html.node`
     <button
       data-id=${params.data_id || 'dropdown'}
       class="dropdown">
@@ -91,6 +89,11 @@ export default function dropdown(params) {
         <span class="material-symbols-outlined"></span>
       </div>
       ${params.ul}`;
+  }
+
+  if (params.pills?.container) {
+
+    params.node = mapp.utils.html.node`${params.pills.container}${params.node}`
   }
 
   return params.node;

--- a/public/views/_default.html
+++ b/public/views/_default.html
@@ -386,7 +386,7 @@
           },
         });
 
-        layersTab.appendChild(mapp.utils.html.node`${localesDropdown}`);
+        layersTab.appendChild(localesDropdown);
       }
 
       if (!window.ol) await mapp.utils.olScript();

--- a/tests/lib/ui/elements/_elements.test.mjs
+++ b/tests/lib/ui/elements/_elements.test.mjs
@@ -1,20 +1,22 @@
 import { alert } from './alert.test.mjs';
 import { confirm } from './confirm.test.mjs';
 import { dialog } from './dialog.test.mjs';
+import { dropdown } from './dropdown.test.mjs';
 import { layerStyle } from './layerStyle.test.mjs';
 import { pills } from './pills.test.mjs';
 import { slider } from './slider.test.mjs';
 
 export const elements = {
-  setup,
-  slider,
-  layerStyle,
-  pills,
   alert,
   confirm,
   dialog,
+  dropdown,
+  layerStyle,
+  pills,
+  setup,
+  slider,
 };
 
 function setup() {
-  codi.describe({ name: 'UI Elements:', id: 'ui_elements' }, () => {});
+  codi.describe({ id: 'ui_elements', name: 'UI Elements:' }, () => {});
 }

--- a/tests/lib/ui/elements/dropdown.test.mjs
+++ b/tests/lib/ui/elements/dropdown.test.mjs
@@ -1,0 +1,44 @@
+export function dropdown() {
+  codi.describe({ id: 'ui_elements_dropdown', name: 'Dropdown:' }, () => {
+    codi.it(
+      { name: 'Dropdown basic test', parentId: 'ui_elements_dropdown' },
+      () => {
+        const params = {
+          entries: [
+            {
+              field: 'ting_field_1',
+              label: 'ting_1',
+              option: 'ting_1',
+              selected: true,
+            },
+            {
+              field: 'ting_field_2',
+              label: 'ting_2',
+              option: 'ting_2',
+              selected: false,
+            },
+            {
+              field: 'ting_field_3',
+              label: 'ting_3',
+              option: 'ting_3',
+              selected: false,
+            },
+          ],
+        };
+
+        const node = mapp.ui.elements.dropdown(params);
+
+        const head = node.querySelector('div.head');
+
+        const list = node.querySelector('ul');
+
+        const items = node.querySelectorAll('li');
+
+        codi.assertTrue(node instanceof HTMLElement);
+        codi.assertTrue(head !== null);
+        codi.assertTrue(list !== null);
+        codi.assertEqual(items.length, 3);
+      },
+    );
+  });
+}


### PR DESCRIPTION
An undefined [`params.pills?.container`] ahead of the dropdown button [node] will return a document fragment.

The params.node should be assigned as a node with the button element or input group.

The node should be composed with the `params.pills?.container` if available. This will return a document fragment.

With this PR, a regular dropdown button without pills will return a node [button] which can be disabled like so.

```js
        const localesDropdown = mapp.ui.elements.dropdown({
          data_id: 'locales-dropdown',
          span: locale.name || locale.key,
          entries: locales.map((locale) => ({
            title: locale.name || locale.key,
            key: locale.key,
          })),
          callback: (e, entry) => {
            window.location.assign(`${mapp.host}?locale=${entry.key}`);
          },
        });

        localesDropdown.disabled = true;

        layersTab.appendChild(localesDropdown);
```