### PR TITLE
user/auth module should return an error if the user from a decoded api key is not found in the ACL

### DIFF
--- a/mod/user/auth.js
+++ b/mod/user/auth.js
@@ -222,10 +222,10 @@ async function checkParamToken(req, res, user) {
     // The request for the stored API key has failed.
     if (rows instanceof Error) return rows;
 
-    // The user does not exist. 
+    // The user does not exist.
     if (rows.length === 0) {
       return new Error('User not found');
-    };
+    }
 
     if (rows.blocked) {
       // The user is blocked.


### PR DESCRIPTION
# Pull Request Template

## Description

If you make a request to an endpoint with a token parameter, the user is looked up against the acl.
However, it is possible that the user doesn't exist in the acl. They may have been removed.
Currently, the whole process crashes on line 158 as rows[0].api doesn't exist.

## Type of Change

Please delete options that are not relevant, and select all options that apply.

- ✅ Bug fix (non-breaking change which fixes an issue)

## How have you tested this?

Create a valid API key, then delete yourself from the acl table. 

## Testing Checklist
- ✅ Existing Tests still pass
- ✅ Ran locally on my machine

## Code Quality Checklist

Please delete options that are not relevant, and select all options that apply.

- ✅ My code follows the guidelines of XYZ
- ✅ My code has been commented
- ✅ Documentation has been updated
- ✅ New and existing unit tests pass locally with my changes
- ✅ Main has been merged into this PR
