### PR TITLE
feat(style.icon_scaling): Add fields array option, to allow for scaling field selection.

### DIFF
--- a/lib/layer/featureStyle.mjs
+++ b/lib/layer/featureStyle.mjs
@@ -63,6 +63,9 @@ export default function featureStyle(layer) {
     // Assign selected style if required.
     selectedStyle(feature);
 
+    // IconScalingStyle will scale icons based on the feature properties
+    iconScalingStyle(feature);
+
     return mapp.utils.style(feature.style, feature);
   };
 
@@ -251,5 +254,40 @@ export default function featureStyle(layer) {
     if (layer.mapview?.locations[`${layer.key}!${feature.properties.id}`]) {
       feature.style = layer.style.selected;
     }
+  }
+
+  function iconScalingStyle(feature) {
+    if (!layer.style.icon_scaling?.field) return;
+
+    let fieldValue = Number(feature.properties[layer.style.icon_scaling.field]);
+
+    console.log(feature.properties);
+
+    if (feature.properties.features?.length > 1) {
+      // Do not scale cluster feature icons.
+      if (!layer.style.icon_scaling.cluster) return;
+
+      fieldValue = 0;
+
+      feature.properties.features.forEach((f) => {
+        // Add field value of each feature in cluster.
+        fieldValue += Number(
+          f.getProperties().properties[layer.style.icon_scaling.field],
+        );
+      });
+
+      if (layer.style.icon_scaling.cluster === 'avg') {
+        // Average fieldValue by dividing the cluster size.
+        fieldValue /= feature.properties.features.length;
+      }
+    }
+
+    if (isNaN(fieldValue)) return;
+
+    const factor =
+      layer.style.icon_scaling.scaleFactor || layer.style.icon_scaling.max || 1;
+
+    // fieldScale must be bigger than 1 to prevent shrinking.
+    feature.style.fieldScale = 1 + fieldValue / factor;
   }
 }

--- a/lib/ui/elements/layerStyle.mjs
+++ b/lib/ui/elements/layerStyle.mjs
@@ -441,6 +441,33 @@ function icon_scaling(layer) {
     );
   }
 
+  if (layer.style.icon_scaling.fields) {
+    const entries = layer.style.icon_scaling.fields.map((val) => ({
+      option: val,
+      title: val,
+    }));
+
+    entries.push({ title: 'No Scaling' });
+
+    content.push(
+      mapp.ui.elements.dropdown({
+        data_id: 'iconScalingFieldsDropdown',
+        label: mapp.dictionary.icon_scaling_field,
+        entries: entries,
+        callback: async (e, options) => {
+          if (options.option) layer.style.icon_scaling.field = options.option;
+          else delete layer.style.icon_scaling.field;
+
+          layer.reload();
+          layer.L.changed();
+        },
+        placeholder:
+          layer.style.icon_scaling.placeholder ||
+          mapp.dictionary.layer_filter_dropdown_select,
+      }),
+    );
+  }
+
   if (layer.style.icon_scaling.icon) {
     layer.style.default.scale ??= 1;
 


### PR DESCRIPTION
## Description
Adds a fields property to style.icon_scaling to allow the user to pick which field to scale on

## GitHub Issue
[#1458](https://github.com/GEOLYTIX/xyz/issues/1458)

## Type of Change
- ✅ Bug fix (non-breaking change which fixes an issue)
- ✅ New feature (non-breaking change which adds functionality)
- ✅ Documentation
- ✅ Testing

## How have you tested this?

Please describe how to test this change and how you verified it worked.

## Testing Checklist
- ✅ Existing Tests still pass
- ✅ Updated Existing Tests
- ✅ New Tests Added
- ✅ Ran locally on my machine

## Code Quality Checklist
- ✅ My code follows the guidelines of XYZ
- ✅ My code has been commented
- ✅ Documentation has been updated
- ✅ New and existing unit tests pass locally with my changes
- ✅ Main has been merged into this PR
