### PR TITLE
Remove view-req-url key

### DIFF
--- a/mod/utils/logger.js
+++ b/mod/utils/logger.js
@@ -6,7 +6,6 @@ Possible log values are:
 
 - query_params: Logs query parameters sent to the query endpoint.
 - query: Logs the sql to executed by calling the query endpoint.
-- view-req-url: Logs the url of the requested view.
 - cloudfront: Logs responses from requests made to cloudfront e.g. <staus_code> - <endpoint>
 - mailer: Logs the response from email sending.
 - mailer_body: Logs email from and two with the body.

--- a/mod/view.js
+++ b/mod/view.js
@@ -36,8 +36,6 @@ The view [template] is a HTML string. Template variables defined within a set of
 @property {Object} [params.user] Requesting user.
 */
 export default async function view(req, res) {
-  logger(req.url, 'view-req-url');
-
   // Property values in the params object will be substituted in the view template.
   const params = {};
 


### PR DESCRIPTION
This PR removes view-req-url key which doesn't add much but the risk of user coontrolled data being logged.

Other endpoints don't have a req.url logger key.

Any request can and should be logged in the edge network to log requests not received by the view or other methods.
