### PR TITLE
fix(vector): Cluster source change event method fails with empty features

### DIFF
--- a/lib/layer/featureFormats.mjs
+++ b/lib/layer/featureFormats.mjs
@@ -149,24 +149,25 @@ The cluster function processes an array of feature data and returns an array of 
 
 It creates Point geometries from coordinate pairs, extracts count and ID information, and assigns additional properties based on the layer's field definitions.
 
-The function also tracks the maximum count across all features in the layer.max_size property.
+The function also tracks the maximum count across all features in the layer.cluster.max_size property.
 
 @param {layer} layer A layer object, likely an OpenLayers layer.
 @param {Array} features An array of feature data, where each feature is represented as an array.
-@property {number} layer.max_size The maximum count across all features.
+@property {layer-cluster} layer.cluster The vector layer cluster configuration.
+@property {integer} cluster.max_size The length of features in the largest cluster feature.
 @property {Object} layer.params
 @property {Array} layer.params.fields Array of field names for additional feature properties.
 @returns {Array} Array of OpenLayers Feature objects.
 */
 export function cluster(layer, features) {
-  layer.max_size = 1;
+  layer.cluster.max_size = 1;
 
   return features.map((vals, i) => {
     const geometry = new ol.geom.Point(vals.shift());
 
     const count = vals.shift();
 
-    layer.max_size = layer.max_size > count ? layer.max_size : count;
+    layer.cluster.max_size = layer.cluster.max_size > count ? layer.cluster.max_size : count;
 
     const id = vals.shift();
 

--- a/lib/layer/featureFormats.mjs
+++ b/lib/layer/featureFormats.mjs
@@ -167,7 +167,8 @@ export function cluster(layer, features) {
 
     const count = vals.shift();
 
-    layer.cluster.max_size = layer.cluster.max_size > count ? layer.cluster.max_size : count;
+    layer.cluster.max_size =
+      layer.cluster.max_size > count ? layer.cluster.max_size : count;
 
     const id = vals.shift();
 

--- a/lib/layer/featureStyle.mjs
+++ b/lib/layer/featureStyle.mjs
@@ -150,11 +150,11 @@ export default function featureStyle(layer) {
       // The clusterScale will be added to the icon scale.
       feature.style.clusterScale = layer.style.cluster.logScale
         ? // A natural log will be applied to the cluster scaling.
-          (Math.log(clusterScale) / Math.log(layer.max_size)) *
+          (Math.log(clusterScale) / Math.log(layer.cluster?.max_size)) *
           Math.log(feature.properties.size || feature.properties.count)
         : // A fraction of the icon clusterScale will be added to the items scale for all but the biggest cluster location.
           1 +
-          (clusterScale / layer.max_size) *
+          (clusterScale / layer.cluster?.max_size) *
             (feature.properties.size || feature.properties.count);
     }
 

--- a/lib/layer/format/vector.mjs
+++ b/lib/layer/format/vector.mjs
@@ -74,6 +74,8 @@ export default function vector(layer) {
 
     if (!features) return;
 
+    console.log([features].flat());
+
     layer.source = new ol.source.Vector({
       features: await mapp.layer.featureFormats[layer.featureFormat](
         layer,
@@ -88,12 +90,32 @@ export default function vector(layer) {
     // Geojson is a cluster layer.
     if (layer.cluster?.distance) {
       // Create cluster source.
+
+      layer.featureGeoms = [];
       layer.cluster.source = new ol.source.Cluster({
         distance: layer.cluster.distance,
         source: layer.source,
+        geometryFunction: (feature) => {
+          const geom = feature.getGeometry();
+          layer.featureGeoms.push(geom);
+          return geom;
+        },
+        createCluster: (point, features) => {
+          console.log(point);
+          console.log(features);
+
+          if (!features.length) {
+            console.log(point.getGeometry())
+          }
+          return new ol.Feature({
+            geometry: point,
+            features: features,
+          });
+        },
       });
 
       layer.L.setSource(layer.cluster.source);
+
       return;
     }
 
@@ -122,8 +144,17 @@ export default function vector(layer) {
 
       delete layer.max_size;
 
+      console.log(layer.featureGeoms);
+
       const feature_counts = layer.cluster.source.getFeatures().map((F) => {
         const features = F.get('features');
+
+        console.log(features);
+
+        if (!features.length) {
+          console.log(F.getGeometry());
+          return;
+        }
 
         // Set cluster feature id for highlight interaction.
         F.set('id', features[0].get('id'), true);

--- a/lib/layer/format/vector.mjs
+++ b/lib/layer/format/vector.mjs
@@ -93,20 +93,7 @@ export default function vector(layer) {
 
       layer.cluster.source = new ol.source.Cluster({
         distance: layer.cluster.distance,
-        source: layer.source,
-        geometryFunction: (feature) => {
-          const geom = feature.getGeometry();
-          return geom;
-        },
-        createCluster: (point, features) => {
-          if (!features.length) {
-            console.log(point);
-          }
-          return new ol.Feature({
-            geometry: point,
-            features: features,
-          });
-        },
+        source: layer.source
       });
 
       layer.L.setSource(layer.cluster.source);

--- a/lib/layer/format/vector.mjs
+++ b/lib/layer/format/vector.mjs
@@ -93,7 +93,7 @@ export default function vector(layer) {
 
       layer.cluster.source = new ol.source.Cluster({
         distance: layer.cluster.distance,
-        source: layer.source
+        source: layer.source,
       });
 
       layer.L.setSource(layer.cluster.source);

--- a/lib/layer/format/vector.mjs
+++ b/lib/layer/format/vector.mjs
@@ -145,7 +145,6 @@ The clusterSourceChange event method is called by changes to the cluster source.
 @property {integer} cluster.max_size The length of features in the largest cluster feature.
 */
 function clusterSourceChange(e, layer) {
-
   delete layer.cluster.max_size;
 
   const features = layer.cluster.source.getFeatures();

--- a/lib/layer/format/vector.mjs
+++ b/lib/layer/format/vector.mjs
@@ -74,13 +74,13 @@ export default function vector(layer) {
 
     if (!features) return;
 
-    console.log([features].flat());
+    layer.Features = await mapp.layer.featureFormats[layer.featureFormat](
+      layer,
+      [features].flat(),
+    );
 
     layer.source = new ol.source.Vector({
-      features: await mapp.layer.featureFormats[layer.featureFormat](
-        layer,
-        [features].flat(),
-      ),
+      features: layer.Features,
     });
 
     delete layer.xhr;
@@ -91,21 +91,16 @@ export default function vector(layer) {
     if (layer.cluster?.distance) {
       // Create cluster source.
 
-      layer.featureGeoms = [];
       layer.cluster.source = new ol.source.Cluster({
         distance: layer.cluster.distance,
         source: layer.source,
         geometryFunction: (feature) => {
           const geom = feature.getGeometry();
-          layer.featureGeoms.push(geom);
           return geom;
         },
         createCluster: (point, features) => {
-          console.log(point);
-          console.log(features);
-
           if (!features.length) {
-            console.log(point.getGeometry())
+            console.log(point);
           }
           return new ol.Feature({
             geometry: point,
@@ -115,6 +110,8 @@ export default function vector(layer) {
       });
 
       layer.L.setSource(layer.cluster.source);
+
+      layer.cluster.source.on('change', (e) => clusterSourceChange(e, layer));
 
       return;
     }
@@ -135,51 +132,58 @@ export default function vector(layer) {
   });
 
   layer.setSource(layer.features);
+}
 
-  // Change method for the cluster feature properties and layer stats.
-  layer.cluster?.distance &&
-    layer.L.on('change', (e) => {
-      // To prevent layer.L.change() from crashing if called before data is loaded.
-      if (!layer.cluster.source) return;
+/**
+@function clusterSourceChange
 
-      delete layer.max_size;
+@description
+The clusterSourceChange event method is called by changes to the cluster source. The method will map all features in cluster source to return an array of features [counts] for each feature in the cluster source. The largest features count from the array will be assigned as the cluster.max_size.
 
-      console.log(layer.featureGeoms);
+@param {layer} layer The Mapp layer object.
+@property {layer-cluster} layer.cluster The vector layer cluster configuration.
+@property {integer} cluster.max_size The length of features in the largest cluster feature.
+*/
+function clusterSourceChange(e, layer) {
 
-      const feature_counts = layer.cluster.source.getFeatures().map((F) => {
-        const features = F.get('features');
+  delete layer.cluster.max_size;
 
-        console.log(features);
+  const features = layer.cluster.source.getFeatures();
 
-        if (!features.length) {
-          console.log(F.getGeometry());
-          return;
-        }
+  if (!features.length) return;
 
-        // Set cluster feature id for highlight interaction.
-        F.set('id', features[0].get('id'), true);
+  const feature_counts = features.map((F) => {
+    const features = F.get('features');
 
-        if (features.length > 1) {
-          // Set cluster count.
-          F.set('count', features.length, true);
-        } else {
-          const featureProperties = features[0].getProperties();
+    // This error indicates and issue with the provided feature geometries in the layer vector source.
+    if (!features.length) {
+      console.error(`Empty cluster feature detected.`);
+      return;
+    }
 
-          // Set feature properties for for single location cluster.
-          Object.entries(featureProperties).forEach((entry) => {
-            F.set(entry[0], entry[1], true);
-          });
-        }
+    // Set cluster feature id for highlight interaction.
+    F.set('id', features[0].get('id'), true);
 
-        // Return length for calculation of max_size.
-        return features.length;
+    if (features.length > 1) {
+      // Set cluster count.
+      F.set('count', features.length, true);
+    } else {
+      const featureProperties = features[0].getProperties();
+
+      // Set feature properties for for single location cluster.
+      Object.entries(featureProperties).forEach((entry) => {
+        F.set(entry[0], entry[1], true);
       });
+    }
 
-      if (!feature_counts.length) return;
+    // Return length for calculation of max_size.
+    return features.length;
+  });
 
-      // Calculate max_size for cluster size styling.
-      layer.max_size = Math.max(...feature_counts);
-    });
+  if (!feature_counts.length) return;
+
+  // Calculate max_size for cluster size styling.
+  layer.cluster.max_size = Math.max(...feature_counts);
 }
 
 /**


### PR DESCRIPTION
This PR creates the clusterSourceChange event method which is called by changes to the cluster source. Previously the logic was tied to the layer change event which caused execution on every render, eg when hovering over a cluster item. This also caused an issue where the method would be called when a layer is added to the map without any features added to the source.

The method will shortcircuit if the cluster source has no features. This should only happen if [all] features are removed from the source, eg. the source is cleared.

The cluster features map is throwing an error if a cluster feature has no features. This is likely to indicate invalid geometries in the vector source, eg. mixed projections.
