### PR TITLE
use relative path in provider file module.

### DIFF
--- a/apps/xyz/mod/provider/file.js
+++ b/apps/xyz/mod/provider/file.js
@@ -38,13 +38,15 @@ export default async function file(ref) {
       throw new Error('Unauthorized');
 
     // Subtitutes {*} with xyzEnv.SRC_* key values.
-    const path = (ref.params?.url || ref).replace(
+    const relativePath = (ref.params?.url || ref).replace(
       /{(?!{)(.*?)}/g,
       (matched) => xyzEnv[`SRC_${matched.replace(/(^{)|(}$)/g, '')}`],
     );
 
+    const path = join(process.cwd(), relativePath)
+
     // Join the releative path with the import directory name to generate a path with platform specific separator as delimiter.
-    const file = readFileSync(join(import.meta.dirname, `../../${path}`));
+    const file = readFileSync(path);
 
     if (path.match(/\.json$/i)) {
       return JSON.parse(file, 'utf8');

--- a/apps/xyz/mod/provider/file.js
+++ b/apps/xyz/mod/provider/file.js
@@ -43,7 +43,7 @@ export default async function file(ref) {
       (matched) => xyzEnv[`SRC_${matched.replace(/(^{)|(}$)/g, '')}`],
     );
 
-    const path = join(process.cwd(), relativePath)
+    const path = join(process.cwd(), relativePath);
 
     // Join the releative path with the import directory name to generate a path with platform specific separator as delimiter.
     const file = readFileSync(path);

--- a/apps/xyz/mod/workspace/templates/_views.js
+++ b/apps/xyz/mod/workspace/templates/_views.js
@@ -4,18 +4,18 @@
 
 export default {
   default_view: {
-    en: 'file:../../public/views/_default.html',
+    en: 'file:/public/views/_default.html',
   },
   login_view: {
-    en: 'file:/../../public/views/_login.html',
+    en: 'file:/public/views/_login.html',
   },
   password_reset_view: {
-    en: 'file:/../../public/views/_login.html',
+    en: 'file:/public/views/_login.html',
   },
   register_view: {
-    en: 'file:/../../public/views/_login.html',
+    en: 'file:/public/views/_login.html',
   },
   user_admin_view: {
-    en: 'file:/../../public/views/_user.html',
+    en: 'file:/public/views/_user.html',
   },
 };

--- a/apps/xyz/tests/assets/view.json
+++ b/apps/xyz/tests/assets/view.json
@@ -1,5 +1,8 @@
 {
   "templates": {
+    "default_view": {
+      "template": "<html lang=\"{{language}}\"></html>"
+    },
     "custom_view": {
       "template": "<html lang=\"{{language}}\">{{varcheck}}</html>"
     }

--- a/apps/xyz/tests/mod/provider/file.test.mjs
+++ b/apps/xyz/tests/mod/provider/file.test.mjs
@@ -1,7 +1,6 @@
 import { describe, expect, it, vi } from 'vitest';
 
 const fsMockFn = vi.fn();
-const mockPathdirnameFn = vi.fn();
 const mockPathJoinFn = vi.fn();
 
 vi.mock('fs', () => ({
@@ -9,12 +8,7 @@ vi.mock('fs', () => ({
 }));
 
 vi.mock('path', () => ({
-  dirname: (...args) => mockPathdirnameFn(...args),
   join: (...args) => mockPathJoinFn(...args),
-}));
-
-vi.mock('url', () => ({
-  fileURLToPath: vi.fn(),
 }));
 
 vi.mock('@geolytix/xyz-app/mod/sign/file.js', () => ({
@@ -33,15 +27,11 @@ describe('file:', () => {
       return JSON.stringify(fileContent);
     });
 
-    mockPathdirnameFn.mockImplementationOnce(() => {
-      return 'test.json';
-    });
-
     mockPathJoinFn.mockImplementationOnce(() => {
-      '../../test.json';
+      return './tests/thing.json';
     });
 
-    const results = await file('../../dir/tests/thing.json');
+    const results = await file('./tests/thing.json');
 
     expect(results).toEqual(fileContent);
   });

--- a/apps/xyz/tests/setup.mjs
+++ b/apps/xyz/tests/setup.mjs
@@ -1,3 +1,13 @@
-// Global test setup for vitest
+import process from 'node:process';
+import { fileURLToPath } from 'node:url';
+
+// Keep fixture paths like file:./tests/assets/... stable regardless of where
+// Vitest was launched from (CLI package dir vs VS Code workspace root).
+const testWorkspaceRoot = fileURLToPath(new URL('..', import.meta.url));
+
+if (process.cwd() !== testWorkspaceRoot) {
+  process.chdir(testWorkspaceRoot);
+}
+
 // Ensures globalThis.xyzEnv exists before any module tries to access it.
 globalThis.xyzEnv ??= {};


### PR DESCRIPTION
This PR ensures that current launch configurations with relative path definitions remain valid.