### PR TITLE
fix(mvt): WKT Properties not allowing callback

### DIFF
--- a/lib/layer/format/mvt.mjs
+++ b/lib/layer/format/mvt.mjs
@@ -75,6 +75,7 @@ export default function MVT(layer) {
   function reload(callback) {
     if (layer.wkt_properties) {
       wktPropertiesLoad(layer);
+      if (callback instanceof Function) callback(layer);
       return;
     }
 


### PR DESCRIPTION
The reload method on an MVT layer for layers with `wkt_properties` set must check for the presence of a callback function and run it if so. 

This is required for when filtering so that the filter icon correctly appears when a filter is applied to a layer. 