### PR TITLE
Do not log user controlled input url

### DIFF
--- a/mod/provider/getFrom.js
+++ b/mod/provider/getFrom.js
@@ -88,7 +88,7 @@ async function Https(url) {
   try {
     const response = await fetch(url);
 
-    logger(`${response.status} - ${url}`, 'fetch');
+    logger(`${response.status} - ${response.url}`, 'fetch');
 
     if (url.match(/\.json$/i)) {
       return await response.json();


### PR DESCRIPTION
The `fetch` logger key is used to log the status and url of fetched resources from the getFrom module.

Logging the req.url passed as template string to the get templates module exposes the risk of logging user controlled data.

The response object exposes the url property with the status. It should be assumed that this input is sanitized and safe to log.
