### PR TITLE
assign viewport on fail or warn

### DIFF
--- a/lib/ui/layers/panels/filter.mjs
+++ b/lib/ui/layers/panels/filter.mjs
@@ -116,6 +116,7 @@ export default function filterPanel(layer) {
   layer.filter.count = mapp.utils.html.node`<span class="bold">`;
 
   layer.changeEndCallbacks.push(updatePanel);
+  layer.showCallbacks.push(updatePanel);
 
   layer.hideCallbacks.push((layer) => {
     if (layer.filter.clearAll?.checkVisibility()) {

--- a/lib/ui/utils/locationCount.mjs
+++ b/lib/ui/utils/locationCount.mjs
@@ -45,5 +45,15 @@ export default async function locationCount(layer) {
     `${layer.mapview.host}/api/query?${paramString}`,
   );
 
+  if (feature_count instanceof Error) {
+    if (layer.filter.viewport) {
+      console.warn('locationCount failed on viewport.');
+      return;
+    } else {
+      layer.filter.viewport = true;
+      return await locationCount(layer);
+    }
+  }
+
   return feature_count;
 }

--- a/lib/ui/utils/locationCount.mjs
+++ b/lib/ui/utils/locationCount.mjs
@@ -46,7 +46,7 @@ export default async function locationCount(layer) {
   );
 
   if (feature_count instanceof Error) {
-    if (layer.filter.viewport) {
+    if (layer.filter?.viewport) {
       console.warn('locationCount failed on viewport.');
       return;
     } else {


### PR DESCRIPTION
The location count method is susceptible to timeouts without the filter.viewport flag.

The viewport will be assigned and the locationCount method will be repeated.

A warning will be issued if the method fails with the viewport flag assigned.

Showing a layer will not trigger a changeEnd event on the mapview. The updatePanel method is debounced and should be added to the showCallbacks as well as the changeEndCallback.