### PR TITLE
hideDisabled layer.view

### DIFF
--- a/lib/ui/layers/view.mjs
+++ b/lib/ui/layers/view.mjs
@@ -137,10 +137,13 @@ export default function layerView(layer) {
   mapp.utils.render(layer.view, layer.drawer);
 
   // The layer may be zoom level restricted.
-  layer.tables &&
+  if (layer.tables) {
     layer.mapview.Map.getTargetElement().addEventListener('changeEnd', () =>
       changeEnd(layer),
     );
+    // Call changeEnd to set the initial state of the layer.
+    changeEnd(layer);
+  }
 
   return layer;
 }

--- a/lib/ui/layers/view.mjs
+++ b/lib/ui/layers/view.mjs
@@ -7,8 +7,8 @@ Dictionary entries:
 - layer_visibility
 - layer_zoom_to_extent
 - zoom_to
-  
-@requires /dictionary 
+
+@requires /dictionary
 
 @module /ui/layers/view
 */
@@ -31,7 +31,7 @@ export default function layerView(layer) {
   // Do not create a layer view.
   if (layer.view === null) return layer;
 
-  layer.view = mapp.utils.html.node`<div 
+  layer.view = mapp.utils.html.node`<div
     data-id=${layer.key}
     class="layer-view">`;
 
@@ -84,7 +84,7 @@ export default function layerView(layer) {
   // Create a div for the magnifying glass icon
   layer.zoomBtn =
     layer.viewConfig.zoomBtn &&
-    mapp.utils.html.node`<button 
+    mapp.utils.html.node`<button
       data-id="zoom-to"
       title=${mapp.dictionary.zoom_to}
       class="material-symbols-outlined"
@@ -114,10 +114,10 @@ export default function layerView(layer) {
       : mapp.utils.html`<div class="material-symbols-outlined caret"></div>`;
 
   const header = mapp.utils.html`
-    <h2>${layer.name || layer.key}</h2> 
+    <h2>${layer.name || layer.key}</h2>
       ${layer.zoomToFilteredExtentBtn || ''}
       ${layer.zoomBtn || ''}
-      ${layer.popoutBtn || ''}  
+      ${layer.popoutBtn || ''}
       ${layer.displayToggle || ''}
       ${caret}`;
 
@@ -152,7 +152,7 @@ export default function layerView(layer) {
 @description
 The viewConfig method will create viewConfig object and update the configuration from legacy properties.
 
-The method will iterate through the panelOrder keys to add panel to the content array. 
+The method will iterate through the panelOrder keys to add panel to the content array.
 
 @param {layer} layer A decorated mapp layer.
 @property {Object} [layer.viewConfig] Control options for elements in the layer.view.
@@ -175,6 +175,7 @@ function viewConfig(layer) {
     displayToggle: true,
     zoomBtn: true,
     zoomToFilteredExtentBtn: true,
+    hideDisabled: false,
   };
 
   // merge defaults with configured props

--- a/lib/ui/layers/view.mjs
+++ b/lib/ui/layers/view.mjs
@@ -93,10 +93,8 @@ export default function layerView(layer) {
   //Create a button for popping out the drawer
   layer.popoutBtn =
     layer.viewConfig.popoutBtn &&
-    mapp.utils.html
-      .node`<button data-id="popout-btn" class="material-symbols-outlined">
-                    open_in_new
-                  </button>`;
+    mapp.utils.html.node`
+      <button data-id="popout-btn" class="material-symbols-outlined">open_in_new</button>`;
 
   // Add on callback for toggle button.
   layer.showCallbacks.push(() => {

--- a/lib/ui/layers/view.mjs
+++ b/lib/ui/layers/view.mjs
@@ -100,7 +100,7 @@ export default function layerView(layer) {
 
   // Add on callback for toggle button.
   layer.showCallbacks.push(() => {
-    layer.displayToggle.classList.add('toggle-on');
+    layer.displayToggle.classList?.add('toggle-on');
   });
 
   // Remove on callback for toggle button.
@@ -111,7 +111,7 @@ export default function layerView(layer) {
   const caret =
     layer.drawer === false
       ? ''
-      : mapp.utils.html`<div class="material-symbols-outlined caret"/>`;
+      : mapp.utils.html`<div class="material-symbols-outlined caret"></div>`;
 
   const header = mapp.utils.html`
     <h2>${layer.name || layer.key}</h2> 
@@ -159,6 +159,7 @@ The method will iterate through the panelOrder keys to add panel to the content 
 @property {Boolean} [viewConfig.displayToggle=true] Controls whether the layer toggle close is displayed.
 @property {Boolean} [viewConfig.zoomBtn=true] Controls whether the zoom magnifying glass is displayed.
 @property {Boolean} [layer.zoomBtn] Legacy property for viewConfig.zoomBtn.
+@property {Boolean} [viewConfig.hideDisabled=false] Controls whether the layer view is hidden when layer is outside its zoom range. When set to true layer will be temporarily hidden in the list until it's within restricted zoom again.
 @property {Array} [layer.tables] Array of data tables for different zoom level.
 @property {Boolean} [viewConfig.zoomToFilteredExtentBtn=true] Controls whether the zoom to extent button is displayed.
 @property {Array} [viewConfig.panelOrder=['draw-drawer', 'dataviews-drawer', 'filter-drawer', 'style-drawer', 'meta']] Controls which panels are added to the view and in which order, will be assigned from layer.panelOrder if not explicit.
@@ -167,11 +168,17 @@ The method will iterate through the panelOrder keys to add panel to the content 
 @property {string} [layer.classList] Legacy property for viewConfig.classList.
 */
 function viewConfig(layer) {
-  layer.viewConfig ??= {
+  layer.viewConfig ??= {};
+
+  // default view options
+  const viewConfigDefaults = {
     displayToggle: true,
     zoomBtn: true,
     zoomToFilteredExtentBtn: true,
   };
+
+  // merge defaults with configured props
+  layer.viewConfig = { ...viewConfigDefaults, ...layer.viewConfig };
 
   // The zoomBtn should not be created.
   if (layer.zoomBtn === false) {
@@ -181,9 +188,10 @@ function viewConfig(layer) {
 
   if (layer.popout) layer.viewConfig.popoutBtn = true;
 
-  // The zoomBtn is not possible without a tables config.
+  // The zoomBtn and hideDisabled is not possible without a tables config.
   if (!layer.tables) {
     delete layer.viewConfig.zoomBtn;
+    delete layer.viewConfig.hideDisabled;
   }
 
   // Assign viewConfig.panelOrder from legacy JSON layer config.
@@ -282,6 +290,10 @@ function changeEnd(layer) {
 
   // Check whether the layer can be displayed at current zoom.
   if (layer.tableCurrent()) {
+    if (layer.viewConfig.hideDisabled) {
+      layer.view.classList.remove('display-none');
+    }
+
     // The zoomBtn is hidden if the layer is in range.
     if (layer.zoomBtn instanceof HTMLElement) {
       layer.zoomBtn.style.setProperty('display', 'none');
@@ -323,5 +335,9 @@ function changeEnd(layer) {
       el.disabled = true;
       el.classList.add('disabled');
     });
+
+    if (layer.viewConfig.hideDisabled) {
+      layer.view.classList.add('display-none');
+    }
   }
 }

--- a/lib/ui/layers/view.mjs
+++ b/lib/ui/layers/view.mjs
@@ -100,7 +100,7 @@ export default function layerView(layer) {
 
   // Add on callback for toggle button.
   layer.showCallbacks.push(() => {
-    layer.displayToggle.classList?.add('toggle-on');
+    layer.displayToggle.classList.add('toggle-on');
   });
 
   // Remove on callback for toggle button.
@@ -108,6 +108,7 @@ export default function layerView(layer) {
     !layer.zoomDisplay && layer.displayToggle.classList.remove('toggle-on');
   });
 
+  // The caret element is a visual indicator of the drawer expanded state.
   const caret =
     layer.drawer === false
       ? ''
@@ -170,7 +171,6 @@ The method will iterate through the panelOrder keys to add panel to the content 
 function viewConfig(layer) {
   layer.viewConfig ??= {};
 
-  // default view options
   const viewConfigDefaults = {
     displayToggle: true,
     zoomBtn: true,
@@ -178,8 +178,11 @@ function viewConfig(layer) {
     hideDisabled: false,
   };
 
-  // merge defaults with configured props
-  layer.viewConfig = { ...viewConfigDefaults, ...layer.viewConfig };
+  // spread layer viewConfig into defaults
+  layer.viewConfig = {
+    ...viewConfigDefaults,
+    ...layer.viewConfig,
+  };
 
   // The zoomBtn should not be created.
   if (layer.zoomBtn === false) {


### PR DESCRIPTION
`viewConfig` now supports `hideDisabled` flag for layers with multiple zoom levels.

When set to true layer view container will be hidden in the layer list until the layer is within restricted zoom level again.

`viewConfig` now merges defaults with layer configuration props - previously the object would be entirely overwritten with the loss of most common defaults.

Please note that with property `display: none` in css we cannot access the element style, classlist, attributes etc as it cannot be found within the page. This may matter for existing custom show/hide layer callbacks which would need some checks whether the tags within the layer view are accessible.

I've gone for the use of the common class `display-none`. An alternative approach would be to remove the element from the list and later put it back yet this would require tracking the parent and the index where the element should sit - index may be changed with upcoming tools for importing layers.

```json
{
  "format": "mvt",
  "srid": "3857",
  "geom": "geom_3857",
  "qID": "id",
  "tables": {
    "9": null,
    "10": "dev.scratch",
    "11": "dev.scratch",
    "12": "dev.scratch",
    "13": "dev.scratch",
    "14": null
  },
  "viewConfig": {
    "hideDisabled": true
  }
}
```