### PR TITLE
Log user.email instead of request params.

### DIFF
--- a/mod/provider/getFrom.js
+++ b/mod/provider/getFrom.js
@@ -88,7 +88,7 @@ async function Https(url) {
   try {
     const response = await fetch(url);
 
-    logger(`${response.status} - ${url}`, 'fetch');
+    logger(`${response.status} - ${response.url}`, 'fetch');
 
     if (url.match(/\.json$/i)) {
       return await response.json();

--- a/mod/user/fromACL.js
+++ b/mod/user/fromACL.js
@@ -204,7 +204,7 @@ async function getUser(request) {
     return user;
   }
 
-  return await failedLogin(request);
+  return await failedLogin(user, request);
 }
 
 /**
@@ -269,18 +269,19 @@ An email with the verification token is sent to the user notifying that the acco
 
 It is recommended to reset the password for the account if this happens.
 
+@param {Object} user The user for which login has failed.
 @param {Object} request The request object.
-@param {string} request.email The email address of the user.
-@param {string} request.language The language for the user.
-@param {string} request.host The host for the account verification email.
-@param {string} request.remote_address The IP address of the client.
+@property {string} request.email The email address of the user.
+@property {string} request.language The language for the user.
+@property {string} request.host The host for the account verification email.
+@property {string} request.remote_address The IP address of the client.
 
 @returns {Promise<Error>} A Promise that resolves with an Error.
 */
 
 const maxFailedAttempts = Number.parseInt(xyzEnv.FAILED_ATTEMPTS);
 
-async function failedLogin(request) {
+async function failedLogin(user, request) {
   // Increase failed login attempts counter by 1.
   let rows = await acl(
     `
@@ -288,7 +289,7 @@ async function failedLogin(request) {
     SET failedattempts = failedattempts + 1
     WHERE lower(email) = lower($1)
     RETURNING failedattempts;`,
-    [request.email],
+    [user.email],
   );
 
   if (rows instanceof Error) {
@@ -313,7 +314,7 @@ async function failedLogin(request) {
         verified = false,
         verificationtoken = '${verificationtoken}'
       WHERE lower(email) = lower($1);`,
-      [request.email],
+      [user.email],
     );
 
     if (rows instanceof Error) {
@@ -331,7 +332,7 @@ async function failedLogin(request) {
       language: request.language,
       remote_address: request.remote_address,
       template: 'locked_account',
-      to: request.email,
+      to: user.email,
       verificationtoken,
     });
 
@@ -354,7 +355,7 @@ async function failedLogin(request) {
     language: request.language,
     remote_address: request.remote_address,
     template: 'login_incorrect',
-    to: request.email,
+    to: user.email,
   });
 
   return new Error('auth_failed');

--- a/mod/utils/logger.js
+++ b/mod/utils/logger.js
@@ -8,8 +8,7 @@ Possible log values are:
 - query: Logs the sql to executed by calling the query endpoint.
 - view-req-url: Logs the url of the requested view.
 - cloudfront: Logs responses from requests made to cloudfront e.g. <staus_code> - <endpoint>
-- mailer: Logs the response from email sending.
-- mailer_body: Logs email from and two with the body.
+- mailer: Logs the sent mail template.
 - reqhost: Logs the host for the request.
 - workspace: Logs responses for requests made to /workspace.
 

--- a/mod/utils/logger.js
+++ b/mod/utils/logger.js
@@ -98,7 +98,10 @@ function sanitizeLogValue(value) {
 
   if (value && typeof value === 'object') {
     return Object.fromEntries(
-      Object.entries(value).map(([key, value]) => [key, sanitizeLogValue(value)]),
+      Object.entries(value).map(([key, value]) => [
+        key,
+        sanitizeLogValue(value),
+      ]),
     );
   }
 

--- a/mod/utils/logger.js
+++ b/mod/utils/logger.js
@@ -74,11 +74,35 @@ export default function log(log, key) {
   // Check whether the log for the key should be logged.
   if (!logs.has(key)) return;
 
-  // Write log to logger if configured.
-  logger?.(log, key);
+  const sanitizedLog = { message: sanitizeLogValue(log), time: new Date() };
+
+  // Log structured, sanitized data to prevent CR/LF log injection.
+  logger?.(sanitizedLog, key);
 
   // Log to stdout.
-  console.log(log);
+  console.log(sanitizedLog);
+}
+
+function sanitizeLogValue(value) {
+  if (typeof value === 'string') return value.replaceAll(/[\n\r]/g, '_');
+
+  if (Array.isArray(value)) return value.map(sanitizeLogValue);
+
+  if (value instanceof Error) {
+    return {
+      message: sanitizeLogValue(value.message),
+      name: value.name,
+      stack: sanitizeLogValue(value.stack),
+    };
+  }
+
+  if (value && typeof value === 'object') {
+    return Object.fromEntries(
+      Object.entries(value).map(([key, value]) => [key, sanitizeLogValue(value)]),
+    );
+  }
+
+  return value;
 }
 
 /**

--- a/mod/utils/logger.js
+++ b/mod/utils/logger.js
@@ -6,7 +6,6 @@ Possible log values are:
 
 - query_params: Logs query parameters sent to the query endpoint.
 - query: Logs the sql to executed by calling the query endpoint.
-- view-req-url: Logs the url of the requested view.
 - cloudfront: Logs responses from requests made to cloudfront e.g. <staus_code> - <endpoint>
 - mailer: Logs the response from email sending.
 - mailer_body: Logs email from and two with the body.

--- a/mod/utils/resend.js
+++ b/mod/utils/resend.js
@@ -79,13 +79,10 @@ async function send(params) {
     return;
   }
 
-  let result = `${data.id}\nFrom: ${xyzEnv.TRANSPORT_EMAIL}\nTo: ${params.to}`;
-
-  logger(result, 'mailer');
-
-  result += `\nBody:\n ${mailTemplate.text?.replace('    ', '')}`;
-
-  logger(result, 'mailer_body');
+  logger(
+    `${params.template}\nFrom: ${xyzEnv.TRANSPORT_EMAIL}\nTo: ${params.to}`,
+    'mailer',
+  );
 }
 
 /**

--- a/mod/utils/resend.js
+++ b/mod/utils/resend.js
@@ -72,7 +72,7 @@ async function send(params) {
     to: params.to,
   };
 
-  const { data, error } = await resend.emails.send(mailTemplate);
+  const { error } = await resend.emails.send(mailTemplate);
 
   if (error) {
     console.error(error);

--- a/mod/view.js
+++ b/mod/view.js
@@ -36,8 +36,6 @@ The view [template] is a HTML string. Template variables defined within a set of
 @property {Object} [params.user] Requesting user.
 */
 export default async function view(req, res) {
-  logger(req.url, 'view-req-url');
-
   // Property values in the params object will be substituted in the view template.
   const params = {};
 

--- a/tests/mod/user/fromACL.test.mjs
+++ b/tests/mod/user/fromACL.test.mjs
@@ -19,6 +19,7 @@ vi.mock('bcrypt', () => ({
 const mockAclRows = (query, email) => {
   email = email[0];
   const data = {
+    email: email,
     blocked: email.includes('blocked'),
     password: VALID_AUTH_VALUE,
     language: 'en',
@@ -206,6 +207,7 @@ describe('acl', async () => {
 
     expect(typeof result === 'object').toBeTruthy();
     expect(Object.keys(result)).toEqual([
+      'email',
       'language',
       'approved',
       'verified',

--- a/tests/mod/utils/logger.test.mjs
+++ b/tests/mod/utils/logger.test.mjs
@@ -1,0 +1,65 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+async function importLogger(env = {}) {
+  vi.resetModules();
+  globalThis.xyzEnv = env;
+
+  return (await import('../../../mod/utils/logger.js')).default;
+}
+
+describe('logger Module', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+    delete globalThis.fetch;
+    globalThis.xyzEnv = {};
+  });
+
+  it('logs structured sanitized values to stdout', async () => {
+    const consoleLog = vi.spyOn(console, 'log').mockImplementation(() => {});
+    const log = await importLogger({ LOGS: 'query' });
+
+    log(
+      {
+        params: ['safe', 'line\nbreak'],
+        sql: 'SELECT *\r\nFROM table',
+      },
+      'query',
+    );
+
+    expect(consoleLog).toHaveBeenCalledWith({
+      message: {
+        params: ['safe', 'line_break'],
+        sql: 'SELECT *__FROM table',
+      },
+      time: expect.any(Date),
+    });
+  });
+
+  it('logs structured sanitized values to configured loggers', async () => {
+    globalThis.fetch = vi.fn(() => Promise.resolve());
+    vi.spyOn(console, 'log').mockImplementation(() => {});
+
+    const log = await importLogger({
+      LOGGER: 'logflare:apikey=test_key&source=test_source',
+      LOGS: 'query',
+    });
+
+    log('Data: first line\r\nsecond line', 'query');
+
+    expect(fetch).toHaveBeenCalledWith(
+      'https://api.logflare.app/logs/json?source=test_source',
+      expect.objectContaining({
+        method: 'post',
+      }),
+    );
+
+    const body = JSON.parse(fetch.mock.calls[0][1].body);
+    const processLog = Object.entries(body).find(([key]) => key !== 'key')[1];
+
+    expect(body.key).toBe('query');
+    expect(processLog).toEqual({
+      message: 'Data: first line__second line',
+      time: expect.any(String),
+    });
+  });
+});

--- a/tests/mod/utils/resend.test.mjs
+++ b/tests/mod/utils/resend.test.mjs
@@ -91,7 +91,9 @@ describe('resend Module', () => {
   });
 
   it('does not log a single email when resend returns an error', async () => {
-    const consoleError = vi.spyOn(console, 'error').mockImplementation(() => {});
+    const consoleError = vi
+      .spyOn(console, 'error')
+      .mockImplementation(() => {});
     const error = new Error('send failed');
 
     emailSend.mockResolvedValue({ error });
@@ -198,7 +200,9 @@ describe('resend Module', () => {
   });
 
   it('logs batch send errors and still writes batch log entries', async () => {
-    const consoleError = vi.spyOn(console, 'error').mockImplementation(() => {});
+    const consoleError = vi
+      .spyOn(console, 'error')
+      .mockImplementation(() => {});
     const error = new Error('batch failed');
 
     batchSend.mockResolvedValue({ error });
@@ -212,7 +216,9 @@ describe('resend Module', () => {
       TRANSPORT_PASSWORD: 'secret',
     });
 
-    await mailer.batch([{ name: 'Rob', template: 'hello', to: 'rob@example.com' }]);
+    await mailer.batch([
+      { name: 'Rob', template: 'hello', to: 'rob@example.com' },
+    ]);
 
     expect(consoleError).toHaveBeenCalledWith(error);
     expect(logger).toHaveBeenCalledWith(

--- a/tests/mod/utils/resend.test.mjs
+++ b/tests/mod/utils/resend.test.mjs
@@ -1,0 +1,227 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+const batchSend = vi.fn();
+const emailSend = vi.fn();
+const fileGet = vi.fn();
+const languageTemplates = vi.fn();
+const logger = vi.fn();
+
+vi.mock('resend', () => ({
+  Resend: vi.fn(function Resend() {
+    return {
+      batch: {
+        send: batchSend,
+      },
+      emails: {
+        send: emailSend,
+      },
+    };
+  }),
+}));
+
+vi.mock('../../../mod/provider/getFrom.js', () => ({
+  default: {
+    file: fileGet,
+  },
+}));
+
+vi.mock('../../../mod/utils/languageTemplates.js', () => ({
+  default: languageTemplates,
+}));
+
+vi.mock('../../../mod/utils/logger.js', () => ({
+  default: logger,
+}));
+
+async function importMailer(env = {}) {
+  vi.resetModules();
+  globalThis.xyzEnv = env;
+
+  return (await import('../../../mod/utils/resend.js')).default;
+}
+
+describe('resend Module', () => {
+  afterEach(() => {
+    vi.clearAllMocks();
+    globalThis.xyzEnv = {};
+  });
+
+  it('does not send email when transport is not configured', async () => {
+    const mailer = await importMailer();
+
+    await mailer.send({ template: 'welcome', to: 'user@example.com' });
+    await mailer.batch([{ template: 'welcome', to: 'user@example.com' }]);
+
+    expect(emailSend).not.toHaveBeenCalled();
+    expect(batchSend).not.toHaveBeenCalled();
+  });
+
+  it('sends a single templated email and logs the mailer event', async () => {
+    emailSend.mockResolvedValue({});
+    languageTemplates.mockResolvedValue({
+      html: 'Hello ${name}',
+      subject: 'Welcome ${name}',
+      text: 'Plain ${name}',
+    });
+
+    const mailer = await importMailer({
+      TRANSPORT_EMAIL: 'sender@example.com',
+      TRANSPORT_PASSWORD: 'secret',
+    });
+
+    await mailer.send({
+      name: 'Rob',
+      template: 'welcome',
+      to: 'user@example.com',
+    });
+
+    expect(emailSend).toHaveBeenCalledWith({
+      from: 'sender@example.com',
+      html: undefined,
+      sender: 'sender@example.com',
+      subject: 'Welcome Rob',
+      text: 'Plain Rob',
+      to: 'user@example.com',
+    });
+
+    expect(logger).toHaveBeenCalledWith(
+      'welcome\nFrom: sender@example.com\nTo: user@example.com',
+      'mailer',
+    );
+  });
+
+  it('does not log a single email when resend returns an error', async () => {
+    const consoleError = vi.spyOn(console, 'error').mockImplementation(() => {});
+    const error = new Error('send failed');
+
+    emailSend.mockResolvedValue({ error });
+    languageTemplates.mockResolvedValue({
+      subject: 'Welcome',
+      text: 'Plain body',
+    });
+
+    const mailer = await importMailer({
+      TRANSPORT_EMAIL: 'sender@example.com',
+      TRANSPORT_PASSWORD: 'secret',
+    });
+
+    await mailer.send({ template: 'welcome', to: 'user@example.com' });
+
+    expect(consoleError).toHaveBeenCalledWith(error);
+    expect(logger).not.toHaveBeenCalled();
+  });
+
+  it('fetches html template bodies for html-only email', async () => {
+    emailSend.mockResolvedValue({});
+    fileGet.mockResolvedValue('<p>Hello ${name}</p>');
+    languageTemplates.mockResolvedValue({
+      html: 'file:html-template',
+      subject: 'Welcome ${name}',
+    });
+
+    const mailer = await importMailer({
+      TRANSPORT_EMAIL: 'sender@example.com',
+      TRANSPORT_PASSWORD: 'secret',
+    });
+
+    await mailer.send({
+      name: 'Rob',
+      template: 'welcome',
+      to: 'user@example.com',
+    });
+
+    expect(fileGet).toHaveBeenCalledWith('file:html-template');
+    expect(emailSend).toHaveBeenCalledWith({
+      from: 'sender@example.com',
+      html: '<p>Hello Rob</p>',
+      sender: 'sender@example.com',
+      subject: 'Welcome Rob',
+      text: undefined,
+      to: 'user@example.com',
+    });
+  });
+
+  it('fetches file template bodies before sending batch email', async () => {
+    batchSend.mockResolvedValue({});
+    fileGet.mockResolvedValue('    Body for ${name}');
+    languageTemplates
+      .mockResolvedValueOnce({
+        html: 'file:unused-html',
+        subject: 'Welcome ${name}',
+        text: 'file:text-template',
+      })
+      .mockResolvedValueOnce({
+        subject: 'Hello ${name}',
+        text: 'Second ${name}',
+      });
+
+    const mailer = await importMailer({
+      TRANSPORT_EMAIL: 'sender@example.com',
+      TRANSPORT_PASSWORD: 'secret',
+    });
+
+    await mailer.batch([
+      { name: 'Rob', template: 'welcome', to: 'rob@example.com' },
+      { name: 'Ada', template: 'hello', to: 'ada@example.com' },
+    ]);
+
+    expect(fileGet).toHaveBeenCalledWith('file:text-template');
+    expect(batchSend).toHaveBeenCalledWith([
+      {
+        from: 'sender@example.com',
+        html: undefined,
+        sender: 'sender@example.com',
+        subject: 'Welcome Rob',
+        text: '    Body for Rob',
+        to: 'rob@example.com',
+      },
+      {
+        from: 'sender@example.com',
+        html: undefined,
+        sender: 'sender@example.com',
+        subject: 'Hello Ada',
+        text: 'Second Ada',
+        to: 'ada@example.com',
+      },
+    ]);
+
+    expect(logger).toHaveBeenNthCalledWith(
+      1,
+      'From: sender@example.com\nTo: rob@example.com,ada@example.com',
+      'mailer',
+    );
+    expect(logger).toHaveBeenNthCalledWith(
+      2,
+      'From: sender@example.com\nTo: rob@example.com,ada@example.com\nBody:\n Body for Rob',
+      'mailer_body',
+    );
+  });
+
+  it('logs batch send errors and still writes batch log entries', async () => {
+    const consoleError = vi.spyOn(console, 'error').mockImplementation(() => {});
+    const error = new Error('batch failed');
+
+    batchSend.mockResolvedValue({ error });
+    languageTemplates.mockResolvedValue({
+      subject: 'Hello ${name}',
+      text: 'Body ${name}',
+    });
+
+    const mailer = await importMailer({
+      TRANSPORT_EMAIL: 'sender@example.com',
+      TRANSPORT_PASSWORD: 'secret',
+    });
+
+    await mailer.batch([{ name: 'Rob', template: 'hello', to: 'rob@example.com' }]);
+
+    expect(consoleError).toHaveBeenCalledWith(error);
+    expect(logger).toHaveBeenCalledWith(
+      'From: sender@example.com\nTo: rob@example.com',
+      'mailer',
+    );
+    expect(logger).toHaveBeenCalledWith(
+      'From: sender@example.com\nTo: rob@example.com\nBody:\n Body Rob',
+      'mailer_body',
+    );
+  });
+});


### PR DESCRIPTION
This PR reduces the risk of logging sensitive or user-controlled data across mailer, view, and fetch logging.

## Summary

- Removes the `mailer_body` logger key, which could include sensitive request body data and provides limited logging value.
- Updates the `mailer` logger key to read the recipient email address from the user object instead of the request body, avoiding logging user-controlled input.
- Removes the `view-req-url` logger key because it adds limited value and may expose user-controlled request URL data.
- Updates `fetch` logging in the `getFrom` module to log the fetched response URL and status instead of logging the request URL passed into the template module.
- Corrects the params/property documentation for the `fromACL` method.

## Rationale

Request-derived values such as body fields and request URLs can contain sensitive or user-controlled data. Logging these values increases risk without adding much operational value.

Request-level logging should happen at the edge/network layer, where all incoming requests can be captured consistently, including requests that never reach view handlers or other application methods.

For fetched resources, the response object already exposes the final `url` alongside the response `status`. This is a better logging source than the original request URL passed into the template module, and it avoids logging unsanitized user-controlled input.