### PR TITLE
fix(entry - tooltip): Check if tooltip exists and remove if so

### DIFF
--- a/lib/ui/locations/infoj.mjs
+++ b/lib/ui/locations/infoj.mjs
@@ -547,6 +547,14 @@ function entryTooltipIcon(entry) {
 
   if (!label_element) return;
 
+  // Check if tooltip already exists, if so remove as its content may have changed.
+  entry.data_id ??= 'ui-elements-tooltip';
+
+  const existing_tooltip = label_element.querySelector(
+    '[data-id="' + entry.data_id + '"]',
+  );
+  if (existing_tooltip) existing_tooltip.remove();
+
   const tooltip = mapp.ui.elements.tooltip({
     content: entry.tooltip,
   });


### PR DESCRIPTION
## Description
When a `type:dataview`, that is `display:true` is reloaded after a different `infoj` field is updated, the tooltip is being duplicated.

## Type of Change
- ✅ Bug fix (non-breaking change which fixes an issue)

## Testing Checklist
- ✅ Existing Tests still pass
- ✅ Ran locally on my machine

## Code Quality Checklist
- ✅ My code follows the guidelines of XYZ
- ✅ My code has been commented