### PR TITLE
Merge direct layer role payloads into resolved workspace objects

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-**v4.22.4**
+**v4.22.5**
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 ![Codi Unit Tests](https://github.com/GEOLYTIX/xyz/actions/workflows/unit_tests.yml/badge.svg)

--- a/lib/mapp.mjs
+++ b/lib/mapp.mjs
@@ -52,5 +52,5 @@ globalThis.mapp = {
   Mapview,
   plugins,
   utils,
-  version: '4.22.4',
+  version: '4.22.5',
 };

--- a/mod/workspace/mergeTemplates.js
+++ b/mod/workspace/mergeTemplates.js
@@ -50,7 +50,7 @@ export default async function mergeTemplates(obj, roles) {
 
   obj.roles ??= {};
   //const directRoles = structuredClone(obj.roles);
-  
+
   if (obj.role) {
     obj.roles[obj.role] ??= true;
   }

--- a/mod/workspace/mergeTemplates.js
+++ b/mod/workspace/mergeTemplates.js
@@ -87,7 +87,10 @@ export default async function mergeTemplates(obj, roles) {
   // Apply only the original object's direct role payloads before the workspace
   // API strips roles from the response. Template role payloads have already
   // been merged during template preparation.
-  obj = merge(obj, Roles.objMerge({ roles: directRoles }, roles));
+  if (Object.keys(directRoles).length) {
+    const rolesObj = Roles.objMerge({ roles: directRoles }, roles);
+    obj = merge(obj, rolesObj);
+  }
 
   return obj;
 }

--- a/mod/workspace/mergeTemplates.js
+++ b/mod/workspace/mergeTemplates.js
@@ -46,9 +46,11 @@ export default async function mergeTemplates(obj, roles) {
   // Cache workspace in module scope for template assignment.
   workspace = await workspaceCache();
 
-  obj.roles ??= {};
-  const directRoles = structuredClone(obj.roles);
+  obj = Roles.objMerge(obj, roles);
 
+  obj.roles ??= {};
+  //const directRoles = structuredClone(obj.roles);
+  
   if (obj.role) {
     obj.roles[obj.role] ??= true;
   }
@@ -87,10 +89,10 @@ export default async function mergeTemplates(obj, roles) {
   // Apply only the original object's direct role payloads before the workspace
   // API strips roles from the response. Template role payloads have already
   // been merged during template preparation.
-  if (Object.keys(directRoles).length) {
-    const rolesObj = Roles.objMerge({ roles: directRoles }, roles);
-    obj = merge(obj, rolesObj);
-  }
+  // if (Object.keys(directRoles).length) {
+  //   const rolesObj = Roles.objMerge({ roles: directRoles }, roles);
+  //   obj = merge(obj, rolesObj);
+  // }
 
   return obj;
 }

--- a/mod/workspace/mergeTemplates.js
+++ b/mod/workspace/mergeTemplates.js
@@ -47,6 +47,7 @@ export default async function mergeTemplates(obj, roles) {
   workspace = await workspaceCache();
 
   obj.roles ??= {};
+  const directRoles = structuredClone(obj.roles);
 
   if (obj.role) {
     obj.roles[obj.role] ??= true;
@@ -82,6 +83,11 @@ export default async function mergeTemplates(obj, roles) {
   if (!Roles.check(obj, roles)) {
     return new Error('Role access denied.');
   }
+
+  // Apply only the original object's direct role payloads before the workspace
+  // API strips roles from the response. Template role payloads have already
+  // been merged during template preparation.
+  obj = merge(obj, Roles.objMerge({ roles: directRoles }, roles));
 
   return obj;
 }

--- a/mod/workspace/mergeTemplates.js
+++ b/mod/workspace/mergeTemplates.js
@@ -49,7 +49,6 @@ export default async function mergeTemplates(obj, roles) {
   obj = Roles.objMerge(obj, roles);
 
   obj.roles ??= {};
-  //const directRoles = structuredClone(obj.roles);
 
   if (obj.role) {
     obj.roles[obj.role] ??= true;
@@ -85,14 +84,6 @@ export default async function mergeTemplates(obj, roles) {
   if (!Roles.check(obj, roles)) {
     return new Error('Role access denied.');
   }
-
-  // Apply only the original object's direct role payloads before the workspace
-  // API strips roles from the response. Template role payloads have already
-  // been merged during template preparation.
-  // if (Object.keys(directRoles).length) {
-  //   const rolesObj = Roles.objMerge({ roles: directRoles }, roles);
-  //   obj = merge(obj, rolesObj);
-  // }
 
   return obj;
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "xyz",
-  "version": "v4.22.4",
+  "version": "v4.22.5",
   "type": "module",
   "repository": {
     "type": "git",

--- a/tests/mod/workspace/mergeTemplates.test.mjs
+++ b/tests/mod/workspace/mergeTemplates.test.mjs
@@ -78,11 +78,11 @@ await codi.describe(
             current: {},
           },
           roles: {
-            'Pizza Hut': {
-              name: 'PIZZA HUT KEY BRANDS',
+            KEY_BRANDS: {
+              name: 'KEY BRANDS',
               filter: {
                 current: {
-                  pizza_hut_layer: {
+                  key_brands_layer: {
                     in: [true],
                   },
                 },
@@ -91,11 +91,11 @@ await codi.describe(
           },
         };
 
-        const result = await mergeTemplates(layer, ['Pizza Hut']);
+        const result = await mergeTemplates(layer, ['KEY_BRANDS']);
 
-        codi.assertEqual(result.name, 'PIZZA HUT KEY BRANDS');
+        codi.assertEqual(result.name, 'KEY BRANDS');
         codi.assertEqual(result.filter.current, {
-          pizza_hut_layer: {
+          key_brands_layer: {
             in: [true],
           },
         });

--- a/tests/mod/workspace/mergeTemplates.test.mjs
+++ b/tests/mod/workspace/mergeTemplates.test.mjs
@@ -68,6 +68,42 @@ await codi.describe(
 
     await codi.it(
       {
+        name: 'merge direct object roles into resolved object',
+        parentId: 'workspace_mergeTemplates',
+      },
+      async () => {
+        const layer = {
+          name: 'Base name',
+          filter: {
+            current: {},
+          },
+          roles: {
+            'Pizza Hut': {
+              name: 'PIZZA HUT KEY BRANDS',
+              filter: {
+                current: {
+                  pizza_hut_layer: {
+                    in: [true],
+                  },
+                },
+              },
+            },
+          },
+        };
+
+        const result = await mergeTemplates(layer, ['Pizza Hut']);
+
+        codi.assertEqual(result.name, 'PIZZA HUT KEY BRANDS');
+        codi.assertEqual(result.filter.current, {
+          pizza_hut_layer: {
+            in: [true],
+          },
+        });
+      },
+    );
+
+    await codi.it(
+      {
         name: 'mergeTemplates with roles',
         parentId: 'workspace_mergeTemplates',
       },


### PR DESCRIPTION
## What happened? 

This change fixes a gap in workspace object composition where a `roles` object defined directly on a layer could control access, but its matching role payload was not merged into the final resolved layer.

Previously:

- direct layer `roles` were preserved during server-side composition
- `Roles.check()` could allow or deny access based on those roles
- but the matching role payload was never merged into the resolved object
- then `removeRoles()` stripped the raw `roles` object from the API response

That meant users with a matching role would not receive the expected role-specific layer overrides, such as `name`, `filter.current`, or other mergeable properties.

This PR applies the direct object role payload before the workspace API strips `roles` from the response.

## Problem

Given a layer like:

```json
{
  "name": "Base name",
  "roles": {
    "KEY_BRANDS": {
      "name": "KEY BRANDS",
      "filter": {
        "current": {
          "key_brands_layer": {
            "in": [true]
          }
        }
      }
    }
  }
}
```

and a user with role `KEY_BRANDS`, the expected resolved layer should include:

```json
{
  "name": "KEY BRANDS",
  "filter": {
    "current": {
      "key_brands_layer": {
        "in": [true]
      }
    }
  }
}
```

Before this change, access could succeed, but the role payload was not merged, and the client received neither the merged values nor the raw `roles` object.

## Root Cause

`mergeTemplates()` already applied `Roles.objMerge()` to template objects during template preparation, but it did not apply the same behavior to the final resolved object itself.

A first pass at fixing this by calling `Roles.objMerge(obj, roles)` at the end caused a regression: template role payloads were merged twice, which duplicated merged array content like `infoj`.

## Solution

The final merge step now applies only the object's original direct `roles` payload, rather than re-merging all accumulated role data after template composition.

This preserves existing template behavior while enabling direct layer-level role payloads to be merged into the resolved object before response sanitization.

## Changes

- update `mod/workspace/mergeTemplates.js`
- capture the object's original direct `roles`
- after template processing and access checks, merge only those direct role payloads into the resolved object
- avoid reapplying template role payloads that were already merged earlier

## Tests

Added regression coverage for direct object role merging in:

- `tests/mod/workspace/mergeTemplates.test.mjs`