### PR TITLE
fix(geometry): Add check for entry.error to disable entries that have errored

### DIFF
--- a/lib/ui/locations/entries/geometry.mjs
+++ b/lib/ui/locations/entries/geometry.mjs
@@ -12,7 +12,7 @@ Dictionary entries:
 - edit_dialog_modify_shape
 - edit_dialog_save
 
-@requires /dictionary 
+@requires /dictionary
 @requires /utils/olStyle
 @requires /ui/elements/chkbox
 @requires /ui/elements/helpDialog
@@ -93,8 +93,11 @@ export default function geometry(entry) {
   entry.getExtent ??= getExtent;
   entry.modify ??= modify;
   entry.label ??= 'Geometry';
+
   // Must always be set in case the geometry is re-rendered and now has data.
-  entry.disabled = !entry.value && !entry.api;
+  // The entry should be disabled if an error was encountered.
+  // The entry should be disabed if there is no value and no API to generate a value.
+  entry.disabled = (!entry.value && !entry.api) || entry.error;
 
   // Create checkbox to control geometry display.
   entry.chkbox = mapp.ui.elements.chkbox({
@@ -135,7 +138,7 @@ export default function geometry(entry) {
 @this infoj-entry
 
 @description
-Returns the extent of the geometry. 
+Returns the extent of the geometry.
 
 @returns {Array} an array representing an openlayers extent
 */
@@ -201,7 +204,7 @@ async function show() {
 @this infoj-entry
 
 @description
-Removes the entry.L from the location.layer.mapview. 
+Removes the entry.L from the location.layer.mapview.
 */
 function hide() {
   this.display = false;


### PR DESCRIPTION
## Description
A new flag has been added on the isolines entry types which indicates whether the API call yielded an error. 
If this is the case the entry should be disabled. 

On the PR the entry should be disabled:
<img width="458" height="330" alt="screenshot-2026-02-18_10-44-23" src="https://github.com/user-attachments/assets/91766fae-36e8-4c54-8099-eed5844a1c5c" />

This can be achieved by using an incorrect API key. 

## GitHub Issue
#2657

## Type of Change
- ✅ Bug fix (non-breaking change which fixes an issue)


## How have you tested this?
This can be tested on `bugs_testing/plugins/isolines.json` by clicking on a location. 

## Testing Checklist
- ✅ Existing Tests still pass
- ✅ Ran locally on my machine

## Code Quality Checklist
- ✅ My code follows the guidelines of XYZ
- ✅ My code has been commented
- ✅ Documentation has been updated
- ✅ New and existing unit tests pass locally with my changes
- ✅ Main has been merged into this PR
