### PR TITLE
The selected titles should not be assigned with the keepPlaceholder option

### DIFF
--- a/lib/ui/elements/dropdown.mjs
+++ b/lib/ui/elements/dropdown.mjs
@@ -100,12 +100,14 @@ function selectOnChange(e, params) {
       params.pills?.remove(entry.title);
     }
 
-    if (!params.pills) {
+    if (!params.pills && !params.keepPlaceholder) {
+      // join selectedTitles set
+      const placeholderTitles =
+        params.selectedTitles?.size &&
+        Array.from(params.selectedTitles).join(', ');
+
       params.placeHolderOption.textContent =
-        // join selected titles if available.
-        (params.selectedTitles.size > 0 &&
-          Array.from(params.selectedTitles).join(', ')) ||
-        params.placeholder;
+        placeholderTitles || params.placeholder;
     }
 
     params.callback?.(e, [...params.selectedOptions]);


### PR DESCRIPTION
The placeholder should not be replaced with selected titles if the keepPlaceholder flag is true in the config.

The placeholderTitle string is created prior to assignment to prevent a nested condition.