### PR TITLE
Import maplibre from esmImport util

### DIFF
--- a/lib/layer/format/maplibre.mjs
+++ b/lib/layer/format/maplibre.mjs
@@ -1,43 +1,39 @@
 /**
-### mapp.layer.formats.maplibre()
+### /layer/formats/maplibre
+
+The maplibre format module imports the maplibre-gl library from esm and assigns the right-to-left [rtl] language module to display arabic labels correctly.
+
+@requires /utils/esmImport
 
 @module /layer/formats/maplibre
 */
 
-// Assign maplibre from window if already loaded.
-let promise,
-  maplibregl = window.maplibregl;
+let MaplibreGL;
 
-async function MaplibreGL() {
-  if (maplibregl) return new maplibregl.Map(...arguments);
+/**
+@function maplibre
 
-  // Create promise to load maplibre from esm.sh
-  if (!promise)
-    promise = new Promise((resolve) => {
-      import('https://esm.sh/maplibre-gl@4.7.1').then((mod) => {
-        maplibregl = mod.default;
+@description
+The maplibre format method will create a new MaplibreGL.Map() class object in a layer.container element. The layer.container is prepended to the Openlayers mapview.Map target element. A custom Openlayers.layer object will position the Maplibre Map object and return the rendered map into the container.
 
-        // Avoid loading RTL Text Plugin twice, else it will error
-        if (
-          !['deferred', 'loaded'].includes(maplibregl.getRTLTextPluginStatus())
-        ) {
-          maplibregl.setRTLTextPlugin(
-            'https://unpkg.com/@mapbox/mapbox-gl-rtl-text@0.2.3/mapbox-gl-rtl-text.min.js',
-            true, // Lazy load the plugin
-          );
-        }
-        resolve();
-      });
-    });
+@param {layer} layer JSON layer
+@property {Object} layer.style
+@property {string} style.URL The location of a mvt stylesheet.
+@property {string} layer.accessToken An accessToken is required to access tiles and stylesheets from the Mapbox API.
+@property {boolean} layer.preserveDrawingBuffer The preserveDrawingBuffer flag is required in order to render to canvas for screenshots.
 
-  await promise;
+@returns {layer} layer decorated with format methods.
+*/
+export default async function maplibre(layer) {
+  if (!MaplibreGL) {
+    MaplibreGL = await mapp.utils.esmImport('maplibre-gl@5.5.0');
 
-  if (!maplibregl) return;
+    MaplibreGL.setRTLTextPlugin(
+      'https://unpkg.com/@mapbox/mapbox-gl-rtl-text@0.3.0/dist/mapbox-gl-rtl-text.js',
+      true, // Lazy load the plugin
+    );
+  }
 
-  return new maplibregl.Map(...arguments);
-}
-
-export default async (layer) => {
   const className = `mapp-layer-${layer.key} maplibre`;
 
   layer.container = mapp.utils.html.node`<div 
@@ -66,7 +62,7 @@ export default async (layer) => {
     return;
   }
 
-  const maplibreMap = await MaplibreGL({
+  const maplibreMap = new MaplibreGL.Map({
     attributionControl: false,
     boxZoom: false,
     container: layer.container,
@@ -124,7 +120,7 @@ export default async (layer) => {
     },
     zIndex: layer.zIndex,
   });
-};
+}
 
 // transformMapboxUrl and supporting functions are taken from https://github.com/rowanwins/maplibregl-mapbox-request-transformer
 

--- a/lib/layer/format/maplibre.mjs
+++ b/lib/layer/format/maplibre.mjs
@@ -3,6 +3,8 @@
 
 The maplibre format module imports the maplibre-gl library from esm and assigns the right-to-left [rtl] language module to display arabic labels correctly.
 
+CSP access to `unpkg.com` is required in order to assign the rtl-text plugin to the Maplibre library module.
+
 @requires /utils/esmImport
 
 @module /layer/formats/maplibre


### PR DESCRIPTION
The maplibre format module and method are now documented.

The maplibre module is imported with the esmImport util.

The maplibre module has been bumped to v5.5.0

The rtl-text plugin is applied to the imported library stored in the `MaplibreGL` module level variable.

The rtl-text plugin has been bumped to v0.3.0