### PR TITLE
Numeric filters - generate min max to use viewport when defined in filter.

### DIFF
--- a/lib/ui/layers/filters.mjs
+++ b/lib/ui/layers/filters.mjs
@@ -286,20 +286,27 @@ Query the min and max values for a numeric filter field.
 @param {layer} layer MAPP layer typedef object.
 @param {Object} filter Filter object.
 @property {string} filter.field Field to filter.
+@property {Boolean} params.viewport Optional, applies filtering by map current viewport.
 @property {numeric} [filter.min] Min bounds.
 @property {numeric} [filter.max] Max bounds.
 @property {string} [filter.minmax_query] Query template for min max values.
 */
 async function generateMinMax(layer, filter) {
-  const response = await mapp.utils.xhr(
-    `${layer.mapview.host}/api/query?${mapp.utils.paramString({
-      field: filter.field,
-      filter: layer.filter?.current,
-      layer: layer.key,
-      locale: layer.mapview.locale.key,
-      table: layer.tableCurrent(),
+  const queryParams = mapp.utils.queryParams({
+    layer: layer,
+    queryparams: {
+      filter: true,
+      table: true,
       template: filter.minmax_query || `field_minmax`,
-    })}`,
+      field: filter.field,
+    },
+    viewport: filter.viewport,
+  });
+
+  const paramString = mapp.utils.paramString(queryParams);
+
+  const response = await mapp.utils.xhr(
+    `${layer.mapview.host}/api/query?${paramString}`,
   );
 
   // Assign min, max from response if not a number.


### PR DESCRIPTION
Adds support for filter.viewport flag when setting min and max values for the filter field.

Function `generateMinMax` shortened by the use of utilities `queryParams` and `paramString`.