### PR TITLE
bug(dialog): Fix alignment of buttons 

### DIFF
--- a/lib/ui/elements/dialog.mjs
+++ b/lib/ui/elements/dialog.mjs
@@ -88,9 +88,10 @@ export default function dialog(dialog) {
     class="material-symbols-outlined close"
     onclick=${closeDialog}>`;
 
-  dialog.header = !(dialog.header instanceof HTMLElement)
-    ? mapp.utils.html`<h2>${dialog.header}`
-    : dialog.header;
+  dialog.header =
+    dialog.header instanceof HTMLElement
+      ? dialog.header
+      : mapp.utils.html`<h2>${dialog.header}`;
 
   dialog.headerHtml = mapp.utils.html`<header
     class=${dialog.headerDrag ? 'headerDrag' : ''}>

--- a/lib/ui/elements/dialog.mjs
+++ b/lib/ui/elements/dialog.mjs
@@ -88,6 +88,10 @@ export default function dialog(dialog) {
     class="material-symbols-outlined close"
     onclick=${closeDialog}>`;
 
+  dialog.header = !(dialog.header instanceof HTMLElement)
+    ? mapp.utils.html`<h2>${dialog.header}`
+    : dialog.header;
+
   dialog.headerHtml = mapp.utils.html`<header
     class=${dialog.headerDrag ? 'headerDrag' : ''}>
     ${dialog.header}${dialog.minimizeBtn}${dialog.closeBtn}`;

--- a/tests/lib/ui/elements/dialog.test.mjs
+++ b/tests/lib/ui/elements/dialog.test.mjs
@@ -35,6 +35,23 @@ export function dialog() {
           const dialog = mapp.ui.elements.dialog({ ...params });
 
           /**
+           * The dialog header should be an html element
+           * @function it
+           */
+          codi.it(
+            {
+              name: 'Dialog header should be an html element',
+              parentId: 'ui_elements_dialog',
+            },
+            () => {
+              codi.assertTrue(
+                dialog.header.type === 'html',
+                'The dialog header should be am html element',
+              );
+            },
+          );
+
+          /**
            * The dialog should be able to close
            * @function it
            */
@@ -125,19 +142,21 @@ export function dialog() {
 
           const dialog = mapp.ui.elements.dialog(new_params);
 
-          dialog.node
-            .querySelector('#Map > dialog > header > button:nth-child(1)')
-            .dispatchEvent(new Event('click'));
+          const minimizeBtn = dialog.node.querySelector('[data-id=minimize]');
+
+          minimizeBtn.dispatchEvent(new Event('click'));
+
           let minimized = dialog.node.classList.contains('minimized');
+
           codi.assertTrue(
             minimized,
             'The dialog content should not be visible',
           );
 
-          dialog.node
-            .querySelector('#Map > dialog > header > button:nth-child(1)')
-            .dispatchEvent(new Event('click'));
+          minimizeBtn.dispatchEvent(new Event('click'));
+
           minimized = dialog.node.classList.contains('minimized');
+
           codi.assertFalse(
             minimized,
             'The dialog content should not be visible',


### PR DESCRIPTION
## Description
A header of a dialog can be supplied as text, this causes erroneous behaviour with the buttons in the header:
![Screenshot from 2025-06-30 15-02-43](https://github.com/user-attachments/assets/d6e42917-b91a-4b10-a63d-444c141efa5b)

This PR turns the text that was supplied, into an `h2` htmlElement:
![Screenshot from 2025-06-30 15-03-49](https://github.com/user-attachments/assets/2757d700-712e-4449-9d43-3ded89328cb2)


## GitHub Issue
[#2227](https://github.com/GEOLYTIX/xyz/issues/2227)

## Type of Change
- ✅ Bug fix (non-breaking change which fixes an issue)

## How have you tested this?
tested locally on `bugs_testing\ui_elements\worskpace.json`

## Testing Checklist

Please delete options that are not relevant, and select all options that apply.
- ✅ Existing Tests still pass
- ✅ Ran locally on my machine

## Code Quality Checklist
- ✅ My code follows the guidelines of XYZ
- ✅ My code has been commented
- ✅ Documentation has been updated
- ✅ New and existing unit tests pass locally with my changes
- ✅ Main has been merged into this PR
