### PR TITLE
Disable geometry entry if api method fails to assign a value.

### DIFF
--- a/lib/ui/locations/entries/geometry.mjs
+++ b/lib/ui/locations/entries/geometry.mjs
@@ -149,6 +149,9 @@ A new OL vector layer entry.L will be created and added to the mapview.
 @this infoj-entry
 */
 async function show() {
+  // Do not show the geometry if the entry has been disabled.
+  if (this.disabled) return;
+
   this.display = true;
 
   // the show event maybe triggered by an API, draw, or modify interaction.
@@ -163,6 +166,11 @@ async function show() {
     this.blocking && this.location.view?.classList.add('disabled');
 
     await this.api(this);
+
+    // A value will not be assigned if the api method request fails.
+    if (!this.value) {
+      this.disabled = true;
+    }
   }
 
   if (this.L) {


### PR DESCRIPTION
A geometry entry must be disabled if the API method fails to assign a value.

The API method should not be called [again] if an entry is diabled.

The chkbox element will be shown as disabled.

![image](https://github.com/user-attachments/assets/bf505374-f635-4cba-bf95-e31a5cd418ac)
