### PR TITLE
Ensure layer always has layer.params.fields

### DIFF
--- a/lib/layer/format/vector.mjs
+++ b/lib/layer/format/vector.mjs
@@ -56,7 +56,8 @@ export default function vector(layer) {
   }
 
   // Set default layer params if nullish.
-  layer.params ??= { fields: [] };
+  layer.params ??= {};
+  layer.params.fields ??= [];
 
   layer.featureFormat ??= layer.format;
 

--- a/lib/ui/locations/entries/layer.mjs
+++ b/lib/ui/locations/entries/layer.mjs
@@ -59,7 +59,7 @@ export default function layer(entry) {
     };
 
     entry.params ??= {};
-
+    entry.params.fields ??= [];
     entry.params.layer_template ??= entry.layer;
 
     // The assignment should only happen once.

--- a/lib/ui/locations/entries/layer.mjs
+++ b/lib/ui/locations/entries/layer.mjs
@@ -59,7 +59,7 @@ export default function layer(entry) {
     };
 
     entry.params ??= {};
-    entry.params.fields ??= [];
+
     entry.params.layer_template ??= entry.layer;
 
     // The assignment should only happen once.


### PR DESCRIPTION
A `type:layer` entry may not have a `params.fields` value if not required. 
This will result in an error that `layer.params.fields is not iterable`. 
This PR nullish assigns to resolve this on the vector layer itself.