### PR TITLE
fix(queryParams): Use Spread Instead of Object.Assign

### DIFF
--- a/lib/utils/queryParams.mjs
+++ b/lib/utils/queryParams.mjs
@@ -53,7 +53,10 @@ function queryParams(_this) {
   // Merge layer queryparams with request queryparams.
   // _this.queryparams takes precedence.
   if (layer?.queryparams) {
-    _this.queryparams = Object.assign(layer.queryparams, _this.queryparams);
+    _this.queryparams = {
+      ...layer.queryparams,
+      ..._this.queryparams,
+    };
   }
 
   // Assign table from layer JSON or layer.tableCurrent() method.


### PR DESCRIPTION
## Description

In #2531, we swapped the order of the `Object.assign()` so that `_this.queryparams` was second. 
However, I am seeing issues whereby the queryparams from `_this` such as `id: true` are being passed directly to the query as `id:true`, not `id:99` for example. 

This behavior occurs because our `Object.assign(layer.queryparams, _this.queryparams)` mutates the layer.queryparams object, causing it to hold temporary request values across different requests. 
The fix requires using the spread syntax ({ ...source1, ...source2 }) to create a true shallow copy that preserves precedence while avoiding side effects on the original layer object.

## GitHub Issue

[Provide the link to the relevant GitHub issue it addresses.](https://github.com/GEOLYTIX/xyz/issues/2530)

## Type of Change

Please delete options that are not relevant, and select all options that apply.

- ✅ Bug fix (non-breaking change which fixes an issue)

## How have you tested this?

Tested locally. 

## Testing Checklist

- ✅ Existing Tests still pass
- ✅ Ran locally on my machine

## Code Quality Checklist

Please delete options that are not relevant, and select all options that apply.

- ✅ My code follows the guidelines of XYZ
- ✅ My code has been commented
- ✅ Documentation has been updated
- ✅ New and existing unit tests pass locally with my changes
- ✅ Main has been merged into this PR
