### PR TITLE
Replace unpkg references with jsdelivr

### DIFF
--- a/lib/layer/format/mapboxStyle.mjs
+++ b/lib/layer/format/mapboxStyle.mjs
@@ -5,7 +5,7 @@ The mapboxStyle layer format requires the ol-mapbox-style plugin for the native 
 
 The plugin is loaded from a script tag through the scriptElement utility method.
 
-CSP access to `unpkg.com` is required in order to import the ol-mapbox-style plugin.
+CSP access to `cdn.jsdelivr.net` is required in order to import the ol-mapbox-style plugin.
 
 @requires ol-mapbox-style
 @requires /utils/scriptElement
@@ -28,7 +28,7 @@ The mapboxStyle method creates an Openlayers VectorTile layer and assigns a mapb
 */
 export default async function mapboxStyle(layer) {
   await mapp.utils.scriptElement(
-    'https://unpkg.com/ol-mapbox-style@13.0.1/dist/olms.js',
+    'https://cdn.jsdelivr.net/npm/ol-mapbox-style@13.0.1/dist/olms.js',
   );
 
   layer.L = new ol.layer.VectorTile({

--- a/public/views/_user.html
+++ b/public/views/_user.html
@@ -16,13 +16,13 @@
     >
 
     <link
-      href="https://unpkg.com/tabulator-tables@6.3.1/dist/css/tabulator.min.css"
+      href="https://cdn.jsdelivr.net/npm/tabulator-tables@6.3.1/dist/css/tabulator.min.css"
       rel="stylesheet"
     >
 
     <script
       type="text/javascript"
-      src="https://unpkg.com/tabulator-tables@6.3.1/dist/js/tabulator.min.js"
+      src="https://cdn.jsdelivr.net/npm/tabulator-tables@6.3.1/dist/js/tabulator.min.js"
       integrity="sha384-SKSq3cuuVWdfrjtLz9wNlqE0bMc903yMS5zGnFtwvfddplgxa1hywtiLyw1CbSHO"
       crossorigin="anonymous"
     ></script>

--- a/tests/lib/utils/scriptElement.test.mjs
+++ b/tests/lib/utils/scriptElement.test.mjs
@@ -12,7 +12,7 @@ export function scriptElementTest() {
         async () => {
           // Setup: Remove any existing test script
           const testSrc =
-            'https://unpkg.com/ol-mapbox-style@13.0.1/dist/olms.js';
+            'https://cdn.jsdelivr.net/npm/ol-mapbox-style@13.0.1/dist/olms.js';
 
           let appended = false;
           const origAppend = document.head.append;


### PR DESCRIPTION
This PR replaces unpkg resources with jsdelivr resource links. jsdelivr has on average better latency. It is beneficial to use just one source rather than multiple sources in the same library.