### PR TITLE
Return feature.length from locationCount method.

### DIFF
--- a/lib/layer/format/vector.mjs
+++ b/lib/layer/format/vector.mjs
@@ -66,52 +66,8 @@ export default function vector(layer) {
 
   clusterConfig(layer);
 
-  layer.setSource = async (features) => {
-    // The layer datasource is empty.
-    if (features === null) {
-      layer.L.setSource(null);
-      mapp.layer.featureFields.reset(layer);
-      mapp.layer.featureFields.process(layer);
-      return;
-    }
-
-    if (!features) return;
-
-    layer.Features = await mapp.layer.featureFormats[layer.featureFormat](
-      layer,
-      [features].flat(),
-    );
-
-    layer.source = new ol.source.Vector({
-      features: layer.Features,
-    });
-
-    delete layer.xhr;
-
-    if (layer.fade) mapp.layer.fade(layer);
-
-    // Geojson is a cluster layer.
-    if (layer.cluster?.distance) {
-      // Create cluster source.
-
-      layer.cluster.source = new ol.source.Cluster({
-        distance: layer.cluster.distance,
-        source: layer.source,
-      });
-
-      layer.L.setSource(layer.cluster.source);
-
-      layer.cluster.source.on('change', (e) => clusterSourceChange(e, layer));
-
-      return;
-    }
-
-    // Set source if not cluster
-    layer.L.setSource(layer.source);
-  };
-
-  // Assign reload method to layer.
   layer.reload = reload;
+  layer.setSource = setSource;
 
   // Create Openlayer Vector Layer
   layer.L = new ol.layer[(layer.vectorImage && 'VectorImage') || 'Vector']({
@@ -122,6 +78,61 @@ export default function vector(layer) {
   });
 
   layer.setSource(layer.features);
+}
+
+/**
+@function setSource
+@this layer
+@async 
+@description
+The setSource method receives the features to be set on a vector layer source. Providing a null argument will remove any features by setting the layer source to null.
+
+The method will trigger methods to reset and process featureFields to update dynamic legends.
+
+The clusterSourceChange method is triggered for cluster layer.
+
+@param {array} [features] The features to be added to the vector layer source.
+*/
+async function setSource(features) {
+  // The layer datasource is empty.
+  if (features === null) {
+    this.L.setSource(null);
+    mapp.layer.featureFields.reset(this);
+    mapp.layer.featureFields.process(this);
+    return;
+  }
+
+  if (!features) return;
+
+  this.Features = await mapp.layer.featureFormats[this.featureFormat](
+    this,
+    [features].flat(),
+  );
+
+  this.source = new ol.source.Vector({
+    features: this.Features,
+  });
+
+  if (this.fade) mapp.layer.fade(this);
+
+  // Geojson is a cluster layer.
+  if (this.cluster?.distance) {
+    // Create cluster source.
+
+    this.cluster.source = new ol.source.Cluster({
+      distance: this.cluster.distance,
+      source: this.source,
+    });
+
+    this.L.setSource(this.cluster.source);
+
+    this.cluster.source.on('change', (e) => clusterSourceChange(e, this));
+
+    return;
+  }
+
+  // Set source if not cluster
+  this.L.setSource(this.source);
 }
 
 /**
@@ -225,19 +236,18 @@ function reload() {
   clearTimeout(layer.timeout);
 
   layer.timeout = setTimeout(() => {
+    const paramString = mapp.utils.paramString({
+      filter: layer.filter?.current,
+      geom,
+      layer: layer.key,
+      locale: layer.mapview.locale.key,
+      srid: layer.srid,
+      table,
+      template: layer.params.template || layer.format,
+      ...layer.params,
+    });
     layer.xhr = mapp.utils
-      .xhr(
-        `${layer.mapview.host}/api/query?${mapp.utils.paramString({
-          filter: layer.filter?.current,
-          geom,
-          layer: layer.key,
-          locale: layer.mapview.locale.key,
-          srid: layer.srid,
-          table,
-          template: layer.params.template || layer.format,
-          ...layer.params,
-        })}`,
-      )
+      .xhr(`${layer.mapview.host}/api/query?${paramString}`)
       .then((features) => {
         // An error will be returned if the xhr fails with a bad request 400.
         if (features instanceof Error) return;

--- a/lib/ui/utils/locationCount.mjs
+++ b/lib/ui/utils/locationCount.mjs
@@ -18,7 +18,7 @@ Returns the length of the layer.Features[] array or the response from a layer_co
 @returns {Integer} The number of locations that pass the filter.
 */
 export default async function locationCount(layer) {
-  if (Array.isArray(layer.Features)) {
+  if (Array.isArray(layer.Features) && !layer.filter?.viewport) {
     return layer.Features.length;
   }
 

--- a/lib/ui/utils/locationCount.mjs
+++ b/lib/ui/utils/locationCount.mjs
@@ -8,8 +8,7 @@ Exports the default locationCount utility method as mapp.ui.utils.locationCount(
 @function locationCount
 
 @description
-Returns a number representing the amount of locations that pass the filter.
-
+Returns the length of the layer.Features[] array or the response from a layer_count query.
 @param {layer} layer
 @property {String} layer.key The layers' identifier.
 @property {Object} layer.filter The filter currently active on the layer.
@@ -19,6 +18,10 @@ Returns a number representing the amount of locations that pass the filter.
 @returns {Integer} The number of locations that pass the filter.
 */
 export default async function locationCount(layer) {
+  if (Array.isArray(layer.Features)) {
+    return layer.Features.length;
+  }
+
   //Whether or not to use the viewport in the query
   const options = {
     layer: layer,


### PR DESCRIPTION
This PR unnests and documents the vector format layer setSource method.

The length of the layer.Features array should be a representation of the location count. A query everytime the viewport changes should not be required.

An MVT format layer will not have features unless a wkt_properties lookup is configured.

MVT layer must use a viewport for the locationCount query as otherwise the query would long running and potentially timeout.