### PR TITLE
layer hideCallback must conditionally check for display of the datavi…

### DIFF
--- a/lib/ui/layers/panels/dataviews.mjs
+++ b/lib/ui/layers/panels/dataviews.mjs
@@ -70,8 +70,10 @@ export default function dataviews(layer) {
     });
 
     layer.hideCallbacks.push(() => {
-      dataview.chkbox.querySelector('input').checked = false;
-      dataview.hide();
+      if (dataview.display) {
+        dataview.chkbox.querySelector('input').checked = false;
+        dataview.hide();
+      }
     });
 
     content.push(dataview.chkbox);


### PR DESCRIPTION
layer hideCallback must conditionally check for display of the dataview before calling hide

This prevents an error whereby an error is thrown that `dataview.remove() is undefined`. 