### PR TITLE
feature(roles): Return roles.tree from workspace, support roles with dot separator.

### DIFF
--- a/lib/layer/format/maplibre.mjs
+++ b/lib/layer/format/maplibre.mjs
@@ -75,7 +75,9 @@ export default async function maplibre(layer) {
     keyboard: false,
     pitchWithRotate: false,
     pixelRatio: 1,
-    preserveDrawingBuffer: layer.preserveDrawingBuffer,
+    canvasContextAttributes: {
+      preserveDrawingBuffer: layer.preserveDrawingBuffer,
+    },
     scrollZoom: false,
     style: layer.style?.object,
     touchZoomRotate: false,

--- a/mod/utils/roles.js
+++ b/mod/utils/roles.js
@@ -1,43 +1,52 @@
 /**
- * Roles utility module for handling role-based access control and object merging
- * @module /utils/roles
- */
+## /utils/roles
+Roles utility module for handling role-based access control and object merging
+
+@requires /utils/merge
+@module /utils/roles
+*/
 
 /**
- * @global
- * @typedef {Object} roles
- * @property {Object} roles - roles configuration object
- * @property {boolean} [roles.*] - Wildcard role indicating unrestricted access
- * @property {Object} [roles.key] - Role-specific properties to merge
- * @property {Object} [roles.'!key'] - Negated role properties (applied when user doesn't have the role)
- */
+@global
+@typedef {Object} roles
+@property {Object} roles - roles configuration object
+@property {boolean} [roles.*] - Wildcard role indicating unrestricted access
+@property {Object} [roles.key] - Role-specific properties to merge
+@property {Object} [roles.'!key'] - Negated role properties (applied when user doesn't have the role)
+*/
 
 import merge from './merge.js';
 
 export { check, objMerge };
 
 /**
- * Checks if an object should be accessible based on user roles
- * @param {Object} obj - The object to check access for
- * @param {roles} obj.roles - Role configuration object
- * @param {Array<string>} user_roles - Array of roles assigned to the user
- * @returns {(Object|boolean)} Returns the original object if access is granted, false otherwise
- *
- * @example
- * // Object with unrestricted access
- * check({ roles: { '*': true }, data: 'content' }, ['user']) // returns object
- *
- * // Object with role restriction
- * check({ roles: { admin: true }, data: 'content' }, ['user']) // returns false
- * check({ roles: { admin: true }, data: 'content' }, ['admin']) // returns object
- *
- * // Object with negated roles
- * check({ roles: { '!guest': true }, data: 'content' }, ['guest']) // returns false
- * check({ roles: { '!guest': true }, data: 'content' }, ['user']) // returns object
- */
+@function check
+@description
+Checks if an object should be accessible based on user roles
+
+```js
+// Object with unrestricted access
+check({ roles: { '*': true }, data: 'content' }, ['user']) // returns object
+
+// Object with role restriction
+check({ roles: { admin: true }, data: 'content' }, ['user']) // returns false
+check({ roles: { admin: true }, data: 'content' }, ['admin']) // returns object
+
+// Object with negated roles
+check({ roles: { '!guest': true }, data: 'content' }, ['guest']) // returns false
+check({ roles: { '!guest': true }, data: 'content' }, ['user']) // returns object
+```
+
+@param {Object} obj The object to check access for
+@param {Array<string>} user_roles Array of roles assigned to the user
+@property {roles} obj.roles Role configuration object
+@returns {(Object|boolean)} Returns the original object if access is granted, false otherwise
+*/
 function check(obj, user_roles) {
   // The object to check has no roles assigned.
   if (!obj.roles) return obj;
+
+  if (user_roles === true) return obj;
 
   // Always return object with '*' asterisk role.
   if (Object.hasOwn(obj.roles, '*')) return obj;

--- a/mod/utils/roles.js
+++ b/mod/utils/roles.js
@@ -144,9 +144,10 @@ export function objMerge(obj, user_roles) {
       // Get last role from a dot tree role string.
       const popRole = role.split('.').pop();
 
-      if (user_roles.includes(popRole)) return true;
-      if (notIncludesNegatedRole(popRole, user_roles)) return true;
-      return false;
+      return (
+        user_roles.includes(popRole) ||
+        notIncludesNegatedRole(popRole, user_roles)
+      );
     })
     .forEach((role) => {
       merge(clone, clone.roles[role]);

--- a/mod/workspace/_workspace.js
+++ b/mod/workspace/_workspace.js
@@ -351,6 +351,13 @@ function roles(req, res) {
 @param {req} res HTTP response.
 */
 async function rolestree(req, res) {
+  if (!req.params.user?.admin) {
+    res
+      .status(403)
+      .send(`Admin credentials are required to test the workspace sources.`);
+    return;
+  }
+
   // Force re-caching of workspace.
   workspace = await workspaceCache(true);
 

--- a/tests/mod/utils/roles.test.mjs
+++ b/tests/mod/utils/roles.test.mjs
@@ -1,4 +1,4 @@
-import { check, objMerge } from '../../../mod/utils/roles.js';
+import { check, objMerge, fromObj } from '../../../mod/utils/roles.js';
 
 codi.describe({ name: 'Roles Module', id: 'roles_module' }, async () => {
   codi.describe(
@@ -85,6 +85,54 @@ codi.describe({ name: 'Roles Module', id: 'roles_module' }, async () => {
           const obj = { roles: { admin: true, user: true } };
           const result = check(obj, ['guest']);
           codi.assertEqual(result, false);
+        },
+      );
+
+      codi.it(
+        {
+          name: 'should handle dot notation roles',
+          parentId: 'roles_module_check',
+        },
+        () => {
+          const obj = { roles: { 'namespace.admin': true } };
+          const result = check(obj, ['admin']);
+          codi.assertEqual(result, obj);
+        },
+      );
+
+      codi.it(
+        {
+          name: 'should return false if user_roles is null',
+          parentId: 'roles_module_check',
+        },
+        () => {
+          const obj = { roles: { admin: true } };
+          const result = check(obj, null);
+          codi.assertEqual(result, false);
+        },
+      );
+
+      codi.it(
+        {
+          name: 'should handle mixed positive and negated roles',
+          parentId: 'roles_module_check',
+        },
+        () => {
+          const obj = { roles: { admin: true, '!guest': true } };
+          const result = check(obj, ['guest']);
+          codi.assertEqual(result, false);
+        },
+      );
+
+      codi.it(
+        {
+          name: 'should return the object with empty roles object',
+          parentId: 'roles_module_check',
+        },
+        () => {
+          const obj = { roles: {} };
+          const result = check(obj, ['user']);
+          codi.assertEqual(result, obj);
         },
       );
     },
@@ -260,6 +308,334 @@ codi.describe({ name: 'Roles Module', id: 'roles_module' }, async () => {
           obj = objMerge(obj, user_roles);
 
           codi.assertEqual(obj.layer.filter, expected_filter);
+        },
+      );
+
+      codi.it(
+        {
+          name: 'should return the input object if user_roles is not an array',
+          parentId: 'roles_module_objMerge',
+        },
+        () => {
+          const obj = { a: 1, b: 2 };
+          codi.assertEqual(objMerge(obj, 'not-array'), obj);
+        },
+      );
+
+      codi.it(
+        {
+          name: 'should handle objects with null/undefined nested values',
+          parentId: 'roles_module_objMerge',
+        },
+        () => {
+          const obj = {
+            nullValue: null,
+            undefinedValue: undefined,
+            roles: {
+              admin: { text: 'admin' }
+            }
+          };
+          const result = objMerge(obj, ['admin']);
+          codi.assertEqual(result.nullValue, null);
+          codi.assertEqual(result.undefinedValue, undefined);
+          codi.assertEqual(result.text, 'admin');
+        },
+      );
+
+      codi.it(
+        {
+          name: 'should handle roles object that is an array',
+          parentId: 'roles_module_objMerge',
+        },
+        () => {
+          const obj = {
+            data: 'test',
+            roles: ['admin', 'user']
+          };
+          const result = objMerge(obj, ['admin']);
+          codi.assertEqual(result, obj);
+        },
+      );
+
+      codi.it(
+        {
+          name: 'should handle roles object that is a function',
+          parentId: 'roles_module_objMerge',
+        },
+        () => {
+          const obj = {
+            data: 'test',
+            roles: () => 'function'
+          };
+          const result = objMerge(obj, ['admin']);
+          codi.assertEqual(result, obj);
+        },
+      );
+
+      codi.it(
+        {
+          name: 'should handle dot notation roles',
+          parentId: 'roles_module_objMerge',
+        },
+        () => {
+          const obj = {
+            roles: {
+              'namespace.admin': { text: 'admin' },
+              'namespace.user': { text: 'user' }
+            }
+          };
+          const result = objMerge(obj, ['admin']);
+          codi.assertEqual(result.text, 'admin');
+        },
+      );
+
+      codi.it(
+        {
+          name: 'should filter out roles with true values',
+          parentId: 'roles_module_objMerge',
+        },
+        () => {
+          const obj = {
+            roles: {
+              admin: true,
+              user: { text: 'user' }
+            }
+          };
+          const result = objMerge(obj, ['admin', 'user']);
+          codi.assertEqual(result.text, 'user');
+        },
+      );
+
+      codi.it(
+        {
+          name: 'should filter out roles with null values',
+          parentId: 'roles_module_objMerge',
+        },
+        () => {
+          const obj = {
+            roles: {
+              admin: null,
+              user: { text: 'user' }
+            }
+          };
+          const result = objMerge(obj, ['admin', 'user']);
+          codi.assertEqual(result.text, 'user');
+        },
+      );
+
+      codi.it(
+        {
+          name: 'should handle deep nested structures with roles at multiple levels',
+          parentId: 'roles_module_objMerge',
+        },
+        () => {
+          const obj = {
+            level1: {
+              level2: {
+                roles: {
+                  admin: { deepText: 'deep admin' }
+                }
+              },
+              roles: {
+                user: { midText: 'mid user' }
+              }
+            },
+            roles: {
+              root: { rootText: 'root' }
+            }
+          };
+          const result = objMerge(obj, ['admin', 'user', 'root']);
+          codi.assertEqual(result.rootText, 'root');
+          codi.assertEqual(result.level1.midText, 'mid user');
+          codi.assertEqual(result.level1.level2.deepText, 'deep admin');
+        },
+      );
+    },
+  );
+
+  codi.describe(
+    {
+      name: 'fromObj()',
+      id: 'roles_module_fromObj',
+      parentId: 'roles_module',
+    },
+    () => {
+      codi.it(
+        {
+          name: 'should add roles to Set',
+          parentId: 'roles_module_fromObj',
+        },
+        () => {
+          const rolesSet = new Set();
+          const obj = {
+            roles: {
+              admin: true,
+              user: true,
+              guest: true
+            }
+          };
+          fromObj(rolesSet, obj);
+          codi.assertEqual(rolesSet.has('admin'), true);
+          codi.assertEqual(rolesSet.has('user'), true);
+          codi.assertEqual(rolesSet.has('guest'), true);
+        },
+      );
+
+      codi.it(
+        {
+          name: 'should handle negated roles by removing ! prefix',
+          parentId: 'roles_module_fromObj',
+        },
+        () => {
+          const rolesSet = new Set();
+          const obj = {
+            roles: {
+              '!admin': true,
+              '!guest': true,
+              user: true
+            }
+          };
+          fromObj(rolesSet, obj);
+          codi.assertEqual(rolesSet.has('admin'), true);
+          codi.assertEqual(rolesSet.has('guest'), true);
+          codi.assertEqual(rolesSet.has('user'), true);
+          codi.assertEqual(rolesSet.has('!admin'), false);
+          codi.assertEqual(rolesSet.has('!guest'), false);
+        },
+      );
+
+      codi.it(
+        {
+          name: 'should recurse through nested objects',
+          parentId: 'roles_module_fromObj',
+        },
+        () => {
+          const rolesSet = new Set();
+          const obj = {
+            level1: {
+              roles: {
+                admin: true
+              },
+              level2: {
+                roles: {
+                  user: true
+                },
+                level3: {
+                  roles: {
+                    guest: true
+                  }
+                }
+              }
+            }
+          };
+          fromObj(rolesSet, obj);
+          codi.assertEqual(rolesSet.has('admin'), true);
+          codi.assertEqual(rolesSet.has('user'), true);
+          codi.assertEqual(rolesSet.has('guest'), true);
+        },
+      );
+
+      codi.it(
+        {
+          name: 'should handle arrays',
+          parentId: 'roles_module_fromObj',
+        },
+        () => {
+          const rolesSet = new Set();
+          const obj = {
+            items: [
+              {
+                roles: {
+                  admin: true
+                }
+              },
+              {
+                roles: {
+                  user: true
+                }
+              }
+            ]
+          };
+          fromObj(rolesSet, obj);
+          codi.assertEqual(rolesSet.has('admin'), true);
+          codi.assertEqual(rolesSet.has('user'), true);
+        },
+      );
+
+      codi.it(
+        {
+          name: 'should handle null and undefined values',
+          parentId: 'roles_module_fromObj',
+        },
+        () => {
+          const rolesSet = new Set();
+          const obj = {
+            nullValue: null,
+            undefinedValue: undefined,
+            roles: {
+              admin: true
+            }
+          };
+          fromObj(rolesSet, obj);
+          codi.assertEqual(rolesSet.has('admin'), true);
+        },
+      );
+
+      codi.it(
+        {
+          name: 'should not duplicate roles in Set',
+          parentId: 'roles_module_fromObj',
+        },
+        () => {
+          const rolesSet = new Set();
+          const obj = {
+            section1: {
+              roles: {
+                admin: true
+              }
+            },
+            section2: {
+              roles: {
+                admin: true,
+                user: true
+              }
+            }
+          };
+          fromObj(rolesSet, obj);
+          codi.assertEqual(rolesSet.size, 2);
+          codi.assertEqual(rolesSet.has('admin'), true);
+          codi.assertEqual(rolesSet.has('user'), true);
+        },
+      );
+
+      codi.it(
+        {
+          name: 'should handle empty objects',
+          parentId: 'roles_module_fromObj',
+        },
+        () => {
+          const rolesSet = new Set();
+          const obj = {};
+          fromObj(rolesSet, obj);
+          codi.assertEqual(rolesSet.size, 0);
+        },
+      );
+
+      codi.it(
+        {
+          name: 'should handle objects with no roles property',
+          parentId: 'roles_module_fromObj',
+        },
+        () => {
+          const rolesSet = new Set();
+          const obj = {
+            data: 'test',
+            nested: {
+              value: 'nested'
+            }
+          };
+          fromObj(rolesSet, obj);
+          codi.assertEqual(rolesSet.size, 0);
         },
       );
     },

--- a/tests/mod/utils/roles.test.mjs
+++ b/tests/mod/utils/roles.test.mjs
@@ -1,4 +1,4 @@
-import { check, objMerge, fromObj } from '../../../mod/utils/roles.js';
+import { check, fromObj, objMerge } from '../../../mod/utils/roles.js';
 
 codi.describe({ name: 'Roles Module', id: 'roles_module' }, async () => {
   codi.describe(
@@ -332,8 +332,8 @@ codi.describe({ name: 'Roles Module', id: 'roles_module' }, async () => {
             nullValue: null,
             undefinedValue: undefined,
             roles: {
-              admin: { text: 'admin' }
-            }
+              admin: { text: 'admin' },
+            },
           };
           const result = objMerge(obj, ['admin']);
           codi.assertEqual(result.nullValue, null);
@@ -350,7 +350,7 @@ codi.describe({ name: 'Roles Module', id: 'roles_module' }, async () => {
         () => {
           const obj = {
             data: 'test',
-            roles: ['admin', 'user']
+            roles: ['admin', 'user'],
           };
           const result = objMerge(obj, ['admin']);
           codi.assertEqual(result, obj);
@@ -365,7 +365,7 @@ codi.describe({ name: 'Roles Module', id: 'roles_module' }, async () => {
         () => {
           const obj = {
             data: 'test',
-            roles: () => 'function'
+            roles: () => 'function',
           };
           const result = objMerge(obj, ['admin']);
           codi.assertEqual(result, obj);
@@ -381,8 +381,8 @@ codi.describe({ name: 'Roles Module', id: 'roles_module' }, async () => {
           const obj = {
             roles: {
               'namespace.admin': { text: 'admin' },
-              'namespace.user': { text: 'user' }
-            }
+              'namespace.user': { text: 'user' },
+            },
           };
           const result = objMerge(obj, ['admin']);
           codi.assertEqual(result.text, 'admin');
@@ -398,8 +398,8 @@ codi.describe({ name: 'Roles Module', id: 'roles_module' }, async () => {
           const obj = {
             roles: {
               admin: true,
-              user: { text: 'user' }
-            }
+              user: { text: 'user' },
+            },
           };
           const result = objMerge(obj, ['admin', 'user']);
           codi.assertEqual(result.text, 'user');
@@ -415,8 +415,8 @@ codi.describe({ name: 'Roles Module', id: 'roles_module' }, async () => {
           const obj = {
             roles: {
               admin: null,
-              user: { text: 'user' }
-            }
+              user: { text: 'user' },
+            },
           };
           const result = objMerge(obj, ['admin', 'user']);
           codi.assertEqual(result.text, 'user');
@@ -433,16 +433,16 @@ codi.describe({ name: 'Roles Module', id: 'roles_module' }, async () => {
             level1: {
               level2: {
                 roles: {
-                  admin: { deepText: 'deep admin' }
-                }
+                  admin: { deepText: 'deep admin' },
+                },
               },
               roles: {
-                user: { midText: 'mid user' }
-              }
+                user: { midText: 'mid user' },
+              },
             },
             roles: {
-              root: { rootText: 'root' }
-            }
+              root: { rootText: 'root' },
+            },
           };
           const result = objMerge(obj, ['admin', 'user', 'root']);
           codi.assertEqual(result.rootText, 'root');
@@ -471,8 +471,8 @@ codi.describe({ name: 'Roles Module', id: 'roles_module' }, async () => {
             roles: {
               admin: true,
               user: true,
-              guest: true
-            }
+              guest: true,
+            },
           };
           fromObj(rolesSet, obj);
           codi.assertEqual(rolesSet.has('admin'), true);
@@ -492,8 +492,8 @@ codi.describe({ name: 'Roles Module', id: 'roles_module' }, async () => {
             roles: {
               '!admin': true,
               '!guest': true,
-              user: true
-            }
+              user: true,
+            },
           };
           fromObj(rolesSet, obj);
           codi.assertEqual(rolesSet.has('admin'), true);
@@ -514,19 +514,19 @@ codi.describe({ name: 'Roles Module', id: 'roles_module' }, async () => {
           const obj = {
             level1: {
               roles: {
-                admin: true
+                admin: true,
               },
               level2: {
                 roles: {
-                  user: true
+                  user: true,
                 },
                 level3: {
                   roles: {
-                    guest: true
-                  }
-                }
-              }
-            }
+                    guest: true,
+                  },
+                },
+              },
+            },
           };
           fromObj(rolesSet, obj);
           codi.assertEqual(rolesSet.has('admin'), true);
@@ -546,15 +546,15 @@ codi.describe({ name: 'Roles Module', id: 'roles_module' }, async () => {
             items: [
               {
                 roles: {
-                  admin: true
-                }
+                  admin: true,
+                },
               },
               {
                 roles: {
-                  user: true
-                }
-              }
-            ]
+                  user: true,
+                },
+              },
+            ],
           };
           fromObj(rolesSet, obj);
           codi.assertEqual(rolesSet.has('admin'), true);
@@ -573,8 +573,8 @@ codi.describe({ name: 'Roles Module', id: 'roles_module' }, async () => {
             nullValue: null,
             undefinedValue: undefined,
             roles: {
-              admin: true
-            }
+              admin: true,
+            },
           };
           fromObj(rolesSet, obj);
           codi.assertEqual(rolesSet.has('admin'), true);
@@ -591,15 +591,15 @@ codi.describe({ name: 'Roles Module', id: 'roles_module' }, async () => {
           const obj = {
             section1: {
               roles: {
-                admin: true
-              }
+                admin: true,
+              },
             },
             section2: {
               roles: {
                 admin: true,
-                user: true
-              }
-            }
+                user: true,
+              },
+            },
           };
           fromObj(rolesSet, obj);
           codi.assertEqual(rolesSet.size, 2);
@@ -631,8 +631,8 @@ codi.describe({ name: 'Roles Module', id: 'roles_module' }, async () => {
           const obj = {
             data: 'test',
             nested: {
-              value: 'nested'
-            }
+              value: 'nested',
+            },
           };
           fromObj(rolesSet, obj);
           codi.assertEqual(rolesSet.size, 0);


### PR DESCRIPTION
This PR adds the option to define a role as a dot seperated string. eg. `Europe.UK.brand_a`

The workspace roles method will pop the last part into the array of roles returned from the workspace.

A JSON object will be returned instead of an array with the `?tree=true` parameter.

eg.
```
{
  Europe: {
    UK: {
      brand_a: {}
    }
  }
}
```

The method to parse a Set of roles from workspace has been moved to the roles utility module.

Any current configurations should work as expected but it should be possible to define a nested structure in order to build an interface to define nested roles.

