### PR TITLE
(bug): Encode userLocale Naming 

### DIFF
--- a/lib/ui/elements/userLocale.mjs
+++ b/lib/ui/elements/userLocale.mjs
@@ -69,7 +69,7 @@ The saveLocale method saves the userlocale to the mapview and calls the listLoca
 */
 async function saveLocale(params, mapview) {
   params.panel.classList.add('disabled');
-  mapview.locale.name = params.localeInput.value;
+  mapview.locale.name = encodeURIComponent(params.localeInput.value);
   const response = await mapp.utils.userLocale.putLocale(mapview);
 
   if (response === mapview.locale.name) {
@@ -89,7 +89,7 @@ async function listLocales(params, mapview) {
   const locales = await mapp.utils.userLocale.list(mapview.locale.workspace);
 
   const list = locales.map((locale) => {
-    const href = `${mapp.host}?locale=${locale.key}&userlocale=${locale.name}`;
+    const href = `${mapp.host}?locale=${locale.key}&userlocale=${decodeURIComponent(locale.name)}`;
 
     const removeBtn = mapp.utils.html`<button
        onclick=${async (e) => await removeLocale(params, mapview, locale.name)}>

--- a/lib/ui/elements/userLocale.mjs
+++ b/lib/ui/elements/userLocale.mjs
@@ -18,7 +18,7 @@ The panel will be disabled during the transaction to save or remove a user local
 
 export default function userLocale(params, mapview) {
   params.localeInput = mapp.utils.html.node`<input
-    type="text" value="${mapview.locale.name || mapview.locale.key}">`;
+    type="text" value="${decodeURIComponent(mapview.locale.name) || mapview.locale.key}">`;
 
   params.ulLocales = mapp.utils.html.node`<div class="user-locales">`;
 
@@ -89,7 +89,7 @@ async function listLocales(params, mapview) {
   const locales = await mapp.utils.userLocale.list(mapview.locale.workspace);
 
   const list = locales.map((locale) => {
-    const href = `${mapp.host}?locale=${locale.key}&userlocale=${decodeURIComponent(locale.name)}`;
+    const href = `${mapp.host}?locale=${locale.key}&userlocale=${encodeURIComponent(locale.name)}`;
 
     const removeBtn = mapp.utils.html`<button
        onclick=${async (e) => await removeLocale(params, mapview, locale.name)}>

--- a/lib/ui/elements/userLocale.mjs
+++ b/lib/ui/elements/userLocale.mjs
@@ -96,7 +96,7 @@ async function listLocales(params, mapview) {
         <span class="material-symbols-outlined">delete</span>
       </button>`;
 
-    return mapp.utils.html`<li>${removeBtn}<a href=${href}>${locale.name}`;
+    return mapp.utils.html`<li>${removeBtn}<a href=${href}>${decodeURIComponent(locale.name)}`;
   });
 
   mapp.utils.render(params.ulLocales, mapp.utils.html`<ul>${list}`);

--- a/lib/ui/elements/userLocale.mjs
+++ b/lib/ui/elements/userLocale.mjs
@@ -96,7 +96,8 @@ async function listLocales(params, mapview) {
         <span class="material-symbols-outlined">delete</span>
       </button>`;
 
-    return mapp.utils.html`<li>${removeBtn}<a href=${href}>${decodeURIComponent(locale.name)}`;
+    return mapp.utils
+      .html`<li>${removeBtn}<a href=${href}>${decodeURIComponent(locale.name)}`;
   });
 
   mapp.utils.render(params.ulLocales, mapp.utils.html`<ul>${list}`);


### PR DESCRIPTION
UserLocale naming input must be encoded to allow special characters.
This must then be decoded when displaying the user locale href. 