### PR TITLE
Add drawer `disableOnHide` flag to reference layer display toggle.

### DIFF
--- a/lib/layer/styleParser.mjs
+++ b/lib/layer/styleParser.mjs
@@ -67,9 +67,9 @@ A lookup will be attempted if the label property is a string. Otherwise the firs
 */
 export default function styleParser(layer) {
   layer.style ??= {};
-  // Assign the disableOnHide class if the drawer flag is not already present. 
+  // Assign the disableOnHide class if the drawer flag is not already present.
   // This ensures that the drawer is disabled when the layer is toggled off.
-  layer.style.drawer ??= "disableOnHide";
+  layer.style.drawer ??= 'disableOnHide';
 
   if (typeof layer.style.highlight === 'object') {
     // Ensure that highlight zIndex is always on top.

--- a/lib/layer/styleParser.mjs
+++ b/lib/layer/styleParser.mjs
@@ -67,6 +67,9 @@ A lookup will be attempted if the label property is a string. Otherwise the firs
 */
 export default function styleParser(layer) {
   layer.style ??= {};
+  // Assign the disableOnHide class if the drawer flag is not already present. 
+  // This ensures that the drawer is disabled when the layer is toggled off.
+  layer.style.drawer ??= "disableOnHide";
 
   if (typeof layer.style.highlight === 'object') {
     // Ensure that highlight zIndex is always on top.

--- a/lib/ui/elements/drawer.mjs
+++ b/lib/ui/elements/drawer.mjs
@@ -63,6 +63,17 @@ export function drawer(params) {
     : mapp.utils.html`
       <div class="notranslate material-symbols-outlined caret">`;
 
+  if (params.drawer === 'disable' && params.layer?.showCallbacks) {
+    params.class += params.layer.display ? '' : ' disabled';
+    params.layer.showCallbacks.push(() => {
+      params.drawer.classList.remove('disabled');
+    });
+    params.layer.hideCallbacks.push(() => {
+      params.drawer.classList.add('disabled');
+      params.drawer.classList.remove('expanded');
+    });
+  }
+
   params.drawer = mapp.utils.html.node`
   <div
     data-id=${params.data_id}

--- a/lib/ui/elements/drawer.mjs
+++ b/lib/ui/elements/drawer.mjs
@@ -16,7 +16,11 @@ The drawer method will create and return drawer element with a header and conten
 @property {string} params.data_id The data-id for drawer element.
 @property {HTML} params.header The header element[s].
 @property {HTML} params.content The content element[s] for the drawer.
-@property {boolean} [params.drawer] Optional flag to skip creation of the expandable container and/or header. Set to `false` creates header and content. Set to `null` creates content only. `disable` sets the drawer to disabled when a layer is toggled.
+@property {boolean} [params.drawer] Optional flag to skip creation of the expandable container and/or header. 
+Set to `false` creates header and content. 
+Set to `null` creates content only. 
+`disableOnHide` sets the drawer to disabled when a layer is turned off.
+By default, all style drawers are given `disableOnHide` behaviour. This can be revoked by passing an empty string or any other value e.g. `showOnHide` to the drawer property.
 @property {HTMLElement} [params.view] The layer view the drawer is in.
 @returns {HTMLElement} The drawer element.
 */
@@ -61,7 +65,7 @@ export function drawer(params) {
     : mapp.utils.html`
       <div class="notranslate material-symbols-outlined caret">`;
 
-  if (params.drawer === 'disable' && params.layer?.showCallbacks) {
+  if (params.drawer === 'disableOnHide' && params.layer?.showCallbacks) {
     params.class += params.layer.display ? '' : ' disabled';
     params.layer.showCallbacks.push(() => {
       params.drawer.classList.remove('disabled');

--- a/lib/ui/elements/drawer.mjs
+++ b/lib/ui/elements/drawer.mjs
@@ -16,12 +16,10 @@ The drawer method will create and return drawer element with a header and conten
 @property {string} params.data_id The data-id for drawer element.
 @property {HTML} params.header The header element[s].
 @property {HTML} params.content The content element[s] for the drawer.
-@property {boolean} [params.popout] Whether the drawer can be popped out into a dialog.
 @property {boolean} [params.drawer] Optional flag to skip creation of the expandable container and/or header. Set to `false` creates header and content. Set to `null` creates content only.
 @property {HTMLElement} [params.view] The layer view the drawer is in.
 @returns {HTMLElement} The drawer element.
 */
-
 export function drawer(params) {
   params.data_id ??= 'drawer';
 
@@ -74,6 +72,8 @@ export function drawer(params) {
     });
   }
 
+  popout(params);
+
   params.drawer = mapp.utils.html.node`
   <div
     data-id=${params.data_id}
@@ -87,60 +87,6 @@ export function drawer(params) {
     <div class="content">
       ${params.content}
     </div>`;
-
-  if (params.popout) {
-    params.popout = {};
-
-    //used for keeping track of where the content came from.
-    params.originalTarget = params.drawer.querySelector('.content');
-
-    params.popoutBtn = params.drawer
-      .querySelector('.header')
-      .querySelector('[data-id=popout-btn]');
-
-    //Append the button if it is not present in the header already.
-    if (!params.popoutBtn) {
-      params.popoutBtn = mapp.utils.html.node`<button
-      data-id="popout-btn"
-      class="notranslate material-symbols-outlined">
-      open_in_new`;
-
-      //Identify the caret element.
-      const beforeElement = params.drawer
-        .querySelector('.header')
-        .querySelector('.caret');
-
-      //Add the popoutBtn to the drawer header.
-      params.drawer
-        .querySelector('.header')
-        .insertBefore(params.popoutBtn, beforeElement);
-    }
-
-    params.popoutBtn.onclick = () => {
-      //Hide the original drawer the popout came from.
-      params.drawer.style.display = 'none';
-
-      params.view = params.drawer.parentElement;
-      popoutDialog(params);
-
-      //If view is provided, check whether there is anything else in the view.
-      if (params.view) {
-        params.viewChildren = Array.from(params.view.children || []).filter(
-          (el) => el.checkVisibility(),
-        );
-      }
-
-      //Hide the caret and close the drawer if theres nothing else in the layer-view
-      if (params.viewChildren && !params.viewChildren.length) {
-        params.view.previousElementSibling.dispatchEvent(new Event('click'));
-        params.view.parentElement.classList.add('empty');
-
-        params.view.previousElementSibling
-          .querySelector('.caret')
-          .style.setProperty('display', 'none');
-      }
-    };
-  }
 
   return params.drawer;
 
@@ -157,6 +103,74 @@ export function drawer(params) {
 
     e.target.parentElement.classList.toggle('expanded');
   }
+}
+
+/**
+@function popout
+
+@description
+The method assigns the popout behaviour to the drawer element if the popout property is not falsy.
+
+@param {Object} params The configuration params for the drawer element.
+@property {HTML} params.drawer The drawer element.
+@property {boolean} [params.popout] Whether the drawer can be popped out into a dialog.
+@property {boolean} [params.drawer] Optional flag to skip creation of the expandable container and/or header. Set to `false` creates header and content. Set to `null` creates content only.
+@property {HTMLElement} [params.view] The layer view the drawer is in.
+*/
+function popout(params) {
+  if (!params.popout) return;
+
+  params.popout = {};
+
+  //used for keeping track of where the content came from.
+  params.originalTarget = params.drawer.querySelector('.content');
+
+  params.popoutBtn = params.drawer
+    .querySelector('.header')
+    .querySelector('[data-id=popout-btn]');
+
+  //Append the button if it is not present in the header already.
+  if (!params.popoutBtn) {
+    params.popoutBtn = mapp.utils.html.node`<button
+      data-id="popout-btn"
+      class="notranslate material-symbols-outlined">
+      open_in_new`;
+
+    //Identify the caret element.
+    const beforeElement = params.drawer
+      .querySelector('.header')
+      .querySelector('.caret');
+
+    //Add the popoutBtn to the drawer header.
+    params.drawer
+      .querySelector('.header')
+      .insertBefore(params.popoutBtn, beforeElement);
+  }
+
+  params.popoutBtn.onclick = () => {
+    //Hide the original drawer the popout came from.
+    params.drawer.style.display = 'none';
+
+    params.view = params.drawer.parentElement;
+    popoutDialog(params);
+
+    //If view is provided, check whether there is anything else in the view.
+    if (params.view) {
+      params.viewChildren = Array.from(params.view.children || []).filter(
+        (el) => el.checkVisibility(),
+      );
+    }
+
+    //Hide the caret and close the drawer if theres nothing else in the layer-view
+    if (params.viewChildren && !params.viewChildren.length) {
+      params.view.previousElementSibling.dispatchEvent(new Event('click'));
+      params.view.parentElement.classList.add('empty');
+
+      params.view.previousElementSibling
+        .querySelector('.caret')
+        .style.setProperty('display', 'none');
+    }
+  };
 }
 
 /**

--- a/lib/ui/elements/drawer.mjs
+++ b/lib/ui/elements/drawer.mjs
@@ -16,7 +16,7 @@ The drawer method will create and return drawer element with a header and conten
 @property {string} params.data_id The data-id for drawer element.
 @property {HTML} params.header The header element[s].
 @property {HTML} params.content The content element[s] for the drawer.
-@property {boolean} [params.drawer] Optional flag to skip creation of the expandable container and/or header. Set to `false` creates header and content. Set to `null` creates content only.
+@property {boolean} [params.drawer] Optional flag to skip creation of the expandable container and/or header. Set to `false` creates header and content. Set to `null` creates content only. `disable` sets the drawer to disabled when a layer is toggled.
 @property {HTMLElement} [params.view] The layer view the drawer is in.
 @returns {HTMLElement} The drawer element.
 */

--- a/lib/ui/elements/drawer.mjs
+++ b/lib/ui/elements/drawer.mjs
@@ -72,8 +72,6 @@ export function drawer(params) {
     });
   }
 
-  popout(params);
-
   params.drawer = mapp.utils.html.node`
   <div
     data-id=${params.data_id}
@@ -87,6 +85,8 @@ export function drawer(params) {
     <div class="content">
       ${params.content}
     </div>`;
+
+  popout(params);
 
   return params.drawer;
 
@@ -285,7 +285,7 @@ dialog: {
   btn_title: "My panel Dialog",
   btn_label: "Open my panel dialog",
   title: "My dialog title",
-  icon: "thumbs_up" 
+  icon: "thumbs_up"
 }
 ```
 


### PR DESCRIPTION
This PR introduces the 'disableOnHide' value for the drawer property.

The drawer property will is checked by the ui/elements/drawer method before the drawer element is assigned to the same prooperty.

Setting a string value eg. 'disableOnHide' will allow to add show and hide callback methods to the layer object.

This can be used to control whether a drawer eg style will be disabled and collapsed when the layer is hidden.

The complex popout logic should be in a seperate method to shortcircuit with the popout propertty falsy rather than the whole logic stuffed into an if condition block.

The styleParser has been updated to apply this new flag to all style objects, providing a consistent UI pattern where the style is collapsed and disabled when a layer is off.