### PR TITLE
Enhancements to confirm and alert dialogs

### DIFF
--- a/lib/ui/elements/alert.mjs
+++ b/lib/ui/elements/alert.mjs
@@ -30,7 +30,7 @@ mapp.ui.elements.alert({
 @property {string} [params.data_id='alert'] The data-id attribute value for the dialog.
 @property {string} [params.title] Text to display in the alert header. Defaults to 'Information'.
 @property {string} [params.text] Text to display in the alert content. 
-@property {string} [params.innerContent] custom HTML fragment to display in the dialog, optional. Overrides text.
+@property {HTMLElement} [params.innerContent] custom HTML fragment to display in the dialog, optional. Overrides text.
 @property {string} [params.icon] Custom Material Symbols icon name to use in the header for message clarity. Defaults to 'info'.
 @returns {HTMLElement} alert The alert element.
 */

--- a/lib/ui/elements/alert.mjs
+++ b/lib/ui/elements/alert.mjs
@@ -30,7 +30,7 @@ mapp.ui.elements.alert({
 @property {string} [params.data_id='alert'] The data-id attribute value for the dialog.
 @property {string} [params.title] Text to display in the alert header. Defaults to 'Information'.
 @property {string} [params.text] Text to display in the alert content. 
-@property {HTMLElement} [params.innerContent] custom HTML fragment to display in the dialog, optional. Overrides text.
+@property {HTMLElement} [params.innerContent] custom HTML fragment to display in the dialog, optional. Overrides `text`.
 @property {string} [params.icon] Custom Material Symbols icon name to use in the header for message clarity. Defaults to 'info'. Set empty string `icon: ''` to skip the symbol entirely.
 @returns {HTMLElement} alert The alert element.
 */
@@ -46,7 +46,7 @@ export default function alert(params) {
 
   params.data_id ??= 'alert';
 
-  params.class ??= 'alert-confirm no-select';
+  params.class ??= 'alert-confirm box-shadow no-select';
 
   // create icon span tag only if icon is not an empty string
   const el_icon =

--- a/lib/ui/elements/alert.mjs
+++ b/lib/ui/elements/alert.mjs
@@ -30,11 +30,12 @@ mapp.ui.elements.alert({
 @property {string} [params.data_id='alert'] The data-id attribute value for the dialog.
 @property {string} [params.title] Text to display in the alert header. Defaults to 'Information'.
 @property {string} [params.text] Text to display in the alert content. 
+@property {string} [params.innerContent] custom HTML fragment to display in the dialog, optional. Overrides text.
 @property {string} [params.icon] Custom Material Symbols icon name to use in the header for message clarity. Defaults to 'info'.
 @returns {HTMLElement} alert The alert element.
 */
 export default function alert(params) {
-  params.title ??= `${mapp.dictionary.information}`;
+  params.title ??= mapp.dictionary.information;
 
   params.icon ??= 'info';
 
@@ -45,12 +46,13 @@ export default function alert(params) {
   params.header = mapp.utils
     .html`<span class="material-symbols-outlined notranslate">${params.icon}</span>${params.title}`;
 
+  params.innerContent ??= mapp.utils.html`<p>${params.text}</p>`;
+
   params.content = mapp.utils.html`
-    <p>${params.text}</p>
+    ${params.innerContent}
     <div class="buttons">
       <button 
-        class="raised bold"
-        style="grid-column: 1/3; margin: 0 5em;"
+        class="action outlined bold"
         onclick=${(e) => {
           e.target.closest('dialog').close();
         }}>${mapp.dictionary.ok}`;

--- a/lib/ui/elements/alert.mjs
+++ b/lib/ui/elements/alert.mjs
@@ -31,7 +31,7 @@ mapp.ui.elements.alert({
 @property {string} [params.title] Text to display in the alert header. Defaults to 'Information'.
 @property {string} [params.text] Text to display in the alert content. 
 @property {HTMLElement} [params.innerContent] custom HTML fragment to display in the dialog, optional. Overrides text.
-@property {string} [params.icon] Custom Material Symbols icon name to use in the header for message clarity. Defaults to 'info'.
+@property {string} [params.icon] Custom Material Symbols icon name to use in the header for message clarity. Defaults to 'info'. Set empty string `icon: ''` to skip the symbol entirely.
 @returns {HTMLElement} alert The alert element.
 */
 export default function alert(params) {
@@ -48,8 +48,14 @@ export default function alert(params) {
 
   params.class ??= 'alert-confirm no-select';
 
-  params.header = mapp.utils
-    .html`<span class="material-symbols-outlined notranslate">${params.icon}</span>${params.title}`;
+  // create icon span tag only if icon is not an empty string
+  const el_icon =
+    params.icon === ''
+      ? ''
+      : mapp.utils
+          .html`<span class="material-symbols-outlined notranslate">${params.icon}</span>`;
+
+  params.header = mapp.utils.html`${el_icon}${params.title}`;
 
   params.innerContent ??= mapp.utils.html`<p>${params.text}</p>`;
 

--- a/lib/ui/elements/alert.mjs
+++ b/lib/ui/elements/alert.mjs
@@ -35,7 +35,6 @@ mapp.ui.elements.alert({
 @returns {HTMLElement} alert The alert element.
 */
 export default function alert(params) {
-
   // Fallback for compatibility with system alert dialog.
   if (typeof params === 'string') {
     params = { text: params };
@@ -60,8 +59,8 @@ export default function alert(params) {
       <button 
         class="action outlined bold"
         onclick=${(e) => {
-      e.target.closest('dialog').close();
-    }}>${mapp.dictionary.ok}`;
+          e.target.closest('dialog').close();
+        }}>${mapp.dictionary.ok}`;
 
   return mapp.ui.elements.dialog(params);
 }

--- a/lib/ui/elements/alert.mjs
+++ b/lib/ui/elements/alert.mjs
@@ -30,17 +30,20 @@ mapp.ui.elements.alert({
 @property {string} [params.data_id='alert'] The data-id attribute value for the dialog.
 @property {string} [params.title] Text to display in the alert header. Defaults to 'Information'.
 @property {string} [params.text] Text to display in the alert content. 
+@property {string} [params.icon] Custom Material Symbols icon name to use in the header for message clarity. Defaults to 'info'.
 @returns {HTMLElement} alert The alert element.
 */
 export default function alert(params) {
   params.title ??= `${mapp.dictionary.information}`;
 
+  params.icon ??= 'info';
+
   params.data_id ??= 'alert';
 
   params.class ??= 'alert-confirm';
 
-  params.header = mapp.utils.html`
-    <h4>${params.title}`;
+  params.header = mapp.utils
+    .html`<span class="material-symbols-outlined notranslate">${params.icon}</span>${params.title}`;
 
   params.content = mapp.utils.html`
     <p>${params.text}</p>

--- a/lib/ui/elements/alert.mjs
+++ b/lib/ui/elements/alert.mjs
@@ -35,6 +35,12 @@ mapp.ui.elements.alert({
 @returns {HTMLElement} alert The alert element.
 */
 export default function alert(params) {
+
+  // Fallback for compatibility with system alert dialog.
+  if (typeof params === 'string') {
+    params = { text: params };
+  }
+
   params.title ??= mapp.dictionary.information;
 
   params.icon ??= 'info';
@@ -54,8 +60,8 @@ export default function alert(params) {
       <button 
         class="action outlined bold"
         onclick=${(e) => {
-          e.target.closest('dialog').close();
-        }}>${mapp.dictionary.ok}`;
+      e.target.closest('dialog').close();
+    }}>${mapp.dictionary.ok}`;
 
   return mapp.ui.elements.dialog(params);
 }

--- a/lib/ui/elements/alert.mjs
+++ b/lib/ui/elements/alert.mjs
@@ -46,7 +46,7 @@ export default function alert(params) {
 
   params.data_id ??= 'alert';
 
-  params.class ??= 'alert-confirm';
+  params.class ??= 'alert-confirm no-select';
 
   params.header = mapp.utils
     .html`<span class="material-symbols-outlined notranslate">${params.icon}</span>${params.title}`;

--- a/lib/ui/elements/confirm.mjs
+++ b/lib/ui/elements/confirm.mjs
@@ -36,12 +36,13 @@ if(confirm) {
 @property {string} [params.data_id='confirm'] The data-id attribute value for the dialog.
 @property {string} [params.title] Text to display in the confirm header. Defaults to 'Confirm'.
 @property {string} [params.text] Text to display in the confirm content.
+@property {string} [params.innerContent] custom HTML fragment to display in the dialog, optional. Overrides text. 
 @property {string} [params.icon] Custom Material Symbols icon name to use in the header for message clarity. Defaults to 'warning'.
 @returns {Promise<boolean>} Returns promise which resolves to true or false whether the question was confirmed.
 */
 export default function confirm(params) {
   return new Promise((resolve, reject) => {
-    params.title ??= `${mapp.dictionary.confirm}`;
+    params.title ??= mapp.dictionary.confirm;
 
     params.icon ??= 'warning';
 
@@ -70,8 +71,10 @@ export default function confirm(params) {
       class="action outlined bold">
       ${mapp.dictionary.cancel}`;
 
-    params.content ??= mapp.utils.html`
-      <p>${params.text}</p>
+    params.innerContent ??= mapp.utils.html`<p>${params.text}</p>`;
+
+    params.content = mapp.utils.html`
+      ${params.innerContent}
       <div class="buttons">
         ${btn_true}  
         ${btn_false}`;

--- a/lib/ui/elements/confirm.mjs
+++ b/lib/ui/elements/confirm.mjs
@@ -65,17 +65,11 @@ export default function confirm(params) {
 
   delete params.closeBtn;
 
-  const btn_true = mapp.utils.html`<button 
-      onclick=${(e) => {
-        handle_user_action(e, true);
-      }}
+  const btn_true = mapp.utils.html.node`<button 
       class="action outlined bold">
       ${mapp.dictionary.ok}`;
 
-  const btn_false = mapp.utils.html`<button
-      onclick=${(e) => {
-        handle_user_action(e, false);
-      }}
+  const btn_false = mapp.utils.html.node`<button
       class="action outlined bold">
       ${mapp.dictionary.cancel}`;
 
@@ -90,21 +84,20 @@ export default function confirm(params) {
   params.class ??= 'alert-confirm box-shadow no-select';
 
   mapp.ui.elements.dialog(params);
-}
 
-/**
-@function handle_user_action
-
-@description
-Handles user response to confirm dialog.
-```
-@param {Object} e Click event on either of confirm window buttons.
-@property {Boolean} response Boolean flag indicating the choice.
-@returns {Promise} The promise will resolve to the user choice whether to proceed or cancel.
-*/
-function handle_user_action(e, response) {
   return new Promise((resolve, reject) => {
-    e.target.closest('dialog').close();
-    resolve(response);
+    const cleanup = (e) => {
+      e.target.closest('dialog').close();
+    };
+
+    btn_true.addEventListener('click', (e) => {
+      resolve(true);
+      cleanup(e);
+    });
+
+    btn_false.addEventListener('click', (e) => {
+      resolve(false);
+      cleanup(e);
+    });
   });
 }

--- a/lib/ui/elements/confirm.mjs
+++ b/lib/ui/elements/confirm.mjs
@@ -72,8 +72,6 @@ export default function confirm(params) {
       onclick=${(e) => {
         e.target.closest('dialog').close();
         resolve(false);
-
-        mapp.ui.elements.alert('You have cancelled this action.')
       }}
       class="action outlined bold">
       ${mapp.dictionary.cancel}`;

--- a/lib/ui/elements/confirm.mjs
+++ b/lib/ui/elements/confirm.mjs
@@ -36,15 +36,19 @@ if(confirm) {
 @property {string} [params.data_id='confirm'] The data-id attribute value for the dialog.
 @property {string} [params.title] Text to display in the confirm header. Defaults to 'Confirm'.
 @property {string} [params.text] Text to display in the confirm content.
+@property {string} [params.icon] Custom Material Symbols icon name to use in the header for message clarity. Defaults to 'warning'.
 @returns {Promise<boolean>} Returns promise which resolves to true or false whether the question was confirmed.
 */
 export default function confirm(params) {
   return new Promise((resolve, reject) => {
     params.title ??= `${mapp.dictionary.confirm}`;
 
+    params.icon ??= 'warning';
+
     params.data_id ??= 'confirm';
 
-    params.header = mapp.utils.html`<h4>${params.title}`;
+    params.header = mapp.utils
+      .html`<span class="material-symbols-outlined notranslate">${params.icon}</span>${params.title}`;
 
     delete params.minimizeBtn;
 
@@ -55,7 +59,7 @@ export default function confirm(params) {
         e.target.closest('dialog').close();
         resolve(true);
       }}
-      class="raised bold">
+      class="action outlined bold">
       ${mapp.dictionary.ok}`;
 
     const btn_false = mapp.utils.html`<button
@@ -63,7 +67,7 @@ export default function confirm(params) {
         e.target.closest('dialog').close();
         resolve(false);
       }}
-      class="raised bold">
+      class="action outlined bold">
       ${mapp.dictionary.cancel}`;
 
     params.content ??= mapp.utils.html`

--- a/lib/ui/elements/confirm.mjs
+++ b/lib/ui/elements/confirm.mjs
@@ -37,7 +37,7 @@ if(confirm) {
 @property {string} [params.title] Text to display in the confirm header. Defaults to 'Confirm'.
 @property {string} [params.text] Text to display in the confirm content.
 @property {HTMLElement} [params.innerContent] custom HTML fragment to display in the dialog, optional. Overrides text. 
-@property {string} [params.icon] Custom Material Symbols icon name to use in the header for message clarity. Defaults to 'warning'.
+@property {string} [params.icon] Custom Material Symbols icon name to use in the header for message clarity. Defaults to 'warning'. Set empty string `icon: ''` to skip the symbol entirely.
 @returns {Promise<boolean>} Returns promise which resolves to true or false whether the question was confirmed.
 */
 export default function confirm(params) {
@@ -51,10 +51,16 @@ export default function confirm(params) {
 
     params.icon ??= 'warning';
 
-    params.data_id ??= 'confirm no-select';
+    params.data_id ??= 'confirm';
 
-    params.header = mapp.utils
-      .html`<span class="material-symbols-outlined notranslate">${params.icon}</span>${params.title}`;
+    // create icon span tag only if icon is not an empty string
+    const el_icon =
+      params.icon === ''
+        ? ''
+        : mapp.utils
+            .html`<span class="material-symbols-outlined notranslate">${params.icon}</span>`;
+
+    params.header = mapp.utils.html`${el_icon}${params.title}`;
 
     delete params.minimizeBtn;
 
@@ -84,7 +90,7 @@ export default function confirm(params) {
         ${btn_true}  
         ${btn_false}`;
 
-    params.class ??= 'alert-confirm box-shadow';
+    params.class ??= 'alert-confirm box-shadow no-select';
 
     mapp.ui.elements.dialog(params);
   });

--- a/lib/ui/elements/confirm.mjs
+++ b/lib/ui/elements/confirm.mjs
@@ -41,6 +41,11 @@ if(confirm) {
 @returns {Promise<boolean>} Returns promise which resolves to true or false whether the question was confirmed.
 */
 export default function confirm(params) {
+  // Fallback for compatibility with system confirm dialog.
+  if (typeof params === 'string') {
+    params = { text: params };
+  }
+
   return new Promise((resolve, reject) => {
     params.title ??= mapp.dictionary.confirm;
 

--- a/lib/ui/elements/confirm.mjs
+++ b/lib/ui/elements/confirm.mjs
@@ -51,7 +51,7 @@ export default function confirm(params) {
 
     params.icon ??= 'warning';
 
-    params.data_id ??= 'confirm';
+    params.data_id ??= 'confirm no-select';
 
     params.header = mapp.utils
       .html`<span class="material-symbols-outlined notranslate">${params.icon}</span>${params.title}`;
@@ -72,6 +72,8 @@ export default function confirm(params) {
       onclick=${(e) => {
         e.target.closest('dialog').close();
         resolve(false);
+
+        mapp.ui.elements.alert('You have cancelled this action.')
       }}
       class="action outlined bold">
       ${mapp.dictionary.cancel}`;

--- a/lib/ui/elements/confirm.mjs
+++ b/lib/ui/elements/confirm.mjs
@@ -86,18 +86,14 @@ export default function confirm(params) {
   mapp.ui.elements.dialog(params);
 
   return new Promise((resolve, reject) => {
-    const cleanup = (e) => {
-      e.target.closest('dialog').close();
-    };
-
     btn_true.addEventListener('click', (e) => {
       resolve(true);
-      cleanup(e);
+      params.close();
     });
 
     btn_false.addEventListener('click', (e) => {
       resolve(false);
-      cleanup(e);
+      params.close();
     });
   });
 }

--- a/lib/ui/elements/confirm.mjs
+++ b/lib/ui/elements/confirm.mjs
@@ -85,13 +85,13 @@ export default function confirm(params) {
 
   mapp.ui.elements.dialog(params);
 
-  return new Promise((resolve, reject) => {
-    btn_true.addEventListener('click', (e) => {
+  return new Promise((resolve) => {
+    btn_true.addEventListener('click', () => {
       resolve(true);
       params.close();
     });
 
-    btn_false.addEventListener('click', (e) => {
+    btn_false.addEventListener('click', () => {
       resolve(false);
       params.close();
     });

--- a/lib/ui/elements/confirm.mjs
+++ b/lib/ui/elements/confirm.mjs
@@ -36,7 +36,7 @@ if(confirm) {
 @property {string} [params.data_id='confirm'] The data-id attribute value for the dialog.
 @property {string} [params.title] Text to display in the confirm header. Defaults to 'Confirm'.
 @property {string} [params.text] Text to display in the confirm content.
-@property {string} [params.innerContent] custom HTML fragment to display in the dialog, optional. Overrides text. 
+@property {HTMLElement} [params.innerContent] custom HTML fragment to display in the dialog, optional. Overrides text. 
 @property {string} [params.icon] Custom Material Symbols icon name to use in the header for message clarity. Defaults to 'warning'.
 @returns {Promise<boolean>} Returns promise which resolves to true or false whether the question was confirmed.
 */

--- a/lib/ui/elements/confirm.mjs
+++ b/lib/ui/elements/confirm.mjs
@@ -100,7 +100,7 @@ Handles user response to confirm dialog.
 ```
 @param {Object} e Click event on either of confirm window buttons.
 @property {Boolean} response Boolean flag indicating the choice.
-@returns {Promise} The promise will resolve to the user choice whether to proceed ot cancel.
+@returns {Promise} The promise will resolve to the user choice whether to proceed or cancel.
 */
 function handle_user_action(e, response) {
   return new Promise((resolve, reject) => {

--- a/lib/ui/elements/confirm.mjs
+++ b/lib/ui/elements/confirm.mjs
@@ -46,52 +46,65 @@ export default function confirm(params) {
     params = { text: params };
   }
 
-  return new Promise((resolve, reject) => {
-    params.title ??= mapp.dictionary.confirm;
+  params.title ??= mapp.dictionary.confirm;
 
-    params.icon ??= 'warning';
+  params.data_id ??= 'confirm';
 
-    params.data_id ??= 'confirm';
+  params.icon ??= 'warning';
 
-    // create icon span tag only if icon is not an empty string
-    const el_icon =
-      params.icon === ''
-        ? ''
-        : mapp.utils
-            .html`<span class="material-symbols-outlined notranslate">${params.icon}</span>`;
+  // create icon span tag only if icon is not an empty string
+  const el_icon =
+    params.icon === ''
+      ? ''
+      : mapp.utils
+          .html`<span class="material-symbols-outlined notranslate">${params.icon}</span>`;
 
-    params.header = mapp.utils.html`${el_icon}${params.title}`;
+  params.header = mapp.utils.html`${el_icon}${params.title}`;
 
-    delete params.minimizeBtn;
+  delete params.minimizeBtn;
 
-    delete params.closeBtn;
+  delete params.closeBtn;
 
-    const btn_true = mapp.utils.html`<button 
+  const btn_true = mapp.utils.html`<button 
       onclick=${(e) => {
-        e.target.closest('dialog').close();
-        resolve(true);
+        handle_user_action(e, true);
       }}
       class="action outlined bold">
       ${mapp.dictionary.ok}`;
 
-    const btn_false = mapp.utils.html`<button
+  const btn_false = mapp.utils.html`<button
       onclick=${(e) => {
-        e.target.closest('dialog').close();
-        resolve(false);
+        handle_user_action(e, false);
       }}
       class="action outlined bold">
       ${mapp.dictionary.cancel}`;
 
-    params.innerContent ??= mapp.utils.html`<p>${params.text}</p>`;
+  params.innerContent ??= mapp.utils.html`<p>${params.text}</p>`;
 
-    params.content = mapp.utils.html`
+  params.content = mapp.utils.html`
       ${params.innerContent}
       <div class="buttons">
         ${btn_true}  
         ${btn_false}`;
 
-    params.class ??= 'alert-confirm box-shadow no-select';
+  params.class ??= 'alert-confirm box-shadow no-select';
 
-    mapp.ui.elements.dialog(params);
+  mapp.ui.elements.dialog(params);
+}
+
+/**
+@function handle_user_action
+
+@description
+Handles user response to confirm dialog.
+```
+@param {Object} e Click event on either of confirm window buttons.
+@property {Boolean} response Boolean flag indicating the choice.
+@returns {Promise} The promise will resolve to the user choice whether to proceed ot cancel.
+*/
+function handle_user_action(e, response) {
+  return new Promise((resolve, reject) => {
+    e.target.closest('dialog').close();
+    resolve(response);
   });
 }

--- a/public/css/base/_button.css
+++ b/public/css/base/_button.css
@@ -19,6 +19,10 @@ button {
     cursor: pointer;
   }
 
+  &:active {
+    scale: 0.96; /* scaling effect as response to click event */
+  }
+
   &:disabled {
     opacity: 0.3;
     &:hover {

--- a/public/css/elements/_alert_confirm.css
+++ b/public/css/elements/_alert_confirm.css
@@ -17,7 +17,7 @@ dialog.alert-confirm {
     align-items: center;
   }
 
-  p {
+  .content > p {
     white-space: pre;
     text-wrap: pretty;
     margin: 1em;

--- a/public/css/elements/_alert_confirm.css
+++ b/public/css/elements/_alert_confirm.css
@@ -20,7 +20,7 @@ dialog.alert-confirm {
   p {
     white-space: pre;
     text-wrap: pretty;
-    margin: 1em 0.5em;
+    margin: 1em;
   }
 
   .buttons {

--- a/public/css/elements/_alert_confirm.css
+++ b/public/css/elements/_alert_confirm.css
@@ -1,11 +1,6 @@
 dialog.alert-confirm {
   width: 350px;
   max-height: 70%;
-  -webkit-touch-callout: none;
-  -webkit-user-select: none;
-  -moz-user-select: none;
-  -ms-user-select: none;
-  user-select: none;
   padding: 0.5em;
 
   &::-webkit-scrollbar {
@@ -23,7 +18,7 @@ dialog.alert-confirm {
   }
 
   .content {
-    padding: 1em;
+    padding: 1em 0;
   }
 
   p {
@@ -33,20 +28,13 @@ dialog.alert-confirm {
   }
 
   .buttons {
-    margin-top: 2em;
     display: flex;
     justify-content: flex-end;
     gap: 0.5em;
+    padding: 0 0.5em;
   }
 
   button {
     min-width: 100px;
-  }
-}
-
-@media only screen and (max-width: 768px) {
-  dialog.alert-confirm {
-    min-width: 350px;
-    max-width: 70%;
   }
 }

--- a/public/css/elements/_alert_confirm.css
+++ b/public/css/elements/_alert_confirm.css
@@ -6,6 +6,7 @@ dialog.alert-confirm {
   -moz-user-select: none;
   -ms-user-select: none;
   user-select: none;
+  padding: 0.5em;
 
   &::-webkit-scrollbar {
     display: none;
@@ -16,7 +17,6 @@ dialog.alert-confirm {
   }
 
   h2 {
-    padding: 0.5em 1em;
     display: flex;
     gap: 0.2em;
     align-items: center;
@@ -35,8 +35,8 @@ dialog.alert-confirm {
   .buttons {
     margin-top: 2em;
     display: flex;
-    justify-content: flex-end; 
-    gap: 0.5em; 
+    justify-content: flex-end;
+    gap: 0.5em;
   }
 
   button {

--- a/public/css/elements/_alert_confirm.css
+++ b/public/css/elements/_alert_confirm.css
@@ -18,7 +18,7 @@ dialog.alert-confirm {
   }
 
   .content > p {
-    white-space: pre;
+    white-space: pre-wrap; /* allows support of line breaks `\n` in text */
     text-wrap: pretty;
     margin: 1em;
   }

--- a/public/css/elements/_alert_confirm.css
+++ b/public/css/elements/_alert_confirm.css
@@ -15,12 +15,11 @@ dialog.alert-confirm {
     outline: none;
   }
 
-  h4 {
+  h2 {
     padding: 0.5em 1em;
-    background-color: var(--color-primary);
-    border-bottom: solid 2px var(--color-border);
-    color: var(--color-font-contrast);
-    width: 100%;
+    display: flex;
+    gap: 0.2em;
+    align-items: center;
   }
 
   .content {
@@ -30,21 +29,18 @@ dialog.alert-confirm {
   p {
     white-space: pre;
     text-wrap: pretty;
-    text-align: center;
     margin: 0 1em 1em;
   }
 
   .buttons {
-    display: grid;
-    grid-template-columns: repeat(2, 1fr);
-    grid-gap: 0.2em;
+    margin-top: 2em;
+    display: flex;
+    justify-content: flex-end; 
+    gap: 0.5em; 
   }
 
   button {
-    float: right;
-    font-size: 0.9em;
-    color: var(--color-primary);
-    z-index: 1005;
+    width: 100px;
   }
 }
 

--- a/public/css/elements/_alert_confirm.css
+++ b/public/css/elements/_alert_confirm.css
@@ -1,7 +1,7 @@
 dialog.alert-confirm {
   width: 350px;
   max-height: 70%;
-  padding: 0.5em;
+  padding: 0.75em;
 
   &::-webkit-scrollbar {
     display: none;
@@ -17,21 +17,16 @@ dialog.alert-confirm {
     align-items: center;
   }
 
-  .content {
-    padding: 1em 0;
-  }
-
   p {
     white-space: pre;
     text-wrap: pretty;
-    margin: 0 1em 1em;
+    margin: 1em 0.5em;
   }
 
   .buttons {
     display: flex;
     justify-content: flex-end;
     gap: 0.5em;
-    padding: 0 0.5em;
   }
 
   button {

--- a/public/css/elements/_alert_confirm.css
+++ b/public/css/elements/_alert_confirm.css
@@ -20,7 +20,7 @@ dialog.alert-confirm {
   .content > p {
     white-space: pre-wrap; /* allows support of line breaks `\n` in text */
     text-wrap: pretty;
-    margin: 1em;
+    margin: 1em 0;
   }
 
   .buttons {

--- a/public/css/elements/_alert_confirm.css
+++ b/public/css/elements/_alert_confirm.css
@@ -40,7 +40,7 @@ dialog.alert-confirm {
   }
 
   button {
-    width: 100px;
+    min-width: 100px;
   }
 }
 

--- a/public/css/mapp.css
+++ b/public/css/mapp.css
@@ -172,6 +172,7 @@ body {
       }
       &.nowrap {
         flex-wrap: nowrap;
+        overflow: scroll;
         & .contents {
           justify-content: flex-start;
           & .label {

--- a/public/css/ui.css
+++ b/public/css/ui.css
@@ -438,7 +438,7 @@ dialog.alert-confirm {
   p {
     white-space: pre;
     text-wrap: pretty;
-    margin: 1em 0.5em;
+    margin: 1em;
   }
   .buttons {
     display: flex;

--- a/public/css/ui.css
+++ b/public/css/ui.css
@@ -431,12 +431,11 @@ dialog.alert-confirm {
   &:focus {
     outline: none;
   }
-  h4 {
+  h2 {
     padding: 0.5em 1em;
-    background-color: var(--color-primary);
-    border-bottom: solid 2px var(--color-border);
-    color: var(--color-font-contrast);
-    width: 100%;
+    display: flex;
+    gap: 0.2em;
+    align-items: center;
   }
   .content {
     padding: 1em;
@@ -444,19 +443,16 @@ dialog.alert-confirm {
   p {
     white-space: pre;
     text-wrap: pretty;
-    text-align: center;
     margin: 0 1em 1em;
   }
   .buttons {
-    display: grid;
-    grid-template-columns: repeat(2, 1fr);
-    grid-gap: 0.2em;
+    margin-top: 2em;
+    display: flex;
+    justify-content: flex-end;
+    gap: 0.5em;
   }
   button {
-    float: right;
-    font-size: 0.9em;
-    color: var(--color-primary);
-    z-index: 1005;
+    width: 100px;
   }
 }
 @media only screen and (max-width: 768px) {

--- a/public/css/ui.css
+++ b/public/css/ui.css
@@ -132,6 +132,9 @@ button {
   &:hover {
     cursor: pointer;
   }
+  &:active {
+    scale: 0.96;
+  }
   &:disabled {
     opacity: 0.3;
     &:hover {
@@ -425,6 +428,7 @@ dialog.alert-confirm {
   -moz-user-select: none;
   -ms-user-select: none;
   user-select: none;
+  padding: 0.5em;
   &::-webkit-scrollbar {
     display: none;
   }
@@ -432,7 +436,6 @@ dialog.alert-confirm {
     outline: none;
   }
   h2 {
-    padding: 0.5em 1em;
     display: flex;
     gap: 0.2em;
     align-items: center;

--- a/public/css/ui.css
+++ b/public/css/ui.css
@@ -438,7 +438,7 @@ dialog.alert-confirm {
   .content > p {
     white-space: pre-wrap;
     text-wrap: pretty;
-    margin: 1em;
+    margin: 1em 0;
   }
   .buttons {
     display: flex;

--- a/public/css/ui.css
+++ b/public/css/ui.css
@@ -423,7 +423,7 @@ input[type=search]::-webkit-calendar-picker-indicator {
 dialog.alert-confirm {
   width: 350px;
   max-height: 70%;
-  padding: 0.5em;
+  padding: 0.75em;
   &::-webkit-scrollbar {
     display: none;
   }
@@ -435,19 +435,15 @@ dialog.alert-confirm {
     gap: 0.2em;
     align-items: center;
   }
-  .content {
-    padding: 1em 0;
-  }
   p {
     white-space: pre;
     text-wrap: pretty;
-    margin: 0 1em 1em;
+    margin: 1em 0.5em;
   }
   .buttons {
     display: flex;
     justify-content: flex-end;
     gap: 0.5em;
-    padding: 0 0.5em;
   }
   button {
     min-width: 100px;

--- a/public/css/ui.css
+++ b/public/css/ui.css
@@ -435,7 +435,7 @@ dialog.alert-confirm {
     gap: 0.2em;
     align-items: center;
   }
-  p {
+  .content > p {
     white-space: pre;
     text-wrap: pretty;
     margin: 1em;

--- a/public/css/ui.css
+++ b/public/css/ui.css
@@ -423,11 +423,6 @@ input[type=search]::-webkit-calendar-picker-indicator {
 dialog.alert-confirm {
   width: 350px;
   max-height: 70%;
-  -webkit-touch-callout: none;
-  -webkit-user-select: none;
-  -moz-user-select: none;
-  -ms-user-select: none;
-  user-select: none;
   padding: 0.5em;
   &::-webkit-scrollbar {
     display: none;
@@ -441,7 +436,7 @@ dialog.alert-confirm {
     align-items: center;
   }
   .content {
-    padding: 1em;
+    padding: 1em 0;
   }
   p {
     white-space: pre;
@@ -449,19 +444,13 @@ dialog.alert-confirm {
     margin: 0 1em 1em;
   }
   .buttons {
-    margin-top: 2em;
     display: flex;
     justify-content: flex-end;
     gap: 0.5em;
+    padding: 0 0.5em;
   }
   button {
     min-width: 100px;
-  }
-}
-@media only screen and (max-width: 768px) {
-  dialog.alert-confirm {
-    min-width: 350px;
-    max-width: 70%;
   }
 }
 

--- a/public/css/ui.css
+++ b/public/css/ui.css
@@ -436,7 +436,7 @@ dialog.alert-confirm {
     align-items: center;
   }
   .content > p {
-    white-space: pre;
+    white-space: pre-wrap;
     text-wrap: pretty;
     margin: 1em;
   }

--- a/public/css/ui.css
+++ b/public/css/ui.css
@@ -455,7 +455,7 @@ dialog.alert-confirm {
     gap: 0.5em;
   }
   button {
-    width: 100px;
+    min-width: 100px;
   }
 }
 @media only screen and (max-width: 768px) {

--- a/public/dictionaries/en.mjs
+++ b/public/dictionaries/en.mjs
@@ -3,7 +3,7 @@ export default {
   circle_config: 'Circle configuration',
   confirm: 'Confirm',
   confirm_delete:
-    'Are you sure you want to delete this feature? This cannot be undone.',
+    'Are you sure you want to delete this feature? \nThis cannot be undone.',
   create: 'Create',
   csv_upload_failed: 'Data import failed, please try again.',
   csv_upload_import: 'Import From CSV',


### PR DESCRIPTION
Introduced changes

* alert/confirm css - removed rules for inverted background and font colour, removed header border. Header now plain.
* removed redundant h4 tag nested inside `header > h2`. Now each dialog has h2 tag only, generated by dialog method.
* buttons now outlined and inside a flexbox aligned right.
* text now aligned left, previously centered which would make it look like a poem.
* removed fixed `z-index: 1005` from confirm/alert buttons, it did nothing.
* new property `icon` - header icons now added for readability. Set `params.icon` to use any icon in the header for better readability and clear context. If unset, fallback to defaults.
* new property `innerContent` - allows adding custom html fragment instead of text only as well as separation of custom html and functional buttons.
* cancel/ok buttons now outside customisable dialog content.
* minor scaling effect on buttons in active state, it gives users response that the button has been clicked.
* updated docs.

<img width="386" height="201" alt="Screenshot 2026-03-27 at 16 11 20" src="https://github.com/user-attachments/assets/8a458dd3-0f15-4bfe-8b40-bec0cb25c387" />
