### PR TITLE
security(api): remove user controlled data (#2216)

### DIFF
--- a/mod/user/saml.js
+++ b/mod/user/saml.js
@@ -90,6 +90,7 @@ This module handles SAML-based Single Sign-On (SSO) authentication. Here's how t
 @property {number} acceptedClockSkewMs - Allowed clock skew in milliseconds
 @property {string} providerName - Name of the Service Provider
 @property {string} logoutCallbackUrl - URL for logout callbacks
+@property {boolean} disableRequestedAuthnContext - If true, disables sending the AuthnContext in SAML authentication requests. Useful for IdPs that do not require or support AuthnContext, or for compatibility with certain SAML providers.
 **/
 
 import { readFileSync } from 'fs';
@@ -141,6 +142,8 @@ const getModule = async () => {
       signatureAlgorithm: xyzEnv.SAML_SIGNATURE_ALGORITHM,
       wantAssertionsSigned: xyzEnv.SAML_WANT_ASSERTIONS_SIGNED,
       wantAuthnResponseSigned: xyzEnv.SAML_AUTHN_RESPONSE_SIGNED ?? false,
+      disableRequestedAuthnContext:
+        xyzEnv.SAML_DISABLE_REQUESTED_AUTHN_CONTEXT ?? true,
     };
 
     // Create SAML strategy instance


### PR DESCRIPTION
## Summary

This PR introduces a new configuration option, `disableRequestedAuthnContext`, to the SAML module.
This flag allows service providers to control whether the `AuthnContext` is included in SAML authentication requests.
It is particularly useful for compatibility with Identity Providers (IdPs) that do not require or support the `AuthnContext` element.

## Details

- **New Option:**
  `disableRequestedAuthnContext` (boolean)
  When set to `true`, the SAML module will not include the `AuthnContext` in authentication requests. This can resolve compatibility issues with certain IdPs or simplify integration where authentication context is not needed.

- **Default Behavior:**
  The flag defaults to `true` if not explicitly set via the environment variable `SAML_DISABLE_REQUESTED_AUTHN_CONTEXT`.

- **Use Case:**
  Some IdPs (or legacy SAML setups) may reject requests containing an `AuthnContext` or may not require it for successful authentication. This flag provides flexibility for such scenarios.

### Documentation Update

The `@typedef {Object} SamlConfig` JSDoc block now includes:

```
@property {boolean} disableRequestedAuthnContext - If true, disables sending the AuthnContext in SAML authentication requests. Useful for IdPs that do not require or support AuthnContext, or for compatibility with certain SAML providers.
```

### Example Usage

```js
samlConfig = {
  // ...other config...
  disableRequestedAuthnContext:
    xyzEnv.SAML_DISABLE_REQUESTED_AUTHN_CONTEXT ?? true,
};
```

#### How to Enable

Set the following environment variable in your deployment:

```bash
"SAML_DISABLE_REQUESTED_AUTHN_CONTEXT":"true"
```

### Why?

This change increases the flexibility and compatibility of the SAML integration, making it easier to work with a wider range of IdPs and SAML configurations.