### PR TITLE
housekeeping: Correcting 'Content-type' to 'Content-Type'

### DIFF
--- a/mod/user/login.js
+++ b/mod/user/login.js
@@ -93,7 +93,7 @@ async function loginBody(req, res) {
       return loginView(req, res);
     }
 
-    return res.status(401).set('Content-type', 'text/plain').send(user.message);
+    return res.status(401).set('Content-Type', 'text/plain').send(user.message);
   }
 
   const token = sign(

--- a/mod/user/register.js
+++ b/mod/user/register.js
@@ -134,7 +134,7 @@ async function registerUserBody(req, res) {
   });
 
   // Return msg. No redirect for password reset.
-  res.set('Content-type', 'text/plain').send(
+  res.set('Content-Type', 'text/plain').send(
     await languageTemplates({
       language: req.body.language,
       template: 'new_account_registered',
@@ -261,7 +261,7 @@ async function passwordReset(req, res) {
   if (user.blocked) {
     res
       .status(403)
-      .set('Content-type', 'text/plain')
+      .set('Content-Type', 'text/plain')
       .send(
         await languageTemplates({
           language: req.body.language,

--- a/mod/workspace/_workspace.js
+++ b/mod/workspace/_workspace.js
@@ -66,7 +66,7 @@ export default async function getKeyMethod(req, res) {
   if (workspace instanceof Error) {
     return res
       .status(500)
-      .set('Content-type', 'text/plain')
+      .set('Content-Type', 'text/plain')
       .send('Failed to load workspace.');
   }
 
@@ -74,7 +74,7 @@ export default async function getKeyMethod(req, res) {
   if (!Object.hasOwn(keyMethods, req.params.key)) {
     return res
       .status(400)
-      .set('Content-type', 'text/plain')
+      .set('Content-Type', 'text/plain')
       .send(`Failed to evaluate '${req.params.key}' param.`);
   }
 
@@ -108,7 +108,7 @@ async function layer(req, res) {
   if (layer instanceof Error) {
     return res
       .status(400)
-      .set('Content-type', 'text/plain')
+      .set('Content-Type', 'text/plain')
       .send(layer.message);
   }
 
@@ -190,7 +190,7 @@ async function getNestedLocales(req, res) {
   if (locale instanceof Error) {
     return res
       .status(400)
-      .set('Content-type', 'text/plain')
+      .set('Content-Type', 'text/plain')
       .send(locale.message);
   }
 
@@ -247,7 +247,7 @@ async function locale(req, res) {
   if (locale instanceof Error) {
     return res
       .status(400)
-      .set('Content-type', 'text/plain')
+      .set('Content-Type', 'text/plain')
       .send(locale.message);
   }
 


### PR DESCRIPTION
This PR is just correcting some header types string formatting for consistency. It shouldn't make a difference for either or.