### PR TITLE
fix(dataviewDialog): Change the overflow property to prevent unecessary scrollbar

### DIFF
--- a/lib/ui/utils/dataviewDialog.mjs
+++ b/lib/ui/utils/dataviewDialog.mjs
@@ -34,21 +34,24 @@ Assigns a `dataview_dialog` object to the dataview which holds the created dialo
 @property {String} dataview.key Key identifier of the chart/table.
 @property {String} dataview.label Label to be used as the dialog header.
 @property {Object} [dataview.dialog_css] An object with and a height and a width.
-@property {boolean} [dataview.disable_resize] A flag for disabling the resize functionality.
+@property {Integer} [dialog_css.width=300] The dialog css width in px.
+@property {Integer} [dialog_css.height=200] The dialog css height in px.
+@property {Integer} [dialog_css.minWidth=300] The dialog css minWidth in px.
+@property {Integer} [dialog_css.minHeight=200] The dialog css minHeight in px.
+@property {String} [dialog_css.resize='both'] The dialog css resize property.
 */
 export default function dataviewDialog(dataview) {
   if (dataview.target !== 'dialog') return;
 
   dataview.dataview_dialog = {};
 
-  let dialog_style = `
+  const dialog_style = `
     width: ${dataview.dialog_css?.width || '300'}px;
     height: ${dataview.dialog_css?.height || '200'}px;
     min-width: ${dataview.dialog_css?.minWidth || '300'}px;
     min-height: ${dataview.dialog_css?.minHeight || '200'}px;
+    resize: ${dataview.dialog_css?.resize || 'both'};
     overflow: hidden !important`;
-
-  if (!dataview.disable_resize) dialog_style += '; resize: both';
 
   Object.assign(dataview.dataview_dialog, {
     header: mapp.utils.html.node`<h1> ${dataview.label}`,


### PR DESCRIPTION
## Description
The dialog was a little too big and a scrollbar would appear when there was actually nothing to scroll to.
To mitigate this i changed the height and min-height and hid the overflow. 

The overflow property is required for resize.

Before:
<img width="857" height="647" alt="4029d3cd-7c2c-45b4-8e89-2cdc743f0e5f" src="https://github.com/user-attachments/assets/19f9deb0-269d-44fb-bd80-d517bac06b82" />

After:
<img width="1366" height="753" alt="screenshot-2026-01-15_10-46-34" src="https://github.com/user-attachments/assets/2c04213c-e54c-4a74-912f-6d74336cadb8" />

## GitHub Issue
#2538 

## Type of Change
- ✅ Bug fix (non-breaking change which fixes an issue)

## How have you tested this?
Tested using `bugs_testing/dataviews/dataview.json`

## Testing Checklist
- ✅ Existing Tests still pass
- ✅ Ran locally on my machine

## Code Quality Checklist
- ✅ My code follows the guidelines of XYZ
- ✅ My code has been commented
- ✅ Documentation has been updated
- ✅ New and existing unit tests pass locally with my changes
- ✅ Main has been merged into this PR
