### PR TITLE
fix(saml): correct user email mapping

### DIFF
--- a/mod/user/saml.js
+++ b/mod/user/saml.js
@@ -374,7 +374,7 @@ async function acs(req, res) {
 
     // Create user Object from SAML attributes
     const user = {
-      email: samlResponse.profile.nameID,
+      email: samlResponse.profile.email,
       nameID: samlResponse.profile.nameID,
       nameIDFormat: samlResponse.profile.nameIDFormat,
       nameQualifier: samlResponse.profile.nameQualifier,


### PR DESCRIPTION
# SAML Profile Correction

The user object was being assigned the nameID to the email property which is incorrect.

I have corrected it to assign the email from the returned saml profile instead of the nameID