### PR TITLE
fix(Location/dataview entry): Shortcircuit on entry.show existing already

### DIFF
--- a/lib/ui/Dataview.mjs
+++ b/lib/ui/Dataview.mjs
@@ -154,7 +154,7 @@ function show() {
 
     this.update instanceof Function && this.update();
   } else if (this.dynamic) {
-    this.create();
+    typeof this.show !== 'function' && this.create();
 
     this.update instanceof Function && this.update();
   } else if (this.reload) {

--- a/lib/ui/locations/entries/dataview.mjs
+++ b/lib/ui/locations/entries/dataview.mjs
@@ -54,10 +54,11 @@ export default function dataview(entry) {
   // A dataview must have a HTMLElement target
   if (entry.target instanceof HTMLElement === false) return;
 
-  // Decorate the dataview entry.
-  if (mapp.ui.Dataview(entry) instanceof Error) return;
+  // Decorate the dataview entry, only if the show method does not yet exist.
+  // Once decorated, the show method exists so we don't need to redecorate on subsequent dataview entry updates.
+  if (!entry.show && mapp.ui.Dataview(entry) instanceof Error) return;
 
-  //If queryCheck is true and theres no data, don't dislpay the dataview
+  //If queryCheck is true and theres no data, don't display the dataview
   if ((!entry.data || entry.data instanceof Error) && entry.queryCheck) {
     entry.chkbox?.classList?.add?.('disabled');
     entry.chkbox.querySelector('input').checked = false;


### PR DESCRIPTION
## Description

This PR fixes an issue where the dataview component is recreated multiple times during dynamic location updates. 
It introduces a short-circuit check using `!entry.show` to verify if the dataview has already been initialised before attempting to decorate it again. 
This ensures it is only created once, and prevents redundant setData calls and exceptions.

``` js
// BEFORE 
// Decorate the dataview entry.
if (mapp.ui.Dataview(entry) instanceof Error) return;

// AFTER 
// Decorate the dataview entry, only if the show method does not yet exist.
// Once decorated, the show method exists so we don't need to redecorate on subsequent dataview entry updates.
if (!entry.show && mapp.ui.Dataview(entry) instanceof Error) return;
```

A check in Dataview.mjs has also been added to check for entry.show too. 
## Type of Change
- ✅ Bug fix (non-breaking change which fixes an issue)

## How have you tested this?
Tested locally and off the PR the warnings and errors fire, on this PR they no longer do.

## Testing Checklist
- ✅ Ran locally on my machine