### PR TITLE
Use flag to control hover query cache

### DIFF
--- a/lib/layer/featureHover.mjs
+++ b/lib/layer/featureHover.mjs
@@ -69,7 +69,7 @@ export default function featureHover(feature, layer) {
   mapp.utils
     .xhr({
       url: `${layer.mapview.host}/api/query?${paramString}`,
-      cache: true,
+      cache: !layer.style.hover.dynamic,
       debounce: { key: 'hover', delay: 100 },
     })
     .then((response) => {


### PR DESCRIPTION
A flag should be used to control whether a hover query should be cached.

The query will not be cached with the dynamic flag.

```
          "hover": {
            "query": "hover_query",
            "display": true,
            "dynamic": true
          }
```