### PR TITLE
fix(Layer/Decorate): GetExtent may return array of [null,null,null,null]

### DIFF
--- a/lib/layer/decorate.mjs
+++ b/lib/layer/decorate.mjs
@@ -143,11 +143,9 @@ async function getExtent() {
     layer.featureSet instanceof Set
   ) {
     ids = [...layer.featureSet];
-  } else if (layer.L && layer.format !== 'mvt') {
-    // return extent from Openlayers source.
-    return layer.L.getSource()?.getExtent();
   }
 
+  // The layer is restricted by either featureLookup or featureSet
   const body = ids.length
     ? JSON.stringify({
         ids: ids,


### PR DESCRIPTION
# Pull Request Template

## Description

This PR addresses an issue where the getExtent may return an array of null values. 
The checks have been moved into the `getExtent` function instead of after the `getExtent()` method is called.
Thus, the check can now be on if the response is false (meaning no extent to zoom to). 

## Type of Change
- ✅ Bug fix (non-breaking change which fixes an issue)

## How have you tested this?
Tested locally when the extent returned is null. 
This can be replicated by adding a default filter to a layer that does not have any data for the filter value, and then trying to zoom to it.

## Testing Checklist
- ✅ Updated Existing Tests
- ✅ Ran locally on my machine

## Code Quality Checklist
- ✅ My code follows the guidelines of XYZ
- ✅ My code has been commented
- ✅ Documentation has been updated
- ✅ New and existing unit tests pass locally with my changes
- ✅ Main has been merged into this PR
