### PR TITLE
fix(dialog): Prevent left and top from going negative

### DIFF
--- a/lib/ui/elements/dialog.mjs
+++ b/lib/ui/elements/dialog.mjs
@@ -164,8 +164,9 @@ export default function dialog(dialog) {
       dialog.node;
 
     // Calculate the maximum allowed positions for the dialog
-    const maxLeft = mapWidth - dialogWidth;
-    const maxTop = mapHeight - dialogHeight;
+    // Prevent negative left and top values
+    const maxLeft = mapWidth - dialogWidth < 0 ? 0 : mapWidth - dialogWidth;
+    const maxTop = mapHeight - dialogHeight < 0 ? 0 : mapHeight - dialogHeight;
 
     // Adjust the dialog's position if it exceeds the map boundaries
     dialog.node.style.left = `${Math.min(Math.max(dialog.node.offsetLeft, 0), maxLeft)}px`;

--- a/lib/ui/utils/dataviewDialog.mjs
+++ b/lib/ui/utils/dataviewDialog.mjs
@@ -40,11 +40,12 @@ export default function dataviewDialog(dataview) {
 
   dataview.dataview_dialog = {};
 
-  const dialog_style = `width: ${dataview.dialog_css?.width || '310'}px; 
-                        height: ${dataview.dialog_css?.height || '300'}px;
-                        min-width: ${dataview.dialog_css?.minWidth || '310'}px;
-                        min-height: ${dataview.dialog_css?.minHeight || '300'}px;
-                        resize: both; overflow: scroll !important`;
+  const dialog_style = `
+    width: ${dataview.dialog_css?.width || '300'}px;
+    height: ${dataview.dialog_css?.height || '300'}px;
+    min-width: ${dataview.dialog_css?.minWidth || '300'}px;
+    min-height: ${dataview.dialog_css?.minHeight || '300'}px;
+    resize: both; overflow: scroll !important`;
 
   Object.assign(dataview.dataview_dialog, {
     header: mapp.utils.html.node`<h1> ${dataview.label}`,

--- a/lib/ui/utils/dataviewDialog.mjs
+++ b/lib/ui/utils/dataviewDialog.mjs
@@ -40,10 +40,10 @@ export default function dataviewDialog(dataview) {
 
   dataview.dataview_dialog = {};
 
-  const dialog_style = `width: ${dataview.dialog_css?.width || '310'}px !important; 
-                        height: ${dataview.dialog_css?.height || '300'}px !important;
-                        min-width: ${dataview.dialog_css?.minWidth || '310'}px !important;
-                        min-height: ${dataview.dialog_css?.minHeight || '300'}px !important;
+  const dialog_style = `width: ${dataview.dialog_css?.width || '310'}px; 
+                        height: ${dataview.dialog_css?.height || '300'}px;
+                        min-width: ${dataview.dialog_css?.minWidth || '310'}px;
+                        min-height: ${dataview.dialog_css?.minHeight || '300'}px;
                         resize: both; overflow: scroll !important`;
 
   Object.assign(dataview.dataview_dialog, {


### PR DESCRIPTION
## Description
This PR corrects an issue where the dialogs `left` and `top` values would go negative when the map was resized, which led to the dialog going over and under the `ctrls-tab`.

## GitHub Issue
[#2144](https://github.com/GEOLYTIX/xyz/issues/2144)

## Type of Change
- ✅ Bug fix (non-breaking change which fixes an issue)
- ✅ Documentation


## How have you tested this?
Tested locally on `bugs_testing/dataviews/dataviews.json` opening the supermarkets dataview on the supermarkets layer and resize the window, the dialog should not go over the `ctrls-tab`.
 
## Testing Checklist
- ✅ Existing Tests still pass
- ✅ Ran locally on my machine

## Code Quality Checklist
- ✅ My code follows the guidelines of XYZ
- ✅ My code has been commented
- ✅ Documentation has been updated
- ✅ New and existing unit tests pass locally with my changes
- ✅ Main has been merged into this PR
