### PR TITLE
Do not validate xForwardedForHeader

### DIFF
--- a/express.js
+++ b/express.js
@@ -63,6 +63,7 @@ const limiter = rateLimit({
   limit: xyzEnv.RATE_LIMIT,
   standardHeaders: 'draft-8',
   windowMs: xyzEnv.RATE_LIMIT_WINDOW,
+  validate: { xForwardedForHeader: false },
 });
 
 app.use(limiter);


### PR DESCRIPTION
xForwardedForHeader should not be evaluated for the express rate limiter.

This will break the execution of express through codespaces.

<img width="1320" height="234" alt="image" src="https://github.com/user-attachments/assets/4c411b4a-3240-42a4-9ae6-84c6e84cb572" />
