### PR TITLE
fix(dropdown/CSS): Enable selected option highlight for single select dropdown

### DIFF
--- a/lib/ui/elements/dropdown.mjs
+++ b/lib/ui/elements/dropdown.mjs
@@ -120,8 +120,13 @@ function selectOnChange(e, params) {
   }
 
   // Single select options can not be unselected.
-  params.options.forEach((option) => option.classList.remove('selected'));
+  params.options.forEach((option) => {
+    option.classList.remove('selected');
+    option.style.backgroundColor = 'var(--color-base-secondary)';
+  });
+
   params.options[selectedIndex].classList.add('selected');
+  params.options[selectedIndex].style.removeProperty('background-color');
 
   if (!params.keepPlaceholder) {
     params.placeHolderOption.textContent = entry.title;
@@ -213,9 +218,9 @@ function searchInput(params) {
 
   const placeholder = params.placeholder || 'Enter search term...';
 
-  const searchInput = mapp.utils.html.node`<input 
+  const searchInput = mapp.utils.html.node`<input
     placeholder=${placeholder}
-    type="search" list=${listId} 
+    type="search" list=${listId}
     onInput=${(e) => onSearchInput(e, params)}
     onfocus="this.placeholder=''"
     onblur=${(e) => (e.target.placeholder = placeholder)}>`;


### PR DESCRIPTION
The selectOnChange method did only toggle the selected class on the option element for params.multi dropdown elements.

This PR adds the selected class to the `params.options[selectedIndex]` element after removing the class from any options element.

This works since the selectedIndex options element will always be on. It is not possible to undo select by clicking on the selected element.


https://github.com/user-attachments/assets/4730a9e1-585f-42f6-9158-9feba9257b38

