### PR TITLE
Use flex frow in drawer header

### DIFF
--- a/lib/ui/layers/view.mjs
+++ b/lib/ui/layers/view.mjs
@@ -46,10 +46,9 @@ export default function layerView(layer) {
   }
 
   // Set visibility if filter.current has property keys.
-  const zoomToFilteredExtentBtnStyle =
-    Object.keys(layer.filter.current).length > 0
-      ? 'visibility: visible;'
-      : 'visibility: hidden;';
+  const zoomToFilteredExtentBtnStyle = !Object.keys(layer.filter.current).length
+    ? 'display: none;'
+    : '';
 
   layer.zoomToFilteredExtentBtn =
     layer.viewConfig.zoomToFilteredExtentBtn &&

--- a/public/css/elements/_dialog.css
+++ b/public/css/elements/_dialog.css
@@ -33,8 +33,8 @@ dialog {
     left: 0;
     background-color: inherit;
 
-    & > :nth-child(2) {
-      margin-left: auto;
+    & > :first-child {
+      flex-grow: 1;
     }
 
     & > .material-symbols-outlined {

--- a/public/css/elements/_drawer.css
+++ b/public/css/elements/_drawer.css
@@ -62,14 +62,11 @@
       height: 1.5em;
     }
 
-    & > :nth-child(1) {
+    & > :first-child {
       overflow: hidden;
       white-space: normal;
       text-overflow: ellipsis;
-    }
-
-    & > :nth-child(2) {
-      margin-left: auto;
+      flex-grow: 1;
     }
   }
 

--- a/public/css/layout/_locationview.css
+++ b/public/css/layout/_locationview.css
@@ -112,7 +112,7 @@
   display: flex;
   align-items: center;
 
-  & > :nth-child(2) {
-    margin-left: auto;
+  & > :first-child {
+    flex-grow: 1;
   }
 }

--- a/public/css/ui.css
+++ b/public/css/ui.css
@@ -553,8 +553,8 @@ dialog {
     top: -1px;
     left: 0;
     background-color: inherit;
-    & > :nth-child(2) {
-      margin-left: auto;
+    & > :first-child {
+      flex-grow: 1;
     }
     & > .material-symbols-outlined {
       font-size: 1.2em;
@@ -653,13 +653,11 @@ dialog {
       width: 1.5em;
       height: 1.5em;
     }
-    & > :nth-child(1) {
+    & > :first-child {
       overflow: hidden;
       white-space: normal;
       text-overflow: ellipsis;
-    }
-    & > :nth-child(2) {
-      margin-left: auto;
+      flex-grow: 1;
     }
   }
   &.flat {
@@ -1247,8 +1245,8 @@ input[type=search]::-webkit-calendar-picker-indicator {
 .flex-spacer {
   display: flex;
   align-items: center;
-  & > :nth-child(2) {
-    margin-left: auto;
+  & > :first-child {
+    flex-grow: 1;
   }
 }
 


### PR DESCRIPTION
Instead of using margin left auto on the second item in a flex display element it is much cleaner to flex-grow:1 the first child.

This way it is not necessary to use visibilkity:hidden but take items out of the flow by using display:none.