### PR TITLE
Patch for distributed themes

### DIFF
--- a/lib/layer/styleParser.mjs
+++ b/lib/layer/styleParser.mjs
@@ -342,6 +342,12 @@ The parseTheme method checks whether a theme and it's categories have consistent
 function parseTheme(theme, layer) {
   if (typeof theme !== 'object') return;
 
+  // Check on if the theme.type exists.
+  if (!Object.hasOwn(mapp.layer.themes, theme.type)) {
+    console.warn(`Layer: ${layer.key}; Theme Type: ${theme.type} unavailable.`);
+    return;
+  }
+
   if (typeof theme.style === 'object') {
     // Assign the default style to the theme.style
     theme.style = {

--- a/lib/layer/themes/distributed.mjs
+++ b/lib/layer/themes/distributed.mjs
@@ -46,7 +46,7 @@ export default function distributed(theme, feature) {
   if (theme.index === undefined) {
     theme.index = 0;
   } else {
-    theme.index++
+    theme.index++;
   }
 
   // Reset cat index to 0 if the index reaches the length of the cat array.
@@ -63,7 +63,6 @@ export default function distributed(theme, feature) {
 
   // A point feature will have matching bbox corner coordinates.
   if (bbox.extent[0] === bbox.extent[2] && bbox.extent[1] === bbox.extent[3]) {
-
     // Assign the style to the lookup object for the feature field property value.
     theme.lookup[val] = theme.categories[theme.index];
 
@@ -85,7 +84,7 @@ export default function distributed(theme, feature) {
   // Push the current bbox into the array.
   theme.boxes.push(bbox);
 
-  const set = new Set(intersects.map((item) => item.themeIdx))
+  const set = new Set(intersects.map((item) => item.themeIdx));
 
   // Current index is already in set of intersecting boxes.
   if (!set.has(theme.index)) {

--- a/lib/layer/themes/distributed.mjs
+++ b/lib/layer/themes/distributed.mjs
@@ -26,7 +26,6 @@ The method will iterate of features which intersect the bounding box of the curr
 export default function distributed(theme, feature) {
   theme.lookup ??= {};
   theme.boxes ??= [];
-  theme.index ??= 0;
   theme.field ??= 'id';
 
   // Get feature identifier for theme.
@@ -41,10 +40,32 @@ export default function distributed(theme, feature) {
     return;
   }
 
+  // Define as 0 or increase theme.index
+  if (theme.index === undefined) {
+    theme.index = 0;
+  } else {
+    theme.index++
+  }
+
+  // Reset cat index to 0 if the index reaches the length of the cat array.
+  if (theme.index === theme.categories.length) {
+    theme.index = 0;
+  }
+
   // Get feature bounding box from geometry extent.
   const bbox = {
     extent: feature.getGeometry().getExtent(),
   };
+
+  // A point feature will have matching bbox corner coordinates.
+  if (bbox[0] === bbox[2] || bbox[1] === bbox[3]) {
+
+    // Assign the style to the lookup object for the feature field property value.
+    theme.lookup[val] = theme.categories[theme.index];
+
+    feature.style = theme.lookup[val].style;
+    return;
+  }
 
   // Find intersecting bounding boxes with their assigned cat index.
   const intersects = theme.boxes.filter(
@@ -71,12 +92,6 @@ export default function distributed(theme, feature) {
   const set = intersects.length
     ? new Set(intersects.map((item) => item.themeIdx))
     : new Set(allCats);
-
-  // Increase the current cat index.
-  theme.index++;
-
-  // Reset cat index to 0 if the index reaches the length of the cat array.
-  if (theme.index === theme.categories.length) theme.index = 0;
 
   // i is the cat index if not in set of intersecting boxes.
   bbox.themeIdx = theme.index;

--- a/lib/layer/themes/distributed.mjs
+++ b/lib/layer/themes/distributed.mjs
@@ -32,7 +32,9 @@ export default function distributed(theme, feature) {
   const val = String(feature.properties[theme.field]);
 
   // Assign theme.style if val is falsy.
-  if (!val) return;
+  if (!val) {
+    return;
+  }
 
   // The feature field property value already has a style assigned.
   if (theme.lookup[val]) {
@@ -57,8 +59,10 @@ export default function distributed(theme, feature) {
     extent: feature.getGeometry().getExtent(),
   };
 
+  if (!bbox.extent) return;
+
   // A point feature will have matching bbox corner coordinates.
-  if (bbox[0] === bbox[2] || bbox[1] === bbox[3]) {
+  if (bbox.extent[0] === bbox.extent[2] && bbox.extent[1] === bbox.extent[3]) {
 
     // Assign the style to the lookup object for the feature field property value.
     theme.lookup[val] = theme.categories[theme.index];
@@ -81,20 +85,7 @@ export default function distributed(theme, feature) {
   // Push the current bbox into the array.
   theme.boxes.push(bbox);
 
-  // If no intersection, the set should be generated as the number of categories in the theme.
-  // This is required for point features which are unlikely to intersect.
-  // As such, the colours are just assigned by looping through the categories.
-  const allCats = Array.from(
-    { length: theme.categories.length },
-    (value, index) => index,
-  );
-
-  const set = intersects.length
-    ? new Set(intersects.map((item) => item.themeIdx))
-    : new Set(allCats);
-
-  // i is the cat index if not in set of intersecting boxes.
-  bbox.themeIdx = theme.index;
+  const set = new Set(intersects.map((item) => item.themeIdx))
 
   // Current index is already in set of intersecting boxes.
   if (!set.has(theme.index)) {
@@ -106,6 +97,8 @@ export default function distributed(theme, feature) {
       break;
     }
   }
+
+  bbox.themeIdx ??= theme.index;
 
   // Assign the style to the lookup object for the feature field property value.
   theme.lookup[val] = theme.categories[bbox.themeIdx];

--- a/lib/layer/themes/distributed.mjs
+++ b/lib/layer/themes/distributed.mjs
@@ -30,7 +30,7 @@ export default function distributed(theme, feature) {
   theme.field ??= 'id';
 
   // Get feature identifier for theme.
-  const val = feature.properties[theme.field];
+  const val = String(feature.properties[theme.field]);
 
   // Assign theme.style if val is falsy.
   if (!val) return;

--- a/lib/layer/themes/distributed.mjs
+++ b/lib/layer/themes/distributed.mjs
@@ -87,7 +87,7 @@ export default function distributed(theme, feature) {
   const set = new Set(intersects.map((item) => item.themeIdx));
 
   // Current index is already in set of intersecting boxes.
-  if (!set.has(theme.index)) {
+  if (set.has(theme.index)) {
     // Find index which is not in set if possible.
     for (let free = 0; free < theme.categories.length; free++) {
       if (set.has(free)) continue;


### PR DESCRIPTION
The value must be parsed as a string. Otherwise the `!val` condition will shortcircuit on an integer or numeric properties.

Object keys are always type string and the lookup cannot work if the val is not type string.