### PR TITLE
fix(Entry/Type:Layer) -Show Panel on Show(); Hide on Hide()

### DIFF
--- a/lib/ui/locations/entries/layer.mjs
+++ b/lib/ui/locations/entries/layer.mjs
@@ -219,8 +219,8 @@ async function decorateLayer(entry) {
     entry.style.default = { ...entry.location?.style, ...entry.style.default };
   }
 
-  // Append style panel to layer panel, if style is available.
-  entry.style.panel && entry.panel.append(entry.style.panel);
+  // Append style panel to layer panel, if style is available and layer is already on.
+  entry.style.panel && entry.display && entry.panel.append(entry.style.panel);
 
   entry.location.removeCallbacks.push(() => {
     entry.remove();
@@ -258,6 +258,10 @@ async function showLayer() {
       // Replace the panel with the display_toggle, as no style panel should be shown.
       entry.panel.replaceChildren(entry.display_toggle);
       return;
+    } 
+    // If data is available, we need to append the style panel, if available.
+    else {
+      entry.style.panel && entry.panel.append(entry.style.panel)
     }
   }
 
@@ -323,6 +327,9 @@ A custom hide [layer] method bound to the [layer] entry which will not update th
 */
 function hideLayer() {
   this.display = false;
+
+  // Remove style panel from layer panel.
+  this.style.panel && this.panel.removeChild(this.style.panel);
 
   // Remove OL layer from mapview.
   this.mapview.Map.removeLayer(this.L);

--- a/lib/ui/locations/entries/layer.mjs
+++ b/lib/ui/locations/entries/layer.mjs
@@ -219,8 +219,11 @@ async function decorateLayer(entry) {
     entry.style.default = { ...entry.location?.style, ...entry.style.default };
   }
 
-  // Append style panel to layer panel, if style is available and layer is already on.
-  entry.style.panel && entry.display && entry.panel.append(entry.style.panel);
+  // Set style panel to display none initially.
+  entry.style.panel?.style.setProperty('display', 'none');
+
+  // Append style panel to layer panel, if style is available.
+  entry.style.panel && entry.panel.append(entry.style.panel);
 
   entry.location.removeCallbacks.push(() => {
     entry.remove();
@@ -259,14 +262,11 @@ async function showLayer() {
       entry.panel.replaceChildren(entry.display_toggle);
       return;
     }
-    // If data is available, we need to append the style panel, if available.
-    else {
-      entry.style.panel && entry.panel.append(entry.style.panel);
-    }
   }
 
   featureData(entry);
 
+  entry.style.panel?.style.setProperty('display', 'block');
   entry.display = true;
 
   try {
@@ -328,9 +328,8 @@ A custom hide [layer] method bound to the [layer] entry which will not update th
 function hideLayer() {
   this.display = false;
 
-  // Remove style panel from layer panel.
-  this.style.panel?.remove();
-
+  // Set style panel to display none.
+  this.style.panel?.style.setProperty('display', 'none');
   // Remove OL layer from mapview.
   this.mapview.Map.removeLayer(this.L);
 

--- a/lib/ui/locations/entries/layer.mjs
+++ b/lib/ui/locations/entries/layer.mjs
@@ -329,7 +329,7 @@ function hideLayer() {
   this.display = false;
 
   // Remove style panel from layer panel.
-  this.style.panel && this.panel.removeChild(this.style.panel);
+  this.style.panel?.remove();
 
   // Remove OL layer from mapview.
   this.mapview.Map.removeLayer(this.L);

--- a/lib/ui/locations/entries/layer.mjs
+++ b/lib/ui/locations/entries/layer.mjs
@@ -258,10 +258,10 @@ async function showLayer() {
       // Replace the panel with the display_toggle, as no style panel should be shown.
       entry.panel.replaceChildren(entry.display_toggle);
       return;
-    } 
+    }
     // If data is available, we need to append the style panel, if available.
     else {
-      entry.style.panel && entry.panel.append(entry.style.panel)
+      entry.style.panel && entry.panel.append(entry.style.panel);
     }
   }
 


### PR DESCRIPTION
## Description
This PR tweaks the display of the style panel for a type layer entry

Initially, style panel is hidden
In show - display it
In hide - hide it

## Type of Change
- ✅ Bug fix (non-breaking change which fixes an issue)

## How have you tested this?
Tested against a type layer which is not display true but returns a style panel
