### PR TITLE
fix(default_view): `try...catch` on locale fetch.

### DIFF
--- a/public/views/_default.html
+++ b/public/views/_default.html
@@ -295,7 +295,7 @@
     locale = await mapp.utils.xhr(
       `${mapp.host}/api/workspace/locale?locale=${locale}&layers=true`,
     );
-    }catch(error){
+    }catch{
       mapp.ui.elements.dialog({
         css_style:
           'padding: 1em; border-color: #000; z-index:9999; max-width: 50%;',


### PR DESCRIPTION
## Description
Attempting to access an instance with no roles was not spawning the dialog as before,

You would simply get this:
<img width="814" height="421" alt="screenshot-2026-02-12_15-53-06" src="https://github.com/user-attachments/assets/a6c460dd-3f5b-4d5f-a5e1-28a97d5974ca" />

With a 400 error in the console. 

On the PR the dialog should be back:
<img width="1463" height="418" alt="screenshot-2026-02-12_15-52-29" src="https://github.com/user-attachments/assets/56570f60-bd22-4836-bdf6-cca32830314b" />

## GitHub Issue


## Type of Change
- ✅ Bug fix (non-breaking change which fixes an issue)

## How have you tested this?
Tested locally on `bugs_testing/draw/workspace.json`

## Testing Checklist
- ✅ Existing Tests still pass
- ✅ Ran locally on my machine

## Code Quality Checklist
- ✅ My code follows the guidelines of XYZ
- ✅ My code has been commented
- ✅ Documentation has been updated
- ✅ New and existing unit tests pass locally with my changes
- ✅ Main has been merged into this PR
