### PR TITLE
feat(util): scriptElement utils module and mapboxStyle format

### DIFF
--- a/lib/layer/format/mapboxStyle.mjs
+++ b/lib/layer/format/mapboxStyle.mjs
@@ -1,16 +1,17 @@
 /**
 ### /layer/formats/mapboxStyle
 
-The module imports ol-mapbox-style plugin for the native display of mapbox style tile layer in Openlayers.
+The mapboxStyle layer format requires the ol-mapbox-style plugin for the native display of mapbox style tile layer in Openlayers.
+
+The plugin is loaded from a script tag through the scriptElement utility method.
 
 CSP access to `unpkg.com` is required in order to import the ol-mapbox-style plugin.
 
-@requires ol-mapbox-style@12.6.1
+@requires ol-mapbox-style
+@requires /utils/scriptElement
 
 @module /layer/formats/mapboxStyle
 */
-
-import 'https://unpkg.com/ol-mapbox-style@12.6.1/dist/olms.js';
 
 /**
 @function mapboxStyle
@@ -26,6 +27,10 @@ The mapboxStyle method creates an Openlayers VectorTile layer and assigns a mapb
 @returns {layer} layer decorated with format methods.
 */
 export default async function mapboxStyle(layer) {
+  await mapp.utils.scriptElement(
+    'https://unpkg.com/ol-mapbox-style@13.0.1/dist/olms.js',
+  );
+
   layer.L = new ol.layer.VectorTile({
     declutter: true,
     zIndex: layer.zIndex,

--- a/lib/utils/_utils.mjs
+++ b/lib/utils/_utils.mjs
@@ -54,6 +54,7 @@ import ping from './ping.mjs';
 import { polygonIntersectFeatures } from './polygonIntersectFeatures.mjs';
 import promiseAll from './promiseAll.mjs';
 import queryParams from './queryParams.mjs';
+import scriptElement from './scriptElement.mjs';
 import * as svgSymbols from './svgSymbols.mjs';
 import svgTemplates from './svgTemplates.mjs';
 import { temporal } from './temporal.mjs';
@@ -90,6 +91,7 @@ export default {
   promiseAll,
   queryParams,
   render,
+  scriptElement,
   simpleStatistics,
   style,
   svg,

--- a/lib/utils/scriptElement.mjs
+++ b/lib/utils/scriptElement.mjs
@@ -24,12 +24,11 @@ The promise resolves with the load event.
 */
 export default async function scriptElement(module) {
   promises[module] ??= new Promise((resolve) => {
-
     const scriptEl = document.createElement('script');
     scriptEl.type = 'module';
-    scriptEl.src = module
+    scriptEl.src = module;
 
-    scriptEl.addEventListener('load', resolve)
+    scriptEl.addEventListener('load', resolve);
 
     document.head.append(scriptEl);
   });

--- a/lib/utils/scriptElement.mjs
+++ b/lib/utils/scriptElement.mjs
@@ -19,16 +19,17 @@ An existing promise will be awaited.
 
 The promise resolves with the load event.
 
-@param {string} src The script element src.
-@returns {Promise<Module>} The promise resolves to the load event for the script element.
+@param {string} module The script element src.
+@returns {Promise<Event>} The promise resolves to the load event for the script element.
 */
 export default async function scriptElement(module) {
-  promises[module] ??= new Promise((resolve) => {
+  promises[module] ??= new Promise((resolve, reject) => {
     const scriptEl = document.createElement('script');
     scriptEl.type = 'module';
     scriptEl.src = module;
 
     scriptEl.addEventListener('load', resolve);
+    scriptEl.addEventListener('error', reject);
 
     document.head.append(scriptEl);
   });

--- a/lib/utils/scriptElement.mjs
+++ b/lib/utils/scriptElement.mjs
@@ -1,0 +1,38 @@
+/**
+### /utils/scriptElement
+
+The module exports a default method to load scripts from tags.
+
+@module /utils/scriptElement
+*/
+
+const promises = {};
+
+/**
+@function scriptElement
+@async
+
+@description
+The scriptElement method adds a promise to the promises object for a script src to be loaded.
+
+An existing promise will be awaited.
+
+The promise resolves with the load event.
+
+@param {string} src The script element src.
+@returns {Promise<Module>} The promise resolves to the load event for the script element.
+*/
+export default async function scriptElement(module) {
+  promises[module] ??= new Promise((resolve) => {
+
+    const scriptEl = document.createElement('script');
+    scriptEl.type = 'module';
+    scriptEl.src = module
+
+    scriptEl.addEventListener('load', resolve)
+
+    document.head.append(scriptEl);
+  });
+
+  return await promises[module];
+}

--- a/tests/lib/utils/_utils.test.mjs
+++ b/tests/lib/utils/_utils.test.mjs
@@ -8,6 +8,7 @@ import { queryParams } from './queryParams.test.mjs';
 import { svgTemplates } from './svgTemplates.test.mjs';
 import { temporal } from './temporal.test.mjs';
 import { versionCheck } from './versionCheck.mjs';
+import { scriptElementTest } from './scriptElement.test.mjs';
 
 export const utilsTest = {
   compose,
@@ -21,6 +22,7 @@ export const utilsTest = {
   svgTemplates,
   temporal,
   versionCheck,
+  scriptElementTest,
 };
 
 function setup() {

--- a/tests/lib/utils/_utils.test.mjs
+++ b/tests/lib/utils/_utils.test.mjs
@@ -5,10 +5,10 @@ import { merge } from './merge.test.mjs';
 import { numericFormatter } from './numericFormatter.test.mjs';
 import { paramString } from './paramString.test.mjs';
 import { queryParams } from './queryParams.test.mjs';
+import { scriptElementTest } from './scriptElement.test.mjs';
 import { svgTemplates } from './svgTemplates.test.mjs';
 import { temporal } from './temporal.test.mjs';
 import { versionCheck } from './versionCheck.mjs';
-import { scriptElementTest } from './scriptElement.test.mjs';
 
 export const utilsTest = {
   compose,

--- a/tests/lib/utils/scriptElement.test.mjs
+++ b/tests/lib/utils/scriptElement.test.mjs
@@ -1,0 +1,37 @@
+import scriptElement from '../../../lib/utils/scriptElement.mjs';
+
+export function scriptElementTest() {
+  codi.describe(
+    { name: 'scriptElement:', id: 'utils_scriptElement', parentId: 'utils' },
+    () => {
+      codi.it(
+        {
+          name: 'loads a script and resolves on load',
+          parentId: 'utils_scriptElement',
+        },
+        async () => {
+          // Setup: Remove any existing test script
+          const testSrc =
+            'https://unpkg.com/ol-mapbox-style@13.0.1/dist/olms.js';
+
+          let appended = false;
+          const origAppend = document.head.append;
+          document.head.append = function (el) {
+            appended = true;
+            origAppend.call(this, el);
+          };
+
+          const result = await scriptElement(testSrc);
+          codi.assertTrue(appended, 'Script element should be appended');
+          codi.assertEqual(
+            result.type,
+            'load',
+            'Should resolve with load event',
+          );
+
+          document.head.append = origAppend;
+        },
+      );
+    },
+  );
+}


### PR DESCRIPTION
The PR adds a utility method to load a script by adding a script element tag to the document head.

The load process will be assigned to a promises object to prevent the same script [src] to be loaded multiple times.

The utility is required to load the mapboxStyle plugin.

The import of the mapboxStyle plugin will throw an exception if Openlayers is not loaded. This will make it impossible to use the mapp library without Openlayers.