### PR TITLE
fix(workspace): Check for templates array type

### DIFF
--- a/mod/workspace/mergeTemplates.js
+++ b/mod/workspace/mergeTemplates.js
@@ -58,7 +58,10 @@ export default async function mergeTemplates(obj, roles) {
       obj = await objTemplate(obj, _template, roles, true);
     }
   } else if (obj.templates instanceof Object) {
-    console.error(`${obj.key} Object must be a templates Array.`);
+    const err = `${obj.key} Object must be a templates Array.`;
+    obj.err ??= [];
+    obj.err.push(err);
+    console.warn(err);
   }
 
   // Substitute ${SRC_*} in object string.


### PR DESCRIPTION
The mergeTemplates method must not crash if the templates property is defined as an object instead of an array.

The iteration for loop should be within an Array.isArray() condition check. An warning should be logged if the property is a different object type.

The warning will be add to the objects err array property to be shown when the mapp library process the object as a layer in the addLayer method.

<img width="757" height="70" alt="image" src="https://github.com/user-attachments/assets/40235240-506b-4a94-8103-31afa1fdaf52" />
