### PR TITLE
fix(saml): user sessionIndex property on token

### DIFF
--- a/mod/user/cookie.js
+++ b/mod/user/cookie.js
@@ -26,7 +26,7 @@ The cookie will be destroyed [set to NULL] with detroy request parameter truthy.
 
 The cookie method will use the jsonwebtoken library to verify the existing cookie.
 
-If veriffied successfully a new token with updated user credentials will be signed.
+If verified successfully a new token with updated user credentials will be signed.
 
 The `xyzEnv.SECRET` variable will be used to sign the token.
 
@@ -51,11 +51,12 @@ export default async function cookie(req, res) {
   }
 
   const cookie = req.cookies?.[xyzEnv.TITLE];
-  const decodedCookie = jwt.decode(cookie);
 
   if (!cookie) {
     return res.send(false);
   }
+
+  const decodedCookie = jwt.decode(cookie);
 
   if (req.params.destroy) {
     // Remove cookie.

--- a/mod/user/cookie.js
+++ b/mod/user/cookie.js
@@ -51,6 +51,7 @@ export default async function cookie(req, res) {
   }
 
   const cookie = req.cookies?.[xyzEnv.TITLE];
+  const decodedCookie = jwt.decode(cookie);
 
   if (!cookie) {
     return res.send(false);
@@ -112,6 +113,12 @@ export default async function cookie(req, res) {
 
       if (payload.session) {
         user.session = payload.session;
+      }
+
+      //If we have a sessionIndex from a SAML IdP then we need to pass it from the
+      //already created cookie as this is not stored in the acl.
+      if (decodedCookie.sessionIndex) {
+        user.sessionIndex = decodedCookie.sessionIndex;
       }
 
       const token = jwt.sign(user, xyzEnv.SECRET, {


### PR DESCRIPTION
# SAML Session Index on a user token in the Cookie 🍪

The `sessionIndex` property from the saml response is now kept when we verify the existing token on the cookie.

This is done by decoding the token from the already existing cookie and checking if the user has a `sessionIndex` property which only comes from SAML authentication.