### PR TITLE
Warning if both assign and merge provided

### DIFF
--- a/lib/ui/locations/infoj.mjs
+++ b/lib/ui/locations/infoj.mjs
@@ -209,6 +209,14 @@ function entryObject(entry) {
     entry.value = fieldEntry.value[entry.json_key];
   }
 
+  // Cannot have both objectAssignFromField and objectMergeFromField set to true.
+  if (entry.objectAssignFromField && entry.objectMergeFromField) {
+    console.warn(
+      `${entry.key}: objectAssignFromField and objectMergeFromField cannot both be used on the same entry.`,
+    );
+    return;
+  }
+
   if (entry.objectAssignFromField) {
     Object.assign(entry, fieldEntry.value);
   }


### PR DESCRIPTION
Added a warning if you provide both `objectAssignFromField` and `objectMergeFromField` as this is incompatible. 