### PR TITLE
Provide svg fallback for icon.url

### DIFF
--- a/lib/utils/olStyle.mjs
+++ b/lib/utils/olStyle.mjs
@@ -126,7 +126,8 @@ function iconStyle(Styles, style, icon, feature) {
   scale *= style.highlightScale || 1;
 
   // Create icon url from svgSymbols method if not defined as url or svg source.
-  icon.url ??= icon.svg || mapp.utils.svgSymbols[icon.type || 'dot'](icon, feature);
+  icon.url ??=
+    icon.svg || mapp.utils.svgSymbols[icon.type || 'dot'](icon, feature);
 
   if (!icon.url) return;
 

--- a/lib/utils/olStyle.mjs
+++ b/lib/utils/olStyle.mjs
@@ -126,7 +126,7 @@ function iconStyle(Styles, style, icon, feature) {
   scale *= style.highlightScale || 1;
 
   // Create icon url from svgSymbols method if not defined as url or svg source.
-  icon.url ??= mapp.utils.svgSymbols[icon.type || 'dot'](icon, feature);
+  icon.url ??= icon.svg || mapp.utils.svgSymbols[icon.type || 'dot'](icon, feature);
 
   if (!icon.url) return;
 


### PR DESCRIPTION
The icon.svg property must be provided as fallback for the icon.url as not all styles may be processed by the style parser.