### PR TITLE
fix(graduated theme/distribution:jenks): Reverse jenks values for greater_than graduated theme

### DIFF
--- a/lib/layer/featureFields.mjs
+++ b/lib/layer/featureFields.mjs
@@ -103,7 +103,7 @@ async function jenks(layer) {
 
   // greater_than graduated theme checks require the order to be large to small.
   if (theme.graduated_breaks === 'greater_than') {
-    layer.featureFields[theme.field].jenks.reverse()
+    layer.featureFields[theme.field].jenks.reverse();
   }
 
   let val;

--- a/lib/layer/themes/graduated.mjs
+++ b/lib/layer/themes/graduated.mjs
@@ -30,15 +30,14 @@ export default function graduated(theme, feature) {
 
   const catValue = Array.isArray(feature.properties.features)
     ? // Reduce array of features to sum catValue
-    feature.properties.features.reduce(
-      (total, F) => total + Number(F.getProperties()[theme.field]),
-      0,
-    )
+      feature.properties.features.reduce(
+        (total, F) => total + Number(F.getProperties()[theme.field]),
+        0,
+      )
     : // Get catValue from cat or field property.
-    parseFloat(feature.properties[theme.field]);
+      parseFloat(feature.properties[theme.field]);
 
   if (!isNaN(catValue) && catValue !== null) {
-
     const index = theme.categories.findIndex(
       graduated_breaks[theme.graduated_breaks](catValue),
     );


### PR DESCRIPTION
The definition of the indexOf functions should be defined outside the closure of the graduated theme feature method.

The layer must be restyled by calling the changed() event method after featureFields have been processed for the distribution.

greater_than graduated_breaks checks require the categories to be ordered large to small values otherwise all values will fall into the first category.