### PR TITLE
Show disabled cat in legend

### DIFF
--- a/lib/layer/themes/categorized.mjs
+++ b/lib/layer/themes/categorized.mjs
@@ -53,7 +53,7 @@ export default function categorized(theme, feature) {
 
         flat ||= Array.isArray(cat.style.icon);
 
-        return cat.style.icon;
+        return cat.style?.icon;
 
         // Filter out empty icon entries from map response.
       })

--- a/lib/layer/themes/categorized.mjs
+++ b/lib/layer/themes/categorized.mjs
@@ -51,9 +51,11 @@ export default function categorized(theme, feature) {
 
         if (!cat) return;
 
+        if (!cat.style) return;
+
         flat ||= Array.isArray(cat.style.icon);
 
-        return cat.style?.icon;
+        return cat.style.icon;
 
         // Filter out empty icon entries from map response.
       })

--- a/lib/ui/layers/legends/utils.mjs
+++ b/lib/ui/layers/legends/utils.mjs
@@ -41,7 +41,7 @@ export function catElement(cat, theme, layer) {
       value: layer.featureFields[cat.field]?.[cat.value],
     };
     cat.count = mapp.utils.formatNumericValue(params);
-    if (!theme.legend?.showEmptyCat && !cat.count) return;
+    if (!cat.disabled && !theme.legend?.showEmptyCat && !cat.count) return;
   }
 
   const catLegendIcon = mapp.ui.elements.legendIcon({


### PR DESCRIPTION
A cat which has been disabled by user input should be shown in the legend. Otherwise it will be impossible to enable the cat by user input.


https://github.com/user-attachments/assets/739d0504-3962-4bb3-a70b-345a386b9114

There must be a conditional check on the style.icon to be returned from the categorized theme method. Otherwise an error will be thrown where the style is set to null.