### PR TITLE
feat(categorized): Hide `distribution:count` when layer is off

### DIFF
--- a/lib/ui/elements/layerStyle.mjs
+++ b/lib/ui/elements/layerStyle.mjs
@@ -369,6 +369,14 @@ function themes(layer) {
 
     const stylePanel = mapp.ui.layers.panels.style(layer);
 
+    const legendDisplay = layer.display ? '' : 'none';
+
+    //Theme with distribution count must only be shown if layer is shown.
+    //Other themes should display regardless.
+    if (layer.style.theme.distribution !== 'count')
+      layer.style.legend.style.removeProperty('display');
+    else layer.style.legend.style.setProperty('display', legendDisplay);
+
     if (layer.style.panel) {
       // Replace children in location layer entry style.panel
       layer.style.panel.replaceChildren(...stylePanel.children);

--- a/lib/ui/layers/legends/categorized.mjs
+++ b/lib/ui/layers/legends/categorized.mjs
@@ -132,6 +132,26 @@ export default function categorizedTheme(layer) {
     layer.style.legend.replaceChildren(...theme.legend.node.children);
   }
 
+  //Determine whether to show the legend based on layer.display
+  const displayStyle = layer.display ? '' : 'none';
+
+  //Hide distribution count themes on load.
+  theme.distribution === 'count' &&
+    theme.legend.node.style.setProperty('display', displayStyle);
+
+  //Set themes to show in style panel on layer show.
+  layer.showCallbacks.push(() => {
+    layer.style.legend.style.removeProperty('display');
+  });
+
+  //Hide distribution count themes when the layer is hidden.
+  layer.hideCallbacks.push(() => {
+    //Only hide the distribution count theme legend.
+    theme.key === layer.style.theme.key &&
+      theme.distribution === 'count' &&
+      layer.style.legend.style.setProperty('display', 'none');
+  });
+
   return theme.legend.node;
 }
 


### PR DESCRIPTION
## Description
This PR adds functionality to hide themes with `distribution: count` until the layer is shown.

Layer is off:
<img width="338" height="142" alt="screenshot-2025-09-24_12-12-49" src="https://github.com/user-attachments/assets/2d7e1a5e-56db-45ec-9346-2042dd89b31d" />

## GitHub Issue
#2410 

## Type of Change

Please delete options that are not relevant, and select all options that apply.
- ✅ New feature (non-breaking change which adds functionality)
- ✅ Documentation

## How have you tested this?
Tested locally using a categorized theme, and a layer with multiple themes.

## Testing Checklist
- ✅ Existing Tests still pass
- ✅ Ran locally on my machine

## Code Quality Checklist
- ✅ My code follows the guidelines of XYZ
- ✅ My code has been commented
- ✅ Documentation has been updated
- ✅ New and existing unit tests pass locally with my changes
- ✅ Main has been merged into this PR
