### PR TITLE
fix(dark_mode): button selector

### DIFF
--- a/lib/plugins/dark_mode.mjs
+++ b/lib/plugins/dark_mode.mjs
@@ -16,7 +16,6 @@ The dark_mode plugin method adds a button to the mapview controls which allows t
 Whether the darkTheme should be applied by default is stored as darkMode flag in the localStorage.
 */
 export function dark_mode(plugin, mapview) {
-
   // If mapbutton doesn't exist, return (for custom views).
   if (!mapview.mapButton) return;
 


### PR DESCRIPTION
Icon change no longer selects from map button element. 
Now icon is changed with reference to the button element itself. 
Previously would throw querySelector error when the button was placed in a container other than `#mapButton`.

The dependence on map button element originated when testing button grouping plugin.


