### PR TITLE
fix(jenks): Filter out nulls to prevent an error in the simpleStatistics jenks function. 

### DIFF
--- a/lib/layer/featureFields.mjs
+++ b/lib/layer/featureFields.mjs
@@ -93,8 +93,8 @@ async function jenks(layer) {
   layer.featureFields[theme.field].values = layer.featureFields[
     theme.field
   ].values
-    .filter((val) => val)
-    .map(parseFloat);
+    .filter((val) => val !== null)
+    .map(Number.parseFloat);
 
   const simpleStatistics = await mapp.utils.simpleStatistics();
 


### PR DESCRIPTION
## Description
Currently, the values on the theme are mapped using `parseFloat`. `parseFloat(null)` yields a `NaN`, passing these `NaNs`
to the jenks function causes an error:
<img width="774" height="234" alt="screenshot-2026-01-20_12-23-45" src="https://github.com/user-attachments/assets/38cf41e9-8b4f-490e-9e76-ab715280eda2" />

This PR just filters out the nulls to prevent the error. 

Off The PR the theme will look like this:
<img width="438" height="352" alt="screenshot-2026-01-20_13-40-53" src="https://github.com/user-attachments/assets/f1069f43-2838-48df-8cc0-2dcc0baa7ade" />

On the PR:
<img width="434" height="350" alt="screenshot-2026-01-20_13-42-03" src="https://github.com/user-attachments/assets/ff45bbe7-13c8-48f2-a4c7-cfb1a3ed5b8c" />

## GitHub Issue
#2615

## Type of Change
- ✅ Bug fix (non-breaking change which fixes an issue)

## How have you tested this?
Tested on `bugs_testing/vector/graduated_jenks.json` on the oa layer

## Testing Checklist
- ✅ Existing Tests still pass
- ✅ Ran locally on my machine

## Code Quality Checklist
- ✅ My code follows the guidelines of XYZ
- ✅ My code has been commented
- ✅ Documentation has been updated
- ✅ New and existing unit tests pass locally with my changes
- ✅ Main has been merged into this PR
