### PR TITLE
fix(legends/Categorized): Remove `theme.field` check for Switch All

### DIFF
--- a/lib/ui/layers/legends/categorized.mjs
+++ b/lib/ui/layers/legends/categorized.mjs
@@ -32,8 +32,7 @@ export default function categorizedTheme(layer) {
   const theme = layer.style.theme;
 
   // Switch all control
-  theme.legend.switch =
-    theme.field && layer.filter && mapp.ui.elements.themeLegendSwitch();
+  theme.legend.switch = layer.filter && mapp.ui.elements.themeLegendSwitch();
 
   theme.categories.forEach((cat) => {
     createLegend(cat, theme, layer);


### PR DESCRIPTION
## Description

Remove check on theme.field as theme.fields now supported. This check was preventing the Switch All and `label switch` class being added, meaning individual categories could not be toggled.

## GitHub Issue

[Provide the link to the relevant GitHub issue it addresses.](https://github.com/GEOLYTIX/xyz/issues/2627)

## Type of Change
- ✅ Bug fix (non-breaking change which fixes an issue)

## How have you tested this?
Test a `categorized` theme with `fields` array on v4.19.9 and v4.20.3. 
Before this PR, the Switch All doesn't appear, on this PR its back and working. 

## Testing Checklist
- ✅ Existing Tests still pass
- ✅ Ran locally on my machine

## Code Quality Checklist
- ✅ My code follows the guidelines of XYZ
- ✅ My code has been commented
- ✅ Documentation has been updated
- ✅ New and existing unit tests pass locally with my changes
- ✅ Main has been merged into this PR
