### PR TITLE
fix(geometry): No Value layer removal

### DIFF
--- a/lib/ui/locations/entries/geometry.mjs
+++ b/lib/ui/locations/entries/geometry.mjs
@@ -76,7 +76,7 @@ export default function geometry(entry) {
 
   // Return if entry has no geometry value and cannot be drawn in to.
   if (!entry.value && !entry.draw && !entry.api) {
-    this.location.removeLayer(this);
+    entry.location.removeLayer(entry);
     return;
   }
 


### PR DESCRIPTION
When a geometry entry has no value and no edit or draw. 
The removeLayer method was mistakenly using `this` which is the `infoj` entries - not `entry`. 