### PR TITLE
shortcircuit locales element method if dropdown is not required

### DIFF
--- a/lib/ui/elements/locales.mjs
+++ b/lib/ui/elements/locales.mjs
@@ -21,6 +21,9 @@ export default async function locales(locale, locales) {
 
   if (!elements.length) return;
 
+  // A dropdown is not required for a single locale without nested locales.
+  if (elements.length === 1 && locales.length === 1) return;
+
   return mapp.utils.html.node`${elements}`;
 }
 


### PR DESCRIPTION
A dropdown should not be displayed if there are no options, eg there is only one accessible locale.