### PR TITLE
Unnest panelClasslist template

### DIFF
--- a/lib/ui/Tabview.mjs
+++ b/lib/ui/Tabview.mjs
@@ -106,10 +106,16 @@ function addTab(entry) {
         style="${entry.tab_style || ''}"
         onclick=${showTab}>${entry.label}`;
 
+  console.log(entry.panel)
+
+  console.log(entry.target)
+
+  const panelClasslist = `panel ${entry.class || ''}`;
+
   entry.panel ??=
     entry.target ||
     mapp.utils.html.node`
-    <div class="${`panel ${entry.class || ''}`}">`;
+    <div class=${panelClasslist}>`;
 
   entry.show = showTab;
 


### PR DESCRIPTION
This draft PR adds console.logs for the entry.panel and entry.target properties in the tabview addTab(entry) method.

The aim is to unnest the classList template used in the construction of the panel property element.

I do not understand when this is required in order to test this and remove the console logs.
