### PR TITLE
fix(Entry/Dataview): Fix for trying to set non-existent checkbox to unchecked

### DIFF
--- a/lib/ui/locations/entries/dataview.mjs
+++ b/lib/ui/locations/entries/dataview.mjs
@@ -66,10 +66,9 @@ export default function dataview(entry) {
 
   //If queryCheck is true and there's no data, don't display the dataview
   if ((!entry.data || entry.data instanceof Error) && entry.queryCheck) {
-    
-   // If chkbox exists, disable it and uncheck it.
+    // If chkbox exists, disable it and uncheck it.
     if (entry.chkbox) {
-      entry.chkbox.classList.add('disabled'); 
+      entry.chkbox.classList.add('disabled');
       entry.chkbox.querySelector('input').checked = false;
     }
     entry.display = false;

--- a/lib/ui/locations/entries/dataview.mjs
+++ b/lib/ui/locations/entries/dataview.mjs
@@ -66,8 +66,12 @@ export default function dataview(entry) {
 
   //If queryCheck is true and there's no data, don't display the dataview
   if ((!entry.data || entry.data instanceof Error) && entry.queryCheck) {
-    entry.chkbox?.classList?.add?.('disabled');
-    entry.chkbox.querySelector('input').checked = false;
+    
+   // If chkbox exists, disable it and uncheck it.
+    if (entry.chkbox) {
+      entry.chkbox.classList.add('disabled'); 
+      entry.chkbox.querySelector('input').checked = false;
+    }
     entry.display = false;
     entry.hide();
   }


### PR DESCRIPTION
## Description
When a dataview with `queryCheck` and no `label` returns no data, the code tries to set the checkbox to unchecked. 
However, without a label, no checkbox is created so this failed. 

This PR addresses that by wrapping it in an if statement.

## Type of Change
- ✅ Bug fix (non-breaking change which fixes an issue)