### PR TITLE
Specify the lang property for the user admin view template

### DIFF
--- a/public/views/_user.html
+++ b/public/views/_user.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html>
+<html lang="en">
   <head data-user="{{user}}" data-dir="{{dir}}">
     <title>XYZ | User Administration</title>
     <link


### PR DESCRIPTION
The user admin view _user.html is missing the lang property for the html block.

https://sonarcloud.io/project/issues?impactSoftwareQualities=RELIABILITY&issueStatuses=OPEN%2CCONFIRMED&id=GEOLYTIX_xyz&open=AYkGl876E6BDbbnr5Fvj&tab=code

<img width="938" height="576" alt="image" src="https://github.com/user-attachments/assets/06e02d41-bd97-46b1-91a8-68647e0b7077" />

This should be english as the default view is english.
