### PR TITLE
(bug): Apply zIndex to mapbox style layer

### DIFF
--- a/lib/layer/format/mapboxStyle.mjs
+++ b/lib/layer/format/mapboxStyle.mjs
@@ -26,7 +26,10 @@ The mapboxStyle method creates an Openlayers VectorTile layer and assigns a mapb
 @returns {layer} layer decorated with format methods.
 */
 export default async function mapboxStyle(layer) {
-  layer.L = new ol.layer.VectorTile({ declutter: true });
+  layer.L = new ol.layer.VectorTile({ 
+    declutter: true,
+    zIndex: layer.zIndex,
+  });
 
   olms.applyStyle(layer.L, layer.style.URL, { accessToken: layer.accessToken });
 }

--- a/lib/layer/format/mapboxStyle.mjs
+++ b/lib/layer/format/mapboxStyle.mjs
@@ -26,7 +26,7 @@ The mapboxStyle method creates an Openlayers VectorTile layer and assigns a mapb
 @returns {layer} layer decorated with format methods.
 */
 export default async function mapboxStyle(layer) {
-  layer.L = new ol.layer.VectorTile({ 
+  layer.L = new ol.layer.VectorTile({
     declutter: true,
     zIndex: layer.zIndex,
   });


### PR DESCRIPTION
The zIndex from the json layer must be applied to the Openlayers VectorTile layer.