### PR TITLE
Review node mailer conditions, defaults and warnings.

### DIFF
--- a/mod/utils/mailer.js
+++ b/mod/utils/mailer.js
@@ -1,13 +1,15 @@
 /**
-@module /utils/mailer
-@description
+## /utils/mailer
 The mailer module provides a way to send emails to clients/admins, etc.
 
-@requires module:/utils/logger
-@requires module:/utils/languageTemplates
-@requires module:/provider/getFrom
+The nodemailer dependency will be imported dynamically on the condition that a TRANSPORT_EMAIL [sender] is defined the process environment.
 
 @requires nodemailer
+@requires /utils/logger
+@requires /utils/languageTemplates
+@requires /provider/getFrom
+
+@module /utils/mailer
 */
 
 import getFrom from '../provider/getFrom.js';
@@ -18,16 +20,7 @@ import logger from './logger.js';
 //Attempt to import node mailer
 let nodeMailer, transport;
 
-if (xyzEnv.TRANSPORT) {
-  console.warn(
-    'Please replace xyzEnv.TRANSPORT with TRANSPORT_HOST,TRANSPORT_EMAIL, and TRANSPORT_PASSWORD',
-  );
-} else if (
-  xyzEnv.TRANSPORT_EMAIL ||
-  xyzEnv.TRANSPORT_USERNAME ||
-  xyzEnv.TRANSPORT_HOST ||
-  xyzEnv.TRANSPORT_PASSWORD
-) {
+if (xyzEnv.TRANSPORT_EMAIL && xyzEnv.TRANSPORT_HOST) {
   try {
     nodeMailer = await import('nodemailer');
   } catch {
@@ -51,33 +44,18 @@ Function which sends email using the nodemailer dependancy.
 @property {String} params.host The URL of the instance.
 */
 async function mailer(params) {
-  // The nodeMailer module could not be imported.
+  // The nodeMailer module is not available.
   if (!nodeMailer) return;
-
-  if (!xyzEnv.TRANSPORT_HOST) {
-    console.warn('xyzEnv.TRANSPORT_HOST missing.');
-    return;
-  }
-
-  if (!xyzEnv.TRANSPORT_EMAIL) {
-    console.warn('xyzEnv.TRANSPORT_EMAIL is missing.');
-    return;
-  }
-
-  if (!xyzEnv.TRANSPORT_PASSWORD) {
-    console.warn('xyzEnv.TRANSPORT_PASSWORD missing.');
-    return;
-  }
 
   if (!transport) {
     transport = nodeMailer.createTransport({
       auth: {
-        pass: xyzEnv.TRANSPORT_PASSWORD,
         user: xyzEnv.TRANSPORT_USERNAME || xyzEnv.TRANSPORT_EMAIL,
+        pass: xyzEnv.TRANSPORT_PASSWORD,
       },
       host: xyzEnv.TRANSPORT_HOST,
       name: xyzEnv.TRANSPORT_NAME || xyzEnv.TRANSPORT_EMAIL.split('@')[0],
-      port: xyzEnv.TRANSPORT_PORT || 587,
+      port: xyzEnv.TRANSPORT_PORT,
       requireTLS: xyzEnv.TRANSPORT_TLS,
       secure: false,
       tls: {

--- a/mod/utils/processEnv.js
+++ b/mod/utils/processEnv.js
@@ -28,13 +28,12 @@ The process.ENV object holds configuration provided to the node process from the
 @property {String} [RETRY_LIMIT='3'] The [utils/dbs module]{@link module:/utils/dbs} will apply the RETRY_LIMIT to the query.client.
 @property {String} [WORKSPACE_AGE] The [workspace/cache module]{@link module:/mod/workspace/cache} flashes the workspace cache after the WORKSPACE_AGE is reached.
 @property {String} [CUSTOM_TEMPLATES] The [workspace/cache module]{@link module:/mod/workspace/cache} caches templates defined as a src in the CUSTOM_TEMPLATES xyzEnv.
-@property {String} [TRANSPORT] The [utils/mailer module]{@link module:/utils/mailer} requires a TRANSPORT xyzEnv.
 @property {String} [TRANSPORT_HOST] The hostname or IP address that the [utils/mailer module]{@link module:/utils/mailer} module connects to.
 @property {String} [TRANSPORT_NAME] The optional hostname of the client, used for identifying to the server in the [utils/mailer module]{@link module:/utils/mailer} module.
 @property {String} [TRANSPORT_EMAIL] The email used to send emails in the [utils/mailer module]{@link module:/utils/mailer} module.
 @property {String} [TRANSPORT_USERNAME] The username used to authenticate in the [utils/mailer module]{@link module:/utils/mailer} module.
 @property {String} [TRANSPORT_PASSWORD] The password used to authenticate in the [utils/mailer module]{@link module:/utils/mailer} module.
-@property {String} [TRANSPORT_PORT] The port used to connect to the host in the [utils/mailer module]{@link module:/utils/mailer} module.
+@property {Integer} [TRANSPORT_PORT] The port used to connect to the host in the [utils/mailer module]{@link module:/utils/mailer} module.
 @property {String} [TRANSPORT_TLS] defines additional node.js TLSSocket options to be passed to the socket constructor used in the [utils/mailer module]{@link module:/utils/mailer} module.
 @property {String} [USER_DOMAINS] The [user/register module]{@link module:/user/register} will limit the registration to user emails for domains provided in the comma seperated USER_DOMAINS xyzEnv.
 @property {String} [SRC_] SRC_* values will replace the key wildcard [*] in the stringified workspace.
@@ -60,35 +59,38 @@ const defaults = {
   COOKIE_TTL: 36000,
   DIR: '',
   FAILED_ATTEMPTS: 3,
-  PORT: 3000, // age in ms
+  PORT: 3000,
   RATE_LIMIT: 1000,
   RATE_LIMIT_WINDOW: 60 * 1000,
   RETRY_LIMIT: 3,
   TITLE: 'GEOLYTIX | XYZ',
-  TRANSPORT_TLS: false, //1000 requests per 1min
+  TRANSPORT_PORT: 587,
+  TRANSPORT_TLS: false,
   WORKSPACE_AGE: 3600000, // 1 min
 };
 
-process.env.PORT ??= defaults.PORT;
-process.env.DIR ??= defaults.DIR;
-process.env.TITLE ??= defaults.TITLE;
-process.env.WORKSPACE_AGE ??= defaults.WORKSPACE_AGE;
 process.env.COOKIE_TTL ??= defaults.COOKIE_TTL;
+process.env.DIR ??= defaults.DIR;
 process.env.FAILED_ATTEMPTS ??= defaults.FAILED_ATTEMPTS;
-process.env.RETRY_LIMIT ??= defaults.RETRY_LIMIT;
-process.env.TRANSPORT_TLS ??= defaults.TRANSPORT_TLS;
+process.env.PORT ??= defaults.PORT;
 process.env.RATE_LIMIT_WINDOW ??= defaults.RATE_LIMIT_WINDOW;
 process.env.RATE_LIMIT ??= defaults.RATE_LIMIT;
+process.env.RETRY_LIMIT ??= defaults.RETRY_LIMIT;
+process.env.TITLE ??= defaults.TITLE;
+process.env.TRANSPORT_PORT ??= defaults.TRANSPORT_PORT;
+process.env.TRANSPORT_TLS ??= defaults.TRANSPORT_TLS;
+process.env.WORKSPACE_AGE ??= defaults.WORKSPACE_AGE;
 
 const xyzEnv = {
   COOKIE_TTL: parseInt(process.env.COOKIE_TTL),
   DIR: process.env.DIR,
   FAILED_ATTEMPTS: process.env.FAILED_ATTEMPTS,
-  PORT: process.env.PORT,
+  PORT: parseInt(process.env.PORT),
   RATE_LIMIT: process.env.RATE_LIMIT,
   RATE_LIMIT_WINDOW: process.env.RATE_LIMIT_WINDOW,
   RETRY_LIMIT: process.env.RETRY_LIMIT,
   TITLE: process.env.TITLE,
+  TRANSPORT_PORT: parseInt(process.env.TRANSPORT_PORT),
   TRANSPORT_TLS: process.env.TRANSPORT_TLS,
   WORKSPACE_AGE: process.env.WORKSPACE_AGE,
 };

--- a/tests/mod/user/register.test.mjs
+++ b/tests/mod/user/register.test.mjs
@@ -9,6 +9,11 @@ console.warn = (log) => {
   mockWarn.push(log);
 };
 
+const mockMailerFn = codi.mock.fn();
+const mockMailer = codi.mock.module('../../../mod/utils/mailer.js', {
+  defaultExport: mockMailerFn,
+});
+
 await codi.describe(
   { name: 'register: ', id: 'user_register', parentId: 'user' },
   async () => {
@@ -114,3 +119,4 @@ await codi.describe(
 );
 
 console.warn = originalWarn;
+mockMailer.restore();


### PR DESCRIPTION
The TRANSPORT_PORT should be assigned as default in the processEnv. The defaults assignment has been alphabetically ordered.

The TRANSPORT param check and warning has now been removed.

The condition for the import should be on TRANSPORT_EMAIL and TRANSPORT_HOST which are both required not either or others.

The warnings have been removed nodemailer will will not be available without the TRANSPORT_EMAIL and TRANSPORT_HOST condition.

The password can only be checked when sending an email which will log an error in this regard.
