### PR TITLE
fix(gazetteer): Use object assign to prevent duplicated search results

### DIFF
--- a/lib/utils/gazetteer.mjs
+++ b/lib/utils/gazetteer.mjs
@@ -66,14 +66,14 @@ export function datasets(term, gazetteer) {
 
   // Search additional datasets.
   gazetteer.datasets?.forEach((dataset) => {
-    const mergeddataset = {
+    Object.assign(dataset, {
       // Merge the gazetteer and dataset objects
       // Ensuring that the dataset takes precedence over the gazetteer
       ...gazetteer,
       ...dataset,
-    };
+    });
 
-    search(term, mergeddataset);
+    search(term, dataset);
   });
 }
 

--- a/tests/lib/utils/_utils.test.mjs
+++ b/tests/lib/utils/_utils.test.mjs
@@ -1,4 +1,5 @@
 import { compose } from './compose.test.mjs';
+import { gazetteer } from './gazetteer.test.mjs';
 import { jsonParser } from './jsonParser.test.mjs';
 import { keyvalue_dictionary } from './keyvalue_dictionary.test.mjs';
 import { merge } from './merge.test.mjs';
@@ -11,6 +12,7 @@ import { versionCheck } from './versionCheck.mjs';
 
 export const utilsTest = {
   compose,
+  gazetteer,
   jsonParser,
   keyvalue_dictionary,
   merge,

--- a/tests/lib/utils/gazetteer.test.mjs
+++ b/tests/lib/utils/gazetteer.test.mjs
@@ -21,7 +21,7 @@ export function gazetteer() {
         'onerror',
       ];
 
-      XMLHttpRequest = class {
+      globalThis.XMLHttpRequest = class {
         constructor() {
           this.abort = () => {
             return this;
@@ -102,7 +102,7 @@ export function gazetteer() {
         },
       );
 
-      XMLHttpRequest = originalXMLHttpRequest;
+      globalThis.XMLHttpRequest = originalXMLHttpRequest;
     },
   );
 }

--- a/tests/lib/utils/gazetteer.test.mjs
+++ b/tests/lib/utils/gazetteer.test.mjs
@@ -1,0 +1,108 @@
+/**
+ * @module utils/gazetteer
+ */
+const originalXMLHttpRequest = XMLHttpRequest;
+
+/**
+ * This function is used as an entry point for the gazetteer Test
+ * @function gazetteer
+ */
+export function gazetteer() {
+  codi.describe(
+    { name: 'Utils: gazetteer Test', id: 'utils_gazetteer', parentId: 'utils' },
+    () => {
+      const expectedXhrKeys = [
+        'abort',
+        'send',
+        'open',
+        'setRequestHeader',
+        'responseType',
+        'onload',
+        'onerror',
+      ];
+
+      XMLHttpRequest = class {
+        constructor() {
+          this.abort = () => {
+            return this;
+          };
+          this.send = () => {
+            return this;
+          };
+          this.open = () => {
+            return this;
+          };
+          this.setRequestHeader = () => {
+            return this;
+          };
+        }
+      };
+
+      codi.it(
+        {
+          name: 'XHR should be assigned to datasets',
+          parentId: 'utils_gazetteer',
+        },
+        () => {
+          const term = 'test';
+
+          const gazetteer = {
+            leading_wildcard: true,
+            limit: 5,
+            datasets: [
+              {
+                mapview: {
+                  host: 'localhost:3000',
+                  locale: { key: 'test' },
+                  layers: {
+                    layer_3: { key: 'layer_3', qID: 'id' },
+                  },
+                },
+                layer: 'layer_3',
+                label: 'Store Name',
+                qterm: 'store',
+                table: 'fake_table',
+                no_result: null,
+              },
+              {
+                mapview: {
+                  host: 'localhost:3000',
+                  locale: { key: 'test' },
+                  layers: {
+                    layer_2: { key: 'layer_2', qID: 'id' },
+                  },
+                },
+                layer: 'layer_2',
+                label: 'Store Name Also',
+                qterm: 'store',
+                table: 'fake_table',
+                no_result: null,
+              },
+            ],
+          };
+
+          mapp.utils.gazetteer.datasets(term, gazetteer);
+
+          const firstDatasetKeys = Object.keys(
+            gazetteer.datasets[0].xhr,
+          ).filter((key) => expectedXhrKeys.includes(key));
+
+          const secondDatasetKeys = Object.keys(
+            gazetteer.datasets[1].xhr,
+          ).filter((key) => expectedXhrKeys.includes(key));
+
+          codi.assertTrue(
+            expectedXhrKeys.length === firstDatasetKeys.length,
+            'first dataset should get an xhr object',
+          );
+          codi.assertTrue(
+            expectedXhrKeys.length === secondDatasetKeys.length,
+            'second dataset should get an xhr object',
+          );
+        },
+      );
+
+      XMLHttpRequest = originalXMLHttpRequest;
+    },
+  );
+}


### PR DESCRIPTION
## Description
An xhr property is assigned to the dataset, by using `Object.assign` and assigning to the dataset we keep the reference to this property. 

By keeping the reference we can abort previous xhr calls and prevent duplicated results. 

Example configuration.
```Json
    "gazetteer": {
      "leading_wildcard": true,
      "limit": 5,
      "no_result": "foo",
      "datasets": [
        {
          "layer": "report_input",
          "title": "Store Name",
          "qterm": "store_name",
          "no_result": null
        },
      ]
    },
```

when typing fast you should see duplicated results:
![Screenshot from 2025-07-08 14-24-45](https://github.com/user-attachments/assets/fb11c92f-98ce-4762-b0e9-5c56bd891474)

## GitHub Issue
[#2259](https://github.com/GEOLYTIX/xyz/issues/2259)

## Type of Change
- ✅ Bug fix (non-breaking change which fixes an issue)
- ✅ Testing

## How have you tested this?
Tested locally, `bugs_testing\ui_elements\workspace.json` and added a gazetteer test.

## Testing Checklist
- ✅ Existing Tests still pass
- ✅ New Tests Added
- ✅ Ran locally on my machine

## Code Quality Checklist
- ✅ My code follows the guidelines of XYZ
- ✅ My code has been commented
- ✅ Documentation has been updated
- ✅ New and existing unit tests pass locally with my changes
- ✅ Main has been merged into this PR
