### PR TITLE
Exclude templates with src ending in html from usage tests.

### DIFF
--- a/mod/workspace/_workspace.js
+++ b/mod/workspace/_workspace.js
@@ -421,7 +421,7 @@ async function test(req, res) {
   testConfig.workspace_templates = new Set(
     Object.entries(workspace.templates)
       .filter(([key, value]) => value._type === 'workspace')
-      .filter(([key, value]) => !value.src || !value.src.endsWith('.html'))
+      .filter(([key, value]) => !value.src?.endsWith('.html'))
       .map(([key, value]) => key),
   );
 

--- a/mod/workspace/_workspace.js
+++ b/mod/workspace/_workspace.js
@@ -421,6 +421,7 @@ async function test(req, res) {
   testConfig.workspace_templates = new Set(
     Object.entries(workspace.templates)
       .filter(([key, value]) => value._type === 'workspace')
+      .filter(([key, value]) => !value.src || !value.src.endsWith('.html'))
       .map(([key, value]) => key),
   );
 


### PR DESCRIPTION
The test method will filter out any template where the src ends with '.html' from tests as these may not be called from any other workspace object.