### PR TITLE
bug(distributed theme): Neighbouring features of the same field not being coloured the same

### DIFF
--- a/lib/layer/themes/distributed.mjs
+++ b/lib/layer/themes/distributed.mjs
@@ -63,9 +63,14 @@ export default function distributed(theme, feature) {
   // If no intersection, the set should be generated as the number of categories in the theme.
   // This is required for point features which are unlikely to intersect.
   // As such, the colours are just assigned by looping through the categories.
+  const allCats = Array.from(
+    { length: theme.categories.length },
+    (value, index) => index,
+  );
+
   const set = intersects.length
-    ? new Set(intersects.map((b) => b.themeIdx))
-    : new Set([...Array(theme.categories.length).keys()]);
+    ? new Set(intersects.map((item) => item.themeIdx))
+    : new Set(allCats);
 
   // Increase the current cat index.
   theme.index++;

--- a/lib/layer/themes/distributed.mjs
+++ b/lib/layer/themes/distributed.mjs
@@ -60,17 +60,21 @@ export default function distributed(theme, feature) {
   // Push the current bbox into the array.
   theme.boxes.push(bbox);
 
-  // Create a set of cat indices from intersecting bounding boxes.
-  const set = new Set(intersects.map((b) => b.themeIdx));
+  // If no intersection, the set should be generated as the number of categories in the theme.
+  // This is required for point features which are unlikely to intersect.
+  // As such, the colours are just assigned by looping through the categories.
+  const set = intersects.length
+    ? new Set(intersects.map((b) => b.themeIdx))
+    : new Set([...Array(theme.categories.length).keys()]);
 
-  // Increase the current cat indix.
+  // Increase the current cat index.
   theme.index++;
 
   // Reset cat index to 0 if the index reaches the length of the cat array.
   if (theme.index === theme.categories.length) theme.index = 0;
 
   // i is the cat index if not in set of intersecting boxes.
-  bbox.themeIdx = theme.index; //!set.has(theme.index) //&& parseInt(theme.index);
+  bbox.themeIdx = theme.index;
 
   // Current index is already in set of intersecting boxes.
   if (!set.has(theme.index)) {


### PR DESCRIPTION
# Pull Request Template

## Description

Non-intersecting features or features that have the same field value (e.g. store_code = 1) were previously all getting the first colour in the categories. This is a bug as previously this worked. 
This PR checks if intersects has no length, if not the set is built from the theme.categories.length.keys() meaning that each feature is coloured differently (using its field value).
This fixes an issue whereby neighbouring features were all being given the colour incorrectly.

On the PR: 
<img width="739" height="454" alt="screenshot-2025-10-01_14-59-43" src="https://github.com/user-attachments/assets/e51a0418-8df3-430b-9331-adaf92055591" />

Off the PR:
<img width="596" height="446" alt="screenshot-2025-10-01_15-00-20" src="https://github.com/user-attachments/assets/e9e32b06-c909-4f82-ba85-bbd087d27ecc" />

## Testing

Tested on a distributed theme on `bugs_testing\ui_elements\workspace.json` on the scratch_wkt layer and switching to the distributed theme. 

## Type of Change
- ✅ Bug fix (non-breaking change which fixes an issue)

## Code Quality Checklist
- ✅ My code follows the guidelines of XYZ
- ✅ My code has been commented
- ✅ Documentation has been updated
- ✅ New and existing unit tests pass locally with my changes
- ✅ Main has been merged into this PR
