### PR TITLE
Remove deprecated Style method

### DIFF
--- a/lib/layer/_layer.mjs
+++ b/lib/layer/_layer.mjs
@@ -43,7 +43,8 @@ export default {
   featureHover,
   featureStyle,
   formats,
-  Style,
+  // The featureStyle method supersedes the deprecated Style method.
+  Style: featureStyle,
   styleParser,
   themes: {
     basic,
@@ -52,21 +53,3 @@ export default {
     graduated,
   },
 };
-
-/**
-@function Style
-@deprecated
-
-@description
-The deprecated `mapp.layer.Style()` method will warn if used and return the `featureStyle()` method which supersedes this method.
-
-@param {Object} layer 
-
-@return {Function} featureStyle
-*/
-function Style(layer) {
-  console.warn(
-    `The mapp.layer.Style() method has been superseeded by the mapp.layer.featureStyle() method.`,
-  );
-  return featureStyle(layer);
-}


### PR DESCRIPTION
There is no need to warn on the deprecated Style method. This method can easily be mapped to the featureStyle method in the export.
