### PR TITLE
bump openlayers to 10.8 in default view and olScript

### DIFF
--- a/lib/utils/_utils.mjs
+++ b/lib/utils/_utils.mjs
@@ -30,7 +30,7 @@ The olScript uses the scriptElement utility method to load the Openlayers Applic
 */
 async function olScript() {
   await mapp.utils.scriptElement(
-    'https://cdn.jsdelivr.net/npm/ol@v10.7.0/dist/ol.js',
+    'https://cdn.jsdelivr.net/npm/ol@v10.8.0/dist/ol.js',
     'application/javascript',
   );
 }

--- a/public/views/_default.html
+++ b/public/views/_default.html
@@ -37,8 +37,8 @@
     >
 
     <script
-      src="https://cdn.jsdelivr.net/npm/ol@v10.7.0/dist/ol.js"
-      integrity="sha384-qOOSJiS2JFfTVFYlMWDZ9lm0HB7AJJ4/T2ddoSLlHWSxIeIhirHrHlarHoEOIev3"
+      src="https://cdn.jsdelivr.net/npm/ol@v10.8.0/dist/ol.js"
+      integrity="sha384-MW7s77hf0z6FJ3pLxOJ3STIrnMERs4FRQEDpqDrHpJX1mG0qr5Zd9glUb5XC4dA0"
       crossorigin="anonymous"
     ></script>
 


### PR DESCRIPTION
Openlayers 10.8 was released in February and introduces a ton of fixes: https://github.com/openlayers/openlayers/releases/tag/v10.8.0

The willReadFrequently flag is now determined by measuring performance.