### PR TITLE
Prevent the use of nested template

### DIFF
--- a/lib/ui/locations/entries/textarea.mjs
+++ b/lib/ui/locations/entries/textarea.mjs
@@ -29,7 +29,7 @@ export default (entry) => {
       ${entry.newValue || entry.value || ''}`;
   }
 
-  entry.css_val ??= ''
+  entry.css_val ??= '';
 
   const node = mapp.utils.html.node`
   <div

--- a/lib/ui/locations/entries/textarea.mjs
+++ b/lib/ui/locations/entries/textarea.mjs
@@ -29,10 +29,12 @@ export default (entry) => {
       ${entry.newValue || entry.value || ''}`;
   }
 
+  entry.css_val ??= ''
+
   const node = mapp.utils.html.node`
   <div
     class="val"
-    style="${`${entry.css_val || ''}`}">${val}`;
+    style="${entry.css_val}">${val}`;
 
   if (!entry.edit && entry.type === 'html') {
     node.innerHTML = entry.value || '';

--- a/lib/ui/locations/entries/textarea.mjs
+++ b/lib/ui/locations/entries/textarea.mjs
@@ -1,4 +1,26 @@
-export default (entry) => {
+/**
+## /ui/locations/entries/textarea
+
+The module exports the default textarea entry method.
+
+@module /ui/locations/entries/textarea
+*/
+
+/**
+@function textarea
+
+@description
+A textarea element will be returned if the entry is editable.
+
+The textarea allows user to create and modify multiline string values.
+
+@param {infoj-entry} entry type:geometry entry.
+@property {Object} entry.value A multiline string.
+@property {Object} [entry.edit] configuration object for editing the value.
+
+@return {HTMLElement} elements for the location view.
+*/
+export default function textarea(entry) {
   let val = entry.type !== 'html' ? entry.value : '';
 
   if (entry.edit) {
@@ -41,4 +63,4 @@ export default (entry) => {
   }
 
   return node;
-};
+}

--- a/lib/ui/locations/entries/time.mjs
+++ b/lib/ui/locations/entries/time.mjs
@@ -24,7 +24,7 @@ export default (entry) => {
     val = stringVal;
   }
 
-  entry.css_val ??= ''
+  entry.css_val ??= '';
 
   const node = mapp.utils.html.node`
     <div

--- a/lib/ui/locations/entries/time.mjs
+++ b/lib/ui/locations/entries/time.mjs
@@ -24,10 +24,12 @@ export default (entry) => {
     val = stringVal;
   }
 
+  entry.css_val ??= ''
+
   const node = mapp.utils.html.node`
     <div
       class="val"
-      style="${`${entry.css_val || ''}`}">
+      style="${entry.css_val}">
       ${val}`;
 
   return node;

--- a/lib/ui/locations/entries/time.mjs
+++ b/lib/ui/locations/entries/time.mjs
@@ -1,4 +1,26 @@
-export default (entry) => {
+/**
+## /ui/locations/entries/time
+
+The module exports the default time entry method.
+
+@module /ui/locations/entries/time
+*/
+
+/**
+@function time
+
+@description
+The entry method returns a formated numeric value. 10.43 > "10:43".
+
+If editable an input type:time will be returned. The onchange event method of the input will parse a float value from the time string and dispatch the valChange event on the location view.
+
+@param {infoj-entry} entry type:geometry entry.
+@property {Object} entry.value A numeric time value.
+@property {Object} [entry.edit] configuration object for editing the value.
+
+@return {HTMLElement} elements for the location view.
+*/
+export default function time(entry) {
   let val;
 
   let stringVal = entry.value?.toString().replace('.', ':');
@@ -33,4 +55,4 @@ export default (entry) => {
       ${val}`;
 
   return node;
-};
+}


### PR DESCRIPTION
<img width="771" height="152" alt="image" src="https://github.com/user-attachments/assets/ed2ada44-2211-4368-ac06-b2e2fdf0b0be" />

<img width="764" height="150" alt="image" src="https://github.com/user-attachments/assets/ec6720fe-ac8f-45ea-ac9b-f0e82e3c9be8" />

The use of nested templates can easily be prevented by assigning a default property value which can be empty string.

Neither of the entry method/modules had any documentation.
