### PR TITLE
fix(dataview): Dynamic dataviews data is not refreshed when data exists

### DIFF
--- a/lib/ui/Tabview.mjs
+++ b/lib/ui/Tabview.mjs
@@ -138,8 +138,8 @@ function addTab(entry) {
     }
 
     if (entry.update instanceof Function) {
-      if (!entry.data || entry.activateUpdate) {
-        // Call dataview update method if data is falsy or activateUpdate flag is set.
+      if (!entry.data || entry.dynamic) {
+        // Call dataview update method if data is falsy or dynamic flag is set.
         entry.update();
       }
     }

--- a/lib/ui/Tabview.mjs
+++ b/lib/ui/Tabview.mjs
@@ -139,8 +139,7 @@ function addTab(entry) {
 
     // Dataviews with the dynamic flag will always update.
     if (!entry.data || entry.dynamic) {
-        entry.update?.();
-      }
+      entry.update?.();
     }
 
     //Show toolbar buttons if there are any

--- a/lib/ui/Tabview.mjs
+++ b/lib/ui/Tabview.mjs
@@ -137,10 +137,9 @@ function addTab(entry) {
       entry.create();
     }
 
-    if (entry.update instanceof Function) {
-      if (!entry.data || entry.dynamic) {
-        // Call dataview update method if data is falsy or dynamic flag is set.
-        entry.update();
+    // Dataviews with the dynamic flag will always update.
+    if (!entry.data || entry.dynamic) {
+        entry.update?.();
       }
     }
 


### PR DESCRIPTION
The `activateUpdate` flag was a legacy flag that's no longer used.
A dataviews refresh is determined by the `dynamic` flag. 
If `dynamic` is set, a dataview is recreated and its data refreshed. 

This is the current behaviour when a dataview is displayed in the `location`. 
However, this PR addresses a misalignment of behaviour when the dataview is displayed in the `tabview`. 
They should work identically regardless of the dataviews target.