### PR TITLE
fix(categorized): Theme Meta Node may not exist

### DIFF
--- a/lib/ui/layers/legends/categorized.mjs
+++ b/lib/ui/layers/legends/categorized.mjs
@@ -142,7 +142,7 @@ export default function categorizedTheme(layer) {
     //Set themes to show in style panel on layer show.
     layer.showCallbacks.push(() => {
       layer.style.legend.style.removeProperty('display');
-      theme.meta_node.style.removeProperty('display');
+      theme.meta_node?.style.removeProperty('display');
     });
 
     //Hide distribution count themes when the layer is hidden.
@@ -150,7 +150,7 @@ export default function categorizedTheme(layer) {
       //Only hide the distribution count theme legend.
       if (theme.key === layer.style.theme.key) {
         layer.style.legend.style.setProperty('display', 'none');
-        theme.meta_node.style.setProperty('display', 'none');
+        theme.meta_node?.style.setProperty('display', 'none');
       }
     });
 
@@ -158,7 +158,7 @@ export default function categorizedTheme(layer) {
     layer.style.legend.style.setProperty('display', displayStyle);
 
     //Hide/Show meta tag.
-    theme.meta_node.style.setProperty('display', displayStyle);
+    theme.meta_node?.style.setProperty('display', displayStyle);
 
     return theme.legend.node;
   }


### PR DESCRIPTION
## Description

Added conditional check on `meta_node` as it doesn't always exist.
Note this PR is into minor as this change for `meta_node` was made of a new feature as part of this PR   https://github.com/GEOLYTIX/xyz/pull/2411 

## Type of Change
- ✅ Bug fix (non-breaking change which fixes an issue)

## How have you tested this?
Use a `categorized` theme without a meta.

## Testing Checklist
- ✅ Existing Tests still pass
- ✅ Ran locally on my machine