### PR TITLE
Update documentation for logger module

### DIFF
--- a/mod/utils/logger.js
+++ b/mod/utils/logger.js
@@ -11,6 +11,7 @@ Possible log values are:
 - view-req-url: Logs the url of the requested view.  
 - cloudfront: Logs responses from requests made to cloudfront e.g. <staus_code> - <endpoint> 
 - mailer: Logs the response from email sending.
+- mailer_body: Logs email from and two with the body.
 - reqhost: Logs the host for the request.
 - workspace: Logs responses for requests made to /workspace.
 

--- a/mod/utils/mailer.js
+++ b/mod/utils/mailer.js
@@ -81,11 +81,20 @@ async function mailer(params) {
     to: params.to,
   };
 
-  const result = await transport
-    .sendMail(mailTemplate)
-    .catch((err) => console.error(err));
+  await transport.sendMail(mailTemplate, (err, info) => {
+    if (err) {
+      console.error(err);
+      return;
+    }
 
-  logger(result, 'mailer');
+    let result = `${info.messageId}\nFrom: ${info.envelope.from}\nTo: ${info.envelope.to}`;
+
+    logger(result, 'mailer');
+
+    result += `\nBody:\n ${mailTemplate.text.replace('    ', '')}`;
+
+    logger(result, 'mailer_body');
+  });
 }
 
 /**


### PR DESCRIPTION
This PR updates the documentation for the logger module.

A list of the available LOG keys has been added to the module documentation.

<img width="868" height="660" alt="image" src="https://github.com/user-attachments/assets/dd9720d0-0b09-4416-a35a-3a5cc1f4c410" />
