### PR TITLE
Change locales loop and names retrieval

### DIFF
--- a/mod/workspace/_workspace.js
+++ b/mod/workspace/_workspace.js
@@ -137,17 +137,25 @@ async function locales(req, res) {
     return;
   }
 
-  const locales = await Promise.all(
-    Object.keys(workspace.locales).map((localeKey) =>
-      getLocale({
-        user: req.params.user,
-        locale: localeKey,
-        roles: req.params.user?.roles,
-      }),
-    ),
-  );
+  const locales = [];
 
-  res.send(locales.filter((locale) => !(locale instanceof Error)));
+  for (const localeKey of Object.keys(workspace.locales)) {
+    const locale = await getLocale({
+      user: req.params.user,
+      locale: localeKey,
+      roles: req.params.user?.roles,
+    });
+
+    if (locale instanceof Error) continue;
+
+    locales.push({
+      key: locale.key,
+      name: locale.name,
+      locales: locale.locales,
+    });
+  }
+
+  res.send(locales);
 }
 
 /**


### PR DESCRIPTION
The return from the get workspace locales should return an array locales with their name, key, and nested locales.

This behaviour changed in this PR for the 4.16 minor release. https://github.com/GEOLYTIX/xyz/pull/2287

An array of the complete locales was now returned.

I change the Promise.all and return array.filter in the first commit for better readability.

The correct locales array is now rertuned. 

<img width="511" height="375" alt="image" src="https://github.com/user-attachments/assets/4dadbf50-0409-462a-a352-666cf5f67f81" />

However; The assignment of the name is still bugged. The name for the uk locale should be 'United Kingdom'.

<img width="620" height="926" alt="image" src="https://github.com/user-attachments/assets/586c7bcf-cd34-4c92-b5ce-f3cb259eb1bb" />
