### PR TITLE
Swap activateUpdate to dynamic

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-**v4.16.1**
+**v4.17.0**
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 ![Codi Unit Tests](https://github.com/GEOLYTIX/xyz/actions/workflows/unit_tests.yml/badge.svg)

--- a/lib/mapp.mjs
+++ b/lib/mapp.mjs
@@ -61,5 +61,5 @@ globalThis.mapp = {
 
   utils,
 
-  version: '4.16.1',
+  version: '4.17.0',
 };

--- a/lib/ui/Tabview.mjs
+++ b/lib/ui/Tabview.mjs
@@ -138,8 +138,8 @@ function addTab(entry) {
     }
 
     if (entry.update instanceof Function) {
-      if (!entry.data || entry.activateUpdate) {
-        // Call dataview update method if data is falsy or activateUpdate flag is set.
+      if (!entry.data || entry.dynamic) {
+        // Call dataview update method if data is falsy or dynamic flag is set.
         entry.update();
       }
     }

--- a/lib/ui/layers/view.mjs
+++ b/lib/ui/layers/view.mjs
@@ -7,8 +7,8 @@ Dictionary entries:
 - layer_visibility
 - layer_zoom_to_extent
 - zoom_to
-  
-@requires /dictionary 
+
+@requires /dictionary
 
 @module /ui/layers/view
 */
@@ -31,7 +31,7 @@ export default function layerView(layer) {
   // Do not create a layer view.
   if (layer.view === null) return layer;
 
-  layer.view = mapp.utils.html.node`<div 
+  layer.view = mapp.utils.html.node`<div
     data-id=${layer.key}
     class="layer-view">`;
 
@@ -84,7 +84,7 @@ export default function layerView(layer) {
   // Create a div for the magnifying glass icon
   layer.zoomBtn =
     layer.viewConfig.zoomBtn &&
-    mapp.utils.html.node`<button 
+    mapp.utils.html.node`<button
       data-id="zoom-to"
       title=${mapp.dictionary.zoom_to}
       class="material-symbols-outlined"
@@ -93,10 +93,8 @@ export default function layerView(layer) {
   //Create a button for popping out the drawer
   layer.popoutBtn =
     layer.viewConfig.popoutBtn &&
-    mapp.utils.html
-      .node`<button data-id="popout-btn" class="material-symbols-outlined">
-                    open_in_new
-                  </button>`;
+    mapp.utils.html.node`
+      <button data-id="popout-btn" class="material-symbols-outlined">open_in_new</button>`;
 
   // Add on callback for toggle button.
   layer.showCallbacks.push(() => {
@@ -108,16 +106,17 @@ export default function layerView(layer) {
     !layer.zoomDisplay && layer.displayToggle.classList.remove('toggle-on');
   });
 
+  // The caret element is a visual indicator of the drawer expanded state.
   const caret =
     layer.drawer === false
       ? ''
-      : mapp.utils.html`<div class="material-symbols-outlined caret"/>`;
+      : mapp.utils.html`<div class="material-symbols-outlined caret"></div>`;
 
   const header = mapp.utils.html`
-    <h2>${layer.name || layer.key}</h2> 
+    <h2>${layer.name || layer.key}</h2>
       ${layer.zoomToFilteredExtentBtn || ''}
       ${layer.zoomBtn || ''}
-      ${layer.popoutBtn || ''}  
+      ${layer.popoutBtn || ''}
       ${layer.displayToggle || ''}
       ${caret}`;
 
@@ -138,10 +137,13 @@ export default function layerView(layer) {
   mapp.utils.render(layer.view, layer.drawer);
 
   // The layer may be zoom level restricted.
-  layer.tables &&
+  if (layer.tables) {
     layer.mapview.Map.getTargetElement().addEventListener('changeEnd', () =>
       changeEnd(layer),
     );
+    // Call changeEnd to set the initial state of the layer.
+    changeEnd(layer);
+  }
 
   return layer;
 }
@@ -152,13 +154,14 @@ export default function layerView(layer) {
 @description
 The viewConfig method will create viewConfig object and update the configuration from legacy properties.
 
-The method will iterate through the panelOrder keys to add panel to the content array. 
+The method will iterate through the panelOrder keys to add panel to the content array.
 
 @param {layer} layer A decorated mapp layer.
 @property {Object} [layer.viewConfig] Control options for elements in the layer.view.
 @property {Boolean} [viewConfig.displayToggle=true] Controls whether the layer toggle close is displayed.
 @property {Boolean} [viewConfig.zoomBtn=true] Controls whether the zoom magnifying glass is displayed.
 @property {Boolean} [layer.zoomBtn] Legacy property for viewConfig.zoomBtn.
+@property {Boolean} [viewConfig.hideDisabled=false] Controls whether the layer view is hidden when layer is outside its zoom range. When set to true layer will be temporarily hidden in the list until it's within restricted zoom again.
 @property {Array} [layer.tables] Array of data tables for different zoom level.
 @property {Boolean} [viewConfig.zoomToFilteredExtentBtn=true] Controls whether the zoom to extent button is displayed.
 @property {Array} [viewConfig.panelOrder=['draw-drawer', 'dataviews-drawer', 'filter-drawer', 'style-drawer', 'meta']] Controls which panels are added to the view and in which order, will be assigned from layer.panelOrder if not explicit.
@@ -167,10 +170,19 @@ The method will iterate through the panelOrder keys to add panel to the content 
 @property {string} [layer.classList] Legacy property for viewConfig.classList.
 */
 function viewConfig(layer) {
-  layer.viewConfig ??= {
+  layer.viewConfig ??= {};
+
+  const viewConfigDefaults = {
     displayToggle: true,
     zoomBtn: true,
     zoomToFilteredExtentBtn: true,
+    hideDisabled: false,
+  };
+
+  // spread layer viewConfig into defaults
+  layer.viewConfig = {
+    ...viewConfigDefaults,
+    ...layer.viewConfig,
   };
 
   // The zoomBtn should not be created.
@@ -181,9 +193,10 @@ function viewConfig(layer) {
 
   if (layer.popout) layer.viewConfig.popoutBtn = true;
 
-  // The zoomBtn is not possible without a tables config.
+  // The zoomBtn and hideDisabled is not possible without a tables config.
   if (!layer.tables) {
     delete layer.viewConfig.zoomBtn;
+    delete layer.viewConfig.hideDisabled;
   }
 
   // Assign viewConfig.panelOrder from legacy JSON layer config.
@@ -282,6 +295,10 @@ function changeEnd(layer) {
 
   // Check whether the layer can be displayed at current zoom.
   if (layer.tableCurrent()) {
+    if (layer.viewConfig.hideDisabled) {
+      layer.view.classList.remove('display-none');
+    }
+
     // The zoomBtn is hidden if the layer is in range.
     if (layer.zoomBtn instanceof HTMLElement) {
       layer.zoomBtn.style.setProperty('display', 'none');
@@ -323,5 +340,9 @@ function changeEnd(layer) {
       el.disabled = true;
       el.classList.add('disabled');
     });
+
+    if (layer.viewConfig.hideDisabled) {
+      layer.view.classList.add('display-none');
+    }
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "xyz",
-  "version": "v4.16.1",
+  "version": "v4.17.0",
   "type": "module",
   "repository": {
     "type": "git",


### PR DESCRIPTION
The `activateUpdate` flag is a legacy flag that is not used anymore. 
A dataviews state should be determined by the `dynamic` flag so that dataviews displayed in the `location` or `tabview` target behave exactly the same. 

When a dataview has the `dynamic` flag, the dataview is recreated and its data is refreshed. 