### PR TITLE
locale / layer queryparams must be assigned in the queryParams module

### DIFF
--- a/lib/utils/queryParams.mjs
+++ b/lib/utils/queryParams.mjs
@@ -50,6 +50,11 @@ function queryParams(_this) {
 
   let layer = _this.layer || _this.location?.layer;
 
+  // Merge layer queryparams with request queryparams.
+  if (layer.queryparams) {
+    Object.assign(_this.queryparams, layer.queryparams);
+  }
+
   // Assign table from layer JSON or layer.tableCurrent() method.
   _this.queryparams.table &&=
     typeof _this.queryparams.table === 'string'

--- a/mod/query.js
+++ b/mod/query.js
@@ -148,11 +148,6 @@ async function layerQuery(req, res) {
     req.params.layer = await getLayer(req.params);
   }
 
-  // Merge layer queryparams with request queryparams.
-  if (req.params.layer.queryparams) {
-    Object.assign(req.params, req.params.layer.queryparams);
-  }
-
   // getLayer will return error on role restrictions.
   if (req.params.layer instanceof Error) {
     return res.status(400).send(req.params.layer.message);


### PR DESCRIPTION
In order for dynamic queryparams to be looked up from the provided params object the layer queryparams must be merged inside the queryParams module, not in the xyz query module which does not have access to the location [eg location.id].