### PR TITLE
fix(queryparams): create empty object if queryparams are undefined

### DIFF
--- a/lib/utils/queryParams.mjs
+++ b/lib/utils/queryParams.mjs
@@ -39,7 +39,6 @@ The queryParams method is particularly useful for calculating the current [viewp
 @returns {object} A params object to create a params string.
 */
 function queryParams(_this) {
-
   // Must be an empty object if undefined.
   _this.queryparams ??= {};
 


### PR DESCRIPTION
#2314 introduced an issue in regards to empty queryparams objects.

Previously an empty queryparams object would be assigned to the query by merging the various objects which may have a queryparams object property.

<img width="623" height="358" alt="image" src="https://github.com/user-attachments/assets/52816112-aa54-457b-9398-d3471acd4987" />

With the queryparams property undefined the params object returned would be undefined. This creates an empty param string which will then ask the XYZ backend to look up an undefined key template which will crash the process.

<img width="633" height="297" alt="image" src="https://github.com/user-attachments/assets/421de501-5248-4fbb-a813-7c20cfd2b615" />

This PR addresses this by creating an empty queryparams object property on the query object _this if undefined.