### PR TITLE
Clean up Openlayers Icon Style creation

### DIFF
--- a/lib/utils/olStyle.mjs
+++ b/lib/utils/olStyle.mjs
@@ -31,7 +31,6 @@ The olStyle method takes a mapp-style JSON representation to create an Openlayer
 
 @returns {Object} An Openlayers feature style object.
 */
-
 export default function olStyle(style, feature) {
   if (!style) return null;
 
@@ -47,41 +46,9 @@ export default function olStyle(style, feature) {
     if (style.icon) {
       // Iterate through icon style array.
       if (Array.isArray(style.icon)) {
-        style.icon.forEach((icon) => iconStyle(style, icon));
+        style.icon.forEach((icon) => iconStyle(Styles, style, icon, feature));
       } else {
-        iconStyle(style, style.icon);
-      }
-
-      function iconStyle(style, icon) {
-        // Calculate scale for icon render.
-        let scale = icon.scale || 1;
-        scale *= style.scale || 1;
-        scale *= style.clusterScale || 1;
-        scale *= style.fieldScale || 1;
-        scale *= style.zoomInScale || 1;
-        scale *= style.zoomOutScale || 1;
-        scale *= style.highlightScale || 1;
-
-        // Create icon url from svgSymbols method if not defined as url or svg source.
-        icon.url =
-          icon.url ||
-          icon.svg ||
-          mapp.utils.svgSymbols[icon.type || 'dot'](icon, feature);
-
-        if (!icon.url) return;
-
-        // Push OL icon Style into Styles array.
-        Styles.push(
-          new ol.style.Style({
-            image: new ol.style.Icon({
-              anchor: icon.anchor || [0.5, 0.5],
-              crossOrigin: 'anonymous',
-              scale: scale,
-              src: icon.url,
-            }),
-            zIndex: style.zIndex,
-          }),
-        );
+        iconStyle(Styles, style, style.icon, feature);
       }
     }
 
@@ -133,4 +100,47 @@ export default function olStyle(style, feature) {
   feature?.set?.('Styles', Styles, true);
 
   return Styles;
+}
+
+/**
+@function iconStyle
+
+@description
+The iconStyle method calculates the scale for the Openlayers Style Icon.
+
+On Openlayers Style Icon requires an URL. A `data:image` URL will be created from the svgSymbols module methods if not explicit.
+
+@param {array} Styles An array of Openlayers style objects.
+@param {feature-style} style A JSON mapp-style object.
+@param {object} icon An array of Openlayers style objects.
+@param {object} feature The Openlayers feature to style with an icon.
+*/
+function iconStyle(Styles, style, icon, feature) {
+  // Calculate scale for icon render.
+  let scale = icon.scale || 1;
+  scale *= style.scale || 1;
+  scale *= style.clusterScale || 1;
+  scale *= style.fieldScale || 1;
+  scale *= style.zoomInScale || 1;
+  scale *= style.zoomOutScale || 1;
+  scale *= style.highlightScale || 1;
+
+  // Create icon url from svgSymbols method if not defined as url or svg source.
+  icon.url ??=
+    icon.svg || mapp.utils.svgSymbols[icon.type || 'dot'](icon, feature);
+
+  if (!icon.url) return;
+
+  // Push OL icon Style into Styles array.
+  Styles.push(
+    new ol.style.Style({
+      image: new ol.style.Icon({
+        anchor: icon.anchor || [0.5, 0.5],
+        crossOrigin: 'anonymous',
+        scale: scale,
+        src: icon.url,
+      }),
+      zIndex: style.zIndex,
+    }),
+  );
 }


### PR DESCRIPTION
The iconStyle method should not be defined in an forEach iteration.