### PR TITLE
fix(register): Register Case Insensitive

### DIFF
--- a/mod/user/register.js
+++ b/mod/user/register.js
@@ -16,13 +16,13 @@ Exports the [user] register method for the /api/user/register route.
 @module /user/register
 */
 
-import bcrypt from "bcrypt";
-import crypto from "crypto";
-import languageTemplates from "../utils/languageTemplates.js";
-import mailer from "../utils/mailer.js";
-import reqHost from "../utils/reqHost.js";
-import view from "../view.js";
-import acl from "./acl.js";
+import bcrypt from 'bcrypt';
+import crypto from 'crypto';
+import languageTemplates from '../utils/languageTemplates.js';
+import mailer from '../utils/mailer.js';
+import reqHost from '../utils/reqHost.js';
+import view from '../view.js';
+import acl from './acl.js';
 
 /**
 @function register
@@ -40,28 +40,28 @@ Post body object with user data.
 */
 
 export default async function register(req, res) {
-	// acl module will export an empty require object without the ACL being configured.
-	if (acl === null) {
-		return res.status(500).send("ACL unavailable.");
-	}
+  // acl module will export an empty require object without the ACL being configured.
+  if (acl === null) {
+    return res.status(500).send('ACL unavailable.');
+  }
 
-	req.params.host = reqHost(req);
+  req.params.host = reqHost(req);
 
-	// Register request [post] body.
-	if (req.body) return registerUserBody(req, res);
+  // Register request [post] body.
+  if (req.body) return registerUserBody(req, res);
 
-	// The login view will set the cookie to null.
-	res.setHeader(
-		"Set-Cookie",
-		`${xyzEnv.TITLE}=null;HttpOnly;Max-Age=0;Path=${xyzEnv.DIR || "/"}`,
-	);
+  // The login view will set the cookie to null.
+  res.setHeader(
+    'Set-Cookie',
+    `${xyzEnv.TITLE}=null;HttpOnly;Max-Age=0;Path=${xyzEnv.DIR || '/'}`,
+  );
 
-	req.params.template = req.params.reset
-		? "password_reset_view"
-		: "register_view";
+  req.params.template = req.params.reset
+    ? 'password_reset_view'
+    : 'register_view';
 
-	// Get request for registration form view.
-	view(req, res);
+  // Get request for registration form view.
+  view(req, res);
 }
 
 /**
@@ -82,65 +82,65 @@ Post body object with user data.
 */
 
 async function registerUserBody(req, res) {
-	checkUserBody(req, res);
+  checkUserBody(req, res);
 
-	if (res.finished) return;
+  if (res.finished) return;
 
-	// The password will be reset for exisiting user accounts.
-	await passwordReset(req, res);
+  // The password will be reset for exisiting user accounts.
+  await passwordReset(req, res);
 
-	if (res.finished) return;
+  if (res.finished) return;
 
-	// Get the date for logs.
-	const date = new Date().toISOString().replace(/\..*/, "");
+  // Get the date for logs.
+  const date = new Date().toISOString().replace(/\..*/, '');
 
-	const expiry_date = parseInt(
-		(new Date().getTime() + xyzEnv.APPROVAL_EXPIRY * 1000 * 60 * 60 * 24) /
-			1000,
-	);
+  const expiry_date = parseInt(
+    (new Date().getTime() + xyzEnv.APPROVAL_EXPIRY * 1000 * 60 * 60 * 24) /
+      1000,
+  );
 
-	const USER = {
-		access_log: [`${date}@${req.ips?.pop() || req.ip}`],
-		email: req.body.email,
-		language: req.body.language,
-		password: req.body.password,
-		password_reset: req.body.password,
-		verificationtoken: req.body.verificationtoken,
-	};
+  const USER = {
+    access_log: [`${date}@${req.ips?.pop() || req.ip}`],
+    email: req.body.email,
+    language: req.body.language,
+    password: req.body.password,
+    password_reset: req.body.password,
+    verificationtoken: req.body.verificationtoken,
+  };
 
-	if (xyzEnv.APPROVAL_EXPIRY) {
-		USER["expires_on"] = expiry_date;
-	}
+  if (xyzEnv.APPROVAL_EXPIRY) {
+    USER['expires_on'] = expiry_date;
+  }
 
-	// Create new user account
-	const KEYS = Object.keys(USER).join(",");
-	const VALUES = Object.keys(USER).map((NULL, i) => `$${i + 1}`);
+  // Create new user account
+  const KEYS = Object.keys(USER).join(',');
+  const VALUES = Object.keys(USER).map((NULL, i) => `$${i + 1}`);
 
-	const rows = await acl(
-		`INSERT INTO acl_schema.acl_table (${KEYS})
+  const rows = await acl(
+    `INSERT INTO acl_schema.acl_table (${KEYS})
     VALUES (${VALUES})`,
-		Object.values(USER),
-	);
+    Object.values(USER),
+  );
 
-	if (rows instanceof Error) {
-		return res.status(500).send("Failed to access ACL.");
-	}
+  if (rows instanceof Error) {
+    return res.status(500).send('Failed to access ACL.');
+  }
 
-	await mailer({
-		host: req.params.host,
-		language: req.body.language,
-		link: `${req.params.host}/api/user/verify/${req.body.verificationtoken}`,
-		remote_address: req.params.remote_address,
-		template: "verify_account",
-		to: req.body.email,
-	});
+  await mailer({
+    host: req.params.host,
+    language: req.body.language,
+    link: `${req.params.host}/api/user/verify/${req.body.verificationtoken}`,
+    remote_address: req.params.remote_address,
+    template: 'verify_account',
+    to: req.body.email,
+  });
 
-	// Return msg. No redirect for password reset.
-	const new_account_registered = await languageTemplates({
-		language: req.body.language,
-		template: "new_account_registered",
-	});
-	res.send(new_account_registered);
+  // Return msg. No redirect for password reset.
+  const new_account_registered = await languageTemplates({
+    language: req.body.language,
+    template: 'new_account_registered',
+  });
+  res.send(new_account_registered);
 }
 
 /**
@@ -170,54 +170,54 @@ Post body object with user data.
 */
 
 function checkUserBody(req, res) {
-	if (!req.body.email) return res.status(400).send("No email provided");
+  if (!req.body.email) return res.status(400).send('No email provided');
 
-	// Test email address
-	if (!/^[a-zA-Z0-9+_.-]+@[a-zA-Z0-9.-]+$/.test(req.body.email)) {
-		return res.status(400).send("Provided email address is invalid");
-	}
+  // Test email address
+  if (!/^[a-zA-Z0-9+_.-]+@[a-zA-Z0-9.-]+$/.test(req.body.email)) {
+    return res.status(400).send('Provided email address is invalid');
+  }
 
-	// Test whether email domain is allowed to register
-	if (xyzEnv.USER_DOMAINS) {
-		// Get array of allowed user email domains from split xyzEnvironment variable.
-		// Note this should be converted to lower case for comparison, as email domains are case insensitive.
-		const allowed_domains = xyzEnv.USER_DOMAINS.toLowerCase().split(",");
+  // Test whether email domain is allowed to register
+  if (xyzEnv.USER_DOMAINS) {
+    // Get array of allowed user email domains from split xyzEnvironment variable.
+    // Note this should be converted to lower case for comparison, as email domains are case insensitive.
+    const allowed_domains = xyzEnv.USER_DOMAINS.toLowerCase().split(',');
 
-		//  Get the user_domain from user email.
-		// Convert to lower case for comparison, as email domains are case insensitive.
-		const user_domain = req.body.email.split("@")[1].toLowerCase();
+    //  Get the user_domain from user email.
+    // Convert to lower case for comparison, as email domains are case insensitive.
+    const user_domain = req.body.email.split('@')[1].toLowerCase();
 
-		// Check whether not some of the allowed_domain includes the user_domain.
-		if (!allowed_domains.some((domain) => user_domain.includes(domain))) {
-			return res.status(400).send("Provided email address is invalid");
-		}
-	}
+    // Check whether not some of the allowed_domain includes the user_domain.
+    if (!allowed_domains.some((domain) => user_domain.includes(domain))) {
+      return res.status(400).send('Provided email address is invalid');
+    }
+  }
 
-	// Test whether a password has been provided.
-	if (!req.body.password) return res.status(400).send("No password provided");
+  // Test whether a password has been provided.
+  if (!req.body.password) return res.status(400).send('No password provided');
 
-	// Create regex to text password complexity from xyzEnv or set default.
-	const passwordRgx = new RegExp(
-		xyzEnv.PASSWORD_REGEXP || "(?=.*?[A-Z])(?=.*?[a-z])(?=.*?[0-9])^.{12,}$",
-	);
+  // Create regex to text password complexity from xyzEnv or set default.
+  const passwordRgx = new RegExp(
+    xyzEnv.PASSWORD_REGEXP || '(?=.*?[A-Z])(?=.*?[a-z])(?=.*?[0-9])^.{12,}$',
+  );
 
-	// Test whether the provided password is valid.
-	if (!passwordRgx.test(req.body.password)) {
-		res.status(403).send("Invalid password provided");
-		return;
-	}
+  // Test whether the provided password is valid.
+  if (!passwordRgx.test(req.body.password)) {
+    res.status(403).send('Invalid password provided');
+    return;
+  }
 
-	// Hash the password.
-	req.body.password = bcrypt.hashSync(req.body.password, 8);
+  // Hash the password.
+  req.body.password = bcrypt.hashSync(req.body.password, 8);
 
-	// Create random verification token.
-	req.body.verificationtoken = crypto.randomBytes(20).toString("hex");
+  // Create random verification token.
+  req.body.verificationtoken = crypto.randomBytes(20).toString('hex');
 
-	// Lookup the provided language key.
-	req.body.language =
-		Intl.Collator.supportedLocalesOf([req.body.language], {
-			localeMatcher: "lookup",
-		})[0] || "en";
+  // Lookup the provided language key.
+  req.body.language =
+    Intl.Collator.supportedLocalesOf([req.body.language], {
+      localeMatcher: 'lookup',
+    })[0] || 'en';
 }
 
 /**
@@ -236,91 +236,91 @@ Post body object with user data.
 */
 
 async function passwordReset(req, res) {
-	// Attempt to retrieve ACL record with matching email field.
-	let rows = await acl(
-		`
+  // Attempt to retrieve ACL record with matching email field.
+  let rows = await acl(
+    `
     SELECT email, password, password_reset, language, blocked
     FROM acl_schema.acl_table
     WHERE lower(email) = lower($1);`,
-		[req.body.email],
-	);
+    [req.body.email],
+  );
 
-	if (rows instanceof Error) {
-		return res.status(500).send("Failed to access ACL.");
-	}
+  if (rows instanceof Error) {
+    return res.status(500).send('Failed to access ACL.');
+  }
 
-	const user = rows[0];
+  const user = rows[0];
 
-	// Register new user.
-	if (!user) return;
+  // Register new user.
+  if (!user) return;
 
-	// Setting the password to NULL will disable access to the account and prevent resetting the password.
-	if (user?.password === null) {
-		res.status(401).send("User account has restricted access");
-		return;
-	}
+  // Setting the password to NULL will disable access to the account and prevent resetting the password.
+  if (user?.password === null) {
+    res.status(401).send('User account has restricted access');
+    return;
+  }
 
-	// Blocked user may not reset their password.
-	if (user.blocked) {
-		const user_blocked = await languageTemplates({
-			language: req.body.language,
-			template: "user_blocked",
-		});
-		res.status(403).send(user_blocked);
-		return;
-	}
+  // Blocked user may not reset their password.
+  if (user.blocked) {
+    const user_blocked = await languageTemplates({
+      language: req.body.language,
+      template: 'user_blocked',
+    });
+    res.status(403).send(user_blocked);
+    return;
+  }
 
-	// Get the date for logs.
-	const date = new Date().toISOString().replace(/\..*/, "");
+  // Get the date for logs.
+  const date = new Date().toISOString().replace(/\..*/, '');
 
-	const expiry_date = parseInt(
-		(new Date().getTime() + xyzEnv.APPROVAL_EXPIRY * 1000 * 60 * 60 * 24) /
-			1000,
-	);
+  const expiry_date = parseInt(
+    (new Date().getTime() + xyzEnv.APPROVAL_EXPIRY * 1000 * 60 * 60 * 24) /
+      1000,
+  );
 
-	const VALUES = [
-		req.body.email,
-		req.body.password,
-		req.body.verificationtoken,
-		`${date}@${req.params.remote_address}`,
-	];
+  const VALUES = [
+    req.body.email,
+    req.body.password,
+    req.body.verificationtoken,
+    `${date}@${req.params.remote_address}`,
+  ];
 
-	if (xyzEnv.APPROVAL_EXPIRY && user.expires_on) {
-		VALUES.push(expiry_date);
-	}
+  if (xyzEnv.APPROVAL_EXPIRY && user.expires_on) {
+    VALUES.push(expiry_date);
+  }
 
-	// Set new password and verification token.
-	// New passwords will only apply after account verification.
-	rows = await acl(
-		`
+  // Set new password and verification token.
+  // New passwords will only apply after account verification.
+  rows = await acl(
+    `
     UPDATE acl_schema.acl_table
     SET
       password_reset = $2,
       verificationtoken = $3,
       access_log = array_append(access_log, $4)
-      ${xyzEnv.APPROVAL_EXPIRY && user.expires_on ? ",expires_on = $5" : ""}
+      ${xyzEnv.APPROVAL_EXPIRY && user.expires_on ? ',expires_on = $5' : ''}
     WHERE lower(email) = lower($1);`,
-		VALUES,
-	);
+    VALUES,
+  );
 
-	if (rows instanceof Error) {
-		return res.status(500).send("Failed to access ACL.");
-	}
+  if (rows instanceof Error) {
+    return res.status(500).send('Failed to access ACL.');
+  }
 
-	// Sent mail with verification token to the account email address.
-	await mailer({
-		host: req.params.host,
-		language: req.body.language,
-		link: `${req.params.host}/api/user/verify/${req.body.verificationtoken}/?language=${req.body.language}`,
-		remote_address: req.params.remote_address,
-		template: "verify_password_reset",
-		to: user.email,
-	});
+  // Sent mail with verification token to the account email address.
+  await mailer({
+    host: req.params.host,
+    language: req.body.language,
+    link: `${req.params.host}/api/user/verify/${req.body.verificationtoken}/?language=${req.body.language}`,
+    remote_address: req.params.remote_address,
+    template: 'verify_password_reset',
+    to: user.email,
+  });
 
-	const password_reset_verification = await languageTemplates({
-		language: req.body.language,
-		template: "password_reset_verification",
-	});
+  const password_reset_verification = await languageTemplates({
+    language: req.body.language,
+    template: 'password_reset_verification',
+  });
 
-	res.send(password_reset_verification);
+  res.send(password_reset_verification);
 }

--- a/tests/mod/user/register.test.mjs
+++ b/tests/mod/user/register.test.mjs
@@ -1,145 +1,145 @@
 globalThis.xyzEnv = {
-	PRIVATE: "192.168.1.1:3000|user:password|acl.test",
+  PRIVATE: '192.168.1.1:3000|user:password|acl.test',
 };
 
 const originalWarn = console.warn;
 const mockWarn = [];
 
 console.warn = (log) => {
-	mockWarn.push(log);
+  mockWarn.push(log);
 };
 
 const mockMailerFn = codi.mock.fn();
-const mockMailer = codi.mock.module("../../../mod/utils/mailer.js", {
-	defaultExport: mockMailerFn,
+const mockMailer = codi.mock.module('../../../mod/utils/mailer.js', {
+  defaultExport: mockMailerFn,
 });
 
 await codi.describe(
-	{ name: "register: ", id: "user_register", parentId: "user" },
-	async () => {
-		const { default: register } = await import("../../../mod/user/register.js");
-		await codi.it(
-			{
-				name: "USER_DOMAINS - full domain with invalid email",
-				parentId: "user_register",
-			},
-			async () => {
-				globalThis.xyzEnv.USER_DOMAINS = "geolytix.com";
+  { name: 'register: ', id: 'user_register', parentId: 'user' },
+  async () => {
+    const { default: register } = await import('../../../mod/user/register.js');
+    await codi.it(
+      {
+        name: 'USER_DOMAINS - full domain with invalid email',
+        parentId: 'user_register',
+      },
+      async () => {
+        globalThis.xyzEnv.USER_DOMAINS = 'geolytix.com';
 
-				const { req, res } = codi.mockHttp.createMocks({
-					headers: {
-						host: "localhost",
-					},
-					body: {
-						email: "dev_1@geolytix.co.uk",
-						password: "ValidPass123!",
-						language: "en",
-					},
-				});
+        const { req, res } = codi.mockHttp.createMocks({
+          headers: {
+            host: 'localhost',
+          },
+          body: {
+            email: 'dev_1@geolytix.co.uk',
+            password: 'ValidPass123!',
+            language: 'en',
+          },
+        });
 
-				await register(req, res);
-				codi.assertTrue(res.statusCode === 400);
-				codi.assertEqual(res._getData(), "Provided email address is invalid");
-			},
-		);
+        await register(req, res);
+        codi.assertTrue(res.statusCode === 400);
+        codi.assertEqual(res._getData(), 'Provided email address is invalid');
+      },
+    );
 
-		await codi.it(
-			{
-				name: "USER_DOMAINS - short domain with invalid email",
-				parentId: "user_register",
-			},
-			async () => {
-				globalThis.xyzEnv.USER_DOMAINS = "geolytix";
+    await codi.it(
+      {
+        name: 'USER_DOMAINS - short domain with invalid email',
+        parentId: 'user_register',
+      },
+      async () => {
+        globalThis.xyzEnv.USER_DOMAINS = 'geolytix';
 
-				const { req, res } = codi.mockHttp.createMocks({
-					headers: {
-						host: "localhost",
-					},
-					body: {
-						email: "dev_1@test.co.uk",
-						password: "ValidPass123!",
-						language: "en",
-					},
-				});
+        const { req, res } = codi.mockHttp.createMocks({
+          headers: {
+            host: 'localhost',
+          },
+          body: {
+            email: 'dev_1@test.co.uk',
+            password: 'ValidPass123!',
+            language: 'en',
+          },
+        });
 
-				await register(req, res);
-				codi.assertTrue(res.statusCode === 400);
-				codi.assertEqual(res._getData(), "Provided email address is invalid");
-			},
-		);
+        await register(req, res);
+        codi.assertTrue(res.statusCode === 400);
+        codi.assertEqual(res._getData(), 'Provided email address is invalid');
+      },
+    );
 
-		await codi.it(
-			{
-				name: "USER_DOMAINS - full domain with valid email",
-				parentId: "user_register",
-			},
-			async () => {
-				globalThis.xyzEnv.USER_DOMAINS = "geolytix.com";
+    await codi.it(
+      {
+        name: 'USER_DOMAINS - full domain with valid email',
+        parentId: 'user_register',
+      },
+      async () => {
+        globalThis.xyzEnv.USER_DOMAINS = 'geolytix.com';
 
-				const { req, res } = codi.mockHttp.createMocks({
-					headers: {
-						host: "localhost",
-					},
-					body: {
-						email: "dev_1@geolytix.com",
-						password: "ValidPass123!",
-						language: "en",
-					},
-				});
+        const { req, res } = codi.mockHttp.createMocks({
+          headers: {
+            host: 'localhost',
+          },
+          body: {
+            email: 'dev_1@geolytix.com',
+            password: 'ValidPass123!',
+            language: 'en',
+          },
+        });
 
-				await register(req, res);
-				codi.assertTrue(res.statusCode === 200);
-			},
-		);
+        await register(req, res);
+        codi.assertTrue(res.statusCode === 200);
+      },
+    );
 
-		await codi.it(
-			{
-				name: "USER_DOMAINS - short domain with valid email",
-				parentId: "user_register",
-			},
-			async () => {
-				globalThis.xyzEnv.USER_DOMAINS = "geolytix";
+    await codi.it(
+      {
+        name: 'USER_DOMAINS - short domain with valid email',
+        parentId: 'user_register',
+      },
+      async () => {
+        globalThis.xyzEnv.USER_DOMAINS = 'geolytix';
 
-				const { req, res } = codi.mockHttp.createMocks({
-					headers: {
-						host: "localhost",
-					},
-					body: {
-						email: "dev_1@geolytix.whatever",
-						password: "ValidPass123!",
-						language: "en",
-					},
-				});
+        const { req, res } = codi.mockHttp.createMocks({
+          headers: {
+            host: 'localhost',
+          },
+          body: {
+            email: 'dev_1@geolytix.whatever',
+            password: 'ValidPass123!',
+            language: 'en',
+          },
+        });
 
-				await register(req, res);
-				codi.assertTrue(res.statusCode === 200);
-			},
-		);
+        await register(req, res);
+        codi.assertTrue(res.statusCode === 200);
+      },
+    );
 
-		await codi.it(
-			{
-				name: "USER_DOMAINS - ensure case insensitivity",
-				parentId: "user_register",
-			},
-			async () => {
-				globalThis.xyzEnv.USER_DOMAINS = "geolytix";
+    await codi.it(
+      {
+        name: 'USER_DOMAINS - ensure case insensitivity',
+        parentId: 'user_register',
+      },
+      async () => {
+        globalThis.xyzEnv.USER_DOMAINS = 'geolytix';
 
-				const { req, res } = codi.mockHttp.createMocks({
-					headers: {
-						host: "localhost",
-					},
-					body: {
-						email: "dev_1@GEOLYTIX.COM",
-						password: "ValidPass123!",
-						language: "en",
-					},
-				});
+        const { req, res } = codi.mockHttp.createMocks({
+          headers: {
+            host: 'localhost',
+          },
+          body: {
+            email: 'dev_1@GEOLYTIX.COM',
+            password: 'ValidPass123!',
+            language: 'en',
+          },
+        });
 
-				await register(req, res);
-				codi.assertTrue(res.statusCode === 200);
-			},
-		);
-	},
+        await register(req, res);
+        codi.assertTrue(res.statusCode === 200);
+      },
+    );
+  },
 );
 
 console.warn = originalWarn;


### PR DESCRIPTION
# Pull Request Template

## Description

The current logic for checking if a user's email domain is on the approved registration whitelist is case-sensitive, which violates RFC standards for email domain names (which are case-insensitive).
The register module has been updated to be case insensitive on the `USER_DOMAINS` registration. 

## Type of Change

Please delete options that are not relevant, and select all options that apply.

- ✅ Bug fix (non-breaking change which fixes an issue)
- ✅ Testing

## How have you tested this?

Tested locally and added an updated test.

## Testing Checklist

Please delete options that are not relevant, and select all options that apply.

- ✅ Existing Tests still pass
- ✅ Updated Existing Tests
- ✅ Ran locally on my machine

## Code Quality Checklist

Please delete options that are not relevant, and select all options that apply.

- ✅ My code follows the guidelines of XYZ
- ✅ My code has been commented
- ✅ Documentation has been updated
- ✅ New and existing unit tests pass locally with my changes
- ✅ Main has been merged into this PR
