### PR TITLE
(bug): Non cached file templates should not be merged on each fetch

### DIFF
--- a/mod/workspace/getTemplate.js
+++ b/mod/workspace/getTemplate.js
@@ -182,9 +182,7 @@ async function moduleTemplate(template, response) {
 @async
 
 @description
-The method merges the response object into the template and removes the src property. 
-
-The merged template object is assigned to the workspace. 
+The method assigns the response object to the template object and removes the src property. 
 
 This effectively caches the template since the src to fetch the template is removed.
 
@@ -201,7 +199,7 @@ A src property beginning with `file:` is not removed since file resources do not
 @returns {Promise<Object|Error>} JSON Template
 */
 async function cacheTemplate(workspace, template, response = {}) {
-  Object.assign(template, response)
+  Object.assign(template, response);
 
   if (template.src) {
     workspace.templates[template.key || template.src] = template;

--- a/mod/workspace/getTemplate.js
+++ b/mod/workspace/getTemplate.js
@@ -201,18 +201,15 @@ A src property beginning with `file:` is not removed since file resources do not
 @returns {Promise<Object|Error>} JSON Template
 */
 async function cacheTemplate(workspace, template, response = {}) {
-  // Get template from src.
-  template = merge(response, template);
+  Object.assign(template, response)
 
   if (template.src) {
     workspace.templates[template.key || template.src] = template;
 
-    delete template.src;
-
-    // TODO fix caching issue for file
-    // if (!template.src.startsWith('file:')) {
-    //   delete template.src;
-    // }
+    // file src templates should not be cached.
+    if (!template.src.startsWith('file:')) {
+      delete template.src;
+    }
   }
 
   return structuredClone(template);

--- a/mod/workspace/getTemplate.js
+++ b/mod/workspace/getTemplate.js
@@ -207,9 +207,12 @@ async function cacheTemplate(workspace, template, response = {}) {
   if (template.src) {
     workspace.templates[template.key || template.src] = template;
 
-    if (!template.src.startsWith('file:')) {
-      delete template.src;
-    }
+    delete template.src;
+
+    // TODO fix caching issue for file
+    // if (!template.src.startsWith('file:')) {
+    //   delete template.src;
+    // }
   }
 
   return structuredClone(template);


### PR DESCRIPTION
The cacheTemplate method should not merge the response into a template but assign the object.

This prevents arrays to increase in length when fetched multiple times from a file src.