### PR TITLE
use email or nameID if email not provided

### DIFF
--- a/mod/user/saml.js
+++ b/mod/user/saml.js
@@ -384,7 +384,7 @@ async function acs(req, res) {
 
     // Perform ACL lookup if enabled
     if (xyzEnv.SAML_ACL) {
-      const aclResponse = await aclLookUp(user.email);
+      const aclResponse = await aclLookUp(user.email || user.nameID);
 
       if (!aclResponse) {
         const url = await samlStrat.getLogoutUrlAsync(user);


### PR DESCRIPTION
# SAML email vs nameID

This pr uses the nameID provided from a saml user profile as the fallback if there is no email provided to the ACL authentication.