### PR TITLE
bug(query): Add check for optional params

### DIFF
--- a/mod/query.js
+++ b/mod/query.js
@@ -188,10 +188,10 @@ async function layerQuery(req, res) {
   req.params.filter = [
     (req.params.layer.filter?.default &&
       `AND ${sqlFilter(req.params.layer.filter.default, req)}`) ||
-      '',
+    '',
     (req.params.filter &&
       `AND ${sqlFilter(JSON.parse(req.params.filter), req)}`) ||
-      '',
+    '',
   ].join(' ');
 
   // Create viewport condition for SQL query.
@@ -420,6 +420,7 @@ function getQueryFromTemplate(req, template) {
       req.params.SQL.length = 0;
     }
 
+    const optionalParams = new Set(['viewport', 'filter']);
     const query_template = template.template
 
       // Replace parameter for identifiers, e.g. table, schema, columns
@@ -428,7 +429,7 @@ function getQueryFromTemplate(req, template) {
         const param = matched.replace(/\${|}/g, '');
 
         // Get param value from request params object.
-        const change = req.params[param];
+        const change = optionalParams.has(param) ? '' : req.params[param];
 
         if (change === undefined) {
           missingParams.push(param);
@@ -436,7 +437,7 @@ function getQueryFromTemplate(req, template) {
 
         // Change value may only contain a limited set of whitelisted characters.
         if (
-          !new Set(['viewport', 'filter']).has(param) &&
+          optionalParams.has(param) &&
           !/^[A-Za-z0-9,"'._-\s]*$/.test(change)
         ) {
           throw new Error(`Substitute \${${param}} value rejected: ${change}`);
@@ -450,7 +451,7 @@ function getQueryFromTemplate(req, template) {
         // Remove template brackets from matched param.
         const param = matched.replace(/%{|}/g, '');
 
-        let val = req.params[param];
+        let val = optionalParams.has(param) ? '' : req.params[param];
 
         if (val === undefined) {
           missingParams.push(param);

--- a/mod/query.js
+++ b/mod/query.js
@@ -429,7 +429,9 @@ function getQueryFromTemplate(req, template) {
         const param = matched.replace(/\${|}/g, '');
 
         // Get param value from request params object.
-        const change = optionalParams.has(param) ? '' : req.params[param];
+        const change = optionalParams.has(param)
+          ? req.params[param] || ''
+          : req.params[param];
 
         if (change === undefined) {
           missingParams.push(param);
@@ -437,7 +439,7 @@ function getQueryFromTemplate(req, template) {
 
         // Change value may only contain a limited set of whitelisted characters.
         if (
-          optionalParams.has(param) &&
+          !optionalParams.has(param) &&
           !/^[A-Za-z0-9,"'._-\s]*$/.test(change)
         ) {
           throw new Error(`Substitute \${${param}} value rejected: ${change}`);
@@ -451,7 +453,9 @@ function getQueryFromTemplate(req, template) {
         // Remove template brackets from matched param.
         const param = matched.replace(/%{|}/g, '');
 
-        let val = optionalParams.has(param) ? '' : req.params[param];
+        let val = optionalParams.has(param)
+          ? req.params[param] || ''
+          : req.params[param];
 
         if (val === undefined) {
           missingParams.push(param);

--- a/mod/query.js
+++ b/mod/query.js
@@ -188,10 +188,10 @@ async function layerQuery(req, res) {
   req.params.filter = [
     (req.params.layer.filter?.default &&
       `AND ${sqlFilter(req.params.layer.filter.default, req)}`) ||
-    '',
+      '',
     (req.params.filter &&
       `AND ${sqlFilter(JSON.parse(req.params.filter), req)}`) ||
-    '',
+      '',
   ].join(' ');
 
   // Create viewport condition for SQL query.


### PR DESCRIPTION
## Description
`viewport` and `filter` are optional params in queries, currently queries such as `location_count` will fail if these are not provided. 
This is caused by the check for missing parameters as previously missing parameters were replaced by ''

In this PR an optionalParams set is created and if the params are in this list they are instead assigned empty string. 

On the PR you should see the location count on the multi-filter:
<img width="344" height="69" alt="screenshot-2025-10-01_16-35-21" src="https://github.com/user-attachments/assets/db07ec32-3589-453d-9df0-d4abcbf4d143" />

Off the PR you will see an erroneous error in the console and the count wont show:
<img width="340" height="62" alt="screenshot-2025-10-01_16-35-40" src="https://github.com/user-attachments/assets/b7650718-2624-4686-9338-c9f99e3adf01" />

## GitHub Issue
#2427

## Type of Change
- ✅ Bug fix (non-breaking change which fixes an issue)

## How have you tested this?
tested lcoally on `bugs_testing\filter\all_filters.json`

## Testing Checklist
- ✅ Existing Tests still pass
- ✅ Ran locally on my machine

## Code Quality Checklist
- ✅ My code follows the guidelines of XYZ
- ✅ My code has been commented
- ✅ Documentation has been updated
- ✅ New and existing unit tests pass locally with my changes
- ✅ Main has been merged into this PR
