### PR TITLE
fix(register): Changed Content-Type to return html

### DIFF
--- a/mod/user/register.js
+++ b/mod/user/register.js
@@ -134,7 +134,7 @@ async function registerUserBody(req, res) {
   });
 
   // Return msg. No redirect for password reset.
-  res.setHeader('Content-Type', 'text/html').send(
+  res.send(
     await languageTemplates({
       language: req.body.language,
       template: 'new_account_registered',
@@ -259,15 +259,12 @@ async function passwordReset(req, res) {
 
   // Blocked user may not reset their password.
   if (user.blocked) {
-    res
-      .status(403)
-      .setHeader('Content-Type', 'text/html')
-      .send(
-        await languageTemplates({
-          language: req.body.language,
-          template: 'user_blocked',
-        }),
-      );
+    res.status(403).send(
+      await languageTemplates({
+        language: req.body.language,
+        template: 'user_blocked',
+      }),
+    );
     return;
   }
 


### PR DESCRIPTION
### Summary	

I have changed the Content-Type set in the register modules to `html` as this will better cater for both text or html.