### PR TITLE
remove api module logging and dbs failure logging

### DIFF
--- a/api/api.js
+++ b/api/api.js
@@ -22,7 +22,6 @@ app.get(`/`, api)
 @requires /user/auth
 @requires /user/saml
 @requires /user/register
-@requires /utils/logger
 @module /api
 */
 
@@ -52,7 +51,6 @@ import auth from '../mod/user/auth.js';
 import login from '../mod/user/login.js';
 import register from '../mod/user/register.js';
 import saml from '../mod/user/saml.js';
-import logger from '../mod/utils/logger.js';
 import { setRedirect } from '../mod/utils/redirect.js';
 import view from '../mod/view.js';
 import workspace from '../mod/workspace/_workspace.js';
@@ -74,8 +72,6 @@ const routes = {
 The API method will redirect requests with a request url length 1 and xyzEnv.DIR.
 
 eg. A request to localhost:3000 with a DIR = "/mapp" will be redirected to localhost:3000/mapp
-
-The request object itself or the request object url will be logged with the `req` or `req_url` keys in xyzEnv.LOGS.
 
 Requests with the url matching the /saml/ path will be passed to the [saml module]{@link module:/user/saml}.
 
@@ -102,8 +98,6 @@ export default function api(req, res) {
     res.setHeader('location', `${xyzEnv.DIR}`);
     return res.status(302).send();
   }
-
-  logger(req.url, 'req_url');
 
   // SAML request.
   if (req.url.match(/\/saml/)) {

--- a/mod/utils/dbs.js
+++ b/mod/utils/dbs.js
@@ -109,7 +109,7 @@ async function clientQuery(pool, query, variables, timeout) {
       if (retryCount < RETRY_LIMIT) {
         // Exponential backoff
         const delay = INITIAL_RETRY_DELAY * Math.pow(2, retryCount - 1);
-        await sleep(delay);
+        await new Promise((resolve) => setTimeout(resolve, delay));
       }
 
       lastError = err;
@@ -122,16 +122,4 @@ async function clientQuery(pool, query, variables, timeout) {
 
   // If we've exhausted all retries, return the last error
   return lastError;
-}
-
-/**
-@function sleep
-@description
-Helper function to pause execution
-
-@param {number} ms Time to sleep in milliseconds
-@returns {Promise<void>}
-*/
-function sleep(ms) {
-  return new Promise((resolve) => setTimeout(resolve, ms));
 }

--- a/mod/utils/dbs.js
+++ b/mod/utils/dbs.js
@@ -99,14 +99,7 @@ async function clientQuery(pool, query, variables, timeout) {
 
       return rows;
     } catch (err) {
-      // Log the error with retry information
-      logger({
-        err,
-        pool: pool.options.dbs,
-        query,
-        retry: retryCount + 1,
-        variables,
-      });
+      console.error(err);
 
       // Return error if not in retry whitelist
       if (!RETRY_CODES.has(err.code)) return err;

--- a/mod/utils/logger.js
+++ b/mod/utils/logger.js
@@ -150,15 +150,12 @@ function postgresql() {
     //This is to pull the short Error message from the stack
     const errorMessage = log.err?.toString().split('\n')[0];
 
-    try {
-      await dbs[params.dbs](
-        `INSERT INTO ${table} (process, datetime, key, log, message)
-        VALUES ($1, $2, $3, $4, $5)`,
-        [process_id, parseInt(Date.now() / 1000), key, logstring, errorMessage],
-        3000,
-      );
-    } catch (error) {
-      console.error('Error while logging to database:', error);
-    }
+    dbs[params.dbs](
+      `INSERT INTO ${table} 
+      (process, datetime, key, log, message)
+      VALUES ($1, $2, $3, $4, $5)`,
+      [process_id, parseInt(Date.now() / 1000), key, logstring, errorMessage],
+      3000,
+    );
   };
 }

--- a/mod/utils/logger.js
+++ b/mod/utils/logger.js
@@ -4,7 +4,6 @@ This module provides a logging utility for the XYZ API. The LOG process environm
 
 Possible log values are:
 
-- req_url: Logs the url of the request.
 - query_params: Logs query parameters sent to the query endpoint.
 - query: Logs the sql to executed by calling the query endpoint.
 - view-req-url: Logs the url of the requested view.


### PR DESCRIPTION
API module logging has been removed in this PR. At best this creates a lot of junk which should be gathered and drained somewhere else. Deployments to vercel and pretty much any other cloud function provider allow to drain request logs. At worst the excessive logs stuff up the database.

#2664 changed the logger module to use the DBS module.

This PR removes the logger from the DBS module. Excessive logs which may stuff up the logging database would otherwise regress as logger then tries to log to the database it's failure to log to the database in the first place.

The call to the DBS module from the logger module shouldn't require to be awaited or tried.

A promise can be awaited instead of awaiting a function that returns the promise.