### PR TITLE
(fix csv_upload): Csv upload schema fix

### DIFF
--- a/lib/utils/csvUpload.mjs
+++ b/lib/utils/csvUpload.mjs
@@ -55,8 +55,8 @@ The methods are used in the chunkRows method to convert the field values to the 
 @property {function} numeric Parse value as float.
 */
 const schemaMethods = {
-  int: (val) => parseInt(val.replace(/[^\d.-]/g, '')) || 'NULL',
-  numeric: (val) => parseFloat(val.replace(/[^\d.-]/g, '')) || 'NULL',
+  int: (val) => parseInt(val.replace(/[^\d.-]/g, '')) || null,
+  numeric: (val) => parseFloat(val.replace(/[^\d.-]/g, '')) || null,
   text: (val) => `${val.replace(/'/g, "''")}`,
 };
 


### PR DESCRIPTION
# Pull Request Template

## Description

We were incorrectly setting no value in the `int` and `numeric` methods to be 'NULL' (text null) which would then crash an insert when trying to insert text into a numeric field. 

This has been corrected by simply setting to `null` (numeric null). 

## GitHub Issue

Provide the link to the relevant GitHub issue it addresses.

## Type of Change

Please delete options that are not relevant, and select all options that apply.

- ✅ Bug fix (non-breaking change which fixes an issue)

## Testing Checklist

Please delete options that are not relevant, and select all options that apply.

- ✅ Existing Tests still pass
- ✅ Ran locally on my machine

## Code Quality Checklist

Please delete options that are not relevant, and select all options that apply.

- ✅ My code follows the guidelines of XYZ
- ✅ My code has been commented
- ✅ Documentation has been updated
- ✅ New and existing unit tests pass locally with my changes
- ✅ Main has been merged into this PR
