### PR TITLE
fix(layerStyle): Else Return Preventing Slider Creation

### DIFF
--- a/lib/ui/elements/layerStyle.mjs
+++ b/lib/ui/elements/layerStyle.mjs
@@ -488,9 +488,6 @@ function icon_scaling(layer) {
         },
       }),
     );
-  } else {
-    // neither layer.style.icon_scaling.field or layer.style.icon_scaling.fields are configured.
-    return;
   }
 
   if (layer.style.icon_scaling.icon) {


### PR DESCRIPTION
The `layerStyle` module checks for the presence of `icon_scaling.field` before generating elements for this. 
However, there was mistakenly an else return at the end of this if statement. 
What this was doing was preventing the generation of icon and cluster scaling sliders being generated. 

You were only able to create them if you have `icon_scaling.field` they should be independent. 

This can be tested by including this in your style object on a layer.
``` json
    "icon_scaling": {
      "icon": true,
      "clusterScale": true
    }
```

