### PR TITLE
StyleParser: Check on if `theme.type` exists

### DIFF
--- a/lib/layer/styleParser.mjs
+++ b/lib/layer/styleParser.mjs
@@ -342,6 +342,12 @@ The parseTheme method checks whether a theme and it's categories have consistent
 function parseTheme(theme, layer) {
   if (typeof theme !== 'object') return;
 
+  // Check on if the theme.type exists.
+  if (!Object.hasOwn(mapp.layer.themes, theme.type)) {
+    console.warn(`Layer: ${layer.key}; Theme Type: ${theme.type} unavailable.`);
+    return;
+  }
+
   if (typeof theme.style === 'object') {
     // Assign the default style to the theme.style
     theme.style = {


### PR DESCRIPTION
## Description

The `styleParser` must check if `theme.type` exists as this is confusing when you have incorrect configuration but no warning or error. 

## Type of Change

Please delete options that are not relevant, and select all options that apply.

- ✅ Bug fix (non-breaking change which fixes an issue)

## How have you tested this?

Just provide a bogus `theme.type` 

## Testing Checklist

Please delete options that are not relevant, and select all options that apply.

- ✅ Existing Tests still pass
- ✅ Ran locally on my machine

## Code Quality Checklist

Please delete options that are not relevant, and select all options that apply.

- ✅ My code follows the guidelines of XYZ
- ✅ My code has been commented
- ✅ Documentation has been updated
- ✅ New and existing unit tests pass locally with my changes
- ✅ Main has been merged into this PR
