### PR TITLE
fix(custom_theme): Applying custom_theme from locale

### DIFF
--- a/lib/plugins/dark_mode.mjs
+++ b/lib/plugins/dark_mode.mjs
@@ -55,7 +55,23 @@ export function dark_mode(plugin, mapview) {
 @description
 The custom_theme object from the locale will be applied through the cssColourTheme utility.
 @param {Object} theme The colourTheme to be applied.
+@example 
+"custom_theme": {
+      "primary": "#311250",
+      "base": "#f2f2f2",
+      "base-secondary": "#f7f7f7",
+      "base-tertiary": "#fafafa",
+      "font": "#3f3f3f",
+      "font-mid": "#858585",
+      "font-contrast": "#dddddd",
+      "border": "#dddddd",
+      "active": "#c864dc",
+      "hover": "#939faa",
+      "changed": "#ffffa7",
+      "info": "#00695c",
+      "danger": "#A21309"
+    }
 */
 export function custom_theme(theme) {
-  mapp.ui.utils.cssColourTheme(theme);
+  mapp.ui.utils.cssColour.setTheme(theme);
 }


### PR DESCRIPTION
## Description

Applying `custom_theme` object from the `locale` should overwrite the colour palette. 
This wasn't working as we weren't calling the function correctly. 

## GitHub Issue

Provide the link to the relevant GitHub issue it addresses.

## Type of Change

Please delete options that are not relevant, and select all options that apply.

- ✅ Bug fix (non-breaking change which fixes an issue)

## How have you tested this?

Tested applying a `custom_theme` from the locale.

## Testing Checklist

- ✅ Existing Tests still pass
- ✅ Ran locally on my machine

## Code Quality Checklist

- ✅ My code follows the guidelines of XYZ
- ✅ My code has been commented
- ✅ New and existing unit tests pass locally with my changes
- ✅ Main has been merged into this PR
