### PR TITLE
Control whether entry options should be dynamic

### DIFF
--- a/lib/ui/locations/entries/text.mjs
+++ b/lib/ui/locations/entries/text.mjs
@@ -104,16 +104,6 @@ function onkeyup(e, entry) {
     ? e.target.value.split(entry.edit.arraySeparator)
     : e.target.value;
 
-  entry.location.infoj.find((el) => {
-    if (
-      (entry.field === el.field || entry.json_field === el.json_field) &&
-      el.edit?.options
-    ) {
-      //Remove options so the query is rerun.
-      el.edit.options = [];
-    }
-  });
-
   entry.location.view?.dispatchEvent(
     new CustomEvent('valChange', { detail: entry }),
   );
@@ -126,11 +116,18 @@ function onkeyup(e, entry) {
 @description
 The textoptions method will render a dropdown control for the edit.options[] array values into the entry.container.
 
+The available options will be queried from the database if edit.dynamic is true or if edit.options is an empty array. The query can be configured to query distinct values from a field or a template.
+
 @param {infoj-entry} entry type:geometry entry.
-@property {Object} entry.value geometry as JSON value.
-@property {Object} entry.edit configuration object for editing the value.
+@property {text} entry.value The current entry value.
+@property {object} entry.edit Configuration for editing the entry value.
+@property {boolean} [edit.dynamic] Always populate options from the database when true.
 */
 async function textoptions(entry) {
+  if (entry.edit.dynamic === true) {
+    entry.edit.options = [];
+  }
+
   if (!entry.edit.options.length) {
     // We can query a particular template or Query distinct field values from the layer table.
     if (entry.jsonb_field || entry.json_field) {


### PR DESCRIPTION
The entry.options should not be reset on keyup.

A flag `edit.dyanamic = true` has been introduced in this PR. The options will be set to an empty array if used. This will force the options to be populated from a query.