### PR TITLE
add iconstyling function

### DIFF
--- a/lib/layer/featureStyle.mjs
+++ b/lib/layer/featureStyle.mjs
@@ -63,6 +63,9 @@ export default function featureStyle(layer) {
     // Assign selected style if required.
     selectedStyle(feature);
 
+    // IconScalingStyle will scale icons based on the feature properties
+    iconScalingStyle(feature);
+
     return mapp.utils.style(feature.style, feature);
   };
 
@@ -251,5 +254,47 @@ export default function featureStyle(layer) {
     if (layer.mapview?.locations[`${layer.key}!${feature.properties.id}`]) {
       feature.style = layer.style.selected;
     }
+  }
+
+  /**
+  @function iconScalingStyle
+  @description
+  Applies the icon scale to based on the field supplied in layer.style.icon_scaling.field
+
+  @param {Object} feature The feature object.
+  */
+  function iconScalingStyle(feature) {
+    if (!layer.style.icon_scaling?.field) return;
+
+    let fieldValue = Number(feature.properties[layer.style.icon_scaling.field]);
+
+    console.log(feature.properties);
+
+    if (feature.properties.features?.length > 1) {
+      // Do not scale cluster feature icons.
+      if (!layer.style.icon_scaling.cluster) return;
+
+      fieldValue = 0;
+
+      feature.properties.features.forEach((f) => {
+        // Add field value of each feature in cluster.
+        fieldValue += Number(
+          f.getProperties().properties[layer.style.icon_scaling.field],
+        );
+      });
+
+      if (layer.style.icon_scaling.cluster === 'avg') {
+        // Average fieldValue by dividing the cluster size.
+        fieldValue /= feature.properties.features.length;
+      }
+    }
+
+    if (isNaN(fieldValue)) return;
+
+    const factor =
+      layer.style.icon_scaling.scaleFactor || layer.style.icon_scaling.max || 1;
+
+    // fieldScale must be bigger than 1 to prevent shrinking.
+    feature.style.fieldScale = 1 + fieldValue / factor;
   }
 }


### PR DESCRIPTION
## Description
Currently the style.icon_scaling.field property does not scale the icons according the field.
This PR adds in the necessary functionality to fix the scaling

## GitHub Issue
[#2251](https://github.com/GEOLYTIX/xyz/issues/2251)

## Type of Change
- ✅ Bug fix (non-breaking change which fixes an issue)
- ✅ Documentation
- ✅ Testing

## How have you tested this?

tested locally on `bugs_testing/styles/icon_scaling.json`

## Testing Checklist
- ✅ Existing Tests still pass
- ✅ Updated Existing Tests
- ✅ New Tests Added
- ✅ Ran locally on my machine

## Code Quality Checklist
- ✅ My code follows the guidelines of XYZ
- ✅ My code has been commented
- ✅ Documentation has been updated
- ✅ New and existing unit tests pass locally with my changes
- ✅ Main has been merged into this PR
