### PR TITLE
fix(Entry/Geometry): Unable to show an initially null geometry when it has data

### DIFF
--- a/lib/ui/locations/entries/geometry.mjs
+++ b/lib/ui/locations/entries/geometry.mjs
@@ -188,7 +188,7 @@ async function show() {
     if (!this.value) {
       this.disabled = true;
     }
-  } 
+  }
   // Else block is only reached if value is now present.
   else {
     this.disabled = false;


### PR DESCRIPTION
# Pull Request Template

## Description

This PR updates the checks in the `show()` method to explicitly check for a disabled entry with no data.
This is required to ensure that a geometry entry that initially had no data, but now does can be visible. 

## GitHub Issue

[Provide the link to the relevant GitHub issue it addresses.](https://github.com/GEOLYTIX/xyz/issues/2555)

## Type of Change

Please delete options that are not relevant, and select all options that apply.

- ✅ Bug fix (non-breaking change which fixes an issue)

## How have you tested this?

To test this, add 2 geometry fields to your layer configuration. 
In the first one, make the field initially empty.
In the second one, make it auto-generate a geometry such as via an api call. 

Add a trigger to the db that once the second field is updated, the first field should be set to have a geometry. 
Add a dependent to the second field to refresh the first.

## Testing Checklist

Please delete options that are not relevant, and select all options that apply.

- ✅ Existing Tests still pass
- ✅ Ran locally on my machine