### PR TITLE
Add neverBuiltDependencies to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,6 +7,9 @@
     "url": "https://github.com/geolytix/xyz"
   },
   "packageManager": "pnpm@10.10.0",
+  "pnpm": {
+    "neverBuiltDependencies": []
+  },
   "scripts": {
     "test": "node --experimental-test-module-mocks node_modules/codi-test-framework/cli.js tests",
     "test-watch": "node --watch-path=. --experimental-test-module-mocks node_modules/codi-test-framework/cli.js tests --quiet",


### PR DESCRIPTION
```js
  "pnpm": {
    "neverBuiltDependencies": []
  },
```

I added this to the package to not built dependencies. The built would be ignored anyways with a warning thrown in the build log.


```
[17:29:13.403] Running build in Washington, D.C., USA (East) – iad1
[17:29:13.403] Build machine configuration: 4 cores, 8 GB
[17:29:13.420] Retrieving list of deployment files...
[17:29:13.424] Skipping build cache, deployment was triggered without cache.
[17:29:14.030] Downloading 1279 deployment files...
[17:29:19.096] Running "vercel build"
[17:29:19.705] Vercel CLI 46.0.3
[17:29:20.614] Installing dependencies...
[17:29:20.615] Detected `pnpm-lock.yaml` version 9 generated by pnpm@10.x with package.json#packageManager pnpm@10.10.0
[17:29:23.207] Lockfile is up to date, resolution step is skipped
[17:29:23.267] Progress: resolved 1, reused 0, downloaded 0, added 0
[17:29:23.339] Packages: +350
[17:29:23.340] ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
[17:29:24.271] Progress: resolved 350, reused 0, downloaded 87, added 36
[17:29:25.272] Progress: resolved 350, reused 0, downloaded 245, added 112
[17:29:26.273] Progress: resolved 350, reused 0, downloaded 350, added 246
[17:29:26.563] Progress: resolved 350, reused 0, downloaded 350, added 350, done
[17:29:26.715] .../esbuild@0.25.9/node_modules/esbuild postinstall$ node install.js
[17:29:26.799] .../esbuild@0.25.9/node_modules/esbuild postinstall: Done
[17:29:27.040] 
[17:29:27.041] dependencies:
[17:29:27.041] + jsonwebtoken 9.0.2
[17:29:27.041] + pg 8.15.6
[17:29:27.041] 
[17:29:27.041] optionalDependencies:
[17:29:27.042] + @aws-sdk/client-s3 3.876.0
[17:29:27.042] + @aws-sdk/cloudfront-signer 3.873.0
[17:29:27.042] + @aws-sdk/s3-request-presigner 3.876.0
[17:29:27.042] + @node-saml/node-saml 5.1.0
[17:29:27.042] + nodemailer 6.10.1
[17:29:27.042] 
[17:29:27.042] devDependencies:
[17:29:27.042] + @biomejs/biome 2.0.0
[17:29:27.042] + clean-jsdoc-theme 4.3.0
[17:29:27.043] + codi-test-framework 1.0.37
[17:29:27.043] + concurrently 9.2.1
[17:29:27.043] + cookie-parser 1.4.7
[17:29:27.043] + dotenv 16.6.1
[17:29:27.043] + esbuild 0.25.9
[17:29:27.043] + express 5.1.0
[17:29:27.044] + express-rate-limit 7.5.1
[17:29:27.044] + nodemon 3.1.10
[17:29:27.044] 
[17:29:27.173] Done in 4.5s using pnpm v10.10.0
[17:29:31.875] Build Completed in /vercel/output [11s]
[17:29:32.225] Deploying outputs...
[17:29:38.913] Deployment completed
[17:29:39.828] Creating build cache...
[17:29:49.670] Created build cache: 9.841s
[17:29:49.671] Uploading build cache [46.21 MB]
[17:29:50.405] Build cache uploaded: 735.029ms
```