### PR TITLE
fix(acl): Release client after everything

### DIFF
--- a/mod/user/acl.js
+++ b/mod/user/acl.js
@@ -34,6 +34,7 @@ export default !connection?.[1]
 
       pool = new Pool({
         connectionString: connection[0],
+        connectionTimeoutMillis: 5000,
       });
 
       return acl;
@@ -41,27 +42,28 @@ export default !connection?.[1]
 
 /**
 @function acl
- 
+
 @description
 The acl method will connect to pg pool and query the ACL with a provided query template. The `/acl_table/` and `/acl_schema/` in the query template will be replaced with values provided as `PRIVATE` or `PUBLIC` environment variable.
- 
+
 @param {string} q Query template.
 @param {array} arr Parameters to be substrituted in query template.
 */
 async function acl(q, arr) {
+  let client;
   try {
-    const client = await pool.connect();
+    client = await pool.connect();
 
     const { rows } = await client.query(
       q.replace(/acl_table/g, acl_table).replace(/acl_schema/g, acl_schema),
       arr,
     );
 
-    client.release();
-
     return rows;
   } catch (err) {
     console.error(err);
     return err;
+  } finally {
+    client?.release();
   }
 }

--- a/mod/user/acl.js
+++ b/mod/user/acl.js
@@ -62,7 +62,7 @@ async function acl(q, arr) {
     return rows;
   } catch (err) {
     console.error(err);
-    return err;
+    return new Error('Failed to connect to ACL.');
   } finally {
     client?.release();
   }

--- a/mod/user/auth.js
+++ b/mod/user/auth.js
@@ -313,7 +313,9 @@ async function checkSession(req, user) {
     );
 
     // The request for the stored session has failed.
-    if (rows instanceof Error) return rows;
+    if (rows instanceof Error) {
+      return rows;
+    }
 
     if (user.session !== rows[0].session) {
       // The stored session doesn't match user.session.


### PR DESCRIPTION
### Summary

If client.query() throws an error the client is never released. It's permanently leaked from the pool. The ACL pool has no explicit max config, so it defaults to 10. After 10 query errors, all 10 connections are checked out and never returned. Every subsequent pool.connect() waits forever (no`connectionTimeoutMillis` set either, so it defaults to infinite).

Since the ACL is used for auth checks on every authenticated request, once the ACL pool is exhausted, every single request to the app hangs indefinitely.

This would create a lockup of unreleased clients in the backend.

### Fix

```diff
--- a/mod/user/acl.js
+++ b/mod/user/acl.js
@@ -32,18 +32,20 @@
 
       pool = new Pool({
         connectionString: connection[0],
+        connectionTimeoutMillis: 5000,
       });
 
       return acl;
     })();
 
 async function acl(q, arr) {
+  let client;
   try {
-    const client = await pool.connect();
+    client = await pool.connect();
 
     const { rows } = await client.query(
       q.replace(/acl_table/g, acl_table).replace(/acl_schema/g, acl_schema),
       arr,
     );
 
-    client.release();
-
     return rows;
   } catch (err) {
     console.error(err);
     return err;
+  } finally {
+    client?.release();
   }
 }
```