### PR TITLE
bug(geometry entry): Add tooltip to Geometry Entry

### DIFF
--- a/lib/ui/locations/entries/geometry.mjs
+++ b/lib/ui/locations/entries/geometry.mjs
@@ -95,6 +95,14 @@ export default function geometry(entry) {
   entry.label ??= 'Geometry';
   entry.disabled ??= !entry.value && !entry.api;
 
+  // If entry.tooltip - create a tooltip element
+  const tooltip =
+    entry.tooltip &&
+    mapp.utils.html.node`<div
+      title=${entry.tooltip}>
+      <span class="tooltip notranslate material-symbols-outlined">help</span>
+    </div>`;
+
   // Create checkbox to control geometry display.
   entry.chkbox = mapp.ui.elements.chkbox({
     checked: entry.display,
@@ -125,7 +133,7 @@ export default function geometry(entry) {
   entry.display && entry.show();
 
   return mapp.utils.html.node`
-    <div class="flex-spacer">${entry.chkbox}${icon}</div>
+    <div class="flex-spacer"><div style="display:flex">${entry.chkbox}${tooltip}</div>${icon}</div>
     ${entry.elements}`;
 }
 


### PR DESCRIPTION
We mistakenly didn't include a tooltip option on `geometry` entries but we did for all entries that use a title. 
This PR adds a tooltip option to the geometry entry method. 

<img width="1359" height="860" alt="Screenshot 2025-09-03 085225" src="https://github.com/user-attachments/assets/0b5053ec-55f1-400f-b8fa-5d4299d7f8f3" />
