### PR TITLE
DRAFT WHILE TESTING - fix(panels/dataviews): When layer is turned off, dataviews are not removed.

### DIFF
--- a/lib/ui/layers/panels/dataviews.mjs
+++ b/lib/ui/layers/panels/dataviews.mjs
@@ -108,7 +108,7 @@ export default function dataviews(layer) {
 @description
 Adds show and hide methods for dataviews with a tabview target
 
-@param {layer} dataview The dataview to add the show nad hide functions to.
+@param {layer} dataview The dataview to add the show and hide functions to.
 */
 function populateTabview(dataview) {
   dataview.tabview = document.querySelector(`[data-id=${dataview.target}]`);
@@ -127,7 +127,11 @@ function populateTabview(dataview) {
 
     dataview.hide ??= () => {
       dataview.display = false;
-      dataview.remove();
+
+      // Remove tab after dataview is hidden.
+      dataview.tabview.dispatchEvent(
+        new CustomEvent('removeTab', { detail: dataview }),
+      );
     };
   }
 }


### PR DESCRIPTION
The `populateTabview` method has been amended to call the `removeTab` method instead of the non-existent `.remove()` method. 
This fixes the described issue as the dataview is correctly removed when the layer is turned off. 

``` js
function populateTabview(dataview) {
  dataview.tabview = document.querySelector(`[data-id=${dataview.target}]`);

  // Return if the named tabview is not found in document.
  if (dataview.tabview) {
    dataview.show ??= () => {
      // Create tab after dataview creation is complete.
      dataview.tabview.dispatchEvent(
        new CustomEvent('addTab', { detail: dataview }),
      );

      // Show the dataview tab.
      dataview.show();
    };

    dataview.hide ??= () => {
      dataview.display = false;

      // Remove tab after dataview is hidden.
      dataview.tabview.dispatchEvent(
        new CustomEvent('removeTab', { detail: dataview }),
      );
    };
  }
}
```