### PR TITLE
feat(locale): Remove locale.queryparams and assign to locale.layer.queryparams instead

### DIFF
--- a/lib/mapview/_mapview.mjs
+++ b/lib/mapview/_mapview.mjs
@@ -101,9 +101,6 @@ export default function decorate(mapview) {
 
   mapviewControls(mapview);
 
-  // Handle legacy setup of locale.queryparams
-  LocaleQueryparamsToLayer(mapview);
-
   // Map
   mapview.Map = new ol.Map({
     controls: mapview.controls,
@@ -463,21 +460,4 @@ async function mapviewPromise(mapview) {
   await Promise.all(asyncPlugins);
 
   return mapview;
-}
-
-/*** 
-@function LocaleQueryparamsToLayer
-@description
-The method checks if the mapview.locale.queryparams is set and assigns it to the locale.layer.queryparams object.
-The mapview.locale.queryparams is a legayc object before the time we had a locale.layer.queryparams object that is merged onto every layer in the locale.
-@param {mapview} mapview The mapview object.
-@property {object} mapview.locale.queryparams The queryparams object to be assigned to the locale.layer.queryparams.
- */
-function LocaleQueryparamsToLayer(mapview) {
-  if (!mapview.locale.queryparams) return;
-
-  // Assign the queryparams object to the locale.layer object
-  mapview.locale.layer ??= {};
-  mapview.locale.layer.queryparams = mapview.locale.queryparams;
-  delete mapview.locale.queryparams;
 }

--- a/lib/mapview/_mapview.mjs
+++ b/lib/mapview/_mapview.mjs
@@ -101,6 +101,9 @@ export default function decorate(mapview) {
 
   mapviewControls(mapview);
 
+  // Handle legacy setup of locale.queryparams
+  LocaleQueryparamsToLayer(mapview);
+
   // Map
   mapview.Map = new ol.Map({
     controls: mapview.controls,
@@ -460,4 +463,21 @@ async function mapviewPromise(mapview) {
   await Promise.all(asyncPlugins);
 
   return mapview;
+}
+
+/*** 
+@function LocaleQueryparamsToLayer
+@description
+The method checks if the mapview.locale.queryparams is set and assigns it to the locale.layer.queryparams object.
+The mapview.locale.queryparams is a legayc object before the time we had a locale.layer.queryparams object that is merged onto every layer in the locale.
+@param {mapview} mapview The mapview object.
+@property {object} mapview.locale.queryparams The queryparams object to be assigned to the locale.layer.queryparams.
+ */
+function LocaleQueryparamsToLayer(mapview) {
+  if (!mapview.locale.queryparams) return;
+
+  // Assign the queryparams object to the locale.layer object
+  mapview.locale.layer ??= {};
+  mapview.locale.layer.queryparams = mapview.locale.queryparams;
+  delete mapview.locale.queryparams;
 }

--- a/lib/ui/Dataview.mjs
+++ b/lib/ui/Dataview.mjs
@@ -113,9 +113,8 @@ export default async function Dataview(_this) {
     });
   }
 
-  // Assign queryparams from layer, locale.
+  // Assign queryparams from layer or this.
   _this.queryparams = {
-    ..._this.layer?.mapview?.locale?.queryparams,
     ..._this.layer?.queryparams,
     ..._this.location?.layer?.queryparams,
     ..._this.queryparams,

--- a/lib/ui/locations/entries/layer.mjs
+++ b/lib/ui/locations/entries/layer.mjs
@@ -232,9 +232,8 @@ async function showLayer() {
   const entry = this;
 
   if (entry.query) {
-    // Assign queryparams from layer, locale.
+    // Assign queryparams from layer or entry.
     entry.queryparams = {
-      ...entry.location?.layer?.mapview?.locale?.queryparams,
       ...entry.location?.layer?.queryparams,
       ...entry.queryparams,
     };

--- a/lib/ui/locations/infoj.mjs
+++ b/lib/ui/locations/infoj.mjs
@@ -465,11 +465,10 @@ function entryQuery(entry) {
     // Assign location layer or mapp.host as fallback if not implicit.
     entry.host ??= entry.location?.layer?.mapview?.host || mapp.host;
 
-    // Assign queryparams from layer, and locale.
+    // Assign queryparams from layer or entry.
     entry.queryparams = {
-      ...entry.queryparams,
       ...entry.location.layer?.queryparams,
-      ...entry.location.layer?.mapview?.locale?.queryparams,
+      ...entry.queryparams,
     };
 
     const queryParams = mapp.utils.queryParams(entry);

--- a/mod/workspace/getLocale.js
+++ b/mod/workspace/getLocale.js
@@ -79,6 +79,11 @@ export default async function getLocale(params, parentLocale) {
     return new Error(locale.message);
   }
 
+  // Assign the queryparams object to the locale.layer object
+  locale.layer ??= {};
+  locale.layer.queryparams = locale.queryparams;
+  delete locale.queryparams;
+
   // The roles property maybe assigned from a template. Templates must be merged prior to the role check.
   locale = await mergeTemplates(locale, params.user?.roles);
 


### PR DESCRIPTION
The `locale.layer` is merged into every `layer` on a locale. 
Thus the `locale.queryparams` was an extra check that was unrequired as we previously checked for `entry.queryparams`, `layer.queryparams` `locale.queryparams`.

This PR assigns `locale.queryparams` to `locale.layer` so it is merged into the `layer`. 

The `queryparams` spreads have also been updated to remove reference to `locale.queryparams` now too.