### PR TITLE
fix(location.updateCount): Move updateCount to filter panel

### DIFF
--- a/lib/ui/layers/filters.mjs
+++ b/lib/ui/layers/filters.mjs
@@ -42,7 +42,6 @@ const filterMethods = {
   reloadCallback,
   removeFilter,
   resetFilter,
-  updateCount,
 };
 
 export default filterMethods;
@@ -97,22 +96,6 @@ function reloadCallback(layer) {
   }
 
   return layer;
-}
-
-/**
-@function updateCount
-
-@description
-The updateCount updates layer.filter.count element with the response from the mapp.ui.utils.locationCount method.
-
-@param {Object} layer
-@property {Object} layer.filter The layer filter configuration.
-@property {HTMLElement} filter.count The location count element in the filter panel.
-*/
-async function updateCount(layer) {
-  const feature_count = await mapp.ui.utils.locationCount(layer);
-
-  layer.filter.count.innerText = feature_count;
 }
 
 /**

--- a/lib/ui/layers/panels/filter.mjs
+++ b/lib/ui/layers/panels/filter.mjs
@@ -74,6 +74,7 @@ export default function filterPanel(layer) {
     callback: async (e, options, filter) => {
       if (!filter.selected) {
         mapp.ui.layers.filters.removeFilter(layer, filter);
+        updateCount(layer);
         return;
       }
 
@@ -84,12 +85,7 @@ export default function filterPanel(layer) {
       layer.filter.clearAll.style.display = 'inline-block';
       layer.filter.resetAll.style.display = 'inline-block';
 
-      //Don't display the count if the layer isn't on
-      if (layer.display) {
-        //Need to call the count as the number will not display the first time it is made visible
-        layer.tableCurrent() && mapp.ui.layers.filters.updateCount(layer);
-        layer.filter.feature_count.style.setProperty('display', 'block');
-      }
+      updateCount(layer);
 
       // Get interface content for filter card.
       filter.content = [
@@ -136,17 +132,13 @@ export default function filterPanel(layer) {
   layer.filter.count = mapp.utils.html.node`<span class="bold">`;
 
   layer.mapview.Map.getTargetElement().addEventListener('changeEnd', () => {
-    //Attempting to call update count without a table will throw an error
-    layer.display &&
-      layer.tableCurrent() &&
-      mapp.ui.layers.filters.updateCount(layer);
+    updateCount(layer);
   });
 
   //Add a hide/show function to the layer callbacks to display and run the count
   layer.showCallbacks.push((layer) => {
     if (layer.filter.clearAll?.checkVisibility()) {
-      layer.tableCurrent() && mapp.ui.layers.filters.updateCount(layer);
-      layer.filter.feature_count.style.setProperty('display', 'block');
+      updateCount(layer);
     }
   });
 
@@ -156,9 +148,8 @@ export default function filterPanel(layer) {
     }
   });
 
-  layer.filter.feature_count = mapp.utils.html.node`<p style="display:none">
-      ${layer.filter.count} Location(s) match your criteria
-    </p>`;
+  layer.filter.feature_count = mapp.utils.html.node`
+    <p style="display:none">${layer.filter.count} Location(s) match your criteria`;
 
   if (layer.filter.drawer === false) {
     layer.filter.view = mapp.utils.html
@@ -183,4 +174,29 @@ export default function filterPanel(layer) {
   }
 
   return layer.filter.view;
+}
+
+/**
+@function updateCount
+
+@description
+The updateCount updates layer.filter.count element with the response from the mapp.ui.utils.locationCount method.
+
+@param {Object} layer
+@property {Object} layer.filter The layer filter configuration.
+@property {HTMLElement} filter.count The location count element in the filter panel.
+*/
+async function updateCount(layer) {
+  if (!layer.display) return;
+
+  if (!Object.keys(layer.filter?.current).length) {
+    layer.filter.feature_count.style.setProperty('display', 'none');
+    return;
+  }
+
+  const feature_count = await mapp.ui.utils.locationCount(layer);
+
+  layer.filter.count.innerText = feature_count;
+
+  layer.filter.feature_count.style.setProperty('display', 'block');
 }


### PR DESCRIPTION
I moved the updateCount method to the filter panel module since the method is only called from there.

The method should short circuit if the layer is not displayed or the current filter length is naught.