### PR TITLE
Allow configuration to filter the available options for circle drawing

### DIFF
--- a/lib/ui/elements/drawing.mjs
+++ b/lib/ui/elements/drawing.mjs
@@ -346,17 +346,21 @@ function circle(layer) {
   layer.draw.circle.unitsOptions ??= ['meter', 'km', 'miles', 'meter2', 'km2'];
 
   const optionsGiven = layer.draw.circle.unitsOptions.join(', ');
-  const unitsAvailable = units.map(unit => unit.option).join(', ');
-  
-  if (!units.some(unit => layer.draw.circle.unitsOptions.includes(unit.option))) {
-    console.log(`layer.draw.circle.unitsOptions - ${optionsGiven}: not found in available options. They are ${unitsAvailable}`);
-    
-    // Set the layer.draw.circle.unitsOption to just meter 
+  const unitsAvailable = units.map((unit) => unit.option).join(', ');
+
+  if (
+    !units.some((unit) => layer.draw.circle.unitsOptions.includes(unit.option))
+  ) {
+    console.log(
+      `layer.draw.circle.unitsOptions - ${optionsGiven}: not found in available options. They are ${unitsAvailable}`,
+    );
+
+    // Set the layer.draw.circle.unitsOption to just meter
     layer.draw.circle.unitsOptions = ['meter'];
   }
-  
+
   const circleUnits = units.filter((unit) =>
-    layer.draw.circle.unitsOptions.includes(unit.option)
+    layer.draw.circle.unitsOptions.includes(unit.option),
   );
 
   // Set layer.draw.circle.units to the first unit in the circleUnits array

--- a/lib/ui/elements/drawing.mjs
+++ b/lib/ui/elements/drawing.mjs
@@ -336,7 +336,7 @@ function circle(layer) {
     }
   });
 
-  Object.keys(circle.unitsConfig).filter((config) => {
+  Object.keys(circle.unitsConfig).forEach((config) => {
     if (!circle.unitsOptions.includes(config)) {
       delete circle.unitsConfig[config];
       return true;

--- a/lib/ui/elements/drawing.mjs
+++ b/lib/ui/elements/drawing.mjs
@@ -269,45 +269,6 @@ function circle_2pt(layer) {
 @return {HTMLElement} The button element.
 */
 function circle(layer) {
-  const helpDialog = {
-    content: mapp.utils.html.node`<li>
-    <ul>${mapp.dictionary.draw_dialog_begin_drawing}</ul>
-    <ul>${mapp.dictionary.draw_dialog_save_single}</ul>`,
-  };
-
-  // Set the default values
-  layer.draw.circle = {
-    geometryFunction: (coordinates) => {
-      const polygonCircular = new ol.geom.Polygon.circular(
-        ol.proj.toLonLat(coordinates),
-        layer.draw.circle.unitConversion[layer.draw.circle.units](
-          layer.draw.circle.radius,
-        ),
-        64,
-      );
-
-      return polygonCircular.transform('EPSG:4326', 'EPSG:3857');
-    },
-    helpDialog,
-    label: mapp.dictionary.draw_circle,
-    layer,
-    radius: 100,
-    radiusMax: 1000,
-    radiusMin: 1,
-
-    // Methods to transform input radius.
-    type: 'Point',
-    unitConversion: {
-      km: (v) => v * 1000,
-      km2: (v) => Math.sqrt((v * 1000000) / Math.PI),
-      meter: (v) => v,
-      meter2: (v) => Math.sqrt(v / Math.PI),
-      miles: (v) => v * 1609.34,
-    },
-    units: 'meter',
-    ...layer.draw.circle,
-  };
-
   // Build an array for the unit, label, min and max values.
   const units = [
     {
@@ -342,6 +303,12 @@ function circle(layer) {
     },
   ];
 
+  const helpDialog = {
+    content: mapp.utils.html.node`<li>
+    <ul>${mapp.dictionary.draw_dialog_begin_drawing}</ul>
+    <ul>${mapp.dictionary.draw_dialog_save_single}</ul>`,
+  };
+
   // Subset the units array to only include the units that are defined in the layer.draw.circle.unitsOptions
   layer.draw.circle.unitsOptions ??= ['meter', 'km', 'miles', 'meter2', 'km2'];
 
@@ -351,7 +318,7 @@ function circle(layer) {
   if (
     !units.some((unit) => layer.draw.circle.unitsOptions.includes(unit.option))
   ) {
-    console.log(
+    console.warn(
       `layer.draw.circle.unitsOptions - ${optionsGiven}: not found in available options. They are ${unitsAvailable}`,
     );
 
@@ -365,6 +332,39 @@ function circle(layer) {
 
   // Set layer.draw.circle.units to the first unit in the circleUnits array
   layer.draw.circle.units = circleUnits[0].option;
+
+  // Set the default values
+  layer.draw.circle = {
+    geometryFunction: (coordinates) => {
+      const polygonCircular = new ol.geom.Polygon.circular(
+        ol.proj.toLonLat(coordinates),
+        layer.draw.circle.unitConversion[layer.draw.circle.units](
+          layer.draw.circle.radius,
+        ),
+        64,
+      );
+
+      return polygonCircular.transform('EPSG:4326', 'EPSG:3857');
+    },
+    helpDialog,
+    label: mapp.dictionary.draw_circle,
+    layer,
+    radius: circleUnits[0].min,
+    radiusMax: circleUnits[0].max,
+    radiusMin: circleUnits[0].min,
+
+    // Methods to transform input radius.
+    type: 'Point',
+    unitConversion: {
+      km: (v) => v * 1000,
+      km2: (v) => Math.sqrt((v * 1000000) / Math.PI),
+      meter: (v) => v,
+      meter2: (v) => Math.sqrt(v / Math.PI),
+      miles: (v) => v * 1609.34,
+    },
+    units: 'meter',
+    ...layer.draw.circle,
+  };
 
   const unitsDropDown = mapp.utils.html.node`
     <div style="display: grid; grid-template-columns: 100px 1fr; align-items: center;">

--- a/lib/ui/elements/drawing.mjs
+++ b/lib/ui/elements/drawing.mjs
@@ -339,15 +339,12 @@ function circle(layer) {
   Object.keys(circle.unitsConfig).forEach((config) => {
     if (!circle.unitsOptions.includes(config)) {
       delete circle.unitsConfig[config];
-      return true;
     }
   });
 
-  circle.units = Object.keys(circle.unitsConfig)[0];
-
   if (!Object.hasOwn(circle.unitsConfig, circle.units)) {
     console.warn(`Unkown circle units conversion ${circle.units}`);
-    circle.units = 'meter';
+    circle.units = Object.keys(circle.unitsConfig)[0];
   }
 
   circle.geometryFunction ??= (coordinates) => {

--- a/lib/ui/elements/drawing.mjs
+++ b/lib/ui/elements/drawing.mjs
@@ -336,6 +336,13 @@ function circle(layer) {
     }
   });
 
+  Object.keys(circle.unitsConfig).filter((config) => {
+    if (!circle.unitsOptions.includes(config))
+      delete circle.unitsConfig[config];
+  });
+
+  circle.units = Object.keys(circle.unitsConfig)[0];
+
   if (!Object.hasOwn(circle.unitsConfig, circle.units)) {
     console.warn(`Unkown circle units conversion ${circle.units}`);
     circle.units = 'meter';

--- a/lib/ui/elements/drawing.mjs
+++ b/lib/ui/elements/drawing.mjs
@@ -345,9 +345,22 @@ function circle(layer) {
   // Subset the units array to only include the units that are defined in the layer.draw.circle.unitsOptions
   layer.draw.circle.unitsOptions ??= ['meter', 'km', 'miles', 'meter2', 'km2'];
 
+  const optionsGiven = layer.draw.circle.unitsOptions.join(', ');
+  const unitsAvailable = units.map(unit => unit.option).join(', ');
+  
+  if (!units.some(unit => layer.draw.circle.unitsOptions.includes(unit.option))) {
+    console.log(`layer.draw.circle.unitsOptions - ${optionsGiven}: not found in available options. They are ${unitsAvailable}`);
+    
+    // Set the layer.draw.circle.unitsOption to just meter 
+    layer.draw.circle.unitsOptions = ['meter'];
+  }
+  
   const circleUnits = units.filter((unit) =>
-    layer.draw.circle.unitsOptions.includes(unit.option),
+    layer.draw.circle.unitsOptions.includes(unit.option)
   );
+
+  // Set layer.draw.circle.units to the first unit in the circleUnits array
+  layer.draw.circle.units = circleUnits[0].option;
 
   const unitsDropDown = mapp.utils.html.node`
     <div style="display: grid; grid-template-columns: 100px 1fr; align-items: center;">

--- a/lib/ui/elements/drawing.mjs
+++ b/lib/ui/elements/drawing.mjs
@@ -337,8 +337,10 @@ function circle(layer) {
   });
 
   Object.keys(circle.unitsConfig).filter((config) => {
-    if (!circle.unitsOptions.includes(config))
+    if (!circle.unitsOptions.includes(config)) {
       delete circle.unitsConfig[config];
+      return true;
+    }
   });
 
   circle.units = Object.keys(circle.unitsConfig)[0];

--- a/lib/ui/elements/drawing.mjs
+++ b/lib/ui/elements/drawing.mjs
@@ -264,97 +264,52 @@ function circle_2pt(layer) {
 
 /**
 @function circle
-@description Creates a button for circle a line on the map.
+@description 
+Create a drawer with config interface elements for circle construction.
 @param {layer} layer Decorated MAPP Layer.
-@return {HTMLElement} The button element.
+@return {HTMLElement} A drawer element with controls for circle configuration.
 */
 function circle(layer) {
-  // Build an array for the unit, label, min and max values.
-  const units = [
-    {
-      max: 1000,
-      min: 1,
-      option: 'meter',
-      title: 'Meter',
-    },
-    {
-      max: 10,
-      min: 1,
-      option: 'km',
-      title: 'KM',
-    },
-    {
-      max: 10,
-      min: 1,
-      option: 'miles',
-      title: 'Miles',
-    },
-    {
-      max: 1000,
-      min: 1,
-      option: 'meter2',
-      title: 'Meter²',
-    },
-    {
-      max: 10,
-      min: 1,
-      option: 'km2',
-      title: 'KM²',
-    },
-  ];
-
   const helpDialog = {
     content: mapp.utils.html.node`<li>
     <ul>${mapp.dictionary.draw_dialog_begin_drawing}</ul>
     <ul>${mapp.dictionary.draw_dialog_save_single}</ul>`,
   };
 
-  // Subset the units array to only include the units that are defined in the layer.draw.circle.unitsOptions
-  layer.draw.circle.unitsOptions ??= ['meter', 'km', 'miles', 'meter2', 'km2'];
-
-  const optionsGiven = layer.draw.circle.unitsOptions.join(', ');
-  const unitsAvailable = units.map((unit) => unit.option).join(', ');
-
-  if (
-    !units.some((unit) => layer.draw.circle.unitsOptions.includes(unit.option))
-  ) {
-    console.warn(
-      `layer.draw.circle.unitsOptions - ${optionsGiven}: not found in available options. They are ${unitsAvailable}`,
-    );
-
-    // Set the layer.draw.circle.unitsOption to just meter
-    layer.draw.circle.unitsOptions = ['meter'];
-  }
-
-  const circleUnits = units.filter((unit) =>
-    layer.draw.circle.unitsOptions.includes(unit.option),
-  );
-
-  // Set layer.draw.circle.units to the first unit in the circleUnits array
-  layer.draw.circle.units = circleUnits[0].option;
-
   // Set the default values
-  layer.draw.circle = {
-    geometryFunction: (coordinates) => {
-      const polygonCircular = new ol.geom.Polygon.circular(
-        ol.proj.toLonLat(coordinates),
-        layer.draw.circle.unitConversion[layer.draw.circle.units](
-          layer.draw.circle.radius,
-        ),
-        64,
-      );
-
-      return polygonCircular.transform('EPSG:4326', 'EPSG:3857');
-    },
+  const circle = {
     helpDialog,
     label: mapp.dictionary.draw_circle,
     layer,
-    radius: circleUnits[0].min,
-    radiusMax: circleUnits[0].max,
-    radiusMin: circleUnits[0].min,
-
-    // Methods to transform input radius.
     type: 'Point',
+    units: 'meter',
+    unitsConfig: {
+      meter: {
+        max: 1000,
+        min: 1,
+        title: 'Meter',
+      },
+      km: {
+        max: 10,
+        min: 1,
+        title: 'KM',
+      },
+      miles: {
+        max: 10,
+        min: 1,
+        title: 'Miles',
+      },
+      meter2: {
+        max: 1000,
+        min: 1,
+        title: 'Meter²',
+      },
+      km2: {
+        max: 10,
+        min: 1,
+        title: 'KM²',
+      },
+    },
     unitConversion: {
       km: (v) => v * 1000,
       km2: (v) => Math.sqrt((v * 1000000) / Math.PI),
@@ -362,85 +317,112 @@ function circle(layer) {
       meter2: (v) => Math.sqrt(v / Math.PI),
       miles: (v) => v * 1609.34,
     },
-    units: 'meter',
     ...layer.draw.circle,
   };
 
-  const unitsDropDown = mapp.utils.html.node`
-    <div style="display: grid; grid-template-columns: 100px 1fr; align-items: center;">
+  layer.draw.circle = circle;
+
+  circle.unitsOptions ??= Object.keys(circle.unitsConfig);
+
+  circle.unitsOptions = circle.unitsOptions.filter((option) => {
+    if (Object.hasOwn(circle.unitsConfig, option)) {
+      circle.unitsConfig[option].option = option;
+      circle.unitsConfig[option].title ??= option;
+
+      return true;
+    } else {
+      console.warn(`Unknown circle drawing unit ${option}`);
+      return false;
+    }
+  });
+
+  if (!Object.hasOwn(circle.unitsConfig, circle.units)) {
+    console.warn(`Unkown circle units conversion ${circle.units}`);
+    circle.units = 'meter';
+  }
+
+  circle.geometryFunction ??= (coordinates) => {
+    const polygonCircular = new ol.geom.Polygon.circular(
+      ol.proj.toLonLat(coordinates),
+      layer.draw.circle.unitConversion[layer.draw.circle.units](
+        layer.draw.circle.radius,
+      ),
+      64,
+    );
+
+    return polygonCircular.transform('EPSG:4326', 'EPSG:3857');
+  };
+
+  circle.unitsDropDown = mapp.utils.html.node`<div 
+    style="display: grid; grid-template-columns: 100px 1fr; align-items: center;">
       <div style="grid-column: 1;">${mapp.dictionary.units}</div>
       <div style="grid-column: 2;">
         ${mapp.ui.elements.dropdown({
-          callback: (e, entry) => {
-            layer.draw.circle.units = entry.option;
-            layer.draw.circle.radiusMin = entry.min;
-            layer.draw.circle.radiusMax = entry.max;
-
-            // Update the value of the slider to ensure it is within the new min and max values.
-            layer.draw.circle.radius =
-              layer.draw.circle.radius > layer.draw.circle.radiusMax
-                ? layer.draw.circle.radiusMax
-                : layer.draw.circle.radius;
-
-            // Render the slider after changes
-            createSlider();
-          },
-          entries: circleUnits,
-          placeholder: circleUnits.find(
-            (entry) => entry.option === layer.draw.circle.units,
-          ).title,
+          callback: (e, entry) => setUnits(circle, entry.option),
+          entries: Object.values(circle.unitsConfig),
+          placeholder: circle.unitsConfig[circle.units].title,
         })}`;
 
-  const rangeSlider = mapp.utils.html.node`<div>`;
+  circle.rangeSlider = mapp.utils.html.node`<div>`;
 
-  createSlider();
+  setUnits(circle, circle.units);
 
-  /**
-  @function createSlider
-  Creates a slider for the circle radius, renders this slider into the rangeSlider div, and assigns a callback function to update the radius value.
-  */
-  function createSlider() {
-    mapp.utils.render(
-      rangeSlider,
-      mapp.ui.elements.slider({
-        callback: (e) => {
-          layer.draw.circle.radius = parseFloat(e);
-        },
-        max: layer.draw.circle.radiusMax,
-        min: layer.draw.circle.radiusMin,
-        val: layer.draw.circle.radius,
-      }),
-    );
-  }
-
-  layer.draw.circle.btn = mapp.utils.html.node`
-  <button
+  circle.btn = mapp.utils.html.node`<button
     class="action wide"
-    onclick=${(e) => drawOnclick(e, layer, layer.draw.circle)}>
-    <span class="material-symbols-outlined">add_circle</span>
-    ${layer.draw.circle.label}`;
+    onclick=${(e) => drawOnclick(e, layer, circle)}>
+      <span class="material-symbols-outlined">add_circle</span>
+      ${circle.label}`;
 
   const content = mapp.utils.html.node`
     <div class="panel flex-col">
-      ${unitsDropDown}
-      ${rangeSlider}
-      ${layer.draw.circle.btn}`;
+      ${circle.unitsDropDown}
+      ${circle.rangeSlider}
+      ${circle.btn}`;
 
   // The config elements are not shown.
-  if (layer.draw.circle.hidePanel) return layer.draw.circle.btn;
+  if (circle.hidePanel) return circle.btn;
 
-  if (layer.draw.circle.drawer === false) {
+  if (circle.drawer === false) {
     return mapp.utils.html`<h3>${mapp.dictionary.circle_config}</h3>${content}`;
   }
 
-  layer.draw.circle.drawer = mapp.ui.elements.drawer({
+  circle.drawer = mapp.ui.elements.drawer({
     header: mapp.utils.html`
     <h3>${mapp.dictionary.circle_config}</h3>
     <div class="material-symbols-outlined caret"/>`,
     content,
   });
 
-  return layer.draw.circle.drawer;
+  return circle.drawer;
+}
+
+/**
+@function setUnits
+@description 
+The setUnits method updates the circle draw config from an units option.
+*/
+function setUnits(circle, option) {
+  const entry = circle.unitsConfig[option];
+
+  circle.units = entry.option;
+
+  circle.radius ??= entry.min;
+
+  // Update the value of the slider to ensure it is within the new min and max values.
+  circle.radius = circle.radius > entry.max ? entry.max : circle.radius;
+
+  // Render the slider after changes
+  mapp.utils.render(
+    circle.rangeSlider,
+    mapp.ui.elements.slider({
+      callback: (e) => {
+        circle.radius = parseFloat(e);
+      },
+      max: entry.max,
+      min: entry.min,
+      val: circle.radius,
+    }),
+  );
 }
 
 /**

--- a/lib/ui/elements/drawing.mjs
+++ b/lib/ui/elements/drawing.mjs
@@ -342,6 +342,13 @@ function circle(layer) {
     },
   ];
 
+  // Subset the units array to only include the units that are defined in the layer.draw.circle.unitsOptions
+  layer.draw.circle.unitsOptions ??= ['meter', 'km', 'miles', 'meter2', 'km2'];
+
+  const circleUnits = units.filter((unit) =>
+    layer.draw.circle.unitsOptions.includes(unit.option),
+  );
+
   const unitsDropDown = mapp.utils.html.node`
     <div style="display: grid; grid-template-columns: 100px 1fr; align-items: center;">
       <div style="grid-column: 1;">${mapp.dictionary.units}</div>
@@ -361,8 +368,8 @@ function circle(layer) {
             // Render the slider after changes
             createSlider();
           },
-          entries: units,
-          placeholder: units.find(
+          entries: circleUnits,
+          placeholder: circleUnits.find(
             (entry) => entry.option === layer.draw.circle.units,
           ).title,
         })}`;

--- a/lib/ui/elements/drawing.mjs
+++ b/lib/ui/elements/drawing.mjs
@@ -336,14 +336,16 @@ function circle(layer) {
     }
   });
 
-  Object.keys(circle.unitsConfig).forEach((config) => {
-    if (!circle.unitsOptions.includes(config)) {
-      delete circle.unitsConfig[config];
-    }
-  });
+  //Check for whether any valid config options were supplied
+  //If not fallback to the full list
+  circle.unitsOptions.length &&
+    Object.keys(circle.unitsConfig).forEach((config) => {
+      if (!circle.unitsOptions.includes(config)) {
+        delete circle.unitsConfig[config];
+      }
+    });
 
   if (!Object.hasOwn(circle.unitsConfig, circle.units)) {
-    console.warn(`Unkown circle units conversion ${circle.units}`);
     circle.units = Object.keys(circle.unitsConfig)[0];
   }
 


### PR DESCRIPTION
Previously it was not possible to say which units you allow for circle configuration. they were all always included. 
This PR introduces the `layer.draw.circle.unitsOptions` array which can be assigned to reduce the options. If it is not included, then they will all be included as normal. 
``` "unitsOptions": ["meter", "km"]``` will subset to just allow the meter and km options. 