### PR TITLE
Location Update Override

### DIFF
--- a/lib/location/decorate.mjs
+++ b/lib/location/decorate.mjs
@@ -36,6 +36,7 @@ A decorated mapp location.
 @property {function} remove {@link module:/location/decorate~remove}
 @property {function} syncFields {@link module:/location/decorate~syncFields}
 @property {function} update {@link module:/location/decorate~update}
+@property {string} [updateTemplate='location_update'] The query template for the location update post query.
 @property {HTMLElement} [view] The location view displayed in the location listview in the default Mapp application view.
 */
 

--- a/lib/location/get.mjs
+++ b/lib/location/get.mjs
@@ -107,7 +107,6 @@ The response properties are mapped into clones of the layer.infoj which will be 
 @param {object} location
 @property {layer} location.layer The layer to which the location belongs.
 @property {layer} [location.getTemplate='location_get'] The query template for the location data.
-@property {layer} [location.updateTemplate='location_update'] The query template for the location update data.
 
 @returns {Promise<object>} The populated location.infoj entries array.
 */
@@ -125,7 +124,6 @@ export async function getInfoj(location) {
   }
 
   location.getTemplate ??= 'location_get';
-  location.updateTemplate ??= 'location_update';
 
   // Get table from layer if not provided.
   location.table ??=


### PR DESCRIPTION
The location.update() methodology uses a stored location_update query.
It is possible to override this on an application level by overwriting in the workspace.
It should be possible to overwrite this on a location-by-location basis, for example in custom views to change how the data is stored while using the location.update scaffolding easily.

We already do this for the location_get query, so this is just following the same pattern.