### PR TITLE
Layer view and drawer cleanup

### DIFF
--- a/lib/ui/elements/drawer.mjs
+++ b/lib/ui/elements/drawer.mjs
@@ -35,7 +35,7 @@ export function drawer(params) {
     params.drawer = mapp.utils.html.node`<div
       class="${'drawer ' + (params.class || '')}"
       data-id=${params.data_id}>
-      <div class="header">${params.header}</div>
+      <div class="header no-select">${params.header}</div>
       <div class="content">${params.content}`;
 
     return params.drawer;
@@ -68,7 +68,7 @@ export function drawer(params) {
     data-id=${params.data_id}
     class=${params.class}>
     <div
-      class="header"
+      class="header no-select"
       onclick=${onClick}>
       ${params.header}
       ${caret}

--- a/lib/ui/layers/listview.mjs
+++ b/lib/ui/layers/listview.mjs
@@ -118,7 +118,7 @@ function createGroup(layer) {
         .forEach((layer) => layer.hide());
     }}>visibility_off`;
 
-  group.meta = mapp.utils.html.node`<div class="meta">`;
+  group.meta = mapp.utils.html.node`<div class="meta no-select">`;
   group.drawer = mapp.ui.elements.drawer({
     class: `layer-group ${layer.groupClassList || ''}`,
     content: group.meta,

--- a/lib/ui/layers/panels/meta.mjs
+++ b/lib/ui/layers/panels/meta.mjs
@@ -17,7 +17,7 @@ The method will create an element with the layer.meta string as innerHTML.
 @returns {HTMLElement} The meta panel element.
 */
 export default function meta(layer) {
-  const meta = mapp.utils.html.node`<p data-id="meta" class="meta">`;
+  const meta = mapp.utils.html.node`<p data-id="meta" class="meta no-select">`;
   meta.innerHTML = layer.meta;
   return meta;
 }

--- a/lib/ui/utils/cssColourTheme.mjs
+++ b/lib/ui/utils/cssColourTheme.mjs
@@ -15,6 +15,9 @@ The secondary base colour should slightly accentuate items rendered relative to 
 ### base-tertiary `#fafafa`
 The tertiary base colour should slightly accentuate items rendered relative to the elements with a secondary base background.
 
+### base-quartenary `#f0eee9`
+The base colour serves the purpose of readability. It should be a hue to cut between secondary and tertiary background. It should be suitable for default font colour. It is used on content layout elements (eg. layer in layers list) that sit inside containers but also wrap inner containers. 
+
 ### font `#3f3f3f`
 The default colour for font characters and icons.
 
@@ -52,6 +55,7 @@ export const themes = {
     base: '#222222',
     'base-secondary': '#555555',
     'base-tertiary': '#444444',
+    'base-quartenary': '#2B2C30',
     border: '#666666',
     changed: '#666600',
     danger: '#ef5350',

--- a/lib/ui/utils/cssColourTheme.mjs
+++ b/lib/ui/utils/cssColourTheme.mjs
@@ -53,8 +53,8 @@ export const themes = {
   dark: {
     active: '#e18335',
     base: '#222222',
-    'base-secondary': '#555555',
-    'base-tertiary': '#444444',
+    'base-secondary': '#444444',
+    'base-tertiary': '#555555',
     'base-quartenary': '#2B2C30',
     border: '#666666',
     changed: '#666600',

--- a/public/css/base/_colours.css
+++ b/public/css/base/_colours.css
@@ -28,8 +28,9 @@
   /* end default colour palette */
 
   /* Global Layout Properties */
-  --container-box-shadow: rgba(60, 64, 67, 0.3) 0px 1px 2px 0px,
-    rgba(60, 64, 67, 0.15) 0px 1px 3px 1px;
+  --container-box-shadow:
+    rgba(60, 64, 67, 0.3) 0px 1px 2px 0px, rgba(60, 64, 67, 0.15) 0px 1px 3px
+    1px;
   --container-border-radius: 3px;
   /* End of Global Layout Properties */
 }

--- a/public/css/base/_colours.css
+++ b/public/css/base/_colours.css
@@ -26,6 +26,12 @@
   --color-info: #0b6f50;
   --color-danger: #a21309;
   /* end default colour palette */
+
+  /* Global Layout Properties */
+  --container-box-shadow: rgba(60, 64, 67, 0.3) 0px 1px 2px 0px,
+    rgba(60, 64, 67, 0.15) 0px 1px 3px 1px;
+  --container-border-radius: 3px;
+  /* End of Global Layout Properties */
 }
 
 * {

--- a/public/css/base/_colours.css
+++ b/public/css/base/_colours.css
@@ -7,6 +7,8 @@
   --color-base: #f2f2f2;
   --color-base-secondary: #f7f7f7;
   --color-base-tertiary: #fafafa;
+  /* background colour for static content readability - cuts between secondary and tertiary */
+  --color-base-quartenary: #f0eee9;
 
   /* Border */
   --color-border: #dddddd;

--- a/public/css/elements/_drawer.css
+++ b/public/css/elements/_drawer.css
@@ -5,31 +5,47 @@
 
 .drawer {
   padding: 2px;
+  margin-top: 2px;
   background-color: var(--color-base-secondary);
   color: var(--color-font);
+  border-radius: var(--container-border-radius);
+  border: 1px solid var(--color-border);
 
-  &.expandable:not(.empty) > .header:hover {
-    cursor: pointer;
+  &.expandable {
+    &:not(.empty) > .header:hover {
+      cursor: pointer;
+    }
+
+    &.empty > .header > .caret {
+      display: none;
+    }
+
+    & > .header {
+      & > .material-symbols-outlined.caret::after {
+        content: 'keyboard_arrow_down';
+        color: var(--color-font-mid);
+        line-height: 1.5em;
+      }
+    }
+
+    &:not(.expanded) > *:not(.header) {
+      display: none !important;
+    }
   }
 
-  &.expandable.empty > .header > .caret {
-    display: none;
-  }
+  &.expanded {
+    padding-bottom: 5px;
 
-  &.expandable > .header > .material-symbols-outlined.caret::after {
-    content: 'keyboard_arrow_down';
-    color: var(--color-font-mid);
-    line-height: 1.5em;
-  }
+    & > .header {
+      border-bottom: solid 1px var(--color-border); /* readability */
+      margin-bottom: 7px;
 
-  &.expandable:not(.expanded) > *:not(.header) {
-    display: none !important;
-  }
-
-  &.expanded > .header > .material-symbols-outlined.caret::after {
-    content: 'keyboard_arrow_up';
-    color: var(--color-font-mid);
-    line-height: 1.5em;
+      & > .material-symbols-outlined.caret::after {
+        content: 'keyboard_arrow_up';
+        color: var(--color-font-mid);
+        line-height: 1.5em;
+      }
+    }
   }
 
   &.disabled {
@@ -63,11 +79,6 @@
       text-overflow: ellipsis;
       flex-grow: 1;
     }
-  }
-
-  &.expandable.expanded {
-    box-shadow: none;
-    border: none;
   }
 
   p {

--- a/public/css/elements/_drawer.css
+++ b/public/css/elements/_drawer.css
@@ -41,11 +41,6 @@
     display: flex;
     align-items: center;
     color: var(--color-font);
-    -webkit-touch-callout: none;
-    -webkit-user-select: none;
-    -moz-user-select: none;
-    -ms-user-select: none;
-    user-select: none;
 
     .material-symbols-outlined {
       font-size: 1.5em;
@@ -68,22 +63,6 @@
       text-overflow: ellipsis;
       flex-grow: 1;
     }
-  }
-
-  &.flat {
-    border-radius: 2px;
-    border: 1px solid var(--color-border);
-  }
-
-  &.raised {
-    border-radius: 2px;
-    box-shadow: 1px 1px 3px var(--color-border);
-    border: 1px solid var(--color-border);
-  }
-
-  &.raised.empty {
-    box-shadow: none;
-    border: none;
   }
 
   &.expandable.expanded {

--- a/public/css/elements/_drawer.css
+++ b/public/css/elements/_drawer.css
@@ -9,7 +9,6 @@
   background-color: var(--color-base-secondary);
   color: var(--color-font);
   border-radius: var(--container-border-radius);
-  border: 1px solid var(--color-border);
 
   &.expandable {
     &:not(.empty) > .header:hover {
@@ -29,13 +28,19 @@
     }
 
     &:not(.expanded) {
+      /* collapsed drawers use box shadow for readability */
+      box-shadow: var(--container-box-shadow);
       & > *:not(.header) {
-      display: none !important;}
+        display: none !important;
+      }
     }
   }
 
   &.expanded {
+    /* expanded drawers use border with no box shadow */
     padding-bottom: 5px;
+    border: 1px solid var(--color-border);
+    box-shadow: none;
 
     & > .header {
       border-bottom: solid 1px var(--color-border); /* readability */
@@ -75,7 +80,7 @@
     }
 
     & > :first-child {
-      margin-left: 5px; 
+      margin-left: 5px;
       overflow: hidden;
       white-space: normal;
       text-overflow: ellipsis;

--- a/public/css/elements/_drawer.css
+++ b/public/css/elements/_drawer.css
@@ -10,6 +10,10 @@
   color: var(--color-font);
   border-radius: var(--container-border-radius);
 
+  &:not(.expandable) {
+    border: 1px solid var(--color-border);
+  }
+
   &.expandable {
     &:not(.empty) > .header:hover {
       cursor: pointer;

--- a/public/css/elements/_drawer.css
+++ b/public/css/elements/_drawer.css
@@ -28,8 +28,9 @@
       }
     }
 
-    &:not(.expanded) > *:not(.header) {
-      display: none !important;
+    &:not(.expanded) {
+      & > *:not(.header) {
+      display: none !important;}
     }
   }
 
@@ -74,6 +75,7 @@
     }
 
     & > :first-child {
+      margin-left: 5px; 
       overflow: hidden;
       white-space: normal;
       text-overflow: ellipsis;

--- a/public/css/elements/_dropdown.css
+++ b/public/css/elements/_dropdown.css
@@ -1,10 +1,10 @@
 .select-dropdown {
   width: 100%;
   color: var(--color-font);
-  background-color: var(--color-base-secondary);
+  background-color: var(--color-base-tertiary);
   border: 1px solid var(--color-border);
   padding: 5px;
-  border-radius: 3px;
+  border-radius: var(--container-border-radius);
 
   option.selected {
     background-color: var(--color-primary);

--- a/public/css/layout/_layerview.css
+++ b/public/css/layout/_layerview.css
@@ -1,58 +1,36 @@
-.drawer.layer-group,
-.drawer.layer-view {
+.layer-group,
+.layer-view {
   margin-top: 7px;
   border-radius: 3px;
-
-  & > .header {
-    & ~ .drawer.layer-view {
-      margin-top: 0;
-    }
-    & ~ .drawer.layer-view ~ .drawer.layer-view {
-      margin-top: 7px;
-    }
-  }
 
   & > .meta {
     padding-bottom: 5px;
   }
-
-  &.expanded {
-    padding-bottom: 5px;
-  }
 }
 
-.drawer.layer-group {
+.layer-group {
   padding-left: 3px;
   padding-right: 3px;
-  background: var(--color-base-tertiary);
+  background: var(--color-base-secondary);
+  box-shadow: var(--container-box-shadow);
+  border: none;
 
   & > * {
     padding-left: 4px;
   }
-
-  & > .drawer.layer-view {
-    background: var(--color-base-tertiary);
-    border: none;
-    box-shadow: none;
-    border-top: 1px solid var(--color-border);
-  }
 }
 
-.drawer.layer-view {
+.layer-view {
+  background: var(--color-base-quartenary);
   padding-left: 5px;
   padding-right: 5px;
+  border: 1px solid var(--color-border);
 
   & > *:not(.header) {
     margin-top: 5px;
   }
 
-  > .header {
-    .material-symbols-outlined {
-      font-size: 1.5em;
-    }
-
-    h2 {
-      font-weight: normal;
-    }
+  h2 {
+    font-weight: normal;
   }
 }

--- a/public/css/layout/_layerview.css
+++ b/public/css/layout/_layerview.css
@@ -14,11 +14,6 @@
 
   & > .meta {
     padding-bottom: 5px;
-    -webkit-touch-callout: none;
-    -webkit-user-select: none;
-    -moz-user-select: none;
-    -ms-user-select: none;
-    user-select: none;
   }
 
   &.expanded {

--- a/public/css/layout/_layerview.css
+++ b/public/css/layout/_layerview.css
@@ -12,8 +12,11 @@
   padding-left: 3px;
   padding-right: 3px;
   background: var(--color-base-secondary);
-  box-shadow: var(--container-box-shadow);
   border: none;
+
+  & > .header > h2 {
+    color: var(--color-primary);
+  }
 
   & > * {
     padding-left: 4px;
@@ -24,7 +27,6 @@
   background: var(--color-base-quartenary);
   padding-left: 5px;
   padding-right: 5px;
-  border: 1px solid var(--color-border);
 
   & > *:not(.header) {
     margin-top: 5px;

--- a/public/css/layout/_locationview.css
+++ b/public/css/layout/_locationview.css
@@ -8,7 +8,7 @@
   display: grid;
   align-items: stretch;
   grid-gap: 5px 10px;
-  padding: 5px 0;
+  padding: 5px;
   grid-template-columns: 1fr 1fr;
 
   & pre {

--- a/public/css/layout/_locationview.css
+++ b/public/css/layout/_locationview.css
@@ -1,7 +1,7 @@
 .location-view.drawer {
   margin-top: 5px;
   border-radius: 5px;
-  background-color: var(--color-base-tertiary);
+  background-color: var(--color-base-secondary);
 }
 
 .location-view-grid {
@@ -12,7 +12,7 @@
   grid-template-columns: 1fr 1fr;
 
   & pre {
-    background-color: var(--color-base-secondary);
+    background-color: var(--color-base-tertiary);
   }
 
   & .contents {
@@ -76,7 +76,7 @@
     border-radius: 2px;
     font-weight: bold;
     font-size: 0.8em;
-    background-color: var(--color-base-secondary);
+    background-color: var(--color-base-tertiary);
 
     &.active {
       background-color: var(--color-active);

--- a/public/css/layout/_locationview.css
+++ b/public/css/layout/_locationview.css
@@ -1,4 +1,4 @@
-.location-view.drawer {
+.location-view {
   margin-top: 5px;
   border-radius: 5px;
   background-color: var(--color-base-secondary);
@@ -44,7 +44,7 @@
     font-weight: bold;
   }
 
-  & .drawer.group {
+  & .group {
     grid-column: 1 / 3;
     display: grid;
     grid-template-columns: 1fr 1fr;

--- a/public/css/mapp.css
+++ b/public/css/mapp.css
@@ -14,6 +14,8 @@
   --color-changed: #ffffa7;
   --color-info: #0b6f50;
   --color-danger: #a21309;
+  --container-box-shadow: rgba(60, 64, 67, 0.3) 0px 1px 2px 0px, rgba(60, 64, 67, 0.15) 0px 1px 3px 1px;
+  --container-border-radius: 3px;
 }
 * {
   transition: 0.2s ease-in-out;

--- a/public/css/mapp.css
+++ b/public/css/mapp.css
@@ -4,6 +4,7 @@
   --color-base: #f2f2f2;
   --color-base-secondary: #f7f7f7;
   --color-base-tertiary: #fafafa;
+  --color-base-quartenary: #f0eee9;
   --color-border: #dddddd;
   --color-font: #3f3f3f;
   --color-font-mid: #858585;

--- a/public/css/ui.css
+++ b/public/css/ui.css
@@ -749,7 +749,6 @@ dialog {
   background-color: var(--color-base-secondary);
   color: var(--color-font);
   border-radius: var(--container-border-radius);
-  border: 1px solid var(--color-border);
   &.expandable {
     &:not(.empty) > .header:hover {
       cursor: pointer;
@@ -765,6 +764,7 @@ dialog {
       }
     }
     &:not(.expanded) {
+      box-shadow: var(--container-box-shadow);
       & > *:not(.header) {
         display: none !important;
       }
@@ -772,6 +772,8 @@ dialog {
   }
   &.expanded {
     padding-bottom: 5px;
+    border: 1px solid var(--color-border);
+    box-shadow: none;
     & > .header {
       border-bottom: solid 1px var(--color-border);
       margin-bottom: 7px;
@@ -1417,8 +1419,10 @@ label.radio {
   padding-left: 3px;
   padding-right: 3px;
   background: var(--color-base-secondary);
-  box-shadow: var(--container-box-shadow);
   border: none;
+  & > .header > h2 {
+    color: var(--color-primary);
+  }
   & > * {
     padding-left: 4px;
   }
@@ -1427,7 +1431,6 @@ label.radio {
   background: var(--color-base-quartenary);
   padding-left: 5px;
   padding-right: 5px;
-  border: 1px solid var(--color-border);
   & > *:not(.header) {
     margin-top: 5px;
   }
@@ -1437,7 +1440,7 @@ label.radio {
 }
 
 /* public/css/layout/_locationview.css */
-.location-view.drawer {
+.location-view {
   margin-top: 5px;
   border-radius: 5px;
   background-color: var(--color-base-secondary);
@@ -1474,7 +1477,7 @@ label.radio {
     display: flex;
     font-weight: bold;
   }
-  & .drawer.group {
+  & .group {
     grid-column: 1 / 3;
     display: grid;
     grid-template-columns: 1fr 1fr;

--- a/public/css/ui.css
+++ b/public/css/ui.css
@@ -14,6 +14,8 @@
   --color-changed: #ffffa7;
   --color-info: #0b6f50;
   --color-danger: #a21309;
+  --container-box-shadow: rgba(60, 64, 67, 0.3) 0px 1px 2px 0px, rgba(60, 64, 67, 0.15) 0px 1px 3px 1px;
+  --container-border-radius: 3px;
 }
 * {
   transition: 0.2s ease-in-out;
@@ -743,26 +745,40 @@ dialog {
 }
 .drawer {
   padding: 2px;
+  margin-top: 2px;
   background-color: var(--color-base-secondary);
   color: var(--color-font);
-  &.expandable:not(.empty) > .header:hover {
-    cursor: pointer;
+  border-radius: var(--container-border-radius);
+  border: 1px solid var(--color-border);
+  &.expandable {
+    &:not(.empty) > .header:hover {
+      cursor: pointer;
+    }
+    &.empty > .header > .caret {
+      display: none;
+    }
+    & > .header {
+      & > .material-symbols-outlined.caret::after {
+        content: "keyboard_arrow_down";
+        color: var(--color-font-mid);
+        line-height: 1.5em;
+      }
+    }
+    &:not(.expanded) > *:not(.header) {
+      display: none !important;
+    }
   }
-  &.expandable.empty > .header > .caret {
-    display: none;
-  }
-  &.expandable > .header > .material-symbols-outlined.caret::after {
-    content: "keyboard_arrow_down";
-    color: var(--color-font-mid);
-    line-height: 1.5em;
-  }
-  &.expandable:not(.expanded) > *:not(.header) {
-    display: none !important;
-  }
-  &.expanded > .header > .material-symbols-outlined.caret::after {
-    content: "keyboard_arrow_up";
-    color: var(--color-font-mid);
-    line-height: 1.5em;
+  &.expanded {
+    padding-bottom: 5px;
+    & > .header {
+      border-bottom: solid 1px var(--color-border);
+      margin-bottom: 7px;
+      & > .material-symbols-outlined.caret::after {
+        content: "keyboard_arrow_up";
+        color: var(--color-font-mid);
+        line-height: 1.5em;
+      }
+    }
   }
   &.disabled {
     opacity: 0.4;
@@ -790,10 +806,6 @@ dialog {
       text-overflow: ellipsis;
       flex-grow: 1;
     }
-  }
-  &.expandable.expanded {
-    box-shadow: none;
-    border: none;
   }
   p {
     padding-left: 0.3em;
@@ -1390,52 +1402,34 @@ label.radio {
 }
 
 /* public/css/layout/_layerview.css */
-.drawer.layer-group,
-.drawer.layer-view {
+.layer-group,
+.layer-view {
   margin-top: 7px;
   border-radius: 3px;
-  & > .header {
-    & ~ .drawer.layer-view {
-      margin-top: 0;
-    }
-    & ~ .drawer.layer-view ~ .drawer.layer-view {
-      margin-top: 7px;
-    }
-  }
   & > .meta {
     padding-bottom: 5px;
   }
-  &.expanded {
-    padding-bottom: 5px;
-  }
 }
-.drawer.layer-group {
+.layer-group {
   padding-left: 3px;
   padding-right: 3px;
-  background: var(--color-base-tertiary);
+  background: var(--color-base-secondary);
+  box-shadow: var(--container-box-shadow);
+  border: none;
   & > * {
     padding-left: 4px;
   }
-  & > .drawer.layer-view {
-    background: var(--color-base-tertiary);
-    border: none;
-    box-shadow: none;
-    border-top: 1px solid var(--color-border);
-  }
 }
-.drawer.layer-view {
+.layer-view {
+  background: var(--color-base-quartenary);
   padding-left: 5px;
   padding-right: 5px;
+  border: 1px solid var(--color-border);
   & > *:not(.header) {
     margin-top: 5px;
   }
-  > .header {
-    .material-symbols-outlined {
-      font-size: 1.5em;
-    }
-    h2 {
-      font-weight: normal;
-    }
+  h2 {
+    font-weight: normal;
   }
 }
 

--- a/public/css/ui.css
+++ b/public/css/ui.css
@@ -764,8 +764,10 @@ dialog {
         line-height: 1.5em;
       }
     }
-    &:not(.expanded) > *:not(.header) {
-      display: none !important;
+    &:not(.expanded) {
+      & > *:not(.header) {
+        display: none !important;
+      }
     }
   }
   &.expanded {
@@ -801,6 +803,7 @@ dialog {
       height: 1.5em;
     }
     & > :first-child {
+      margin-left: 5px;
       overflow: hidden;
       white-space: normal;
       text-overflow: ellipsis;
@@ -1443,7 +1446,7 @@ label.radio {
   display: grid;
   align-items: stretch;
   grid-gap: 5px 10px;
-  padding: 5px 0;
+  padding: 5px;
   grid-template-columns: 1fr 1fr;
   & pre {
     background-color: var(--color-base-tertiary);

--- a/public/css/ui.css
+++ b/public/css/ui.css
@@ -749,6 +749,9 @@ dialog {
   background-color: var(--color-base-secondary);
   color: var(--color-font);
   border-radius: var(--container-border-radius);
+  &:not(.expandable) {
+    border: 1px solid var(--color-border);
+  }
   &.expandable {
     &:not(.empty) > .header:hover {
       cursor: pointer;

--- a/public/css/ui.css
+++ b/public/css/ui.css
@@ -772,11 +772,6 @@ dialog {
     display: flex;
     align-items: center;
     color: var(--color-font);
-    -webkit-touch-callout: none;
-    -webkit-user-select: none;
-    -moz-user-select: none;
-    -ms-user-select: none;
-    user-select: none;
     .material-symbols-outlined {
       font-size: 1.5em;
     }
@@ -795,19 +790,6 @@ dialog {
       text-overflow: ellipsis;
       flex-grow: 1;
     }
-  }
-  &.flat {
-    border-radius: 2px;
-    border: 1px solid var(--color-border);
-  }
-  &.raised {
-    border-radius: 2px;
-    box-shadow: 1px 1px 3px var(--color-border);
-    border: 1px solid var(--color-border);
-  }
-  &.raised.empty {
-    box-shadow: none;
-    border: none;
   }
   &.expandable.expanded {
     box-shadow: none;
@@ -1422,11 +1404,6 @@ label.radio {
   }
   & > .meta {
     padding-bottom: 5px;
-    -webkit-touch-callout: none;
-    -webkit-user-select: none;
-    -moz-user-select: none;
-    -ms-user-select: none;
-    user-select: none;
   }
   &.expanded {
     padding-bottom: 5px;

--- a/public/css/ui.css
+++ b/public/css/ui.css
@@ -4,6 +4,7 @@
   --color-base: #f2f2f2;
   --color-base-secondary: #f7f7f7;
   --color-base-tertiary: #fafafa;
+  --color-base-quartenary: #f0eee9;
   --color-border: #dddddd;
   --color-font: #3f3f3f;
   --color-font-mid: #858585;

--- a/public/css/ui.css
+++ b/public/css/ui.css
@@ -817,10 +817,10 @@ dialog {
 .select-dropdown {
   width: 100%;
   color: var(--color-font);
-  background-color: var(--color-base-secondary);
+  background-color: var(--color-base-tertiary);
   border: 1px solid var(--color-border);
   padding: 5px;
-  border-radius: 3px;
+  border-radius: var(--container-border-radius);
   option.selected {
     background-color: var(--color-primary);
     color: var(--color-font-contrast);
@@ -1437,7 +1437,7 @@ label.radio {
 .location-view.drawer {
   margin-top: 5px;
   border-radius: 5px;
-  background-color: var(--color-base-tertiary);
+  background-color: var(--color-base-secondary);
 }
 .location-view-grid {
   display: grid;
@@ -1446,7 +1446,7 @@ label.radio {
   padding: 5px 0;
   grid-template-columns: 1fr 1fr;
   & pre {
-    background-color: var(--color-base-secondary);
+    background-color: var(--color-base-tertiary);
   }
   & .contents {
     display: contents;
@@ -1499,7 +1499,7 @@ label.radio {
     border-radius: 2px;
     font-weight: bold;
     font-size: 0.8em;
-    background-color: var(--color-base-secondary);
+    background-color: var(--color-base-tertiary);
     &.active {
       background-color: var(--color-active);
     }


### PR DESCRIPTION
Introduced layout changes

* Updated default palette - new base colour introduced for content layout readability. 
* Equivalent colour added to dark mode with addition to palette documentation.
* `.no-select` class now applied on drawer headers and layer meta elements - previously each had a set of no-select rules in respective stylesheets. Redundant rules removed.
* drawer and layerview stylesheets cleaned up - redundant rules moved to lower level drawer stylesheet, improved notation and order for nested rules.
* location view - hierarchy of colours to follow the layer view logic, that is: base -> secondary -> tertiary. Previously it would follow base -> tertiary -> secondary which caused readability clashes against inputs and dropdowns.
* dropdown background now base-tertiary to contrast correctly against drawers.
* layer view stylesheet - css selectors detached from .drawer class.
* location view - aligned padding, now header has the same padding on both sides. Selectors detached from .drawer class.
* dark mode palette - colours for secondary and tertiary switched over, previously tertiary would be darker than secondary which didn't work at all times.
* drawers - expanded drawers now have a flat look with a border.
* drawers - collapsed drawers have box shadow which is a better indication that the element has inner content.
* layer group - font in primary colour for distinction.