### PR TITLE
Use convential element dataset property

### DIFF
--- a/lib/ui/Tabview.mjs
+++ b/lib/ui/Tabview.mjs
@@ -42,7 +42,9 @@ export default function Tabview(tabview) {
     tabview.node.appendChild(mapp.utils.html.node`<div class="panel">`);
 
   // Set data attribute ID from element ID.
-  tabview.id && tabview.node.setAttribute('data-id', tabview.id);
+  if (tabview.id) {
+    tabview.node.dataset.id = tabview.id;
+  }
 
   tabview.addTab = addTab;
 

--- a/lib/ui/elements/pills.mjs
+++ b/lib/ui/elements/pills.mjs
@@ -109,7 +109,7 @@ function remove(val) {
   const component = this;
 
   const pillElement = Array.from(component.container.children).find(
-    (child) => child.getAttribute('data-value') === val.toString(),
+    (child) => child.dataset.value === val.toString(),
   );
 
   pillElement?.remove();


### PR DESCRIPTION
Using generic attribute methods instead of .dataset reduces code readability and maintainability. While functionally equivalent, it makes the code less expressive about working with data attributes and requires manual handling of name conversions between kebab-case and camelCase.