### PR TITLE
The esm import util should log which modules are imported.

### DIFF
--- a/lib/utils/esmImport.mjs
+++ b/lib/utils/esmImport.mjs
@@ -25,6 +25,7 @@ The promise resolves to the module to be imported.
 export default async function esmImport(module) {
   promises[module] ??= new Promise((resolve) => {
     import(`https://esm.sh/${module}`).then((esm) => {
+      console.log(`${module} imported from esm.sh`);
       resolve(esm);
     });
   });


### PR DESCRIPTION
Helpful for debugging plugins that require esm imports.