### PR TITLE
Move dotenv config to processEnv

### DIFF
--- a/express.js
+++ b/express.js
@@ -35,19 +35,15 @@ DIR - Base directory for routes
 RATE_LIMIT - Maximum requests per window (default: 1000)
 RATE_LIMIT_WINDOW - Time window in ms (default: 1 min)
 ```
-@requires dotenv - Environment configuration loading
-@requires express - Web application framework
-@requires cookie-parser - HTTP cookie parsing middleware
-@requires express-rate-limit - Rate limiting middleware
+@requires express Web application framework
+@requires cookie-parser HTTP cookie parsing middleware
+@requires express-rate-limit Rate limiting middleware
 */
 
-import 'dotenv/config';
 import './mod/utils/processEnv.js';
-
 import cookieParser from 'cookie-parser';
 import express from 'express';
 import rateLimit from 'express-rate-limit';
-
 import api from './api/api.js';
 
 if (process.versions.node.split('.')[0] < 22) {

--- a/mod/utils/processEnv.js
+++ b/mod/utils/processEnv.js
@@ -2,6 +2,8 @@
 ## /utils/processEnv
 
 The processEnv utility script is required by the express web server app and the api module to set default environment variables as well ass variables defined in the process environment to the globalThis xyzEnv object.
+
+@requires dotenv Environment configuration loading
 */
 
 /**
@@ -57,6 +59,7 @@ The process.ENV object holds configuration provided to the node process from the
 @property {String} [SLO_CALLBACK] - URL for handling logout callbacks
 */
 
+import 'dotenv/config';
 import { readFileSync } from 'fs';
 
 const defaults = {


### PR DESCRIPTION
The dotenv import must be in the processEnv module for use in deployments which do not use the express app, eg. vercel.