### PR TITLE
fix(layer.entries) - Queryparams from layer and locale must be assigned to entry

### DIFF
--- a/lib/ui/locations/entries/layer.mjs
+++ b/lib/ui/locations/entries/layer.mjs
@@ -227,6 +227,13 @@ async function showLayer() {
   const entry = this;
 
   if (entry.query) {
+    // Assign queryparams from layer, locale.
+    entry.queryparams = {
+      ...entry.location?.layer?.mapview?.locale?.queryparams,
+      ...entry.location?.layer?.queryparams,
+      ...entry.queryparams,
+    };
+
     const paramString = mapp.utils.paramString(mapp.utils.queryParams(entry));
 
     entry.data = await mapp.utils.xhr(


### PR DESCRIPTION
Queryparams from the `layer` and `locale` must be assigned to the `type:layer` entry. This is the identical format to how entry dataviews work and prevents issue where a parameter is defined just once in the `locale` - but is not accessible for `layer` entry queries. 

To test this - simply add queryparams to the `locale` and/or `layer`. 
E.g. 
``` json
"locale": {
"queryparams": {
  "testme": 123
 }
}
```
And check that your type layer entry query contains them in the paramstring 