### PR TITLE
Add notranslate to material-symbols-outlined class elements

### DIFF
--- a/lib/plugins/admin.mjs
+++ b/lib/plugins/admin.mjs
@@ -29,5 +29,5 @@ export function admin(plugin, mapview) {
     <a
       title=${mapp.dictionary.toolbar_admin}
       href="${mapp.host + '/api/user/admin'}">
-      <span class="material-symbols-outlined">supervisor_account`);
+      <span class="notranslate material-symbols-outlined">supervisor_account`);
 }

--- a/lib/plugins/dark_mode.mjs
+++ b/lib/plugins/dark_mode.mjs
@@ -48,7 +48,7 @@ export function dark_mode(plugin, mapview) {
       const modeIcon = mapButton.querySelector('.btn-color-mode span');
       modeIcon.textContent = darkMode ? 'light_mode' : 'dark_mode';
     }}>
-    <span class="material-symbols-outlined">${darkMode ? 'light_mode' : 'dark_mode'}`);
+    <span class="notranslate material-symbols-outlined">${darkMode ? 'light_mode' : 'dark_mode'}`);
 }
 
 /**

--- a/lib/plugins/feature_info.mjs
+++ b/lib/plugins/feature_info.mjs
@@ -36,7 +36,7 @@ export function feature_info(plugin, mapview) {
     title=${mapp.dictionary.feature_info}
     data-id="feature_info"
     onclick=${() => toggleFeatureInfoHighlight(plugin, mapview)}>
-    <span class="material-symbols-outlined">left_click`;
+    <span class="notranslate material-symbols-outlined">left_click`;
 
   btnColumn.append(plugin.btn);
 }

--- a/lib/plugins/fullscreen.mjs
+++ b/lib/plugins/fullscreen.mjs
@@ -37,7 +37,7 @@ export function fullscreen(plugin, mapview) {
       class="mobile-display-none"
       title=${mapp.dictionary.toolbar_fullscreen}
       onclick=${toggleFullscreen}>
-      <span class="material-symbols-outlined">left_panel_close`;
+      <span class="notranslate material-symbols-outlined">left_panel_close`;
 
   btnColumn.append(btn);
 }

--- a/lib/plugins/link_button.mjs
+++ b/lib/plugins/link_button.mjs
@@ -79,7 +79,7 @@ function addButton(link, localeKey) {
 
   link.css_class ??= '';
 
-  const css_class = `material-symbols-outlined ${link.css_class}`;
+  const css_class = `notranslate material-symbols-outlined ${link.css_class}`;
 
   // If no icon name is provided, warn
   if (!link.icon_name) {

--- a/lib/plugins/locator.mjs
+++ b/lib/plugins/locator.mjs
@@ -30,7 +30,7 @@ export function locator(plugin, mapview) {
       onclick=${(e) => {
         e.target.classList.toggle('active');
         mapview.locate();
-      }}><span class="material-symbols-outlined">my_location`;
+      }}><span class="notranslate material-symbols-outlined">my_location`;
 
   btnColumn.append(btn);
 }

--- a/lib/plugins/login.mjs
+++ b/lib/plugins/login.mjs
@@ -29,7 +29,7 @@ export function login(plugin, mapview) {
   const iconName = `${mapp.user ? 'logout' : 'lock_open'}`;
 
   const iconClass =
-    'material-symbols-outlined' + (mapp.user ? ' color-danger' : '');
+    'notranslate material-symbols-outlined' + (mapp.user ? ' color-danger' : '');
 
   btnColumn.appendChild(mapp.utils.html.node`
     <a

--- a/lib/plugins/userIDB.mjs
+++ b/lib/plugins/userIDB.mjs
@@ -37,7 +37,7 @@ export function userIDB(plugin, mapview) {
         plugin.dialog?.close();
       }
     }}>
-    <span class="material-symbols-outlined">rule_settings`;
+    <span class="notranslate material-symbols-outlined">rule_settings`;
 
   // Append the plugin btn to the btnColumn.
   btnColumn.append(plugin.button);
@@ -83,14 +83,14 @@ async function userDialog(plugin) {
     // Push button to add layer to mapview layers.
     items.push(
       {
-        className: 'material-symbols-outlined-important',
+        className: 'notranslate material-symbols-outlined-important',
         onClick: updateUser,
         text: 'person_edit',
         title: 'Update User',
         type: 'button',
       },
       {
-        className: 'material-symbols-outlined-important',
+        className: 'notranslate material-symbols-outlined-important',
         onClick: removeUser,
         text: 'person_remove',
         title: 'Remove User',

--- a/lib/plugins/zoomBtn.mjs
+++ b/lib/plugins/zoomBtn.mjs
@@ -42,7 +42,7 @@ export function zoomBtn(plugin, mapview) {
         const z = parseInt(mapview.Map.getView().getZoom() + 1);
         mapview.Map.getView().setZoom(z);
         e.target.disabled = z >= mapview.locale.maxZoom;
-      }}><span class="material-symbols-outlined">zoom_in`);
+      }}><span class="notranslate material-symbols-outlined">zoom_in`);
 
   // Add zoomOut button.
   const btnZoomOut = btnColumn.appendChild(mapp.utils.html.node`
@@ -54,7 +54,7 @@ export function zoomBtn(plugin, mapview) {
         const z = parseInt(mapview.Map.getView().getZoom() - 1);
         mapview.Map.getView().setZoom(z);
         e.target.disabled = z <= mapview.locale.minZoom;
-      }}><span class="material-symbols-outlined">zoom_out`);
+      }}><span class="notranslate material-symbols-outlined">zoom_out`);
 
   // changeEnd event listener for zoom button
   mapview.Map.getTargetElement().addEventListener('changeEnd', () => {

--- a/lib/plugins/zoomToArea.mjs
+++ b/lib/plugins/zoomToArea.mjs
@@ -57,7 +57,7 @@ export function zoomToArea(plugin, mapview) {
       data-id="zoomtoarea"
       title=${mapp.dictionary.toolbar_zoom_to_area}
       onclick=${toggleZoomInteraction}>
-      <span class="material-symbols-outlined">pageview`;
+      <span class="notranslate material-symbols-outlined">pageview`;
 
   btnColumn.append(btn);
 }

--- a/lib/ui/elements/btnPanel.mjs
+++ b/lib/ui/elements/btnPanel.mjs
@@ -9,7 +9,7 @@ export default (params) => mapp.utils.html.node`
         }}>
         <div class="header">
             <h3>${params.label}</h3>
-            <div class="material-symbols-outlined">${params.icon_name}</div>
+            <div class="notranslate material-symbols-outlined">${params.icon_name}</div>
         </div>
         ${
           params.panel &&

--- a/lib/ui/elements/card.mjs
+++ b/lib/ui/elements/card.mjs
@@ -27,7 +27,7 @@ export default function card(params) {
     <header class="header bold">
       <span>${params.header}</span>
       <button
-        class="material-symbols-outlined color-font-mid"
+        class="notranslate material-symbols-outlined color-font-mid"
         onclick=${(e) => {
           e.target.closest('.drawer').remove();
           if (typeof params.close === 'function') {

--- a/lib/ui/elements/chkbox.mjs
+++ b/lib/ui/elements/chkbox.mjs
@@ -36,7 +36,7 @@ export default function chkbox(params) {
       onchange=${(e) => {
         params.onchange?.(e.target.checked, params.val);
       }}/>
-    <span class="material-symbols-outlined"/>
+    <span class="notranslate material-symbols-outlined"/>
     <span>${params.label}`;
 
   return chkbox;

--- a/lib/ui/elements/dialog.mjs
+++ b/lib/ui/elements/dialog.mjs
@@ -69,7 +69,7 @@ export default function dialog(dialog) {
 
   dialog.minimizeBtn &&= mapp.utils.html`<button
     data-id="minimize"
-    class="minimize-btn material-symbols-outlined"
+    class="minimize-btn notranslate material-symbols-outlined"
     onclick=${(e) => {
       e.target.closest('dialog').classList.toggle('minimized');
     }}>`;
@@ -85,7 +85,7 @@ export default function dialog(dialog) {
 
   dialog.closeBtn &&= mapp.utils.html`<button
     data-id=close
-    class="material-symbols-outlined close"
+    class="notranslate material-symbols-outlined close"
     onclick=${closeDialog}>`;
 
   dialog.header =

--- a/lib/ui/elements/drawer.mjs
+++ b/lib/ui/elements/drawer.mjs
@@ -46,7 +46,7 @@ export default function drawer(params) {
 
     params.popoutBtn = params.drawer.querySelector('[data-id=popout-btn]');
     params.popoutBtn ??= mapp.utils.html
-      .node`<button data-id="popout-btn" class="material-symbols-outlined">
+      .node`<button data-id="popout-btn" class="notranslate material-symbols-outlined">
                     open_in_new
                   </button>`;
 

--- a/lib/ui/elements/drawing.mjs
+++ b/lib/ui/elements/drawing.mjs
@@ -134,7 +134,7 @@ function point(layer) {
     <button
       class="action wide"
       onclick=${(e) => drawOnclick(e, layer, layer.draw.point)}>
-      <span class="material-symbols-outlined">add_location_alt</span>
+      <span class="notranslate material-symbols-outlined">add_location_alt</span>
       ${layer.draw.point.label}`;
 
   return layer.draw.point.btn;
@@ -168,7 +168,7 @@ function line(layer) {
     <button
       class="action wide"
       onclick=${(e) => drawOnclick(e, layer, layer.draw.line)}>
-      <span class="material-symbols-outlined">polyline</span>
+      <span class="notranslate material-symbols-outlined">polyline</span>
       ${layer.draw.line.label}`;
 
   return layer.draw.line.btn;
@@ -203,7 +203,7 @@ function polygon(layer) {
     <button
       class="action wide"
       onclick=${(e) => drawOnclick(e, layer, layer.draw.polygon)}>
-      <span class="material-symbols-outlined">activity_zone</span>
+      <span class="notranslate material-symbols-outlined">activity_zone</span>
       ${layer.draw.polygon.label}`;
 
   return layer.draw.polygon.btn;
@@ -237,7 +237,7 @@ function rectangle(layer) {
   <button
     class="action wide"
     onclick=${(e) => drawOnclick(e, layer, layer.draw.rectangle)}>
-    <span class="material-symbols-outlined">rectangle</span>
+    <span class="notranslate material-symbols-outlined">rectangle</span>
     ${layer.draw.rectangle.label}`;
 
   return layer.draw.rectangle.btn;
@@ -271,7 +271,7 @@ function circle_2pt(layer) {
   <button
     class="action wide"
     onclick=${(e) => drawOnclick(e, layer, layer.draw.circle_2pt)}>
-    <span class="material-symbols-outlined">outbound</span>
+    <span class="notranslate material-symbols-outlined">outbound</span>
     ${layer.draw.circle_2pt.label}`;
 
   return layer.draw.circle_2pt.btn;
@@ -393,7 +393,7 @@ function circle(layer) {
   circle.btn = mapp.utils.html.node`<button
     class="action wide"
     onclick=${(e) => drawOnclick(e, layer, circle)}>
-      <span class="material-symbols-outlined">add_circle</span>
+      <span class="notranslate material-symbols-outlined">add_circle</span>
       ${circle.label}`;
 
   const content = mapp.utils.html.node`
@@ -412,7 +412,7 @@ function circle(layer) {
   circle.drawer = mapp.ui.elements.drawer({
     header: mapp.utils.html`
     <h3>${mapp.dictionary.circle_config}</h3>
-    <div class="material-symbols-outlined caret"/>`,
+    <div class="notranslate material-symbols-outlined caret"/>`,
     content,
     popout: circle.popout,
   });
@@ -501,7 +501,7 @@ function locator(layer) {
           mapp.location.get(location);
         });
       }}>
-      <span class="material-symbols-outlined">my_location</span>
+      <span class="notranslate material-symbols-outlined">my_location</span>
       ${layer.draw.locator.label}`;
 
   return layer.draw.locator.btn;

--- a/lib/ui/elements/pills.mjs
+++ b/lib/ui/elements/pills.mjs
@@ -75,7 +75,7 @@ function add(val) {
   // Only append the remove button to pill if configured.
   if (component.removeCallback) {
     pill.append(mapp.utils.html
-      .node`<button class="material-symbols-outlined close"
+      .node`<button class="notranslate material-symbols-outlined close"
       data-value=${val}
       title=${mapp.dictionary.pill_component_remove}
       onclick=${(e) => {

--- a/lib/ui/elements/toast.mjs
+++ b/lib/ui/elements/toast.mjs
@@ -69,7 +69,7 @@ export default function toast(params = {}) {
     let closeBtn;
     if (params.close) {
       closeBtn = mapp.utils.html`
-        <button class="material-symbols-outlined close"
+        <button class="notranslate material-symbols-outlined close"
           onclick=${hide_toast}>`;
     }
 

--- a/lib/ui/elements/userLocale.mjs
+++ b/lib/ui/elements/userLocale.mjs
@@ -32,7 +32,7 @@ export default function userLocale(params, mapview) {
     <div style="display:flex;">${params.localeInput}
       <button style="font-size: 1.5em;"
         onclick=${async () => await saveLocale(params, mapview)}>
-        <span class="material-symbols-outlined">save</span>
+        <span class="notranslate material-symbols-outlined">save</span>
       </button>
     </div>
     
@@ -93,7 +93,7 @@ async function listLocales(params, mapview) {
 
     const removeBtn = mapp.utils.html`<button
        onclick=${async (e) => await removeLocale(params, mapview, locale.name)}>
-        <span class="material-symbols-outlined">delete</span>
+        <span class="notranslate material-symbols-outlined">delete</span>
       </button>`;
 
     return mapp.utils

--- a/lib/ui/layers/listview.mjs
+++ b/lib/ui/layers/listview.mjs
@@ -110,7 +110,7 @@ function createGroup(layer) {
 
   // Create hide all group layers button
   group.hideLayers = mapp.utils.html.node`<button
-  class="material-symbols-outlined active"
+  class="notranslate material-symbols-outlined active"
     title=${mapp.dictionary.layer_group_hide_layers}
     onclick=${(e) => {
       e.target.style.visibility = 'hidden';
@@ -127,7 +127,7 @@ function createGroup(layer) {
     header: mapp.utils.html`
        <h2>${layer.group}</h2>
        ${group.hideLayers}
-       <div class="material-symbols-outlined caret"/>`,
+       <div class="notranslate material-symbols-outlined caret"/>`,
   });
 
   this.node.appendChild(group.drawer);

--- a/lib/ui/layers/panels/dataviews.mjs
+++ b/lib/ui/layers/panels/dataviews.mjs
@@ -99,7 +99,7 @@ export default function dataviews(layer) {
     data_id: `dataviews-drawer`,
     header: mapp.utils.html`
       <h3>${mapp.dictionary.layer_dataview_header}</h3>
-      <div class="material-symbols-outlined caret"/>`,
+      <div class="notranslate material-symbols-outlined caret"/>`,
     popout: layer.dataviews.popout,
   });
 

--- a/lib/ui/layers/panels/draw.mjs
+++ b/lib/ui/layers/panels/draw.mjs
@@ -58,7 +58,7 @@ export default function drawPanel(layer) {
     data_id: `draw-drawer`,
     header: mapp.utils.html`
       <h3>${mapp.dictionary.layer_add_new_location}</h3>
-      <div class="material-symbols-outlined caret"/>`,
+      <div class="notranslate material-symbols-outlined caret"/>`,
     content,
     popout: layer.draw.popout,
   });

--- a/lib/ui/layers/panels/filter.mjs
+++ b/lib/ui/layers/panels/filter.mjs
@@ -161,7 +161,7 @@ export default function filterPanel(layer) {
       class: `raised ${layer.filter.classList || ''}`,
       header: mapp.utils.html`
         <h3>${mapp.dictionary.layer_filter_header}</h3>
-        <div class="material-symbols-outlined caret"/>`,
+        <div class="notranslate material-symbols-outlined caret"/>`,
       content: mapp.utils.html`
         ${layer.filter.dropdown}
         ${layer.filter.clearAll}

--- a/lib/ui/layers/panels/reports.mjs
+++ b/lib/ui/layers/panels/reports.mjs
@@ -52,7 +52,7 @@ export default function reports(layer) {
         class="link-with-img"
         target="_blank"
         href="${href}">
-        <span class="material-symbols-outlined">summarize</span>
+        <span class="notranslate material-symbols-outlined">summarize</span>
         <span>${report.title || report.key}`);
   }
 
@@ -66,7 +66,7 @@ export default function reports(layer) {
     data_id: `reports-drawer`,
     header: mapp.utils.html`
       <h3>Reports</h3>
-      <div class="material-symbols-outlined caret"/>`,
+      <div class="notranslate material-symbols-outlined caret"/>`,
     content: reportLinks,
     popout: layer.reports.popout,
   });

--- a/lib/ui/layers/panels/style.mjs
+++ b/lib/ui/layers/panels/style.mjs
@@ -64,7 +64,7 @@ export default function stylePanel(layer) {
   // Create header for layer.view style drawer.
   const header = mapp.utils.html`
     <h3>${mapp.dictionary.layer_style_header}</h3>
-    <div class="material-symbols-outlined caret"/>`;
+    <div class="notranslate material-symbols-outlined caret"/>`;
 
   if (layer.style.drawer === false) {
     layer.style.drawer = mapp.utils.html

--- a/lib/ui/layers/view.mjs
+++ b/lib/ui/layers/view.mjs
@@ -56,7 +56,7 @@ export default function layerView(layer) {
       data-id=zoomToFilteredExtentBtn
       title=${mapp.dictionary.layer_zoom_to_extent}
       style=${zoomToFilteredExtentBtnStyle}
-      class="material-symbols-outlined"
+      class="notranslate material-symbols-outlined"
       onclick=${async (e) => {
         // disable button if no locations were found.
         e.target.disabled = !(await layer.zoomToExtent());
@@ -65,7 +65,7 @@ export default function layerView(layer) {
       }}>filter_alt`;
 
   // The displayToggle element should be on if the layer is displayed or should be displayed in zoom range.
-  const displayToggleClass = `material-symbols-outlined toggle ${
+  const displayToggleClass = `notranslate material-symbols-outlined toggle ${
     layer.zoomDisplay || layer.display ? 'toggle-on' : ''
   }`;
 
@@ -87,14 +87,14 @@ export default function layerView(layer) {
     mapp.utils.html.node`<button
       data-id="zoom-to"
       title=${mapp.dictionary.zoom_to}
-      class="material-symbols-outlined"
+      class="notranslate material-symbols-outlined"
       onclick=${() => zoomToRange(layer)}>arrows_input`;
 
   //Create a button for popping out the drawer
   layer.popoutBtn =
     layer.viewConfig.popoutBtn &&
     mapp.utils.html.node`
-      <button data-id="popout-btn" class="material-symbols-outlined">open_in_new</button>`;
+      <button data-id="popout-btn" class="notranslate material-symbols-outlined">open_in_new</button>`;
 
   // Add on callback for toggle button.
   layer.showCallbacks.push(() => {
@@ -110,7 +110,7 @@ export default function layerView(layer) {
   const caret =
     layer.drawer === false
       ? ''
-      : mapp.utils.html`<div class="material-symbols-outlined caret"></div>`;
+      : mapp.utils.html`<div class="notranslate material-symbols-outlined caret"></div>`;
 
   const header = mapp.utils.html`
     <h2>${layer.name || layer.key}</h2>

--- a/lib/ui/locations/entries/boolean.mjs
+++ b/lib/ui/locations/entries/boolean.mjs
@@ -49,6 +49,6 @@ export default function boolean(entry) {
 
   return mapp.utils.html.node`
     <div class="link-with-img">
-      <div class="material-symbols-outlined">${iconName}</div>
+      <div class="notranslate material-symbols-outlined">${iconName}</div>
       <span>${entry.label}`;
 }

--- a/lib/ui/locations/entries/cloudinary.mjs
+++ b/lib/ui/locations/entries/cloudinary.mjs
@@ -38,7 +38,7 @@ function image(entry) {
       entry.edit &&
       mapp.utils.html`<button 
       title="${mapp.dictionary.delete}"
-      class="material-symbols-outlined color-danger delete"
+      class="notranslate material-symbols-outlined color-danger delete"
       data-name=${entry.value.replace(/^.*\//, '').replace(/\.([\w-]{3})/, '')}
       data-src=${entry.value}
       onclick=${(e) => trash(e, entry, mapp.dictionary.remove_image_confirm)}>delete`;
@@ -57,7 +57,7 @@ function image(entry) {
         e.preventDefault();
         upload(e, entry);
       }}>
-      <p><span class="material-symbols-outlined add">add_a_photo</span>${mapp.dictionary.drag_and_drop_image}</p>
+      <p><span class="notranslate material-symbols-outlined add">add_a_photo</span>${mapp.dictionary.drag_and_drop_image}</p>
       <input
         type="file"
         accept="image/*;capture=camera" onchange=${(e) => {
@@ -85,7 +85,7 @@ function images(entry) {
     const trashBtn =
       entry.edit &&
       mapp.utils.html`<button title="${mapp.dictionary.delete}"
-      class="material-symbols-outlined color-danger delete"
+      class="notranslate material-symbols-outlined color-danger delete"
       data-name=${image.replace(/^.*\//, '').replace(/\.([\w-]{3})/, '')}
       data-src=${image}
       onclick=${(e) => trash(e, entry, mapp.dictionary.remove_image_confirm)}>delete`;
@@ -105,7 +105,7 @@ function images(entry) {
         e.preventDefault();
         upload(e, entry);
       }}>
-      <p><span class="material-symbols-outlined add">add_a_photo</span>${mapp.dictionary.drag_and_drop_image}</p>
+      <p><span class="notranslate material-symbols-outlined add">add_a_photo</span>${mapp.dictionary.drag_and_drop_image}</p>
       <input
         type="file"
         accept="image/*;capture=camera" onchange=${(e) => {
@@ -137,7 +137,7 @@ function documents(entry) {
       entry.edit &&
       mapp.utils.html`<button 
       title="${mapp.dictionary.delete}"
-      class="material-symbols-outlined color-danger delete"
+      class="notranslate material-symbols-outlined color-danger delete"
       data-name=${doc.replace(/^.*\//, '').replace(/\.([\w-]{3})/, '')}
       data-href=${doc}
       onclick=${(e) => trash(e, entry, mapp.dictionary.remove_document_confirm)}>delete`;
@@ -156,7 +156,7 @@ function documents(entry) {
         e.preventDefault();
         upload(e, entry);
       }}>
-      <p><span class="material-symbols-outlined add-doc">add_notes</span>${mapp.dictionary.drag_and_drop_doc}</p>
+      <p><span class="notranslate material-symbols-outlined add-doc">add_notes</span>${mapp.dictionary.drag_and_drop_doc}</p>
       <input type="file"
         accept=".txt,.pdf,.doc,.docx,.xls,.xlsx,application/msword,application/vnd.openxmlformats-officedocument.wordprocessingml.document;"
         onchange=${(e) => upload(e, entry)}>`;

--- a/lib/ui/locations/entries/geometry.mjs
+++ b/lib/ui/locations/entries/geometry.mjs
@@ -236,7 +236,7 @@ function edit(entry) {
           entry.location.layer.mapview.interactions.highlight();
         }
       }}>
-      <span class="material-symbols-outlined">format_shapes</span>
+      <span class="notranslate material-symbols-outlined">format_shapes</span>
       ${entry.edit.modify_label}`;
 
   entry.elements.push(entry.edit.modify_btn);
@@ -247,7 +247,7 @@ function edit(entry) {
   entry.edit.delete &&
     entry.elements.push(mapp.utils.html`<button class="action wide"
     onclick=${() => deleteGeometry(entry)}>
-    <span class="material-symbols-outlined color-danger">ink_eraser</span>
+    <span class="notranslate material-symbols-outlined color-danger">ink_eraser</span>
     <span style="color: var(--color-danger)">${entry.edit.delete_label}</span>`);
 }
 

--- a/lib/ui/locations/entries/link.mjs
+++ b/lib/ui/locations/entries/link.mjs
@@ -25,7 +25,7 @@ Styling options include altering icon name and its css class and also a placehol
 @property {string} [entry.label] Text to display, defaults to generic link text.
 @property {string} [entry.data_id] Optional data_id for element identification.
 @property {string} [entry.link_class] Optional classList string applied to the link element, eg. `outlined`.
-@property {string} [entry.icon_class] Optional classList string appended to the `material-symbols-outlined` class for the icon element. 
+@property {string} [entry.icon_class] Optional classList string appended to the `notranslate material-symbols-outlined` class for the icon element. 
 @property {string} [entry.icon_name] Optional icon name from Material Icons `https://fonts.google.com/icons`. Defaults to `open_in_new` and sets to `description` for reports.
 
 @return {HTMLElement} <a> tag with inline content.
@@ -65,7 +65,7 @@ export default function link_entry(entry) {
 
   entry.icon_name ??= 'open_in_new';
   entry.icon_class ??= '';
-  const icon_class = `material-symbols-outlined ${entry.icon_class}`;
+  const icon_class = `notranslate material-symbols-outlined ${entry.icon_class}`;
 
   entry.link_class ??= '';
   const link_class = `link-with-img ${entry.link_class}`;

--- a/lib/ui/locations/entries/title.mjs
+++ b/lib/ui/locations/entries/title.mjs
@@ -33,7 +33,7 @@ export default function title(entry) {
   const tooltipIcon =
     entry.tooltip &&
     mapp.utils.html`
-      <span class="tooltip material-symbols-outlined">help</span>`;
+      <span class="tooltip notranslate material-symbols-outlined">help</span>`;
 
   return mapp.utils.html.node`
       <div

--- a/lib/ui/locations/infoj.mjs
+++ b/lib/ui/locations/infoj.mjs
@@ -348,7 +348,7 @@ function entryGroup(entry) {
         class: `group`,
         header: mapp.utils.html`
           <h3>${entry.group}</h3>
-          <div class="material-symbols-outlined caret"/>`,
+          <div class="notranslate material-symbols-outlined caret"/>`,
       }),
     );
   }

--- a/lib/ui/locations/view.mjs
+++ b/lib/ui/locations/view.mjs
@@ -35,7 +35,7 @@ export default function view(location) {
   // Header with expander icon.
   const header = [
     mapp.utils.html`<h2>${location.record.symbol}`,
-    mapp.utils.html`<div class="material-symbols-outlined caret"/>`,
+    mapp.utils.html`<div class="notranslate material-symbols-outlined caret"/>`,
   ];
 
   // Zoom to location bounds.
@@ -46,7 +46,7 @@ export default function view(location) {
   ) {
     header.push(mapp.utils.html`<button
       title = ${mapp.dictionary.location_zoom}
-      class = "material-symbols-outlined"
+      class = "notranslate material-symbols-outlined"
       onclick = ${() => location.flyTo()}>search`);
   }
 
@@ -58,7 +58,7 @@ export default function view(location) {
   // Update icon.
   header.push(mapp.utils.html`<button
     title=${mapp.dictionary.location_save}
-    class="btn-save material-symbols-outlined color-info"
+    class="btn-save notranslate material-symbols-outlined color-info"
     style="display: none;"
     onclick = ${() => {
       location.view.classList.add('disabled');
@@ -74,14 +74,14 @@ export default function view(location) {
   if (location.layer?.edit?.delete || location.layer?.deleteLocation) {
     header.push(mapp.utils.html`<button
       title=${mapp.dictionary.location_delete}
-      class="material-symbols-outlined color-danger"
+      class="notranslate material-symbols-outlined color-danger"
       onclick = ${() => location.trash()}>delete`);
   }
 
   // Clear selection.
   header.push(mapp.utils.html`<button
     title=${mapp.dictionary.location_remove}
-    class="material-symbols-outlined"
+    class="notranslate material-symbols-outlined"
     onclick=${location_remove}>close</button>`);
 
   /**
@@ -179,7 +179,7 @@ function toggleLocationViewEdits(location) {
   // Remove edits if location is not new.
   !location.new && location.removeEdits();
 
-  const classList = `material-symbols-outlined ${location.new ? 'toggle-on' : ''}`;
+  const classList = `notranslate material-symbols-outlined ${location.new ? 'toggle-on' : ''}`;
 
   // Create edit toggle button.
   location.editToggle = mapp.utils.html.node`<button

--- a/lib/ui/utils/dataview.mjs
+++ b/lib/ui/utils/dataview.mjs
@@ -184,7 +184,7 @@ async function updateDialog(dataview) {
   function renderUpdateMenu(items) {
     // Push button to add layer to mapview layers.
     items.push({
-      className: 'material-symbols-outlined-important',
+      className: 'notranslate material-symbols-outlined-important',
       onClick: updateDataview,
       text: 'sync',
       title: 'Update Dataview Query',
@@ -192,7 +192,7 @@ async function updateDialog(dataview) {
     });
 
     items.push({
-      className: 'material-symbols-outlined-important',
+      className: 'notranslate material-symbols-outlined-important',
       onClick: setDataview,
       text: 'data_object',
       title: 'Set Dataview Data',

--- a/lib/ui/utils/imagePreview.mjs
+++ b/lib/ui/utils/imagePreview.mjs
@@ -19,7 +19,7 @@ export default function imagePreview(e) {
       class="bg-image" 
       style=${`background-image:url(${e.target.src})`}>
     <button 
-      class="btn-close material-symbols-outlined"
+      class="btn-close notranslate material-symbols-outlined"
       onclick=${(e) => e.target.closest('.interface-mask').remove()}>close</button>`;
 
   document.body.append(previewElement);

--- a/public/views/_default.html
+++ b/public/views/_default.html
@@ -189,8 +189,8 @@
 
     <div id="ctrls">
       <div id="ctrl-tabs" class="hover">
-        <div data-id="layers" class="active material-symbols-outlined"></div>
-        <div data-id="locations" class="material-symbols-outlined"></div>
+        <div data-id="layers" class="active notranslate material-symbols-outlined"></div>
+        <div data-id="locations" class="notranslate material-symbols-outlined"></div>
       </div>
 
       <div id="ctrl-panel">


### PR DESCRIPTION
This PR adds the notranslate class to any instance of ` material-symbols-outlined`, `'material-symbols-outlined`, and `"material-symbols-outlined`.

The text content of these icon elements will not be translated through google translate.