### PR TITLE
Add viewConfig.keyOrder to layer view module

### DIFF
--- a/lib/ui/layers/view.mjs
+++ b/lib/ui/layers/view.mjs
@@ -110,7 +110,7 @@ function viewConfig(layer) {
 
   if (layer.viewConfig.keyOrder) {
 
-        // Create content from layer view panels and plugins
+    // Create content from layer view panel methods which may be extended through plugins.
     layer.viewConfig.content = Object.keys(layer)
       .sort((a, b) => {
         return layer.viewConfig.keyOrder.indexOf(a) - layer.viewConfig.keyOrder.indexOf(b);

--- a/lib/ui/layers/view.mjs
+++ b/lib/ui/layers/view.mjs
@@ -108,20 +108,31 @@ function viewConfig(layer) {
     ];
   }
 
-  // Create content from layer view panels and plugins
-  layer.viewConfig.content = Object.keys(layer)
-    .map((key) => mapp.ui.layers?.panels?.[key]?.(layer))
-    .filter((panel) => typeof panel !== 'undefined');
+  if (layer.viewConfig.keyOrder) {
 
-  if (Array.isArray(layer.viewConfig.panelOrder)) {
-    // Sort the content array according to the data-id in the panelOrder array.
-    layer.viewConfig.content.sort((a, b) => {
-      return layer.viewConfig.panelOrder.findIndex(
-        (chk) => chk === a.dataset?.id,
-      ) < layer.viewConfig.panelOrder.findIndex((chk) => chk === b.dataset?.id)
-        ? 1
-        : -1;
-    });
+        // Create content from layer view panels and plugins
+    layer.viewConfig.content = Object.keys(layer)
+      .sort((a, b) => {
+        return layer.viewConfig.keyOrder.indexOf(a) - layer.viewConfig.keyOrder.indexOf(b);
+      })
+      .map((key) => mapp.ui.layers?.panels?.[key]?.(layer))
+      .filter((panel) => typeof panel !== 'undefined');
+
+  } else {
+
+    // Create content from layer view panels and plugins
+    layer.viewConfig.content = Object.keys(layer)
+      .map((key) => mapp.ui.layers?.panels?.[key]?.(layer))
+      .filter((panel) => typeof panel !== 'undefined');
+
+    if (Array.isArray(layer.viewConfig.panelOrder)) {
+      // Sort the content array according to the data-id in the panelOrder array.
+      layer.viewConfig.content.sort((a, b) => {
+        const aIndex = layer.viewConfig.panelOrder.findIndex((chk) => chk === a.dataset?.id);
+        const bIndex = layer.viewConfig.panelOrder.findIndex((chk) => chk === b.dataset?.id);
+        return aIndex < bIndex ? 1 : -1;
+      });
+    }
   }
 
   // layer.classList is the legacy configuration for layer.viewConfig.classList


### PR DESCRIPTION
I believe that the panelOrder is wrong and misleading. A much cleaner approach would be to use a keyOrder array which does exctly that.

```js
    layer.viewConfig.content = Object.keys(layer)
      .sort((a, b) => {
        return layer.viewConfig.keyOrder.indexOf(a) - layer.viewConfig.keyOrder.indexOf(b);
      })
      .map((key) => mapp.ui.layers?.panels?.[key]?.(layer))
      .filter((panel) => typeof panel !== 'undefined');
```