### PR TITLE
fix(Gazetteer): Must use no response or debounced, not optional chain

### DIFF
--- a/lib/utils/gazetteer.mjs
+++ b/lib/utils/gazetteer.mjs
@@ -128,7 +128,7 @@ function search(term, dataset) {
       if (!dataset.input.value.length) return;
 
       // No results or debounced.
-      if (!response?.debounce) {
+      if (!response || response?.debounce) {
         if (dataset.no_result === null) return;
         dataset.list.append(mapp.utils.html.node`
         <li>


### PR DESCRIPTION
## Description
In this PR - the initial issue was addressed. At the end of the PR I made a mistake and converted the check to an optional chain. 
This was wrong 
The line `if(!response?.debounce)` does not do the same thing as `if(!response || response?.debounce` as we need to check for either no response, or for a debounce value of true. 

## Type of Change
- ✅ Bug fix (non-breaking change which fixes an issue)

## How have you tested this?
Tested locally.