### PR TITLE
fix(dataview): Disable entry checkbox on null when queryCheck is used

### DIFF
--- a/lib/ui/locations/entries/dataview.mjs
+++ b/lib/ui/locations/entries/dataview.mjs
@@ -57,8 +57,16 @@ export default function dataview(entry) {
   // Decorate the dataview entry.
   if (mapp.ui.Dataview(entry) instanceof Error) return;
 
+  //If queryCheck is true and theres no data, don't dislpay the dataview
+  if ((!entry.data || entry.data instanceof Error) && entry.queryCheck) {
+    entry.chkbox?.classList?.add?.('disabled');
+    entry.chkbox.querySelector('input').checked = false;
+    entry.display = false;
+    entry.hide();
+  }
+
   // Dataview should be displayed.
-  entry.display && !entry.queryCheck && entry.show?.();
+  entry.display && entry.show?.();
 
   // Return elements to location view.
   return mapp.utils.html.node`

--- a/lib/ui/locations/entries/dataview.mjs
+++ b/lib/ui/locations/entries/dataview.mjs
@@ -58,7 +58,7 @@ export default function dataview(entry) {
   if (mapp.ui.Dataview(entry) instanceof Error) return;
 
   // Dataview should be displayed.
-  entry.display && entry.show?.();
+  entry.display && !entry.queryCheck && entry.show?.();
 
   // Return elements to location view.
   return mapp.utils.html.node`

--- a/lib/ui/locations/infoj.mjs
+++ b/lib/ui/locations/infoj.mjs
@@ -464,19 +464,6 @@ function entryQuery(entry) {
         const el = mapp.ui.locations.entries[entry.type]?.(entry);
 
         el && entry.node.appendChild(el);
-
-        if (
-          (!response || response instanceof Error) &&
-          entry.type === 'dataview'
-        ) {
-          entry.chkbox.classList.add('disabled');
-          entry.chkbox.querySelector('input').checked = false;
-          entry.hide();
-        } else {
-          entry.chkbox.classList.remove('disabled');
-          entry.display && entry.show();
-          entry.chkbox.querySelector('input').checked = entry.display;
-        }
       });
 
     return true;

--- a/lib/ui/locations/infoj.mjs
+++ b/lib/ui/locations/infoj.mjs
@@ -465,14 +465,14 @@ function entryQuery(entry) {
 
         el && entry.node.appendChild(el);
 
-        if (!entry.value && entry.type === 'dataview') {
-          entry.chkbox.querySelector('input').disabled = true;
+        if (!response && entry.type === 'dataview') {
+          entry.chkbox.classList.add('disabled');
           entry.chkbox.querySelector('input').checked = false;
-          entry.chkbox.style.cursor = 'not-allowed';
+          entry.hide();
         } else {
-          entry.chkbox.querySelector('input').disabled = false;
-          entry.chkbox.querySelector('input').checked = true;
-          entry.chkbox.style.removeProperty('cursor');
+          entry.chkbox.classList.remove('disabled');
+          entry.display && entry.show();
+          entry.chkbox.querySelector('input').checked = entry.display;
         }
       });
 

--- a/lib/ui/locations/infoj.mjs
+++ b/lib/ui/locations/infoj.mjs
@@ -464,6 +464,16 @@ function entryQuery(entry) {
         const el = mapp.ui.locations.entries[entry.type]?.(entry);
 
         el && entry.node.appendChild(el);
+
+        if (!entry.value && entry.type === 'dataview') {
+          entry.chkbox.querySelector('input').disabled = true;
+          entry.chkbox.querySelector('input').checked = false;
+          entry.chkbox.style.cursor = 'not-allowed';
+        } else {
+          entry.chkbox.querySelector('input').disabled = false;
+          entry.chkbox.querySelector('input').checked = true;
+          entry.chkbox.style.removeProperty('cursor');
+        }
       });
 
     return true;

--- a/lib/ui/locations/infoj.mjs
+++ b/lib/ui/locations/infoj.mjs
@@ -465,7 +465,10 @@ function entryQuery(entry) {
 
         el && entry.node.appendChild(el);
 
-        if (!response && entry.type === 'dataview') {
+        if (
+          (!response || response instanceof Error) &&
+          entry.type === 'dataview'
+        ) {
           entry.chkbox.classList.add('disabled');
           entry.chkbox.querySelector('input').checked = false;
           entry.hide();


### PR DESCRIPTION
## Description
This PR disables the dataview checkbox on an entry when `queryCheck: true` is used and the query returns null.

## GitHub Issue
[#2132](https://github.com/GEOLYTIX/xyz/issues/2132)

## Type of Change
- ✅ Bug fix (non-breaking change which fixes an issue)

## How have you tested this?
Tested locally using `bugs_testing/dataviews/tabulator_workspace.json` 
[Localhost link](http://localhost:3000/latest/?layers=OSM,supermarkets,scratch&locations=scratch!1013711&z=7&lat=52.7&lng=-1.12)

## Testing Checklist
- ✅ Existing Tests still pass
- ✅ Ran locally on my machine

## Code Quality Checklist
- ✅ My code follows the guidelines of XYZ
- ✅ My code has been commented
- ✅ Documentation has been updated
- ✅ New and existing unit tests pass locally with my changes
- ✅ Main has been merged into this PR
