### PR TITLE
Remove 'err' condition from logger

### DIFF
--- a/mod/utils/dbs.js
+++ b/mod/utils/dbs.js
@@ -49,11 +49,7 @@ Object.keys(xyzEnv)
 
     // Handle pool errors
     pool.on('error', (err, client) => {
-      logger({
-        err,
-        message: 'Unexpected error on idle client',
-        pool: id,
-      });
+      console.error(err);
     });
 
     // Assigning clientQuery method to dbs property.

--- a/mod/utils/logger.js
+++ b/mod/utils/logger.js
@@ -70,20 +70,14 @@ const logger =
 Logs a message to the configured logger or console.
 
 @param {string|Object} log The message or object to log.
-@param {string} [key='err'] The log level or key.
+@param {string} key The log level or key.
 */
-export default function log(log, key = 'err') {
+export default function log(log, key) {
   // Check whether the log for the key should be logged.
   if (!logs.has(key)) return;
 
   // Write log to logger if configured.
   logger?.(log, key);
-
-  if (key === 'err') {
-    // Log errors as such.
-    console.error(log);
-    return;
-  }
 
   // Log to stdout.
   console.log(log);


### PR DESCRIPTION
The err condition for the logger is only ever used for the dbs module on error oof the pool. This error should be logged directly to stdout.

The logger should not be concerned with log.error that could have a potential user controlled data value.