### PR TITLE
fix(node-pg): Don't re-run queries that timeout

### DIFF
--- a/mod/utils/dbs.js
+++ b/mod/utils/dbs.js
@@ -99,6 +99,9 @@ async function clientQuery(pool, query, variables, timeout) {
         variables,
       });
 
+      // Statement timeout
+      if (err.code === '57014') return err;
+
       retryCount++;
 
       if (retryCount < RETRY_LIMIT) {


### PR DESCRIPTION
## Timeout queries short circuit

### Summary

This PR addresses the issue of long running queries which timeout result in an instance being bogged down. 

### Changes
This PR checks for the error code '57014' being returned from the pg server which indicates that the query timeout and should not be re-run.