### PR TITLE
fix(Tabview): Add check on layer dataviews

### DIFF
--- a/lib/ui/Tabview.mjs
+++ b/lib/ui/Tabview.mjs
@@ -86,7 +86,7 @@ function addTab(entry) {
 
   //Hide disable tab closing if the layer.dataviews has hide true
   if (entry.layer?.dataviews?.[entry.key]) {
-    entry.disableTabClose = entry.layer.dataviews.hide || entry.disableTabClose;
+    entry.disableTabClose = entry.layer.dataviews.hide;
   }
 
   entry.activate ??= activateTab;

--- a/lib/ui/Tabview.mjs
+++ b/lib/ui/Tabview.mjs
@@ -86,7 +86,7 @@ function addTab(entry) {
 
   //Hide disable tab closing if the layer.dataviews has hide true
   if (entry.layer?.dataviews?.[entry.key]) {
-    entry.disableTabClose = entry.layer.dataviews.hide;
+    entry.disableTabClose ??= entry.layer.dataviews.hide;
   }
 
   entry.activate ??= activateTab;

--- a/lib/ui/Tabview.mjs
+++ b/lib/ui/Tabview.mjs
@@ -85,7 +85,7 @@ function addTab(entry) {
   const tabview = this;
 
   //Hide disable tab closing if the layer.dataviews has hide true
-  if (entry.layer?.dataviews[entry.key]) {
+  if (entry.layer?.dataviews?.[entry.key]) {
     entry.disableTabClose = entry.layer.dataviews.hide || entry.disableTabClose;
   }
 


### PR DESCRIPTION
## Description
`layer.dataviews` might be undefined, checking for a key on undefined object causes an error so the tabview would not open. 

This PR just adds a optional check on whether the layer has dataviews. 

## GitHub Issue
#2444 

## Type of Change
- ✅ Bug fix (non-breaking change which fixes an issue)

## How have you tested this?
Tested locally using `bugs_testing\dataviews\tabulator_workspace.json` off the PR opening a location will cause the error. 

## Testing Checklist
- ✅ Existing Tests still pass
- ✅ Ran locally on my machine

## Code Quality Checklist
- ✅ My code follows the guidelines of XYZ
- ✅ My code has been commented
- ✅ Documentation has been updated
- ✅ New and existing unit tests pass locally with my changes
- ✅ Main has been merged into this PR
