### PR TITLE
fix(Entry/Dataview): Check on `entry.display` and `entry.create`

### DIFF
--- a/lib/ui/Dataview.mjs
+++ b/lib/ui/Dataview.mjs
@@ -154,7 +154,9 @@ async function show() {
 
     this.update instanceof Function && this.update();
   } else if (this.dynamic) {
+    // The create method will set existing data but will not query data.
     this.create instanceof Function && (await this.create());
+    // The update method will query data.
     this.update instanceof Function && this.update();
   } else if (this.reload) {
     this.update instanceof Function && this.update();

--- a/lib/ui/Dataview.mjs
+++ b/lib/ui/Dataview.mjs
@@ -154,7 +154,7 @@ async function show() {
 
     this.update instanceof Function && this.update();
   } else if (this.dynamic) {
-    this.create instanceof Function && await this.create();
+    this.create instanceof Function && (await this.create());
     this.update instanceof Function && this.update();
   } else if (this.reload) {
     this.update instanceof Function && this.update();

--- a/lib/ui/Dataview.mjs
+++ b/lib/ui/Dataview.mjs
@@ -150,16 +150,15 @@ async function show() {
     this.create = () => {
       mapp.ui.utils[this.dataview].create(this);
     };
-    this.create();
-
-    this.update instanceof Function && this.update();
+    await this.create();
+    typeof this.update === 'function' && this.update();
   } else if (this.dynamic) {
     // The create method will set existing data but will not query data.
-    this.create instanceof Function && (await this.create());
+    typeof this.create === 'function' && (await this.create());
     // The update method will query data.
-    this.update instanceof Function && this.update();
+    typeof this.update === 'function' && this.update();
   } else if (this.reload) {
-    this.update instanceof Function && this.update();
+    typeof this.update === 'function' && this.update();
   }
 
   //Show toolbar buttons if there are any

--- a/lib/ui/Dataview.mjs
+++ b/lib/ui/Dataview.mjs
@@ -143,19 +143,18 @@ The update() method will be executed if the `dataview.reload` flag is set.
 
 The `dataview.target` element style display property will be set to 'block'.
 */
-function show() {
+async function show() {
   this.display = true;
 
   if (this.create === undefined) {
-    this.create = function () {
+    this.create = () => {
       mapp.ui.utils[this.dataview].create(this);
     };
     this.create();
 
     this.update instanceof Function && this.update();
   } else if (this.dynamic) {
-    typeof this.show !== 'function' && this.create();
-
+    this.create instanceof Function && await this.create();
     this.update instanceof Function && this.update();
   } else if (this.reload) {
     this.update instanceof Function && this.update();

--- a/lib/ui/Dataview.mjs
+++ b/lib/ui/Dataview.mjs
@@ -150,7 +150,7 @@ async function show() {
     this.create = () => {
       mapp.ui.utils[this.dataview].create(this);
     };
-    await this.create();
+    this.create();
     typeof this.update === 'function' && this.update();
   } else if (this.dynamic) {
     // The create method will set existing data but will not query data.

--- a/lib/ui/locations/entries/dataview.mjs
+++ b/lib/ui/locations/entries/dataview.mjs
@@ -54,8 +54,9 @@ export default function dataview(entry) {
   // A dataview must have a HTMLElement target
   if (entry.target instanceof HTMLElement === false) return;
 
-  // If the show method does not exist, just return the element for the location.
-  if (!entry.show) {
+  // If the show method does not exist and create does 
+  // just provide the UI for the user to turn on the dataview when they are ready.
+  if (!entry.show && entry.create) {
     return mapp.utils.html.node`
     ${entry.chkbox || ''}
     ${entry.locationViewTarget || ''}`;
@@ -64,7 +65,7 @@ export default function dataview(entry) {
   // Decorate the dataview entry.
   if (mapp.ui.Dataview(entry) instanceof Error) return;
 
-  //If queryCheck is true and theres no data, don't display the dataview
+  //If queryCheck is true and there's no data, don't display the dataview
   if ((!entry.data || entry.data instanceof Error) && entry.queryCheck) {
     entry.chkbox?.classList?.add?.('disabled');
     entry.chkbox.querySelector('input').checked = false;

--- a/lib/ui/locations/entries/dataview.mjs
+++ b/lib/ui/locations/entries/dataview.mjs
@@ -54,7 +54,7 @@ export default function dataview(entry) {
   // A dataview must have a HTMLElement target
   if (entry.target instanceof HTMLElement === false) return;
 
-  // If the show method does not exist and create does 
+  // If the show method does not exist and create does
   // just provide the UI for the user to turn on the dataview when they are ready.
   if (!entry.show && entry.create) {
     return mapp.utils.html.node`

--- a/lib/ui/locations/entries/dataview.mjs
+++ b/lib/ui/locations/entries/dataview.mjs
@@ -54,16 +54,15 @@ export default function dataview(entry) {
   // A dataview must have a HTMLElement target
   if (entry.target instanceof HTMLElement === false) return;
 
-  // If the show method does not exist and create does
-  // just provide the UI for the user to turn on the dataview when they are ready.
-  if (!entry.show && entry.create) {
+  // The dataview has been decorated but should not be displayed.
+  if (!entry.display && entry.create instanceof Function) {
     return mapp.utils.html.node`
     ${entry.chkbox || ''}
     ${entry.locationViewTarget || ''}`;
   }
 
-  // Decorate the dataview entry.
-  if (mapp.ui.Dataview(entry) instanceof Error) return;
+  // The dataview doesn't have a create method and needs to be decorated.
+  if (!entry.create && mapp.ui.Dataview(entry) instanceof Error) return;
 
   //If queryCheck is true and there's no data, don't display the dataview
   if ((!entry.data || entry.data instanceof Error) && entry.queryCheck) {

--- a/lib/ui/locations/entries/dataview.mjs
+++ b/lib/ui/locations/entries/dataview.mjs
@@ -55,7 +55,7 @@ export default function dataview(entry) {
   if (entry.target instanceof HTMLElement === false) return;
 
   // The dataview has been decorated but should not be displayed.
-  if (!entry.display && entry.create instanceof Function) {
+  if (!entry.display && typeof entry.create === 'function') {
     return mapp.utils.html.node`
     ${entry.chkbox || ''}
     ${entry.locationViewTarget || ''}`;


### PR DESCRIPTION
The previous fix meant that dvs with a target of location were not being rendered into the location view. 
In this PR we: 
- Check on if entry.display does not exist but create does. 
- This means the dv is already decorated, so just return the checkbox to be used by the user.

Added bugs_testing\dataviews\dv_all_options.json - which has all 16 combinations of table / chart and the flags - if we test against this we should cover all use cases 🤞
<img width="1266" height="782" alt="image" src="https://github.com/user-attachments/assets/6d3c56ed-d760-4171-8045-fe6b403d7d79" />
