### PR TITLE
fix(location_count): Use qID instead of *

### DIFF
--- a/lib/ui/utils/locationCount.mjs
+++ b/lib/ui/utils/locationCount.mjs
@@ -34,6 +34,7 @@ export default async function locationCount(layer) {
     filter: layer.filter?.current,
     layer: layer.key,
     table: layer.tableCurrent(),
+    qID: layer.qID,
     template: 'location_count',
   });
 

--- a/mod/workspace/templates/location_count.js
+++ b/mod/workspace/templates/location_count.js
@@ -6,6 +6,6 @@ The location_count layer query returns the count of table records which pass the
 @module /workspace/templates/location_count
 */
 export default `
-  SELECT count(*) as location_count
+  SELECT count(\${qID}) as location_count
   FROM \${table}
   WHERE true \${filter} \${viewport}`;


### PR DESCRIPTION
The location_count query should count the qID field and not * to prevent a `variable not found in subplan target list` type error.