### PR TITLE
Remove CLRF character in user-controlled data

### DIFF
--- a/mod/utils/logger.js
+++ b/mod/utils/logger.js
@@ -76,6 +76,10 @@ export default function log(log, key = 'err') {
   // Check whether the log for the key should be logged.
   if (!logs.has(key)) return;
 
+  if (typeof log === 'string') {
+    log = log.replace(/[\n\r]/g, '_');
+  }
+
   // Write log to logger if configured.
   logger?.(log, key);
 

--- a/mod/utils/logger.js
+++ b/mod/utils/logger.js
@@ -77,7 +77,7 @@ export default function log(log, key = 'err') {
   if (!logs.has(key)) return;
 
   if (typeof log === 'string') {
-    log = log.replace(/[\n\r]/g, '_');
+    log = { log: log.replace(/[\n\r]/g, '_') };
   }
 
   // Write log to logger if configured.


### PR DESCRIPTION
The log param provided to the logger module may be a string from user controlled data, eg. `req.url`, `req.params.msg`.

Log injection occurs when an application fails to sanitize untrusted data used for logging.

An attacker can forge log content to prevent an organization from being able to trace back malicious activities.

Data used for logging should be content-restricted and typed. This can be done by validating the data content or sanitizing it.
Validation and sanitization mainly revolve around preventing carriage return (CR) and line feed (LF) characters. However, further actions could be required based on the application context and the logged data usage.

This PR removes CLRF characters in from string log params provided to the logger log method.
