### PR TITLE
fix(entry/dataviews): Fix Missing checkbox

### DIFF
--- a/lib/ui/locations/entries/dataview.mjs
+++ b/lib/ui/locations/entries/dataview.mjs
@@ -54,9 +54,15 @@ export default function dataview(entry) {
   // A dataview must have a HTMLElement target
   if (entry.target instanceof HTMLElement === false) return;
 
-  // Decorate the dataview entry, only if the show method does not yet exist.
-  // Once decorated, the show method exists so we don't need to redecorate on subsequent dataview entry updates.
-  if (!entry.show && mapp.ui.Dataview(entry) instanceof Error) return;
+  // If the show method does not exist, just return the element for the location.
+  if (!entry.show) {
+      return mapp.utils.html.node`
+    ${entry.chkbox || ''}
+    ${entry.locationViewTarget || ''}`;
+  };
+
+  // Decorate the dataview entry.
+  if (mapp.ui.Dataview(entry) instanceof Error) return;
 
   //If queryCheck is true and theres no data, don't display the dataview
   if ((!entry.data || entry.data instanceof Error) && entry.queryCheck) {

--- a/lib/ui/locations/entries/dataview.mjs
+++ b/lib/ui/locations/entries/dataview.mjs
@@ -56,10 +56,10 @@ export default function dataview(entry) {
 
   // If the show method does not exist, just return the element for the location.
   if (!entry.show) {
-      return mapp.utils.html.node`
+    return mapp.utils.html.node`
     ${entry.chkbox || ''}
     ${entry.locationViewTarget || ''}`;
-  };
+  }
 
   // Decorate the dataview entry.
   if (mapp.ui.Dataview(entry) instanceof Error) return;


### PR DESCRIPTION
# Pull Request Template

## Description
In this PR - https://github.com/GEOLYTIX/xyz/pull/2748 , we added a check to return if `entry.show` did not exist. However, we returned without providing the checkbox. This meant that the entry was never possible to turn on the infoj later on by the user.

The checkbox must be returned when show does not exist, so that the user could turn it on themselves.

## Type of Change
- ✅ Bug fix (non-breaking change which fixes an issue)

## How have you tested this?
Tested locally against an entry that is not display true. 
