### PR TITLE
Bump mapbox ol style and maplibre imports

### DIFF
--- a/lib/layer/format/mapboxStyle.mjs
+++ b/lib/layer/format/mapboxStyle.mjs
@@ -27,7 +27,6 @@ The mapboxStyle method creates an Openlayers VectorTile layer and assigns a mapb
 @returns {layer} layer decorated with format methods.
 */
 export default async function mapboxStyle(layer) {
-
   await mapp.utils.scriptElement(
     'https://cdn.jsdelivr.net/npm/ol-mapbox-style@13.4.0/dist/olms.js',
   );
@@ -35,6 +34,6 @@ export default async function mapboxStyle(layer) {
   layer.L = new olms.MapboxVectorLayer({
     zIndex: layer.zIndex,
     styleUrl: layer.style.URL,
-    accessToken: layer.accessToken
+    accessToken: layer.accessToken,
   });
 }

--- a/lib/layer/format/mapboxStyle.mjs
+++ b/lib/layer/format/mapboxStyle.mjs
@@ -27,14 +27,14 @@ The mapboxStyle method creates an Openlayers VectorTile layer and assigns a mapb
 @returns {layer} layer decorated with format methods.
 */
 export default async function mapboxStyle(layer) {
+
   await mapp.utils.scriptElement(
-    'https://cdn.jsdelivr.net/npm/ol-mapbox-style@13.0.1/dist/olms.js',
+    'https://cdn.jsdelivr.net/npm/ol-mapbox-style@13.4.0/dist/olms.js',
   );
 
-  layer.L = new ol.layer.VectorTile({
-    declutter: true,
+  layer.L = new olms.MapboxVectorLayer({
     zIndex: layer.zIndex,
+    styleUrl: layer.style.URL,
+    accessToken: layer.accessToken
   });
-
-  olms.applyStyle(layer.L, layer.style.URL, { accessToken: layer.accessToken });
 }

--- a/lib/layer/format/maplibre.mjs
+++ b/lib/layer/format/maplibre.mjs
@@ -31,7 +31,7 @@ The maplibre format method will create a new MaplibreGL.Map() class object in a 
 */
 export default async function maplibre(layer) {
   if (!MaplibreGL) {
-    MaplibreGL = await mapp.utils.esmImport('maplibre-gl@5.5.0');
+    MaplibreGL = await mapp.utils.esmImport('maplibre-gl@5.23.0');
 
     MaplibreGL.setRTLTextPlugin(
       'https://cdn.jsdelivr.net/npm/@mapbox/mapbox-gl-rtl-text@0.3.0/dist/mapbox-gl-rtl-text.min.js',


### PR DESCRIPTION
There have been quite a few fixes to the ol-mapbox-style library.

https://github.com/openlayers/ol-mapbox-style/releases

Most importantly there is now MapboxVectorLayer format extension rather than applying the style to an ol VectorTileLayer.

We also bumped Maplibre-GL to 5.23 which includes a year of fixes.

https://github.com/maplibre/maplibre-gl-js/releases/tag/v5.23.0