### PR TITLE
(bug) : Locale.layer must not be deleted

### DIFF
--- a/mod/workspace/getLocale.js
+++ b/mod/workspace/getLocale.js
@@ -112,7 +112,6 @@ export default async function getLocale(params, parentLocale) {
   }
 
   // Remove properties which are only required for the fetching templates and composing workspace objects.
-  delete locale.layer;
   delete locale.src;
   delete locale.template;
   delete locale.templates;


### PR DESCRIPTION
# Pull Request Template

## Description
`locale.layer` must not be deleted. This was incorrectly meaning that locales that used a `layer.filter.default` to subset data to a specific country for example was not being passed to the `minmax` layer query. 

## GitHub Issue

https://github.com/GEOLYTIX/xyz/issues/2170

## Type of Change

Please delete options that are not relevant, and select all options that apply.

- ✅ Bug fix (non-breaking change which fixes an issue)

## Testing Checklist

Please delete options that are not relevant, and select all options that apply.

- ✅ Existing Tests still pass
- ✅ Updated Existing Tests
- ✅ New Tests Added
- ✅ Ran locally on my machine

## Code Quality Checklist

Please delete options that are not relevant, and select all options that apply.

- ✅ My code follows the guidelines of XYZ
- ✅ My code has been commented
- ✅ Documentation has been updated
- ✅ New and existing unit tests pass locally with my changes
- ✅ Main has been merged into this PR
