### PR TITLE
Enable caching of cloudfront templates

### DIFF
--- a/mod/provider/_provider.js
+++ b/mod/provider/_provider.js
@@ -7,7 +7,6 @@ Functions for handling 3rd party service provider requests
 
 import cloudfront from './cloudfront.js';
 import file from './file.js';
-
 import s3 from './s3.js';
 
 /**
@@ -19,7 +18,7 @@ The provider method looks up a provider module method matching the provider requ
 
 The response from the method is returned with the HTTP response.
 
-@param {Object} req HTTP request.
+@param {req} req HTTP request.
 @param {Object} res HTTP response.
 @param {Object} req.params Request parameter.
 @param {string} params.signer Provider module to handle the request.

--- a/mod/provider/cloudfront.js
+++ b/mod/provider/cloudfront.js
@@ -37,7 +37,6 @@ export default cloudfront_signer ? cloudfront : null;
 const cacheMap = new Map();
 
 async function cloudfront(ref, cache) {
-
   const url = ref.params?.url || ref;
 
   // Return signedURL only from request.

--- a/mod/provider/cloudfront.js
+++ b/mod/provider/cloudfront.js
@@ -34,10 +34,9 @@ The req param is string if the request for a resource is passed from the getFrom
 export default cloudfront_signer ? cloudfront : null;
 
 function cloudfront(req) {
+  const url = req.params?.url || req;
 
-  const url = (req.params?.url || req)
-
-  return Fetch(url)
+  return Fetch(url);
 }
 
 /**

--- a/mod/provider/getFrom.js
+++ b/mod/provider/getFrom.js
@@ -17,7 +17,7 @@ async function Cloudfront(ref, cache) {
     return console.error('Cloudfront key is missing');
   }
 
-  const src = ref.split(':')[1]
+  const src = ref.split(':')[1];
 
   return await cloudfront(src, cache);
 }

--- a/mod/provider/getFrom.js
+++ b/mod/provider/getFrom.js
@@ -7,25 +7,40 @@ import file from '../provider/file.js';
 import logger from '../utils/logger.js';
 
 export default {
-  cloudfront: (ref) =>
-    xyzEnv.KEY_CLOUDFRONT
-      ? cloudfront(ref.split(':')[1])
-      : console.error('Cloudfront key is missing'),
-  file: (ref) => file(ref.split(':')[1]),
-  https: async (url) => {
-    try {
-      const response = await fetch(url);
-
-      logger(`${response.status} - ${url}`, 'fetch');
-
-      if (url.match(/\.json$/i)) {
-        return await response.json();
-      }
-
-      return await response.text();
-    } catch (err) {
-      console.error(err);
-      return err;
-    }
-  },
+  cloudfront: Cloudfront,
+  file: File,
+  https: Https,
 };
+
+async function Cloudfront(ref, cache) {
+  if (!xyzEnv.KEY_CLOUDFRONT) {
+    return console.error('Cloudfront key is missing');
+  }
+
+  const src = ref.split(':')[1]
+
+  return await cloudfront(src, cache);
+}
+
+function File(ref) {
+  const src = ref.split(':')[1];
+
+  return file(src);
+}
+
+async function Https(url) {
+  try {
+    const response = await fetch(url);
+
+    logger(`${response.status} - ${url}`, 'fetch');
+
+    if (url.match(/\.json$/i)) {
+      return await response.json();
+    }
+
+    return await response.text();
+  } catch (err) {
+    console.error(err);
+    return err;
+  }
+}

--- a/mod/provider/getFrom.js
+++ b/mod/provider/getFrom.js
@@ -52,9 +52,8 @@ async function Cloudfront(ref, cache) {
     }
     response = await cachedURL;
   } else {
-
     // The cacheMap must be cleared to prevent cached resource never being updated between role requests or tests.
-    cacheMap.clear()
+    cacheMap.clear();
     response = await cloudfront(url);
   }
 

--- a/mod/sign/cloudfront.js
+++ b/mod/sign/cloudfront.js
@@ -6,7 +6,7 @@ The cloudfront sign module exports a method to sign requests to an AWS cloudfron
 @requires fs
 @requires path
 @requires aws-sdk/cloudfront-signer
-@requires module:/utils/processEnv
+@requires /utils/processEnv
 @module /sign/cloudfront
 */
 
@@ -50,14 +50,15 @@ export default xyzEnv.KEY_CLOUDFRONT
 @description
 The method creates a signed URL for a cloudfront resource.
 
-@param {String} req_url Cloudfront resource URL.
+@param {req|string} req Request object or URL string.
 
 @returns {Promise<String>} The method resolves to a string which contains the signed url.
 */
-async function cloudfront_signer(req_url) {
+async function cloudfront_signer(req) {
   try {
+
     // Substitutes {*} with xyzEnv.SRC_* key values.
-    const url = req_url.replace(
+    const url = (req.params?.url || req).replace(
       /{(?!{)(.*?)}/g,
       (matched) => xyzEnv[`SRC_${matched.replace(/(^{)|(}$)/g, '')}`],
     );

--- a/mod/sign/cloudfront.js
+++ b/mod/sign/cloudfront.js
@@ -56,7 +56,6 @@ The method creates a signed URL for a cloudfront resource.
 */
 async function cloudfront_signer(req) {
   try {
-
     // Substitutes {*} with xyzEnv.SRC_* key values.
     const url = (req.params?.url || req).replace(
       /{(?!{)(.*?)}/g,

--- a/mod/sign/cloudinary.js
+++ b/mod/sign/cloudinary.js
@@ -4,9 +4,9 @@
 Exports the cloudinary signer method.
 
 @requires crypto
+@requires /utils/processEnv
 
 @module /sign/cloudinary
-@requires module:/utils/processEnv
 */
 
 import { createHash } from 'crypto';
@@ -14,7 +14,6 @@ import { createHash } from 'crypto';
 /**
 @function cloudinary
 @async
-
 
 @description
 The cloudinary signer method signs requests for the cloudinary service.
@@ -25,12 +24,12 @@ A request to destroy a resource stored in the cloudinary service can be signed w
 
 A folder and public_id parameter for resources to be uploaded or destroyed are required.
 
-@param {Object} req HTTP request.
-@param {Object} res HTTP response.
-@param {Object} req.params Request parameter.
-@param {string} params.folder
-@param {string} params.public_id
-@param {string} params.destroy
+@param {req} req HTTP request.
+@param {req} res HTTP response.
+@property {Object} req.params Request parameter.
+@property {string} params.folder
+@property {string} params.public_id
+@property {string} params.destroy
 
 @returns {Promise} The promise resolves into the response from the signerModules method.
 */

--- a/mod/workspace/_workspace.js
+++ b/mod/workspace/_workspace.js
@@ -637,6 +637,7 @@ async function cacheTemplates(params) {
       locale: localeKey,
       user: params.user,
       ignoreRoles: true,
+      cache: true,
     });
 
     // If the locale has no layers, just skip it.
@@ -649,6 +650,7 @@ async function cacheTemplates(params) {
         locale: localeKey,
         user: params.user,
         ignoreRoles: true,
+        cache: true,
       });
 
       locale.layers[layerKey] = layer;
@@ -659,6 +661,6 @@ async function cacheTemplates(params) {
 
   // hydrating/caching all the templates
   for (const key of Object.keys(workspace.templates)) {
-    await getTemplate(key);
+    await getTemplate(key, true);
   }
 }

--- a/mod/workspace/_workspace.js
+++ b/mod/workspace/_workspace.js
@@ -616,9 +616,11 @@ function removeRoles(obj) {
 @description
 Gets and caches a complete workspace with all locales, layers, and templates pre-loaded.
 
-The workspaceCache method will be forced to clear the cached workspace and load the workspace again which may have changed. This is required for testing purposes. If templates should be loaded in order to extract roles it may be beneficial to use already cached templates.
+The workspaceCache method will be called with the params force flag. If true, any cached templates as well as the workspace itself will be reset.
 
-The method will iterate over the workspace.locales to cache any templates defined in the locales object.
+The method will iterate over the workspace.locales and each layer defined in the locales.
+
+The getLocale and getLayer method will be called with the cache true flag. This flag will passed on to the getTemplate method. Templates fetched from an external source will be cached in a Map object. This is to prevent that the same template used in multiple locales or layers will be fetched multiple times.
 
 A getLayer promise for each layer in a locale will be added to a promises array. All getLayer promises must be settled before the next locale can be processed.
 

--- a/mod/workspace/getLayer.js
+++ b/mod/workspace/getLayer.js
@@ -70,7 +70,7 @@ export default async function getLayer(params, locale) {
     layer = locale.layers[params.layer];
   } else {
     // A layer maybe defined as a template only.
-    layer = await getTemplate(params.layer);
+    layer = await getTemplate(params.layer, params.cache);
 
     if (!layer || layer instanceof Error) {
       return new Error('Unable to validate layer param.');
@@ -96,7 +96,7 @@ export default async function getLayer(params, locale) {
     ? Roles.objMerge(layer, params.user?.roles)
     : layer;
 
-  layer = await mergeTemplates(layer, params.user?.roles);
+  layer = await mergeTemplates(layer, params.user?.roles, params.cache);
 
   // Assign layer key as name with no existing name on layer object.
   layer.name ??= layer.key;

--- a/mod/workspace/getLayer.js
+++ b/mod/workspace/getLayer.js
@@ -47,6 +47,7 @@ Template properties will be removed as these are not required by the MAPP API bu
 @property {string} [params.locale] Locale key.
 @property {string} [params.layer] Layer key.
 @property {Object} [params.user] Requesting user.
+@property {Boolean} [params.cache] Templates associated with the layer should be cached and not requested multiple times.
 @property {Boolean} [params.ignoreRoles] Whether role check should be performed.
 @property {Array} [user.roles] User roles.
 

--- a/mod/workspace/getLocale.js
+++ b/mod/workspace/getLocale.js
@@ -77,7 +77,7 @@ export default async function getLocale(params, parentLocale) {
   } else if (Object.hasOwn(workspace.locales, localeKey)) {
     locale = workspace.locales[localeKey];
   } else {
-    locale = await getTemplate(localeKey);
+    locale = await getTemplate(localeKey, params.cache);
   }
 
   if (locale instanceof Error) {
@@ -85,7 +85,7 @@ export default async function getLocale(params, parentLocale) {
   }
 
   // The roles property maybe assigned from a template. Templates must be merged prior to the role check.
-  locale = await mergeTemplates(locale, params.user?.roles);
+  locale = await mergeTemplates(locale, params.user?.roles, params.cache);
 
   //If the user is an admin we don't need to check roles
   if (

--- a/mod/workspace/getLocale.js
+++ b/mod/workspace/getLocale.js
@@ -46,6 +46,7 @@ Template properties will be removed as these are not required by the MAPP API bu
 @property {string} [params.locale] Locale key.
 @property {array} [params.locale] An array of locale keys to be merged as a nested locale.
 @property {Object} [params.user] Requesting user.
+@property {Boolean} [params.cache] Templates associated with the locale should be cached and not requested multiple times.
 @property {Boolean} [params.ignoreRoles] Whether role check should be performed.
 @property {Array} [user.roles] User roles.
 

--- a/mod/workspace/getTemplate.js
+++ b/mod/workspace/getTemplate.js
@@ -45,7 +45,7 @@ The key will be assigned to the template object as key property.
 
 @returns {Promise<Object|Error>} JSON Template
 */
-export default async function getTemplate(key) {
+export default async function getTemplate(key, cache) {
   if (key === undefined) {
     return new Error('Undefined template key.');
   }
@@ -90,7 +90,7 @@ export default async function getTemplate(key) {
       return err;
     }
 
-    response = await getFrom[method](template.src);
+    response = await getFrom[method](template.src, cache);
 
     if (response instanceof Error) {
       template.err = response;

--- a/mod/workspace/getTemplate.js
+++ b/mod/workspace/getTemplate.js
@@ -42,6 +42,7 @@ A template can be cached by removing the src property in the workspace.templates
 The key will be assigned to the template object as key property.
 
 @param {string} key
+@param {boolean} cache Templates should be cached and not requested multiple times.
 
 @returns {Promise<Object|Error>} JSON Template
 */

--- a/mod/workspace/mergeTemplates.js
+++ b/mod/workspace/mergeTemplates.js
@@ -42,19 +42,19 @@ An array of templates can be defined as obj.templates[]. The templates will be m
 
 @returns {Promise} The layer or locale provided as obj param.
 */
-export default async function mergeTemplates(obj, roles) {
+export default async function mergeTemplates(obj, roles, cache) {
   // Cache workspace in module scope for template assignment.
   workspace = await workspaceCache();
 
   // The object has an implicit template to merge into.
   if (typeof obj.template === 'string' || obj.template instanceof Object) {
-    obj = await objTemplate(obj, obj.template, roles);
+    obj = await objTemplate(obj, obj.template, roles, null, cache);
     if (obj instanceof Error) return obj;
   }
 
   // The _template can be a string or object [with src]
   for (const _template of obj.templates || []) {
-    obj = await objTemplate(obj, _template, roles, true);
+    obj = await objTemplate(obj, _template, roles, true, cache);
   }
 
   // Substitute ${SRC_*} in object string.
@@ -93,8 +93,8 @@ The template will be merged into the obj with the reverse flag.
 
 @returns {Promise<Object>} Returns the merged obj.
 */
-async function objTemplate(obj, template, roles, reverse) {
-  template = await getTemplate(template);
+async function objTemplate(obj, template, roles, reverse, cache) {
+  template = await getTemplate(template, cache);
 
   // Failed to get template matching obj.template from template.src!
   if (template instanceof Error) {

--- a/mod/workspace/mergeTemplates.js
+++ b/mod/workspace/mergeTemplates.js
@@ -34,7 +34,8 @@ The method will check for a template matching the obj.key string property if obj
 An array of templates can be defined as obj.templates[]. The templates will be merged into the obj in the order the template keys are in the templates[] array.
 
 @param {Object} obj 
-@param {array} [roles] An array of user roles from request params. 
+@param {array} [roles] An array of user roles from request params.
+@param {boolean} cache Templates should be cached and not requested multiple times.
 
 @property {string} [obj.template] Key of template for the object.
 @property {string} obj.key Fallback for lookup of template if not an implicit property.

--- a/tests/mod/provider/cloudfront.test.mjs
+++ b/tests/mod/provider/cloudfront.test.mjs
@@ -42,35 +42,6 @@ await codi.describe(
       },
     );
 
-    await codi.it(
-      { name: 'Return only signedURL', parentId: 'provider_cloudfront' },
-      async () => {
-        const expected = {
-          url: 'https://aws.signed.url.com/*',
-        };
-
-        mockedCloudfrontFn.mock.mockImplementation(
-          function cloudfront_signer() {
-            return expected.url;
-          },
-        );
-
-        const { req } = codi.mockHttp.createMocks({
-          params: {
-            signedURL: true,
-          },
-        });
-
-        const result = await cloudfront(req);
-
-        codi.assertEqual(
-          result,
-          expected.url,
-          'We should see the expected URL returned',
-        );
-      },
-    );
-
     await codi.describe(
       {
         name: 'Fetches signedURL',


### PR DESCRIPTION
This PR introduces the caching of cloudfront resources in a cachedMap.

Cloudfront resources should only be loaded if needed since the templates may change at rest and it is not possible to uncache resources in cloud functions.

The workspace test and the roles request require all templates to be loaded in order to check the templates for roles.

The cacheTemplates method of the workspace api module can thefore send a cache flag parameter.

This parameter flag must be passed the getLocale and getLayer methods, via the mergeTemplates, to the getTemplates method and from there to the cloudfront provider.

With the cache param set to null I see that many templates and fetched and parsed multiple resulting in the workspace caching to take about 17 seconds which will fail deployed to vercel.

https://github.com/user-attachments/assets/b0a08877-3018-40ec-8160-3e7c2bdb6873

With caching enabled I can load the same workspace in about 5 seconds.

https://github.com/user-attachments/assets/230b845c-ecc1-46b9-b93a-09d82e4f86ed
