### PR TITLE
Support lineDash in style

### DIFF
--- a/lib/ui/elements/legendIcon.mjs
+++ b/lib/ui/elements/legendIcon.mjs
@@ -167,7 +167,8 @@ function createLineSymbol(style) {
       d=${path}
       fill="none"
       stroke=${style.strokeColor}
-      stroke-width=${style.strokeWidth || 1}/>`;
+      stroke-width=${style.strokeWidth || 1}
+      stroke-dasharray=${style.lineDash || ''} />`;
 
   const backgroundImage = `data:image/svg+xml,${encodeURIComponent(xmlSerializer.serializeToString(icon))}`;
 
@@ -209,7 +210,8 @@ function createPolygonSymbol(style) {
       fill=${style.fillColor}
       fill-opacity=${style.fillOpacity || 1}
       stroke=${style.strokeColor}
-      stroke-width=${style.strokeWidth || 1}>`;
+      stroke-width=${style.strokeWidth || 1}
+      stroke-dasharray=${style.lineDash || ''} >`;
 
   const backgroundImage = `data:image/svg+xml,${encodeURIComponent(xmlSerializer.serializeToString(icon))}`;
 


### PR DESCRIPTION
This PR adds the `stroke-dasharray` property to the svg creation which fixes the bug where lineDash was not being displayed in the legend. 

Before
<img width="1350" height="850" alt="image" src="https://github.com/user-attachments/assets/a306629f-d4d9-4f97-a5a2-d4ab96761160" />


After
<img width="1349" height="876" alt="image" src="https://github.com/user-attachments/assets/3e4b1932-1ba7-4609-8d93-cae48e136d2e" />

Can be tested with any style object that includes `lineDash` array.