### PR TITLE
fix(vector): Feature count returns when array is empty

### DIFF
--- a/lib/layer/format/vector.mjs
+++ b/lib/layer/format/vector.mjs
@@ -125,6 +125,8 @@ export default function vector(layer) {
       const feature_counts = layer.cluster.source.getFeatures().map((F) => {
         const features = F.get('features');
 
+        if (!features.length) return;
+
         // Set cluster feature id for highlight interaction.
         F.set('id', features[0].get('id'), true);
 


### PR DESCRIPTION
In vector.mjs when feature count needed for clustering is called some feature arrays are empty and the first array entry features[0] doesn't exist.

Adds an earlier check on array length.