### PR TITLE
fix(image): Fix for image preview close button

### DIFF
--- a/public/css/layout/_image_preview.css
+++ b/public/css/layout/_image_preview.css
@@ -13,11 +13,10 @@
     background-repeat: no-repeat;
     background-size: contain;
     background-position: center;
+    display: flex;
+    justify-content: flex-end;
 
     & > .btn-close {
-      position: absolute;
-      top: 5%;
-      right: 5%;
       width: 50px;
       height: 50px;
       background-color: var(--color-primary);

--- a/public/css/ui.css
+++ b/public/css/ui.css
@@ -1210,10 +1210,9 @@ form.login-form {
     background-repeat: no-repeat;
     background-size: contain;
     background-position: center;
+    display: flex;
+    justify-content: flex-end;
     & > .btn-close {
-      position: absolute;
-      top: 5%;
-      right: 5%;
       width: 50px;
       height: 50px;
       background-color: var(--color-primary);


### PR DESCRIPTION
# Pull Request Template

## Description

Fixes issue whereby the close button on imagePreview was not visible. 
Using `var(--color-font-contrast)` so fix works with dark mode or any custom colour palette.

<img width="1342" height="897" alt="image" src="https://github.com/user-attachments/assets/a83c0347-b8b1-4908-ac32-7169b3394445" />


## GitHub Issue

#2465 

## Type of Change

- ✅ Bug fix (non-breaking change which fixes an issue)

## How have you tested this?

Add image to the infoj and click on it to open imagePreview.

## Testing Checklist

- ✅ Existing Tests still pass
- ✅ Ran locally on my machine

## Code Quality Checklist

- ✅ My code follows the guidelines of XYZ
- ✅ New and existing unit tests pass locally with my changes
