### PR TITLE
fix(templates): Get Template defined on Locale

### DIFF
--- a/public/views/_default.html
+++ b/public/views/_default.html
@@ -356,7 +356,7 @@
       `${mapp.host}/api/workspace/locale?locale=${locale}&layers=true`,
     );
 
-    if (locale instanceof Error || locales.length === 0) {
+    if (locale instanceof Error) {
       // Create the Dialog.node
       mapp.ui.elements.dialog({
         css_style:


### PR DESCRIPTION
There is an issue with **locales that are loaded from templates** that have
roles defined in the locale template.

This prevents the roles check being performed as the locale doesn't have a roles
object until we fetch it.

The fix for this is that when fetching the locales from
`/api/workspace/locales` we then get each locale instead of checking against
what's currently in the cached workspace. At this point a roles check is done
and if the user doesn't have access to the role it won't be returned.

Closes #2283