### PR TITLE
Cloudfront fetch must return err on failure to fetch

### DIFF
--- a/mod/provider/cloudfront.js
+++ b/mod/provider/cloudfront.js
@@ -36,9 +36,9 @@ The fetched will resource body will be parsed as JSON if the URL ends in `.json`
 export default cloudfront_signer ? cloudfront : null;
 
 async function cloudfront(req) {
-  const url = req.params?.url || req;
-
   try {
+    const url = req.params?.url || req;
+
     const signedURL = await cloudfront_signer(url);
 
     if (signedURL instanceof Error) {

--- a/mod/provider/cloudfront.js
+++ b/mod/provider/cloudfront.js
@@ -19,60 +19,49 @@ import logger from '../utils/logger.js';
 @function cloudfront
 
 @description
-The cloudfront method returns an async Fetch method which must be awaited to resolve into a cloudfront resource.
+The cloudfront provider method will parse an URL from the request parameter and sign this request through the cloudfront signer module.
 
-A req param will be provided by requests through the provider endpoint module.
+The module will attempt to fetch a resource from the signed request URL.
 
-The req param is string if the request for a resource is passed from the getFrom module.
+An error will be returned if the signing or fetching fails.
+
+The fetched will resource body will be parsed as JSON if the URL ends in `.json`. Otherwise the resource body will be parsed as text.
 
 @param {req|string} req Request object or URL string.
 @property {object} [req.params] Request params.
 @property {string} params.url URL in request param.
 
-@returns {function} The async fetch function is returned.
+@returns {Promise<Object|Error>}
 */
 export default cloudfront_signer ? cloudfront : null;
 
-function cloudfront(req) {
+async function cloudfront(req) {
   const url = req.params?.url || req;
 
-  return Fetch(url);
-}
+  try {
+    const signedURL = await cloudfront_signer(url);
 
-/**
-@function fetch
-@async
+    if (signedURL instanceof Error) {
+      return signedURL;
+    }
 
-@description
-The url string is passed to the cloudfront signer to request a signed URL.
+    const timestamp = Date.now();
 
-The resource is fetched from the signed cloudfront URL.
+    // Fetch will fail with an invalid domain.
+    const response = await fetch(signedURL);
 
-The response is parsed as JSON if the URL ending matches `.json`
+    logger(
+      `${Date.now() - timestamp}: ${response.status} - ${url}`,
+      'cloudfront',
+    );
 
-@param {string} url Cloudfront resource URL.
+    if (response.status >= 300) return new Error(`${response.status} ${url}`);
 
-@returns {Promise<String|JSON|Error>} The fetch is resolved into either a string or JSON depending on the url ending.
-*/
-async function Fetch(url) {
-  const signedURL = await cloudfront_signer(url);
+    if (url.match(/\.json$/i)) return await response.json();
 
-  if (signedURL instanceof Error) {
-    return signedURL;
+    return await response.text();
+  } catch (err) {
+    console.error(err);
+    return err;
   }
-
-  const timestamp = Date.now();
-
-  const response = await fetch(signedURL);
-
-  logger(
-    `${Date.now() - timestamp}: ${response.status} - ${url}`,
-    'cloudfront',
-  );
-
-  if (response.status >= 300) return new Error(`${response.status} ${url}`);
-
-  if (url.match(/\.json$/i)) return await response.json();
-
-  return await response.text();
 }

--- a/tests/mod/provider/cloudfront.test.mjs
+++ b/tests/mod/provider/cloudfront.test.mjs
@@ -1,109 +1,200 @@
 import { createMocks } from 'node-mocks-http';
-import { MockAgent, setGlobalDispatcher } from 'undici';
-import { describe, expect, it, vi } from 'vitest';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 
-globalThis.xyzEnv = {};
+const signerMock = vi.fn();
+const loggerMock = vi.fn();
 
-const mockedCloudfrontFn = vi.fn();
+async function importCloudfront({ signerExport } = {}) {
+  vi.resetModules();
 
-vi.mock('../../../mod/sign/cloudfront.js', () => ({
-  default: (...args) => mockedCloudfrontFn(...args),
-}));
+  vi.doMock('../../../mod/sign/cloudfront.js', () => ({
+    default:
+      signerExport === undefined
+        ? (...args) => signerMock(...args)
+        : signerExport,
+  }));
 
-const mockAgent = new MockAgent();
-setGlobalDispatcher(mockAgent);
+  vi.doMock('../../../mod/utils/logger.js', () => ({
+    default: (...args) => loggerMock(...args),
+  }));
 
-const { default: cloudfront } = await import(
-  '../../../mod/provider/cloudfront.js'
-);
+  return (await import('../../../mod/provider/cloudfront.js')).default;
+}
 
 describe('cloudfront:', () => {
-  it('Should handle cloudfront signer error', async () => {
-    mockedCloudfrontFn.mockImplementation(() => {
-      return new Error('Cloudfront found an error');
-    });
-
-    const { req } = createMocks();
-
-    const result = await cloudfront(req);
-
-    expect(result).toBeInstanceOf(Error);
+  afterEach(() => {
+    signerMock.mockReset();
+    loggerMock.mockReset();
+    vi.restoreAllMocks();
+    vi.unstubAllGlobals();
+    vi.resetModules();
   });
 
-  describe('Fetches signedURL', () => {
-    const testCases = {
-      error: {
-        status: 300,
-        body: 'test string',
-        params: {
-          url: 'http://localhost:3000/thing1.json',
-          path: '/thing1.json',
-        },
-        expected: new Error(),
-      },
-      json: {
-        status: 200,
-        body: {
-          objectKey: 'example-image.jpg',
-          bucketName: 'my-aws-bucket',
-          region: 'us-east-1',
-          expires: '2023-12-31T23:59:59Z',
-          headers: {
-            'Content-Type': 'image/jpeg',
-            'Cache-Control': 'max-age=3600',
-          },
-        },
-        params: {
-          url: 'http://localhost:3000/proper.json',
-          path: '/proper.json',
-        },
-        expected: {
-          objectKey: 'example-image.jpg',
-          bucketName: 'my-aws-bucket',
-          region: 'us-east-1',
-          expires: '2023-12-31T23:59:59Z',
-          headers: {
-            'Content-Type': 'image/jpeg',
-            'Cache-Control': 'max-age=3600',
-          },
-        },
-      },
+  it('exports null when the signer export is falsy', async () => {
+    // Arrange
+    const cloudfront = await importCloudfront({ signerExport: null });
+
+    // Act
+    const result = cloudfront;
+
+    // Assert
+    expect(result).toBeNull();
+  });
+
+  it('reads the URL from req.params.url and returns JSON for .json URLs', async () => {
+    // Arrange
+    const cloudfront = await importCloudfront();
+    const payload = { ok: true };
+    const response = {
+      status: 200,
+      json: vi.fn().mockResolvedValue(payload),
+      text: vi.fn(),
     };
 
-    const mockPool = mockAgent.get(new RegExp('http://localhost:3000'));
+    signerMock.mockResolvedValue('https://signed.example/data.json?sig=1');
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue(response));
+    vi.spyOn(Date, 'now').mockReturnValueOnce(100).mockReturnValueOnce(145);
 
-    for (const test of Object.keys(testCases)) {
-      it(`${test}`, async () => {
-        mockedCloudfrontFn.mockImplementation(() => {
-          return testCases[test].params.url;
-        });
+    const { req } = createMocks({
+      params: { url: 'https://origin.example/data.JSON' },
+    });
 
-        const { req } = createMocks(
-          {
-            params: {
-              url: testCases[test].params.url,
-              body: testCases[test].body,
-            },
-          },
-          {
-            locals: {
-              statusCode: testCases[test].status,
-            },
-          },
-        );
+    // Act
+    const result = await cloudfront(req);
 
-        mockPool
-          .intercept({ path: testCases[test].params.path })
-          .reply(testCases[test].status, testCases[test].body);
+    // Assert
+    expect(result).toEqual(payload);
+    expect(signerMock).toHaveBeenCalledWith('https://origin.example/data.JSON');
+    expect(fetch).toHaveBeenCalledWith(
+      'https://signed.example/data.json?sig=1',
+    );
+    expect(response.json).toHaveBeenCalledTimes(1);
+    expect(response.text).not.toHaveBeenCalled();
+    expect(loggerMock).toHaveBeenCalledWith(
+      '45: 200 - https://origin.example/data.JSON',
+      'cloudfront',
+    );
+  });
 
-        const results = await cloudfront(req);
+  it('reads the URL from a raw string and returns text for non-json URLs', async () => {
+    // Arrange
+    const cloudfront = await importCloudfront();
+    const response = {
+      status: 200,
+      json: vi.fn(),
+      text: vi.fn().mockResolvedValue('plain text body'),
+    };
+    const url = 'https://origin.example/file.txt';
 
-        if (testCases[test].expected instanceof Error) {
-          expect(results).toBeInstanceOf(Error);
-        } else {
-          expect(results).toEqual(testCases[test].expected);
-        }
-      });
-    }
+    signerMock.mockResolvedValue('https://signed.example/file.txt?sig=1');
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue(response));
+    vi.spyOn(Date, 'now').mockReturnValueOnce(200).mockReturnValueOnce(260);
+
+    // Act
+    const result = await cloudfront(url);
+
+    // Assert
+    expect(result).toEqual('plain text body');
+    expect(signerMock).toHaveBeenCalledWith(url);
+    expect(fetch).toHaveBeenCalledWith('https://signed.example/file.txt?sig=1');
+    expect(response.text).toHaveBeenCalledTimes(1);
+    expect(response.json).not.toHaveBeenCalled();
+    expect(loggerMock).toHaveBeenCalledWith(
+      '60: 200 - https://origin.example/file.txt',
+      'cloudfront',
+    );
+  });
+
+  it('returns a signer Error without fetching', async () => {
+    // Arrange
+    const cloudfront = await importCloudfront();
+    const expected = new Error('Cloudfront signer error');
+
+    signerMock.mockResolvedValue(expected);
+    vi.stubGlobal('fetch', vi.fn());
+
+    const { req } = createMocks({
+      params: { url: 'https://origin.example/error.json' },
+    });
+
+    // Act
+    const result = await cloudfront(req);
+
+    // Assert
+    expect(result).toBe(expected);
+    expect(fetch).not.toHaveBeenCalled();
+    expect(loggerMock).not.toHaveBeenCalled();
+  });
+
+  it('returns an Error for responses with status >= 300 and still logs the request', async () => {
+    // Arrange
+    const cloudfront = await importCloudfront();
+    const response = {
+      status: 404,
+      json: vi.fn(),
+      text: vi.fn(),
+    };
+
+    signerMock.mockResolvedValue('https://signed.example/missing.json?sig=1');
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue(response));
+    vi.spyOn(Date, 'now').mockReturnValueOnce(300).mockReturnValueOnce(309);
+
+    const { req } = createMocks({
+      params: { url: 'https://origin.example/missing.json' },
+    });
+
+    // Act
+    const result = await cloudfront(req);
+
+    // Assert
+    expect(result).toBeInstanceOf(Error);
+    expect(result.message).toBe('404 https://origin.example/missing.json');
+    expect(response.json).not.toHaveBeenCalled();
+    expect(response.text).not.toHaveBeenCalled();
+    expect(loggerMock).toHaveBeenCalledWith(
+      '9: 404 - https://origin.example/missing.json',
+      'cloudfront',
+    );
+  });
+
+  it('catches signer failures, logs to console.error, and returns the error', async () => {
+    // Arrange
+    const cloudfront = await importCloudfront();
+    const expected = new Error('signer threw');
+    const consoleError = vi
+      .spyOn(console, 'error')
+      .mockImplementation(() => {});
+
+    signerMock.mockRejectedValue(expected);
+    vi.stubGlobal('fetch', vi.fn());
+
+    // Act
+    const result = await cloudfront('https://origin.example/rejected.txt');
+
+    // Assert
+    expect(result).toBe(expected);
+    expect(consoleError).toHaveBeenCalledWith(expected);
+    expect(fetch).not.toHaveBeenCalled();
+    expect(loggerMock).not.toHaveBeenCalled();
+  });
+
+  it('catches fetch failures, logs to console.error, and returns the error', async () => {
+    // Arrange
+    const cloudfront = await importCloudfront();
+    const expected = new Error('fetch failed');
+    const consoleError = vi
+      .spyOn(console, 'error')
+      .mockImplementation(() => {});
+
+    signerMock.mockResolvedValue('https://signed.example/broken.txt?sig=1');
+    vi.stubGlobal('fetch', vi.fn().mockRejectedValue(expected));
+
+    // Act
+    const result = await cloudfront('https://origin.example/broken.txt');
+
+    // Assert
+    expect(result).toBe(expected);
+    expect(consoleError).toHaveBeenCalledWith(expected);
+    expect(loggerMock).not.toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
Rather than returning the async Fetch method from the cloudfront provide module method the fetch should be resolved inside the method.

The method must be tried to account for the fetch method failing.

The fetch response will be 403 if the signed url path is wrong or the file doesn't exist eg. `cloudfront:dev.geolytix.io/bogus.json`

The fetch method will crash if the domain is bogus eg. `cloudfront:bogus.io/file.json`

Resource parsing will crash if the resource cannot be parsed as assumed. eg. `cloudfront:dev.geolytix.io/text.json`