### PR TITLE
Slider css - grid column template to include grid gap.

### DIFF
--- a/public/css/elements/_slider.css
+++ b/public/css/elements/_slider.css
@@ -1,7 +1,7 @@
 .input-range {
   --dif: calc(var(--max) - var(--min));
   display: grid;
-  grid-template-columns: 50% 50%;
+  grid-template-columns: repeat(2, 1fr);
   grid-gap: 0.2em;
   position: relative;
   width: 100%;

--- a/public/css/ui.css
+++ b/public/css/ui.css
@@ -825,7 +825,7 @@ dialog {
 .input-range {
   --dif: calc(var(--max) - var(--min));
   display: grid;
-  grid-template-columns: 50% 50%;
+  grid-template-columns: repeat(2, 1fr);
   grid-gap: 0.2em;
   position: relative;
   width: 100%;


### PR DESCRIPTION
This is a css fix for slider that creates a horizontal scrollbar within a multi filter dialog.
It originated when the svg thumb orange dot was replaced with css styling which required adding grid gap in order to separate pseudo elements from value inputs as they displayed very close to each other.

The slider outer container was previously set to 2 columns of 50% each:

`grid-template-columns: 50% 50%`

which is a strict layout not taking gaps into account.

This pr replaces the rule with 

`grid-template-columns: repeat(2, 1fr)` 

which calculates even space including inner gaps.

I have verified dual slider in filter panel, in multi filter dialog and slider in manual circle creation.
