### PR TITLE
fix(roles): Check whether object has roles first

### DIFF
--- a/mod/utils/roles.js
+++ b/mod/utils/roles.js
@@ -43,7 +43,6 @@ The check is also passed if the obj does not have a roles property.
 @returns {boolean} Returns true if check is passed, false otherwise.
 */
 export function check(obj, user_roles) {
-
   // The object to check has no roles assigned.
   if (!obj.roles) return true;
 


### PR DESCRIPTION
The check for the obj.roles must happen first. Otherwise a public workspace without roles will fail to load.