### PR TITLE
Bump nodemailer to 7.0.9+

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "@aws-sdk/cloudfront-signer": "^3.621.0",
     "@aws-sdk/s3-request-presigner": "^3.691.0",
     "@node-saml/node-saml": "^5.0.1",
-    "nodemailer": "^6.10.0"
+    "nodemailer": "^7.0.9"
   },
   "dependencies": {
     "dotenv": "^17.2.2",


### PR DESCRIPTION
Dependabot flagged a vulnerability in earlier versions of nodemailer.

https://github.com/GEOLYTIX/xyz/security/dependabot/23