### PR TITLE
fix(filterDialog): unnest filterDialog method

### DIFF
--- a/lib/ui/layers/panels/filter.mjs
+++ b/lib/ui/layers/panels/filter.mjs
@@ -413,7 +413,7 @@ function openDialog(layer) {
     closeBtn: true,
     onClose: () => {
       // Toggle the active class on the button
-      layer.filter.dialog_btn.classList.remove('active');
+      layer.filter.dialog.btn.classList.remove('active');
     },
   });
 

--- a/lib/ui/layers/panels/filter.mjs
+++ b/lib/ui/layers/panels/filter.mjs
@@ -146,49 +146,11 @@ export default function filterPanel(layer) {
     layer.filter.viewport_description,
   ];
 
-  if (layer.filter.dialog) {
-    if (layer.filter.dialog === true) layer.filter.dialog = {};
-
-    layer.filter.dialog.btn_title ??= mapp.dictionary.filter_btn_title;
-    layer.filter.dialog.btn_label ??= mapp.dictionary.filter_btn_label;
-
-    layer.filter.dialog_btn = mapp.utils.html.node`<button 
-    class="flat wide primary-colour multi_hover"
-    data-id=${`multifilter-${layer.key}`}
-    title=${layer.filter.dialog.btn_title}
-    onclick=${(e) => {
-      // classList.toggle resolves as true when the class is added.
-      if (layer.filter.dialog_btn.classList.toggle('active')) {
-        openDialog(layer);
-      } else {
-        // The decorated dialog object has a close method.
-        layer.filter.dialog.close();
-      }
-    }}>${layer.filter.dialog.btn_label}`;
-
-    //Show the dialog on layer display
-    if (layer.filter.dialog.showOnLayerDisplay) {
-      layer.showCallbacks.push(() => {
-        !layer.filter.dialog_btn.classList.contains('active') &&
-          layer.filter.dialog_btn.dispatchEvent(new Event('click'));
-        return layer;
-      });
-
-      layer.display &&
-        layer.filter.dialog_btn.dispatchEvent(new Event('click'));
-    }
-
-    //Hide the dialog when the layer is hidden
-    layer.hideCallbacks.push(() => {
-      layer.filter.dialog_btn.classList.contains('active') &&
-        layer.filter.dialog_btn.dispatchEvent(new Event('click'));
-      return layer;
-    });
-  }
+  filterDialog(layer);
 
   if (layer.filter.drawer === false) {
     layer.filter.view =
-      layer.filter.dialog_btn ||
+      layer.filter.dialog?.btn ||
       mapp.utils.html
         .node`<div data-id="filter-drawer"><h3>${mapp.dictionary.filter_header}</h3>
     ${layer.filter.content}`;
@@ -199,7 +161,7 @@ export default function filterPanel(layer) {
       header: mapp.utils.html`
         <h3>${mapp.dictionary.filter_header}</h3>
         <div class="material-symbols-outlined caret"/>`,
-      content: layer.filter.dialog_btn || layer.filter.content,
+      content: layer.filter.dialog?.btn || layer.filter.content,
       popout: layer.filter.popout,
       view: layer.view,
     };
@@ -345,6 +307,60 @@ function updatePanel(layer) {
       layer.filter.feature_count.style.setProperty('display', 'block');
     });
   }, 1000);
+}
+
+/**
+@function filterDialog
+
+@description
+The filterDialog method creates a button to toggle the filter dialog if configured.
+
+@param {Object} layer
+@property {Object} layer.filter The layer filter configuration.
+@property {Object} [filter.dialog] The configuration for the filter dialog.
+@property {String} [dialog.btn_title] The title string for the filter dialog toggle button.
+@property {String} [dialog.btn_label] The label string for the filter dialog toggle button.
+@property {Object} [dialog.showOnLayerDisplay] Show dialog in layer showCallback.
+*/
+function filterDialog(layer) {
+  if (!layer.filter.dialog) return;
+
+  if (layer.filter.dialog === true) layer.filter.dialog = {};
+
+  layer.filter.dialog.btn_title ??= mapp.dictionary.filter_btn_title;
+  layer.filter.dialog.btn_label ??= mapp.dictionary.filter_btn_label;
+
+  layer.filter.dialog.btn = mapp.utils.html.node`<button 
+    class="flat wide primary-colour multi_hover"
+    data-id=${`multifilter-${layer.key}`}
+    title=${layer.filter.dialog.btn_title}
+    onclick=${(e) => {
+      // classList.toggle resolves as true when the class is added.
+      if (layer.filter.dialog?.btn.classList.toggle('active')) {
+        openDialog(layer);
+      } else {
+        // The decorated dialog object has a close method.
+        layer.filter.dialog.close();
+      }
+    }}>${layer.filter.dialog.btn_label}`;
+
+  //Show the dialog on layer display
+  if (layer.filter.dialog.showOnLayerDisplay) {
+    layer.showCallbacks.push(() => {
+      !layer.filter.dialog?.btn.classList.contains('active') &&
+        layer.filter.dialog?.btn.dispatchEvent(new Event('click'));
+      return layer;
+    });
+
+    layer.display && layer.filter.dialog?.btn.dispatchEvent(new Event('click'));
+  }
+
+  //Hide the dialog when the layer is hidden
+  layer.hideCallbacks.push(() => {
+    layer.filter.dialog?.btn.classList.contains('active') &&
+      layer.filter.dialog?.btn.dispatchEvent(new Event('click'));
+    return layer;
+  });
 }
 
 /**


### PR DESCRIPTION
The `filter.dialog{}` configuration object and it's properties were not documented in the 4.17 inclusion.

The dialog button creation has has been moved to the filterDialog method which documents these properties.
