### PR TITLE
fix(distributed_theme.legend): Assign `filterOnly` to filter only on the map

### DIFF
--- a/lib/ui/layers/legends/distributed.mjs
+++ b/lib/ui/layers/legends/distributed.mjs
@@ -20,6 +20,7 @@ The distributedTheme method creates and returns a distributed theme legend for t
 @returns {HTMLElement} The distributed theme legend element.
 */
 export default function distributedTheme(layer) {
+  //Apply filterOnly so the filtering action on the theme is only visual.
   layer.style.theme.filterOnly = true;
   const theme = layer.style.theme;
 

--- a/lib/ui/layers/legends/distributed.mjs
+++ b/lib/ui/layers/legends/distributed.mjs
@@ -20,6 +20,7 @@ The distributedTheme method creates and returns a distributed theme legend for t
 @returns {HTMLElement} The distributed theme legend element.
 */
 export default function distributedTheme(layer) {
+  layer.style.theme.filterOnly = true;
   const theme = layer.style.theme;
 
   themeLegend(theme);

--- a/lib/ui/layers/legends/utils.mjs
+++ b/lib/ui/layers/legends/utils.mjs
@@ -29,7 +29,7 @@ export function catElement(cat, theme, layer) {
 
   // Check whether cat is in current filter.
   cat.disabled = layer.filter?.current[cat.field]?.ni?.some(
-    (el) => el === cat.value || cat.values.includes(el),
+    (el) => el === cat.value || cat.values?.includes(el),
   );
 
   if (!cat.disabled) {
@@ -198,10 +198,13 @@ async function filterRemove(layer, cat) {
     }
   } else {
     // Splice value out of the NI array.
-    layer.filter.current[cat.field].ni.splice(
-      layer.filter.current[cat.field].ni.indexOf(cat.value),
-      1,
-    );
+    const catValue = cat.values || [cat.value];
+    for (const val of catValue) {
+      layer.filter.current[cat.field].ni.splice(
+        layer.filter.current[cat.field].ni.indexOf(val),
+        1,
+      );
+    }
   }
 
   // Delete current field filter if NI array is empty.

--- a/lib/ui/layers/legends/utils.mjs
+++ b/lib/ui/layers/legends/utils.mjs
@@ -28,7 +28,9 @@ export function catElement(cat, theme, layer) {
   cat.field ??= theme.field;
 
   // Check whether cat is in current filter.
-  cat.disabled = layer.filter?.current[cat.field]?.ni?.includes(cat.value);
+  cat.disabled = layer.filter?.current[cat.field]?.ni?.some(
+    (el) => el === cat.value || cat.values.includes(el),
+  );
 
   if (!cat.disabled) {
     // The style must be restored for the theme layer render.
@@ -157,7 +159,7 @@ async function filterAdd(layer, cat) {
   }
 
   // Push cat value into the NI filter array.
-  layer.filter.current[cat.field].ni.push(cat.keys || cat.value);
+  layer.filter.current[cat.field].ni.push(cat.keys || cat.value || cat.values);
 
   // Flatten the filter in case of arrays filter.
   layer.filter.current[cat.field].ni =
@@ -255,7 +257,7 @@ export function clusterLegend(layer) {
 
 /**
 @function themeLegend
-@description 
+@description
 The method assigns theme.legend properties to control the layout through css classes.
 
 @param {object} theme

--- a/lib/ui/layers/legends/utils.mjs
+++ b/lib/ui/layers/legends/utils.mjs
@@ -28,9 +28,7 @@ export function catElement(cat, theme, layer) {
   cat.field ??= theme.field;
 
   // Check whether cat is in current filter.
-  cat.disabled = layer.filter?.current[cat.field]?.ni?.some(
-    (el) => el === cat.value || cat.values?.includes(el),
-  );
+  cat.disabled ??= layer.filter?.current[cat.field]?.ni?.includes(cat.value);
 
   if (!cat.disabled) {
     // The style must be restored for the theme layer render.
@@ -159,7 +157,7 @@ async function filterAdd(layer, cat) {
   }
 
   // Push cat value into the NI filter array.
-  layer.filter.current[cat.field].ni.push(cat.keys || cat.value || cat.values);
+  layer.filter.current[cat.field].ni.push(cat.keys || cat.value);
 
   // Flatten the filter in case of arrays filter.
   layer.filter.current[cat.field].ni =
@@ -198,13 +196,10 @@ async function filterRemove(layer, cat) {
     }
   } else {
     // Splice value out of the NI array.
-    const catValue = cat.values || [cat.value];
-    for (const val of catValue) {
-      layer.filter.current[cat.field].ni.splice(
-        layer.filter.current[cat.field].ni.indexOf(val),
-        1,
-      );
-    }
+    layer.filter.current[cat.field].ni.splice(
+      layer.filter.current[cat.field].ni.indexOf(cat.value),
+      1,
+    );
   }
 
   // Delete current field filter if NI array is empty.


### PR DESCRIPTION
## Description
Distributed theme values will never match what is in the `filter.current` so in this PR we set the filterOnly flag true for all distributed themes. This change will make it so the filter is only visual and does not interact with the `filter.current` of the layer:
<img width="710" height="40" alt="screenshot-2026-04-08_11-39-16" src="https://github.com/user-attachments/assets/d334ecd9-c252-4400-9f94-37b34afaf437" />

The disabled flag for the category selected is also nullish checked on the filter as the the `filterAdd` function sets the flag so the property should not be overwritten from the filter. 

## GitHub Issue
#2745

## Type of Change
- ✅ Bug fix (non-breaking change which fixes an issue)

## How have you tested this?

> [!IMPORTANT]
> Tested locally on `bugs_testing/styles/distributed_themes.json`

## Testing Checklist
- ✅ Existing Tests still pass
- ✅ Ran locally on my machine

## Code Quality Checklist
- ✅ My code follows the guidelines of XYZ
- ✅ My code has been commented
- ✅ Documentation has been updated
- ✅ New and existing unit tests pass locally with my changes
- ✅ Main has been merged into this PR
