### PR TITLE
fix(Admin View): _user view should not require dataset user property

### DIFF
--- a/public/views/_user.html
+++ b/public/views/_user.html
@@ -1,6 +1,6 @@
 <!DOCTYPE html>
 <html lang="en">
-  <head data-user="{{user}}" data-dir="{{dir}}">
+  <head data-dir="{{dir}}">
     <title>XYZ | User Administration</title>
     <link
       rel="icon"
@@ -146,11 +146,6 @@
 
   <script>
   window.onload = async () => {
-
-    if (!document.head.dataset.user) {
-      window.location.href = '?login=true'
-      return;
-    }
 
     // Get list of available roles from workspace.
     const rolesList = await xhrPromise(`${document.head.dataset.dir}/api/workspace/roles`)


### PR DESCRIPTION
The user property contains non whitelisted character and will be filtered out by the view module.

The user dataset value is not required in the admin view and has been removed from the head and script.