### PR TITLE
feature(dbs): White List error codes for retry

### DIFF
--- a/mod/utils/dbs.js
+++ b/mod/utils/dbs.js
@@ -19,14 +19,14 @@ import logger from './logger.js';
 
 const RETRY_LIMIT = xyzEnv.RETRY_LIMIT;
 
-const RETRY_CODES = [
+const RETRY_CODES = new Set([
   '53300', // too_many_connections
   '57P01', // admin_shutdown
   '57P02', // crash_shutdown
   '57P03', // cannot_connect_now
   '08000', // connection_exception
   '08006', // connection_failure
-];
+]);
 
 const INITIAL_RETRY_DELAY = 1000;
 
@@ -109,7 +109,7 @@ async function clientQuery(pool, query, variables, timeout) {
       });
 
       // Return error if not in retry whitelist
-      if (!RETRY_CODES.includes(err.code)) return err;
+      if (!RETRY_CODES.has(err.code)) return err;
 
       retryCount++;
 


### PR DESCRIPTION
## Summary

This PR addresses the RFC to have a white list of error codes for the retry logic to use.

The current codes that I have added in are the following: 

### Connection & Server Issues

- **`53300` (too_many_connections):** The database has reached its maximum client limit. Retrying is useful because a slot may free up in a few milliseconds.
- **`57P01` (admin_shutdown):** The server was manually shut down (e.g., for maintenance).
- **`57P02` (crash_shutdown):** The database process crashed and is restarting.
- **`57P03` (cannot_connect_now):** The database is currently starting up or in recovery mode (e.g., right after a crash).

### Network Issues

- **`08000` (connection_exception):** A generic error indicating the connection was lost or failed.
- **`08006` (connection_failure):** The specific error for when the client detects the connection to the server has dropped. Retrying triggers a new connection attempt.

If you think of any others that might be needed you can have a look at this [list](https://www.postgresql.org/docs/current/errcodes-appendix.html) and add them in to the list at the top of the `./mod/utils/dbs.js` module