### PR TITLE
chore(biome): v2.2.6 bump & enable html parsing interpolation

### DIFF
--- a/.github/workflows/biome.yml
+++ b/.github/workflows/biome.yml
@@ -14,6 +14,6 @@ jobs:
       - name: Setup Biome
         uses: biomejs/setup-biome@v2
         with:
-          version: 2.1.3
+          version: 2.2.6
       - name: Run Biome
         run: biome ci .

--- a/biome.json
+++ b/biome.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://biomejs.dev/schemas/2.1.3/schema.json",
+  "$schema": "https://biomejs.dev/schemas/2.2.6/schema.json",
   "assist": {
     "actions": {
       "source": {
@@ -42,6 +42,9 @@
   "html": {
     "formatter": {
       "enabled": true
+    },
+    "parser": {
+      "interpolation": true
     }
   },
   "javascript": {

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "pg": "~8.15.1"
   },
   "devDependencies": {
-    "@biomejs/biome": "2.1.3",
+    "@biomejs/biome": "2.2.6",
     "clean-jsdoc-theme": "^4.3.0",
     "codi-test-framework": "1.0.37",
     "concurrently": "^9.1.0",

--- a/public/views/_default.html
+++ b/public/views/_default.html
@@ -1,7 +1,7 @@
 <!doctype html>
 <html lang="{{language}}">
   <head data-dir="{{dir}}" data-login="{{login}}">
-    <title>{{ title }}</title>
+    <title>{{title}}</title>
 
     <link
       rel="icon"

--- a/public/views/_login.html
+++ b/public/views/_login.html
@@ -1,7 +1,7 @@
 <!doctype html>
 <html lang="{{language}}">
   <head data-dir="{{dir}}">
-    <title>{{ title }}</title>
+    <title>{{title}}</title>
     <link
       rel="icon"
       type="image/x-icon"


### PR DESCRIPTION
# Biome v2.2.6

I have bumped the biome package as it helps address parsing double text expressions that we have in our html views.

eg: `{{title}}`

Enabling this to be parsed in the formatter will prevent it from being formatted in biome (in html files).

