### PR TITLE
fix(xhr): Use url as key in the Map

### DIFF
--- a/lib/utils/xhr.mjs
+++ b/lib/utils/xhr.mjs
@@ -51,8 +51,8 @@ export function xhr(params) {
     }
 
     // Check whether a request with the same params has already been resolved.
-    if (params.cache && requestMap.has(params))
-      return resolve(requestMap.get(params));
+    if (params.cache && requestMap.has(params.url))
+      return resolve(requestMap.get(params.url));
 
     // Assign 'GET' as default method if no body is provided.
     params.method ??= params.body ? 'POST' : 'GET';
@@ -85,7 +85,7 @@ export function xhr(params) {
       }
 
       // Cache the response in the requestMap
-      params.cache && requestMap.set(params, e.target.response);
+      params.cache && requestMap.set(params.url, e.target.response);
 
       resolve(params.resolveTarget ? e.target : e.target.response);
     };


### PR DESCRIPTION
## Description
It is possible to pass a cache flag to the XHR util, In this PR the response is assigned to the Map object via the url of the request
e.g.
`mapp.utils.xhr({url: test.com, cache: true})`, will create a key value pair in the map with the url as the key. 

Repeating a request with cache true, should also be much faster the second time you call it. 

## GitHub Issue
#2524

## Type of Change
- ✅ Bug fix (non-breaking change which fixes an issue)

## How have you tested this?
Tested locally 

## Testing Checklist
- ✅ Existing Tests still pass
- ✅ Ran locally on my machine

## Code Quality Checklist
- ✅ My code follows the guidelines of XYZ
- ✅ My code has been commented
- ✅ Documentation has been updated
- ✅ New and existing unit tests pass locally with my changes
- ✅ Main has been merged into this PR
