### PR TITLE
Prevent multi-field categorized themes from mutating default style

### DIFF
--- a/lib/layer/featureStyle.mjs
+++ b/lib/layer/featureStyle.mjs
@@ -40,8 +40,8 @@ export default function featureStyle(layer) {
       return null;
     }
 
-    // Set style.default as feature.style.
-    feature.style = layer.style.default;
+    // Clone default style to prevent mutation of the default style object.
+    feature.style ??= structuredClone(layer.style.default);
 
     if (Object.hasOwn(mapp.layer.themes, layer.style.theme?.type)) {
       // Apply theme style to style object.

--- a/lib/layer/featureStyle.mjs
+++ b/lib/layer/featureStyle.mjs
@@ -41,7 +41,7 @@ export default function featureStyle(layer) {
     }
 
     // Clone default style to prevent mutation of the default style object.
-    feature.style ??= structuredClone(layer.style.default);
+    feature.style = structuredClone(layer.style.default);
 
     if (Object.hasOwn(mapp.layer.themes, layer.style.theme?.type)) {
       // Apply theme style to style object.

--- a/lib/layer/themes/categorized.mjs
+++ b/lib/layer/themes/categorized.mjs
@@ -31,41 +31,35 @@ export default function categorized(theme, feature) {
   // Cluster features can not be styled by category.
   if (feature.properties.features?.length > 1) return;
 
-  let flat;
-
   // Theme is using multiple fields.
   if (Array.isArray(theme.fields)) {
-    // Map different theme fields
-    const icons = theme.fields
-      .map((field) => {
-        // Get the field value from feature properties
-        const catValue = feature.properties[field];
+    const icons = [];
+    feature.style.icon = [];
 
-        // Find category matching field and catValue
-        const cat = theme.categories.find(
-          (cat) =>
-            (cat.value === encodeURIComponent(catValue) ||
-              cat.value === catValue) &&
-            cat.field === field,
-        );
+    for (const field of theme.fields) {
+      // Get the field value from feature properties
+      const catValue = feature.properties[field];
 
-        if (!cat) return;
+      // Find category matching field and catValue
+      const cat = theme.categories.find(
+        (cat) =>
+          (cat.value === encodeURIComponent(catValue) ||
+            cat.value === catValue) &&
+          cat.field === field,
+      );
 
-        if (!cat.style) return;
+      if (!cat) continue;
 
-        flat ||= Array.isArray(cat.style.icon);
+      if (!cat.style) continue;
 
-        return cat.style.icon;
+      if (!cat.style.icon) continue;
 
-        // Filter out empty icon entries from map response.
-      })
-      .filter((icon) => !!icon);
+      Array.isArray(cat.style.icon)
+        ? feature.style.icon.push(...cat.style.icon)
+        : feature.style.icon.push(cat.style.icon);
+    }
 
-    feature.style = {
-      ...feature.style,
-      icon: flat ? icons.flat() : icons,
-    };
-
+    // Do not assign theme.field is theme.fields are parsed.
     return;
   }
 

--- a/lib/layer/themes/categorized.mjs
+++ b/lib/layer/themes/categorized.mjs
@@ -36,7 +36,7 @@ export default function categorized(theme, feature) {
   // Theme is using multiple fields.
   if (Array.isArray(theme.fields)) {
     // Map different theme fields
-    feature.style.icon = theme.fields
+    const icons = theme.fields
       .map((field) => {
         // Get the field value from feature properties
         const catValue = feature.properties[field];
@@ -61,9 +61,10 @@ export default function categorized(theme, feature) {
       })
       .filter((icon) => !!icon);
 
-    if (flat) {
-      feature.style.icon = feature.style.icon.flat();
-    }
+    feature.style = {
+      ...feature.style,
+      icon: flat ? icons.flat() : icons,
+    };
 
     return;
   }

--- a/lib/layer/themes/categorized.mjs
+++ b/lib/layer/themes/categorized.mjs
@@ -71,12 +71,7 @@ The icon styles array will not be reassigned if it already exists on the feature
 function themeFieldsLookup(theme, feature) {
   if (!Array.isArray(theme.fields)) return;
 
-  if (Array.isArray(feature.style.icon)) {
-    // Do not reassign feature.style.icon.
-    return true;
-  }
-
-  feature.style.icon = [];
+  const icons = [];
 
   for (const field of theme.fields) {
     // Get the field value from feature properties
@@ -97,9 +92,14 @@ function themeFieldsLookup(theme, feature) {
     if (!cat.style.icon) continue;
 
     Array.isArray(cat.style.icon)
-      ? feature.style.icon.push(...cat.style.icon)
-      : feature.style.icon.push(cat.style.icon);
+      ? icons.push(...cat.style.icon)
+      : icons.push(cat.style.icon);
   }
+
+  feature.style = {
+    ...feature.style,
+    icon: icons,
+  };
 
   // Do not assign theme.field is theme.fields are parsed.
   return true;

--- a/lib/layer/themes/categorized.mjs
+++ b/lib/layer/themes/categorized.mjs
@@ -14,13 +14,10 @@ The categorized theme method will assign a style from category matching the feat
 
 Cluster features may not be styled by a categorized theme.
 
-A theme can have a fields array to apply an icon style array for the individual property fields.
-
 @param {Object} theme The theme configuration object.
 @param {Object} feature The feature object.
 @property {Array} theme.categories
 @property {string} [theme.field] The feature property field to theme.
-@property {array} [theme.fields] A fields array to style multiple feature properties.
 @property {Object} feature.properties
 @property {Array} [properties.features] A cluster feature will have a features array property.
 */
@@ -31,34 +28,7 @@ export default function categorized(theme, feature) {
   // Cluster features can not be styled by category.
   if (feature.properties.features?.length > 1) return;
 
-  // Theme is using multiple fields.
-  if (Array.isArray(theme.fields)) {
-    const icons = [];
-    feature.style.icon = [];
-
-    for (const field of theme.fields) {
-      // Get the field value from feature properties
-      const catValue = feature.properties[field];
-
-      // Find category matching field and catValue
-      const cat = theme.categories.find(
-        (cat) =>
-          (cat.value === encodeURIComponent(catValue) ||
-            cat.value === catValue) &&
-          cat.field === field,
-      );
-
-      if (!cat) continue;
-
-      if (!cat.style) continue;
-
-      if (!cat.style.icon) continue;
-
-      Array.isArray(cat.style.icon)
-        ? feature.style.icon.push(...cat.style.icon)
-        : feature.style.icon.push(cat.style.icon);
-    }
-
+  if (themeFieldsLookup(theme, feature)) {
     // Do not assign theme.field is theme.fields are parsed.
     return;
   }
@@ -82,4 +52,55 @@ export default function categorized(theme, feature) {
     ...feature.style,
     ...cat.style,
   };
+}
+
+/**
+@function themeFieldsLookup
+
+@description
+For categorical themes on multiple fields, the themeFieldsLookup function will loop through the theme.fields and apply an array of icon styles to the feature.style.icon property for each matching category.
+
+The icon styles array will not be reassigned if it already exists on the feature.style to prevent parsing the theme.categories on every feature in the render.
+
+@param {Object} theme The theme configuration object.
+@param {Object} feature The feature object.
+@property {Array} theme.categories
+@property {array} [theme.fields] A fields array to style multiple feature properties.
+@property {Object} feature.properties
+*/
+function themeFieldsLookup(theme, feature) {
+  if (!Array.isArray(theme.fields)) return;
+
+  if (Array.isArray(feature.style.icon)) {
+    // Do not reassign feature.style.icon.
+    return true;
+  }
+
+  feature.style.icon = [];
+
+  for (const field of theme.fields) {
+    // Get the field value from feature properties
+    const catValue = feature.properties[field];
+
+    // Find category matching field and catValue
+    const cat = theme.categories
+      .filter((cat) => cat.field === field)
+      .find(
+        (cat) =>
+          cat.value === encodeURIComponent(catValue) || cat.value === catValue,
+      );
+
+    if (!cat) continue;
+
+    if (!cat.style) continue;
+
+    if (!cat.style.icon) continue;
+
+    Array.isArray(cat.style.icon)
+      ? feature.style.icon.push(...cat.style.icon)
+      : feature.style.icon.push(cat.style.icon);
+  }
+
+  // Do not assign theme.field is theme.fields are parsed.
+  return true;
 }

--- a/lib/ui/elements/legendIcon.mjs
+++ b/lib/ui/elements/legendIcon.mjs
@@ -57,7 +57,6 @@ The createIconFromArray method iterates through an `style.icon[]` array to creat
 
 @returns {HTMLElement} A HTML element for the style.
 */
-
 function createIconFromArray(style) {
   const canvas = document.createElement('canvas');
   canvas.width = style.width;
@@ -158,12 +157,25 @@ function createIconFromInlineStyle(style) {
   return mapp.utils.html.node`<div style=${inlineStyle}>`;
 }
 
+/**
+@function svgSymbolUrl
+
+@description
+The svgSymbolUrl function returns the URL for an SVG symbol based on its type.
+
+The method will return undefined if the symbol type is not found in the mapp.utils.svgSymbols object. This is to prevent errors when an invalid symbol type is provided.
+
+@param {string} icon The icon type to create from svgSymbols.
+
+@returns {SVGElement} Icon SVG element from mapp.utils.svgSymbols.
+*/
 function svgSymbolUrl(icon) {
-  const method = mapp.utils.svgSymbols[icon.type || 'dot'];
+  // Assign 'dot' as default.
+  icon.type ??= 'dot';
 
-  if (typeof method !== 'function') return;
+  if (!Object.hasOwn(mapp.utils.svgSymbols, icon.type)) return;
 
-  return method(icon);
+  return mapp.utils.svgSymbols[icon.type];
 }
 
 /**
@@ -176,7 +188,6 @@ The createLineSymbol creates an icon for a stroke [line] style object.
 
 @returns {HTMLElement} A HTML element for the style.
 */
-
 function createLineSymbol(style) {
   const path = `M 0,${style.height / 2} L ${style.width / 2},${style.height / 2} ${style.width / 2},${style.height / 2} ${style.width},${style.height / 2}`;
 
@@ -217,7 +228,6 @@ The createPolygonSymbol creates an icon for a fill [polygon] style object.
 
 @returns {HTMLElement} A HTML element for the style.
 */
-
 function createPolygonSymbol(style) {
   style.fillOpacity ??= 1;
   style.strokeWidth ??= 1;

--- a/lib/ui/elements/legendIcon.mjs
+++ b/lib/ui/elements/legendIcon.mjs
@@ -86,11 +86,9 @@ function createIconFromArray(style) {
   const legendScale = style.icon[0].legendScale || 1;
 
   for (const icon of style.icon) {
-    if (icon.type && Object.hasOwn(mapp.utils.svgSymbols, icon.type)) {
-      icon.url = mapp.utils.svgSymbols[icon.type](icon);
-    }
+    const iconUrl = icon.url || icon.svg || svgSymbolUrl(icon);
 
-    if (!icon.url) {
+    if (!iconUrl) {
       console.warn(
         'legendIcon: icon has no url, the svg or template may be missing/invalid: ',
         icon,
@@ -102,7 +100,7 @@ function createIconFromArray(style) {
       anchor: icon.legendAnchor || [0.5, 0.5],
       crossOrigin: 'anonymous',
       scale: legendScale * (icon.scale || 1),
-      src: icon.url,
+      src: iconUrl,
     });
 
     icon.legendStyle = new ol.style.Style({
@@ -140,7 +138,14 @@ function createIconFromInlineStyle(style) {
     style.svg ||
     style.icon?.url ||
     style.url ||
-    mapp.utils.svgSymbols[style.icon?.type || style.type](style.icon || style);
+    svgSymbolUrl(style.icon || style);
+
+  if (!iconUrl) {
+    console.warn(
+      'legendIcon: icon has no url, the svg or template may be missing/invalid: ',
+      style.icon || style,
+    );
+  }
 
   const inlineStyle = `
     background-position: center;
@@ -151,6 +156,14 @@ function createIconFromInlineStyle(style) {
     background-image: url(${iconUrl})`;
 
   return mapp.utils.html.node`<div style=${inlineStyle}>`;
+}
+
+function svgSymbolUrl(icon) {
+  const method = mapp.utils.svgSymbols[icon.type || 'dot'];
+
+  if (typeof method !== 'function') return;
+
+  return method(icon);
 }
 
 /**


### PR DESCRIPTION
**Summary**
This change fixes a mutation issue in categorized theme rendering when a theme uses multiple fields. The generated icon array is now applied via a new feature style object instead of assigning directly to `feature.style.icon`.

**Problem**
For multi-field categorized themes, `feature.style` can initially reference `layer.style.default`. Assigning directly to `feature.style.icon` mutates the shared default style during render. That runtime mutation can then leak into saved user locales or other serialized style config.

**Solution**
Build the icon list in a local `icons` variable, then assign a new style object:

```js
feature.style = {
  ...feature.style,
  icon: flat ? icons.flat() : icons,
};
```

This preserves the existing icon composition behavior while preventing mutation of the original style config.