### PR TITLE
locale and layer queryparams

### DIFF
--- a/lib/ui/Dataview.mjs
+++ b/lib/ui/Dataview.mjs
@@ -113,14 +113,6 @@ export default async function Dataview(_this) {
     });
   }
 
-  // Assign queryparams from layer, locale.
-  _this.queryparams = {
-    ..._this.layer?.mapview?.locale?.queryparams,
-    ..._this.layer?.queryparams,
-    ..._this.location?.layer?.queryparams,
-    ..._this.queryparams,
-  };
-
   // Assign default update method.
   _this.update ??= updateDataview;
 

--- a/lib/ui/locations/entries/layer.mjs
+++ b/lib/ui/locations/entries/layer.mjs
@@ -232,14 +232,10 @@ async function showLayer() {
   const entry = this;
 
   if (entry.query) {
-    // Assign queryparams from layer, locale.
-    entry.queryparams = {
-      ...entry.location?.layer?.mapview?.locale?.queryparams,
-      ...entry.location?.layer?.queryparams,
-      ...entry.queryparams,
-    };
 
-    const paramString = mapp.utils.paramString(mapp.utils.queryParams(entry));
+    const queryParams = mapp.utils.queryParams(entry)
+
+    const paramString = mapp.utils.paramString(queryParams);
 
     entry.data = await mapp.utils.xhr(
       `${entry.mapview.host}/api/query?${paramString}`,

--- a/lib/ui/locations/infoj.mjs
+++ b/lib/ui/locations/infoj.mjs
@@ -465,13 +465,6 @@ function entryQuery(entry) {
     // Assign location layer or mapp.host as fallback if not implicit.
     entry.host ??= entry.location?.layer?.mapview?.host || mapp.host;
 
-    // Assign queryparams from layer, and locale.
-    entry.queryparams = {
-      ...entry.queryparams,
-      ...entry.location.layer?.queryparams,
-      ...entry.location.layer?.mapview?.locale?.queryparams,
-    };
-
     const queryParams = mapp.utils.queryParams(entry);
 
     const paramString = mapp.utils.paramString(queryParams);

--- a/mod/query.js
+++ b/mod/query.js
@@ -148,6 +148,11 @@ async function layerQuery(req, res) {
     req.params.layer = await getLayer(req.params);
   }
 
+  // Merge layer queryparams with request queryparams.
+  if (req.params.layer.queryparams) {
+    Object.assign(req.params, req.params.layer.queryparams)
+  }
+  
   // getLayer will return error on role restrictions.
   if (req.params.layer instanceof Error) {
     return res.status(400).send(req.params.layer.message);

--- a/mod/workspace/getLayer.js
+++ b/mod/workspace/getLayer.js
@@ -104,6 +104,14 @@ export default async function getLayer(params, locale) {
   // Assign dbs from locale if nullish on layer.
   layer.dbs ??= locale.dbs;
 
+  // Merge locale.queryparams into layer.
+  if (locale.queryparams) {
+    layer.queryparams = {
+      ...locale.queryparams,
+      ...layer.queryparams,
+    };
+  }
+
   // Remove properties which are only required for the fetching templates and composing workspace objects.
   delete layer.src;
   delete layer.template;


### PR DESCRIPTION
Instead of sending locale and layer query params back and forth from the XYZ to MAPP client having to do complex merges at multiple points it may be much easier to do merge locale queryparams in the getLayer method and layer queryparams into the request object in the query module.