### PR TITLE
Fix issue vector layer srid issues

### DIFF
--- a/lib/layer/featureFormats.mjs
+++ b/lib/layer/featureFormats.mjs
@@ -86,12 +86,14 @@ export function wkt(layer, features) {
       properties[field] = feature[i];
     });
 
+    const geometry = formatWKT.readGeometry(properties.wkt_geometry, {
+      dataProjection: 'EPSG:' + layer.srid,
+      featureProjection: 'EPSG:' + layer.mapview.srid,
+    });
+
     // Return feature from geometry with properties.
     return new ol.Feature({
-      geometry: formatWKT.readGeometry(properties.wkt_geometry, {
-        dataProjection: 'EPSG:' + layer.srid,
-        featureProjection: 'EPSG:' + layer.mapview.srid,
-      }),
+      geometry,
       ...properties,
     });
   });

--- a/lib/layer/format/vector.mjs
+++ b/lib/layer/format/vector.mjs
@@ -205,7 +205,7 @@ function reload(callback) {
   // Set request params.fields for styling.
   layer.params.fields = mapp.layer.featureFields.fieldsArray(layer);
 
-  const bounds = layer.mapview.getBounds();
+  const bounds = layer.mapview.getBounds(layer.srid);
 
   // Assign current viewport if queryparam is truthy.
   layer.params.viewport &&= [
@@ -213,7 +213,7 @@ function reload(callback) {
     bounds.south,
     bounds.east,
     bounds.north,
-    layer.mapview.srid,
+    layer.srid,
   ];
 
   // Assign current viewport if queryparam is truthy.


### PR DESCRIPTION
Vector layer need tto request the viewport according to the layer.srid, not the mapview srid. That's known by the mapview itself.

Moved assignment of geometry out of ol.Feature() method in featureFormats for debugging.