### PR TITLE
Add consent plugin

### DIFF
--- a/lib/plugins/_plugins.mjs
+++ b/lib/plugins/_plugins.mjs
@@ -6,6 +6,7 @@ The module exports a collection of core mapp plugins.
 @module /plugins
 
 @requires module:/plugins/admin
+@requires module:/plugins/consent
 @requires module:/plugins/feature_info
 @requires module:/plugins/fullscreen
 @requires module:/plugins/layer_order
@@ -21,6 +22,7 @@ The module exports a collection of core mapp plugins.
 */
 
 import { admin } from './admin.mjs';
+import { consent } from './consent.mjs';
 import { custom_theme, dark_mode } from './dark_mode.mjs';
 import { feature_info } from './feature_info.mjs';
 import { fullscreen } from './fullscreen.mjs';
@@ -53,6 +55,7 @@ import { zoomToArea } from './zoomToArea.mjs';
 
 const plugins = {
   admin,
+  consent,
   custom_theme,
   dark_mode,
   feature_info,

--- a/lib/plugins/consent.mjs
+++ b/lib/plugins/consent.mjs
@@ -1,5 +1,5 @@
 /**
-## /plugins/dark_mode
+## /plugins/consent
 
 The module exports method to display and store configurable user consent.
 

--- a/lib/plugins/consent.mjs
+++ b/lib/plugins/consent.mjs
@@ -1,0 +1,60 @@
+/**
+## /plugins/dark_mode
+
+The module exports method to display and store configurable user consent.
+
+@requires /utils/userIndexedDB
+@requires /ui/elements/confirm
+
+@module /plugins/consent
+*/
+
+/**
+@function consent
+@async
+
+@description
+The method will shortcircuit without a mapp.user{} object.
+
+The method will shortcircuit without a consent text being defined in the plugin configuration.
+
+The method awaits the confirm dialog promise to resolve and stores the response as the user.consent property in the userIndexedDB user store.
+
+The confirm dialog will not be displayed if consent has been provided previously.
+
+```json
+"consent": {
+  "text": "Please confirm you consent to user 3rd party cookies."
+}
+```
+
+@param {Object} plugin The consent configuration.
+@param {mapview} mapview
+@property {string} plugin.text The text shown in the consent dialog.
+@property {string} [plugin.title="mapp.user.consent"] The title for the consent confirmation dialog.
+*/
+export async function consent(plugin, mapview) {
+  if (!mapp.user) return;
+
+  if (!plugin.text) {
+    console.warn('consent plugin is missing consent text');
+    return;
+  }
+
+  if (mapp.user.consent) {
+    console.log('mapp.user has consent flag');
+    return;
+  }
+
+  plugin.title ??= 'mapp.user.consent';
+
+  mapp.user.consent = await mapp.ui.elements.confirm(plugin);
+
+  if (mapp.user.consent) {
+    await mapp.utils.userIndexedDB.put({
+      store: 'user',
+      name: mapp.user.email,
+      obj: mapp.user,
+    });
+  }
+}


### PR DESCRIPTION
This PR adds a core plugin which awaits a confirm dialog to store consent in the indexedDB user store.

The consent text must be configured.
