### PR TITLE
update vercel-sync

### DIFF
--- a/utils/sync-vercel-env.js
+++ b/utils/sync-vercel-env.js
@@ -287,6 +287,12 @@ Note: This script requires a linked Vercel project. Run 'vercel link' first.
 `);
 }
 
+/**
+ * @function checkCustomeEnvironment
+ * @description
+ * This function checks if the environment provided via the cli flags is a
+ * custom environment
+ */
 async function checkCustomeEnvironment() {
   if (!['production', 'development', 'preview'].includes(envType)) {
     const { data } = await apiRequest(


### PR DESCRIPTION
The vercel sync script was not updating custom environments because I assumed that you could just give the environment name to the projects endpoint but you need to get the custom environment id first and then use it in the update request