### PR TITLE
feat(legends.categorized): Distribution Count - Format Number

### DIFF
--- a/lib/ui/layers/legends/categorized.mjs
+++ b/lib/ui/layers/legends/categorized.mjs
@@ -51,7 +51,11 @@ export default function categorizedTheme(layer) {
       layer.filter?.current[cat.field]?.ni?.indexOf(cat.value) >= 0;
 
     if (layer.featureFields && theme.distribution === 'count') {
-      cat.count = layer.featureFields[cat.field]?.[cat.value];
+      // Build a params object to pass to the numericFormatter.
+      const params = {
+        value: layer.featureFields[cat.field]?.[cat.value],
+      };
+      cat.count = mapp.utils.formatNumericValue(params);
       if (!cat.disabled && !cat.count) return;
     }
 


### PR DESCRIPTION
The value in the categorized count when using `distribution: count` in a theme was not formatted. 
This PR simply formats the number using the `mapp.utils.formatNumericValue` method. 

<img width="336" height="421" alt="image" src="https://github.com/user-attachments/assets/f0e80a12-9cda-4d80-9000-8fb4f9bf2351" />

<img width="354" height="476" alt="image" src="https://github.com/user-attachments/assets/f73f31a5-a5c7-4524-9ada-042381cf3393" />

``` json
"theme": {
  "title": "I AM A THEME",
  "type": "categorized",
  "field": "field_a",
  "distribution": "count",
  "cat": {
    "Value_1": {
      "style": {
        "strokeColor": "#a93226",
        "fillColor": "#a93226",
        "fillOpacity": 0.4,
        "strokeWidth": 3
      }
    },
    "Value_2": {
      "style": {
        "strokeColor": "#b03a2e",
        "fillColor": "#b03a2e",
        "fillOpacity": 0.4
      }
    }
  }
```