### PR TITLE
feat(helpDialog): Control help dialog display. 

### DIFF
--- a/lib/plugins/_plugins.mjs
+++ b/lib/plugins/_plugins.mjs
@@ -8,6 +8,7 @@ The module exports a collection of core mapp plugins.
 @requires module:/plugins/admin
 @requires module:/plugins/feature_info
 @requires module:/plugins/fullscreen
+@requires module:/plugins/disable_help
 @requires module:/plugins/link_button
 @requires module:/plugins/locator
 @requires module:/plugins/login
@@ -21,6 +22,7 @@ The module exports a collection of core mapp plugins.
 
 import { admin } from './admin.mjs';
 import { custom_theme, dark_mode } from './dark_mode.mjs';
+import { disable_help } from './disable_help.mjs';
 import { feature_info } from './feature_info.mjs';
 import { fullscreen } from './fullscreen.mjs';
 import { link_button } from './link_button.mjs';
@@ -51,6 +53,7 @@ import { zoomToArea } from './zoomToArea.mjs';
 const plugins = {
   admin,
   custom_theme,
+  disable_help,
   dark_mode,
   feature_info,
   fullscreen,

--- a/lib/plugins/disable_help.mjs
+++ b/lib/plugins/disable_help.mjs
@@ -1,13 +1,30 @@
-export function disable_help(plugin, mapview) {
+/**
+### /plugins/disable_help
+ 
+The disable_help plugin appends the disable_help button to the button panel.
+
+@module /plugins/disable_help
+*/
+
+/**
+@function disable_help
+
+A plugin for controlling whether helpDialogs are displayed. 
+
+@param {Object} plugin The disable_help config from the locale.
+@param {Object} mapview The mapview object.
+*/
+export async function disable_help(plugin, mapview) {
   const btnColumn = mapview.mapButton;
 
   // the btnColumn element only exist in the default mapp view.
   if (!btnColumn) return;
 
-  btnColumn.appendChild(mapp.utils.html.node`                                   
-    <button                                                                          
-      title=${mapp.dictionary.disable_help}                                    
-      onclick=${(e) =>
-      e.target.classList.toggle('active')}>                                  
-      <span class="notranslate material-symbols-outlined strikethrough">help_center`);
+  const hideHelpBtn = mapp.ui.elements.helpDialogControl(mapview, plugin);
+
+  btnColumn.appendChild(hideHelpBtn);
+
+  //Preclick the button if the setting is found in the index.
+  const indexLocale = await mapp.utils.userLocale.get(mapview.locale);
+  indexLocale.hideHelp && hideHelpBtn.dispatchEvent(new Event('click'));
 }

--- a/lib/plugins/disable_help.mjs
+++ b/lib/plugins/disable_help.mjs
@@ -1,0 +1,13 @@
+export function disable_help(plugin, mapview) {
+  const btnColumn = mapview.mapButton;
+
+  // the btnColumn element only exist in the default mapp view.
+  if (!btnColumn) return;
+
+  btnColumn.appendChild(mapp.utils.html.node`                                   
+    <button                                                                          
+      title=${mapp.dictionary.disable_help}                                    
+      onclick=${(e) =>
+      e.target.classList.toggle('active')}>                                  
+      <span class="notranslate material-symbols-outlined strikethrough">help_center`);
+}

--- a/lib/ui/elements/_elements.mjs
+++ b/lib/ui/elements/_elements.mjs
@@ -41,6 +41,7 @@ import drawer from './drawer.mjs';
 import drawing from './drawing.mjs';
 import dropdown from './dropdown.mjs';
 import helpDialog from './helpDialog.mjs';
+import helpDialogControl from './helpDialogControl.mjs';
 import jsoneditor from './jsoneditor.mjs';
 import layerStyle from './layerStyle.mjs';
 import legendIcon from './legendIcon.mjs';
@@ -65,6 +66,7 @@ export default {
   drawing,
   dropdown,
   helpDialog,
+  helpDialogControl,
   jsoneditor,
   layerStyle,
   legendIcon,

--- a/lib/ui/elements/drawing.mjs
+++ b/lib/ui/elements/drawing.mjs
@@ -104,6 +104,9 @@ async function drawOnclick(e, layer, interaction) {
 
   interaction.helpDialog.data_id = 'dialog_drawing';
 
+  //Hide the associated help dialog
+  interaction.helpDialog.hideHelp = layer.hideHelp;
+
   mapp.ui.elements.helpDialog(interaction.helpDialog);
 }
 

--- a/lib/ui/elements/helpDialog.mjs
+++ b/lib/ui/elements/helpDialog.mjs
@@ -1,12 +1,33 @@
-let helpDialog;
+/**
+### /ui/elements/helpDialog
+ 
+The helpDialog module creates the help dialogs displayed during certain map interactions.
 
-export default (params) => {
+@module /ui/elements/helpDialog
+*/
+
+//Null instantiation of the help_dialog.
+let help_dialog;
+
+/**
+@function helpDialog
+
+A dialog that describes how certain map controls work.
+
+@param {Object} params Config paramaters for the dialog.
+@property {String|HTMLElement} params.header The header displayed on the dialog.
+@property {String|HTMLElement} params.content The content of the dialog.
+@property {boolean} params.hideHelp Whether or not the dialog is created/displayed.
+*/
+export default function helpDialog(params) {
   // Only one helpDialog.node can be shown at any one time.
   helpDialog?.node.remove();
 
-  if (!params) return;
+  if (params?.hideHelp || !params) {
+    return;
+  }
 
-  helpDialog = {
+  help_dialog = {
     closeBtn: true,
     contained: true,
     css_style: 'padding: 0.5em;',
@@ -20,5 +41,5 @@ export default (params) => {
   };
 
   // Create the helpDialog.node
-  mapp.ui.elements.dialog(helpDialog);
-};
+  mapp.ui.elements.dialog(help_dialog);
+}

--- a/lib/ui/elements/helpDialogControl.mjs
+++ b/lib/ui/elements/helpDialogControl.mjs
@@ -1,0 +1,89 @@
+/**
+### /ui/elements/helpDialogControl
+
+The helpDialogControl module returns etheir a button or a div to control whether help dialogs should be displayed.
+
+@module /ui/elements/helpDialogControl
+*/
+
+/**
+@function helpDialogControl
+Creates the interfaces for controlling whether helpdialogs are displayed.
+
+Creates either a circular button or a div with an on/off button.
+
+@param {Object} mapview The mapview object.
+@param {Object} [plugin] The disable_help config from the locale.
+
+@returns {HTMLElement} Either a button or a div with the means to control help dialogs displaying.
+*/
+
+export default function helpDialogControl(mapview, plugin) {
+  //Provide the ciruclar button
+  if (plugin) {
+    return mapp.utils.html
+      .node`                                                                         
+    <button                                                                         
+            title=${mapp.dictionary.disable_help}                                         
+            onclick=${(e) => {
+              const on = e.target.classList.toggle('active');
+              hideHelp(mapview, on);
+            }}>                                                                           
+     <span class="notranslate material-symbols-outlined strikethrough">help_center`;
+  }
+
+  //Provide the div with a brief explanation
+  const settingsContent = mapp.utils.html`<div style="margin: 1em 0">
+            <p> We display help dialogs for certain interactions such as drawing and editing geometries.<br />
+                You can contol whether these dialogs display below.
+            </p>
+              <div style="display:flex; gap: 1em">
+                <button data-id="display-help-on" class="action raised bold active"
+                  onclick=${() => hideHelp(mapview, false)}>
+                  <span class="material-symbols-outlined notranslate">task_alt</span>
+                  On
+                </button>
+                <button data-id="display-help-off" class="action raised bold active"
+                  onclick=${() => hideHelp(mapview, true)}>   
+                  <span class="material-symbols-outlined notranslate">task_alt</span>  
+                  Off                                                                   
+                </button>                                                              
+              </div>`;
+
+  return settingsContent;
+}
+
+/**
+@function hideHelp
+Sets the hideHelp attribute on the layers present in the mapview to hide the help dialogs 
+in drawing, modifying, etc interactions.
+
+@param {Object} mapview The mapview object.
+@param {boolean} [off] Flag for controlling help dialog hideHelp property.
+
+*/
+function hideHelp(mapview, off) {
+  //Loop over the layers in the mapview.
+  for (const [_, layer] of Object.Entries(mapview.layers)) {
+    if (
+      layer.draw ||
+      layer.infoj?.find?.((entry) => entry.type === 'geometry' && entry.edit)
+    ) {
+      //Set hideHelp on applicable layers.
+      layer.hideHelp = off;
+
+      layer.reload?.();
+    }
+  }
+
+  //Close any open locations.
+  for (const location of Object.keys(mapview.locations)) {
+    mapview.locations[location].remove();
+  }
+
+  //Set it hideHelp locale wide.
+  mapview.locale.hideHelp = off;
+
+  //Put the new locale in the indexdb
+  mapp.utils.userLocale.putLocale(mapview);
+}

--- a/lib/ui/layers/view.mjs
+++ b/lib/ui/layers/view.mjs
@@ -31,6 +31,9 @@ export default function layerView(layer) {
   // Do not create a layer view.
   if (layer.view === null) return layer;
 
+  //Assign hideHelp flag from the locale.
+  layer.hideHelp ??= layer.mapview.locale.hideHelp;
+
   layer.view = mapp.utils.html.node`<div
     data-id=${layer.key}
     class="layer-view">`;

--- a/lib/ui/locations/entries/geometry.mjs
+++ b/lib/ui/locations/entries/geometry.mjs
@@ -94,6 +94,7 @@ export default function geometry(entry) {
   entry.modify ??= modify;
   entry.label ??= 'Geometry';
   entry.disabled ??= !entry.value && !entry.api;
+  entry.hideHelp ??= entry.location.layer.hideHelp;
 
   // Create checkbox to control geometry display.
   entry.chkbox = mapp.ui.elements.chkbox({
@@ -230,12 +231,12 @@ function edit(entry) {
       class="action wide"
       data-id="modify-btn"
       onclick=${() => {
-        if (entry.edit.modify_btn.classList.toggle('active')) {
-          entry.modify();
-        } else {
-          entry.location.layer.mapview.interactions.highlight();
-        }
-      }}>
+      if (entry.edit.modify_btn.classList.toggle('active')) {
+        entry.modify();
+      } else {
+        entry.location.layer.mapview.interactions.highlight();
+      }
+    }}>
       <span class="notranslate material-symbols-outlined">format_shapes</span>
       ${entry.edit.modify_label}`;
 
@@ -314,6 +315,7 @@ async function modify() {
       <ul>${mapp.dictionary.edit_dialog_modify_shape}</ul>
       <ul>${mapp.dictionary.edit_dialog_save}</ul>`,
     header: mapp.utils.html`<h3>${mapp.dictionary.edit_dialog_title}</h3>`,
+    hideHelp: entry.hideHelp,
   };
 
   mapp.ui.elements.helpDialog(helpDialog);

--- a/lib/ui/locations/infoj.mjs
+++ b/lib/ui/locations/infoj.mjs
@@ -93,6 +93,9 @@ export default function infoj(location, infoj_order) {
   for (const entry of infoj) {
     entry.key ??= entry.field || keyIdx++;
 
+    //Assign the hideHelp to the entry from the layer
+    entry.hideHelp ??= location.layer.hideHelp;
+
     // The location view entries should not be processed if the view is disabled.
     if (location.view?.classList.contains('disabled')) break;
 

--- a/public/css/layout/_toolbars.css
+++ b/public/css/layout/_toolbars.css
@@ -14,6 +14,26 @@
 
   & span {
     line-height: normal;
+
+    &.strikethrough {
+      position: relative;
+    }
+
+    &.strikethrough:before {
+      position: absolute;
+      content: '';
+      left: 0;
+      top: 45%;
+      right: 0;
+      border-top: 2px solid;
+      border-color: inherit;
+
+      -webkit-transform: rotate(45deg);
+      -moz-transform: rotate(45deg);
+      -ms-transform: rotate(45deg);
+      -o-transform: rotate(45deg);
+      transform: rotate(45deg);
+    }
   }
 
   & button,

--- a/public/css/ui.css
+++ b/public/css/ui.css
@@ -1473,6 +1473,23 @@ dialog {
   }
   & span {
     line-height: normal;
+    &.strikethrough {
+      position: relative;
+    }
+    &.strikethrough:before {
+      position: absolute;
+      content: "";
+      left: 0;
+      top: 45%;
+      right: 0;
+      border-top: 2px solid;
+      border-color: inherit;
+      -webkit-transform: rotate(45deg);
+      -moz-transform: rotate(45deg);
+      -ms-transform: rotate(45deg);
+      -o-transform: rotate(45deg);
+      transform: rotate(45deg);
+    }
   }
   & button,
   & > div,


### PR DESCRIPTION
## Description
This PR adds a plugin and a utility for controlling whether helpDialogs are displayed. 

The plugin adds a button the button column:
<img width="61" height="317" alt="screenshot-2025-09-18_15-26-50" src="https://github.com/user-attachments/assets/192875da-7573-4082-ac2f-9833cb64456c" />

When clicked adds `hideHelp` to all the layers in the mapview where applicable and reloads said layers. 

`hideHelp` will also be applied to the locale and written to the indexDB

The plugin is called with `disable_help: {}` in the locale. 
## GitHub Issue
#1854 

## Type of Change
- ✅ New feature (non-breaking change which adds functionality)
- ✅ Documentation

## How have you tested this?
Tested Locally on `bugs_testing\plugins\process_pipe.js`. Can also be tested by simply adding
`disable_help: {}` to any locale.

## Testing Checklist
- ✅ Existing Tests still pass
- ✅ Ran locally on my machine

## Code Quality Checklist
- ✅ My code follows the guidelines of XYZ
- ✅ My code has been commented
- ✅ Documentation has been updated
- ✅ New and existing unit tests pass locally with my changes
- ✅ Main has been merged into this PR
