### PR TITLE
fix(styleParser): Theme parsing issue

### DIFF
--- a/lib/layer/decorate.mjs
+++ b/lib/layer/decorate.mjs
@@ -10,8 +10,6 @@ Common interface methods such as layer.show, and hide are assigned to the layer 
 
 A blank layer.filter object will be set if the filter has not been defined in the JSON layer.
 
-The first theme from the layer.style.themes array will be assigned as layer.style.theme if not already set.
-
 Any plugins matching layer keys will be executed with the layer being passed as argument to the plugin method.
 
 The layer object is returned from the decorator.

--- a/lib/layer/styleParser.mjs
+++ b/lib/layer/styleParser.mjs
@@ -83,6 +83,12 @@ export default function styleParser(layer) {
 
   if (layer.style?.themes) {
     Object.keys(layer.style.themes).forEach((key) => {
+      // A theme will be represented by a string if the theme has already been parsed as layer.style.theme{}
+      if (layer.style.themes[key] === key) {
+        layer.style.themes[key] = layer.style.theme;
+        return;
+      }
+
       // required for the lookup of self referenced objects
       layer.style.themes[key].key = key;
 


### PR DESCRIPTION
The layer.style.theme property can be a string. In this case the styleParser will assign the theme from the themes object.

This will cause the theme in the themes object to become a string in the jsonParser as the same object should not be parsed twice.

Hence the theme must be assigned back from the style.theme to the style.themes{} object to prevent the styleParser falling over.

This can be tested by storing a locale/layer with the userLocale plugin. The layer.style.theme property is of type string.

```js
          "theme": "categorized-theme",
          "themes": {
            "grad": {
              "type": "graduated",
              "field": "numeric_field",
              "legend": {
                "layout": "flex",
                "alignContents": "centered",
                "horizontal": true,
                "nowrap": true
              },
              "cat_arr": [
                {
                  "value": 0,
                  "label": "0",
                  "style": {
                    "fillColor": "#33d14b"
                  }
                },
                {
                  "value": 0.5,
                  "label": "0 to 0.5",
                  "style": {
                    "fillColor": "#00c2ba"
                  }
                },
                {
                  "value": 1,
                  "label": "0.5 to 1",
                  "style": {
                    "fillColor": "#00aef1"
                  }
                },
                {
                  "value": 1.5,
                  "label": "1 to 1.5",
                  "style": {
                    "fillColor": "#8a85ff"
                  }
                }
              ]
            },
            "categorized-theme": {
              "type": "categorized",
              "field": "char_field",
              "distribution": "count",
              "cat_arr": [
                {
                  "value": "028C6",
                  "style": {
                    "fillColor": "blue"
                  }
                },
                {
                  "value": "520C2",
                  "style": {
                    "fillColor": "red"
                  }
                },
                {
                  "value": "D9A9F",
                  "style": {
                    "fillColor": "green"
                  }
                }
              ]
            }
          }
```