### PR TITLE
Revise iteration of layer.style.elements and check for labels and hovers

### DIFF
--- a/lib/ui/elements/layerStyle.mjs
+++ b/lib/ui/elements/layerStyle.mjs
@@ -180,13 +180,21 @@ function label(layer) {
 
   if (layer.style.label.hidden) return;
 
+  if (layer.style.labelCheckbox) {
+    return layer.style.labelCheckbox;
+  }
+
+  // The title will only be shown in dropdown for multiple labels option.
+  let label = layer.style.labels && mapp.dictionary.layer_style_display_labels;
+
+  // Assign label from single label object title.
+  label ??=
+    layer.style.label.title || mapp.dictionary.layer_style_display_labels;
+
   layer.style.labelCheckbox = mapp.ui.elements.chkbox({
     checked: !!layer.style.label.display,
     data_id: `labelCheckbox-${layer.key}`,
-    label:
-      (layer.style.labels && mapp.dictionary.layer_style_display_labels) ||
-      layer.style.label.title ||
-      mapp.dictionary.layer_style_display_labels,
+    label,
     onchange: (checked) => {
       layer.style.label.display = checked;
       layer.reload();
@@ -269,6 +277,9 @@ function labels(layer) {
     layer.style.label.display = display;
 
     layer.reload();
+
+    // layer.reload does not trigger changeEndCallbacks.
+    zoomLabel(layer);
   }
 }
 

--- a/lib/ui/elements/layerStyle.mjs
+++ b/lib/ui/elements/layerStyle.mjs
@@ -59,12 +59,15 @@ function panel(layer) {
   layer.style.elements ??= Object.keys(layer.style);
 
   // The layer.style.elements define which elements should be added in which order to the layer.style.view element.
-  const content = layer.style.elements
-    .filter((key) => Object.hasOwn(layer.style, key))
-    .filter((key) => Object.hasOwn(methods, key))
-    .map((key) => methods[key](layer))
-    .flat()
-    .filter((element) => !!element);
+  const content = [];
+
+  for (const key of layer.style.elements) {
+    // Array may be defined in layer json with keys not defined in the layer.style.
+    if (!Object.hasOwn(layer.style, key)) continue;
+    if (!Object.hasOwn(methods, key)) continue;
+    const element = methods[key](layer);
+    if (element) content.push(element);
+  }
 
   if (!content.length) return;
 
@@ -248,6 +251,15 @@ function labels(layer) {
       title: layer.style.labels[key].title || key,
     }));
 
+  return mapp.utils.html`
+  <div>${mapp.dictionary.layer_style_select_label}</div>
+  ${mapp.ui.elements.dropdown({
+    callback,
+    data_id: 'labelsDropdown',
+    entries,
+    placeholder: layer.style.label.title,
+  })}`;
+
   function callback(e, entry) {
     const display = layer.style.label.display;
 
@@ -258,16 +270,6 @@ function labels(layer) {
 
     layer.reload();
   }
-
-  return mapp.utils
-    .html`<div>${mapp.dictionary.layer_style_select_label}</div>${mapp.ui.elements.dropdown(
-    {
-      callback,
-      data_id: 'labelsDropdown',
-      entries,
-      placeholder: layer.style.label.title,
-    },
-  )}`;
 }
 
 function opacitySlider(layer) {
@@ -306,12 +308,18 @@ function theme(layer) {
   if (!layer.style.theme) return;
 
   // Handle setLabel and labels in layer style.
-  if (layer.style.theme?.setLabel && layer.style.labels) {
+  if (
+    layer.style.labels &&
+    Object.hasOwn(layer.style.labels, layer.style.theme?.setLabel)
+  ) {
     layer.style.label = layer.style.labels[layer.style.theme.setLabel];
   }
 
   // Handle setHover and hovers in layer style.
-  if (layer.style.theme?.setHover && layer.style.hovers) {
+  if (
+    layer.style.hovers &&
+    Object.hasOwn(layer.style.hovers, layer.style.theme?.setHover)
+  ) {
     layer.style.hover = layer.style.hovers[layer.style.theme.setHover];
   }
 


### PR DESCRIPTION
The setHover and setLabels values need to be checked against the properties in the style.labels or style.hovers object. If the object does not have the own property the object will be set to undefined which cause a typeerror when the changemethod checks for the min or maxZoom properties of undefined.

The filter/filter/map/flat/filter iteration was impossible to debug and is not very performant since under the hood js will create nested generator methods to yield results.