### PR TITLE
Monorepo Package Versioning

### DIFF
--- a/apps/auth/package.json
+++ b/apps/auth/package.json
@@ -1,6 +1,5 @@
 {
   "name": "@geolytix/xyz-auth-app",
-  "version": "v1.0.0",
   "description": "Optional custom auth backend app",
   "type": "module",
   "scripts": {

--- a/apps/auth/package.json
+++ b/apps/auth/package.json
@@ -11,7 +11,7 @@
     "./server": "./server.js"
   },
   "dependencies": {
-    "@geolytix/xyz-app": "file:../xyz",
-    "express": "5.2.0"
+    "@geolytix/xyz-app": "workspace:*",
+    "express": "catalog:"
   }
 }

--- a/apps/mapp/package.json
+++ b/apps/mapp/package.json
@@ -12,6 +12,6 @@
   },
   "license": "MIT",
   "devDependencies": {
-    "esbuild": "^0.25.0"
+    "esbuild": "catalog:"
   }
 }

--- a/apps/mapp/package.json
+++ b/apps/mapp/package.json
@@ -1,6 +1,5 @@
 {
   "name": "@geolytix/mapp",
-  "version": "v4.22.1",
   "type": "module",
   "repository": {
     "type": "git",

--- a/apps/saml/package.json
+++ b/apps/saml/package.json
@@ -1,6 +1,5 @@
 {
   "name": "@geolytix/xyz-saml-app",
-  "version": "v1.0.0",
   "description": "Optional SAML backend app",
   "type": "module",
   "scripts": {

--- a/apps/saml/package.json
+++ b/apps/saml/package.json
@@ -11,9 +11,9 @@
     "./server": "./server.js"
   },
   "dependencies": {
-    "@node-saml/node-saml": "^5.0.1",
-    "@geolytix/xyz-app": "file:../xyz",
-    "express": "5.2.0",
-    "jsonwebtoken": "^9.0.2"
+    "@node-saml/node-saml": "catalog:",
+    "@geolytix/xyz-app": "workspace:*",
+    "express": "catalog:",
+    "jsonwebtoken": "catalog:"
   }
 }

--- a/apps/xyz/package.json
+++ b/apps/xyz/package.json
@@ -1,6 +1,5 @@
 {
   "name": "@geolytix/xyz-app",
-  "version": "v4.22.1",
   "type": "module",
   "exports": {
     ".": "./api.js",

--- a/apps/xyz/package.json
+++ b/apps/xyz/package.json
@@ -22,17 +22,17 @@
   },
   "license": "MIT",
   "optionalDependencies": {
-    "@aws-sdk/client-s3": "^3.691.0",
-    "@aws-sdk/cloudfront-signer": "^3.621.0",
-    "@aws-sdk/s3-request-presigner": "^3.691.0",
-    "resend": "^6.4.2"
+    "@aws-sdk/client-s3": "catalog:",
+    "@aws-sdk/cloudfront-signer": "catalog:",
+    "@aws-sdk/s3-request-presigner": "catalog:",
+    "resend": "catalog:"
   },
   "dependencies": {
-    "bcrypt": "^6.0.0",
-    "cookie-parser": "^1.4.5",
-    "express": "5.2.0",
-    "express-rate-limit": "^7.5.1",
-    "jsonwebtoken": "^9.0.2",
-    "pg": "~8.15.1"
+    "bcrypt": "catalog:",
+    "cookie-parser": "catalog:",
+    "express": "catalog:",
+    "express-rate-limit": "catalog:",
+    "jsonwebtoken": "catalog:",
+    "pg": "catalog:"
   }
 }

--- a/package.json
+++ b/package.json
@@ -27,19 +27,19 @@
   },
   "license": "MIT",
   "dependencies": {
-    "@geolytix/mapp": "file:apps/mapp",
-    "@geolytix/xyz-auth-app": "file:apps/auth",
-    "@geolytix/xyz-app": "file:apps/xyz",
-    "@geolytix/xyz-saml-app": "file:apps/saml"
+    "@geolytix/mapp": "workspace:*",
+    "@geolytix/xyz-auth-app": "workspace:*",
+    "@geolytix/xyz-app": "workspace:*",
+    "@geolytix/xyz-saml-app": "workspace:*"
   },
   "devDependencies": {
-    "@biomejs/biome": "2.2.6",
-    "@vitest/coverage-v8": "4.1.4",
-    "clean-jsdoc-theme": "^4.3.2",
-    "dotenv": "^17.4.2",
-    "node-mocks-http": "^1.17.2",
-    "turbo": "^2.9.6",
-    "undici": "^7.25.0",
-    "vitest": "4.1.4"
+    "@biomejs/biome": "catalog:",
+    "@vitest/coverage-v8": "catalog:",
+    "clean-jsdoc-theme": "catalog:",
+    "dotenv": "catalog:",
+    "node-mocks-http": "catalog:",
+    "turbo": "catalog:",
+    "undici": "catalog:",
+    "vitest": "catalog:"
   }
 }

--- a/package.json
+++ b/package.json
@@ -6,10 +6,7 @@
     "type": "git",
     "url": "https://github.com/geolytix/xyz"
   },
-  "packageManager": "pnpm@10.33.0",
-  "pnpm": {
-    "neverBuiltDependencies": []
-  },
+  "packageManager": "pnpm@11.1.3",
   "scripts": {
     "dev": "turbo run dev --filter=@geolytix/xyz-app",
     "dev:auth": "turbo run dev --filter=@geolytix/xyz-auth-app",

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -3,6 +3,9 @@ packages:
   - apps/mapp
   - apps/saml
   - apps/xyz
+allowBuilds:
+  bcrypt: false
+  esbuild: false
 catalog:
   "@aws-sdk/client-s3": ^3.691.0
   "@aws-sdk/cloudfront-signer": ^3.621.0

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,5 +1,26 @@
 packages:
-  - "apps/auth"
-  - "apps/mapp"
-  - "apps/saml"
-  - "apps/xyz"
+  - apps/auth
+  - apps/mapp
+  - apps/saml
+  - apps/xyz
+catalog:
+  "@aws-sdk/client-s3": ^3.691.0
+  "@aws-sdk/cloudfront-signer": ^3.621.0
+  "@aws-sdk/s3-request-presigner": ^3.691.0
+  "@biomejs/biome": 2.2.6
+  "@node-saml/node-saml": ^5.0.1
+  "@vitest/coverage-v8": 4.1.4
+  bcrypt: ^6.0.0
+  clean-jsdoc-theme: ^4.3.2
+  cookie-parser: ^1.4.5
+  dotenv: ^17.4.2
+  esbuild: ^0.25.0
+  express: 5.2.0
+  express-rate-limit: ^7.5.1
+  jsonwebtoken: ^9.0.2
+  node-mocks-http: ^1.17.2
+  pg: ~8.15.1
+  resend: ^6.4.2
+  turbo: ^2.9.6
+  undici: ^7.25.0
+  vitest: 4.1.4


### PR DESCRIPTION
### Summary
This PR updates the package/versioning setup so dependency versions are centralized at the workspace root and app packages no longer carry their own version fields.

**The Craic?**
- Upgraded the workspace package manager from `pnpm@10.33.0` to `pnpm@11.1.3`.
- Added a root-level pnpm `catalog` in `pnpm-workspace.yaml` for shared dependency versions.
- Converted app/package dependencies to use `catalog:` instead of repeating concrete versions in each `package.json`.
- Converted local monorepo references from `file:` to `workspace:*`.
- Removed `version` fields from app package manifests so the root package version is the single source of truth.
- Added `allowBuilds` entries for `bcrypt` and `esbuild` in `pnpm-workspace.yaml`.
- Removed the root `pnpm.neverBuiltDependencies` config from `package.json`.

**Intent**
This makes the repo behave more like a single-version monorepo:

```text
root package.json = authoritative version
apps/*/package.json = package identity and dependencies only
pnpm-workspace.yaml = centralized dependency version catalog
```

**Notable Dependency Changes**
Local workspace dependencies now use:

```json
"@geolytix/xyz-app": "workspace:*"
```

Shared external dependencies now use:

```json
"express": "catalog:"
```

with the actual version declared once in `pnpm-workspace.yaml`:

```yaml
catalog:
  express: 5.2.0
```