### PR TITLE
Bump jsoneditor import from esmImport util

### DIFF
--- a/lib/ui/elements/jsoneditor.mjs
+++ b/lib/ui/elements/jsoneditor.mjs
@@ -9,7 +9,7 @@ The module dynamically imports the [vanilla-jsoneditor]{@link https://www.npmjs.
 */
 
 /**
-@function esmImport
+@function createJSONEditor
 @async
 
 @description

--- a/lib/ui/elements/jsoneditor.mjs
+++ b/lib/ui/elements/jsoneditor.mjs
@@ -3,32 +3,10 @@
 
 The module dynamically imports the [vanilla-jsoneditor]{@link https://www.npmjs.com/package/vanilla-jsoneditor} from esm.sh and exports a utility method to create a jsoneditor control.
 
+@requires /utils/esmImport
+
 @module /ui/elements/jsoneditor
 */
-
-let promise, mod;
-
-/**
-@function esmImport
-@async
-
-@description
-The method dynamically imports the jsoneditor module from esm.sh and asssigns the module to the esm variable.
-
-A promise for the import will be assigned to the promise variable on first call.
-
-The method awaits the import promise to resolve the esm module.
-*/
-async function esmImport() {
-  promise ??= new Promise((resolve) => {
-    import('https://esm.sh/vanilla-jsoneditor@2.3.3').then((esm) => {
-      mod = esm;
-      resolve();
-    });
-  });
-
-  await promise;
-}
 
 /**
 @function esmImport
@@ -44,7 +22,7 @@ The method dynamically imports the jsoneditor module from esm.sh and asssigns th
 @returns {object} Exports a jsoneditor instance.
 */
 export default async function createJSONEditor(params) {
-  await esmImport();
+  const mod = await mapp.utils.esmImport('vanilla-jsoneditor@3.3.1');
 
   const content = {};
 


### PR DESCRIPTION
The jsonEditor should imported through the esmImport util.

The jsonEditor dependency has been bumped to 3.3.1 which includes a ton of patches. https://github.com/josdejong/svelte-jsoneditor/releases