### PR TITLE
CSS - search input rules (minor)

### DIFF
--- a/public/css/base/_inputs.css
+++ b/public/css/base/_inputs.css
@@ -92,11 +92,6 @@ input[type='search']::after {
   color: var(--color-font);
 }
 
-input[type='search']:focus + ul,
-input[type='search'] + ul:active {
-  display: block;
-}
-
 input[type='search']::-webkit-search-cancel-button,
 input[type='search']::-webkit-search-decoration:hover,
 input[type='search']::-webkit-search-cancel-button:hover {

--- a/public/css/elements/_searchbox.css
+++ b/public/css/elements/_searchbox.css
@@ -5,7 +5,6 @@
   isolation: isolate;
 
   & > ul {
-    display: none;
     max-height: 500px;
     overflow-y: auto;
     overflow-x: hidden;

--- a/public/css/ui.css
+++ b/public/css/ui.css
@@ -338,10 +338,6 @@ input[type=number] {
 input[type=search]::after {
   color: var(--color-font);
 }
-input[type=search]:focus + ul,
-input[type=search] + ul:active {
-  display: block;
-}
 input[type=search]::-webkit-search-cancel-button,
 input[type=search]::-webkit-search-decoration:hover,
 input[type=search]::-webkit-search-cancel-button:hover {
@@ -1005,7 +1001,6 @@ label.radio {
   background-color: var(--color-base-tertiary);
   isolation: isolate;
   & > ul {
-    display: none;
     max-height: 500px;
     overflow-y: auto;
     overflow-x: hidden;


### PR DESCRIPTION
This gazetteer/searchbox problem was detected on MacOS Safari.

The click on the list item wouldn't fire the callback function - i.e. the map wouldn't respond to the selected search.

It would merely make the `<ul>` element disappear as the first rule to execute would be CSS display 'block' to 'none' switch.

Here's the culprit:

<img width="464" height="225" alt="Screenshot 2026-02-03 at 14 40 28" src="https://github.com/user-attachments/assets/4c73fe78-1f92-4f86-b0c3-6b92198e1b8d" />

The search callback would never happen as the click would first switch display property and then the `<li>` target element would no longer be accessible in the document. So no click event callback afterwards.

Safari is less forgiving of these workflows and would execute css first. Yet once an element hits "display:none" it cannot be accessed by the browser.

I have removed the display: none / display: block switch from `<ul>` elements in searchbox lists.
This is not needed as the lists are cleared and filled in accordance with returned search results.
Empty `<ul>` takes no space anyway while it is still accessible in the DOM.