### PR TITLE
bug(draw-drawer): classList accidentally removed

### DIFF
--- a/lib/ui/layers/panels/draw.mjs
+++ b/lib/ui/layers/panels/draw.mjs
@@ -60,6 +60,7 @@ export default function drawPanel(layer) {
       <h3>${mapp.dictionary.layer_add_new_location}</h3>
       <div class="notranslate material-symbols-outlined caret"/>`,
     content,
+    class: layer.draw.classList,
     popout: layer.draw.popout,
   });
 


### PR DESCRIPTION
## Description

Correcting an issue whereby the `classList` for a `draw` object was not being applied to the `drawer`. 

## Type of Change

Please delete options that are not relevant, and select all options that apply.

- ✅ Bug fix (non-breaking change which fixes an issue)

## How have you tested this?

Provide this configuration on and off the PR. 
``` json
"draw": {
  "classList": "expanded",
  "point": true
}
```

## Testing Checklist

Please delete options that are not relevant, and select all options that apply.

- ✅ Existing Tests still pass
- ✅ Ran locally on my machine

## Code Quality Checklist

Please delete options that are not relevant, and select all options that apply.

- ✅ My code follows the guidelines of XYZ
- ✅ My code has been commented
- ✅ Documentation has been updated
- ✅ New and existing unit tests pass locally with my changes
- ✅ Main has been merged into this PR
