### PR TITLE
Catch XHR if you can

### DIFF
--- a/lib/mapview/addLayer.mjs
+++ b/lib/mapview/addLayer.mjs
@@ -26,7 +26,7 @@ A renderComplete event will be assigned to the Openlayers mapview.Map{}. This pr
 
 @returns {array} The array of decorated layers is returned.
 */
-export default async function addLayer(layers=[]) {
+export default async function addLayer(layers = []) {
   // A single JSON layer is provided.
   if (layers instanceof Object && !Array.isArray(layers)) {
     // Create array of layers with single JSON layer.

--- a/lib/utils/xhr.mjs
+++ b/lib/utils/xhr.mjs
@@ -93,7 +93,7 @@ export function xhr(params) {
     } catch (err) {
       return err;
     }
-  }).catch(err => {
+  }).catch((err) => {
     return err;
   });
 }


### PR DESCRIPTION
The promise returned from the xhr utils module should catch any unhandled error and return this error.

The mapview.addLayer method should use an empty array as default for the param being undefined.