### PR TITLE
feat(signer): cloudfront redirect

### DIFF
--- a/mod/sign/_sign.js
+++ b/mod/sign/_sign.js
@@ -32,6 +32,7 @@ The response from the method is returned with the HTTP response.
 @param {Object} res HTTP response.
 @param {Object} req.params Request parameter.
 @param {string} params.signer Signer module to sign the request.
+@param {bool} params.redirect Redirect the signer request to the signed URL.
 
 @returns {Promise} The promise resolves into the response from the signerModules method.
 */


### PR DESCRIPTION
An endpoint that requests content into a buffer is no longer supported via the cloudfront provider. So a signed URL from the cloudfront CDN should be used in favor. 

There is a problem where we have static URLs such as anchor tags in the front end. These urls should be replaced with the cloudfront signer `/api/sign/cloudfront` and use the redirect param `?redirect=true`. 