### PR TITLE
Fix(numericInput): Fix for numeric input with suffixes/prefixes

### DIFF
--- a/lib/ui/elements/numericInput.mjs
+++ b/lib/ui/elements/numericInput.mjs
@@ -34,7 +34,7 @@ export default function numericInput(params) {
     placeholder=${params.placeholder}
     value=${value}
     onchange=${(e) => oninput(e, params)}
-    onclick=${(e) => (e.target.value = mapp.utils.unformatStringValue({ ...params, stringValue: e.target.value }))}
+    onfocus=${(e) => (e.target.value = mapp.utils.unformatStringValue({ ...params, stringValue: e.target.value }))}
     oninput=${(e) => oninput(e, params)}>`;
 
   return numericInput;


### PR DESCRIPTION
## Description
Using numeric type with a suffix would disallow editing the field as there would be a string value in the field.
In this PR we remove the suffix and prefix when the input box is clicked: 

<img width="342" height="67" alt="screenshot-2025-12-03_13-26-42" src="https://github.com/user-attachments/assets/addda616-1558-42aa-9eb1-aafd1d14806d" />
<img width="334" height="62" alt="screenshot-2025-12-03_13-26-55" src="https://github.com/user-attachments/assets/62e251e9-6d1a-42a8-9766-7dda4215f16c" />

Once saved the prefix and suffix will return. 
## GitHub Issue
#2532 

## Type of Change
- ✅ Bug fix (non-breaking change which fixes an issue)

## How have you tested this?
Tested locally on an numeric field with edit true

## Testing Checklist
- ✅ Existing Tests still pass
- ✅ Ran locally on my machine

## Code Quality Checklist
- ✅ My code follows the guidelines of XYZ
- ✅ My code has been commented
- ✅ Documentation has been updated
- ✅ New and existing unit tests pass locally with my changes
- ✅ Main has been merged into this PR
