### PR TITLE
fix(Format/Vector): Call changed() method if features already exist

### DIFF
--- a/lib/layer/format/vector.mjs
+++ b/lib/layer/format/vector.mjs
@@ -192,7 +192,10 @@ function reload() {
   const layer = this;
 
   // Do not reload the layer if features have been assigned.
-  if (layer.features) return;
+  if (layer.features) {
+    layer.L.changed();
+    return;
+  }
 
   const table = layer.tableCurrent();
 


### PR DESCRIPTION
## Description
A `type:layer` entry may have `features`. 
When you then change the theme on this entry, nothing happens. 
This is due to the check in the `vector` module on the presence of features. 

This PR fixes this issue by calling the `changed()` method when features exist, ensuring that the render is reapplied. 

## Type of Change
- ✅ Bug fix (non-breaking change which fixes an issue)

## How have you tested this?
Tested locally against a `geojson` type layer entry.
