### PR TITLE
fix(mergeTemplates): Roles object creating dot notation roles mistakenly

### DIFF
--- a/mod/utils/roles.js
+++ b/mod/utils/roles.js
@@ -240,7 +240,7 @@ export function combine(child, parent) {
   }
 
   // Handle simple locale-style role combination
-  combineLocaleRoles(child, parent);
+  combineObjRoles(child, parent);
 }
 
 /**
@@ -304,35 +304,35 @@ function combineTemplateRoles(template, obj) {
 }
 
 /**
-@function combineLocaleRoles
+@function combineObjRoles
 @description
-Combines roles for nested locales. Creates parent.child role combinations.
+Combines roles for nested objects, such as locales.
 
-@param {Object} child The child locale.
-@param {Object} parent The parent locale.
+@param {Object} child Nested object.
+@param {Object} parent Parent object.
 */
-function combineLocaleRoles(child, parent) {
+function combineObjRoles(child, parent) {
   if (!parent || !child) return;
-
-  // Ensure roles objects exist
-  child.roles ??= {};
-  parent.roles ??= {};
 
   const childRole = typeof child.role === 'string' ? child.role : undefined;
   const parentRole = typeof parent.role === 'string' ? parent.role : undefined;
 
-  // Convert string role properties to roles object entries
+  // Assign child.role string property to child.roles object property.
   if (childRole) {
+    child.roles ??= {};
     child.roles[childRole] ??= true;
   }
 
+  // Assign parent.role string property to parent.roles object property.
   if (parentRole) {
+    parent.roles ??= {};
     parent.roles[parentRole] ??= true;
   }
 
-  // Dot notation should only be generated from explicit role strings.
+  // Nested roles will only be created if both parent and child have a role string property defined. This is to prevent unnecessary role combinations for objects that do not have role restrictions.
   if (!childRole || !parentRole) return;
 
+  // Get parent roles that match the parent role or end with the parent role.
   const parentRoles = Object.keys(parent.roles).filter((role) => {
     return (
       role === parentRole ||
@@ -341,7 +341,7 @@ function combineLocaleRoles(child, parent) {
     );
   });
 
-  // Create combinations Parent.Child
+  // Create nested child role keys in child.roles object property by concatenating parent role keys with the child role string.
   parentRoles.forEach((role) => {
     child.roles[`${role}.${childRole}`] ??= true;
   });

--- a/mod/utils/roles.js
+++ b/mod/utils/roles.js
@@ -318,24 +318,31 @@ function combineLocaleRoles(child, parent) {
   child.roles ??= {};
   parent.roles ??= {};
 
+  const childRole = typeof child.role === 'string' ? child.role : undefined;
+  const parentRole = typeof parent.role === 'string' ? parent.role : undefined;
+
   // Convert string role properties to roles object entries
-  if (child.role && typeof child.role === 'string') {
-    child.roles[child.role] ??= true;
+  if (childRole) {
+    child.roles[childRole] ??= true;
   }
 
-  if (parent.role && typeof parent.role === 'string') {
-    parent.roles[parent.role] ??= true;
+  if (parentRole) {
+    parent.roles[parentRole] ??= true;
   }
 
-  // Identify roles specific to the child (not present in parent)
-  const specificChildRoles = Object.keys(child.roles).filter(
-    (role) => !parent.roles[role],
-  );
+  // Dot notation should only be generated from explicit role strings.
+  if (!childRole || !parentRole) return;
+
+  const parentRoles = Object.keys(parent.roles).filter((role) => {
+    return (
+      role === parentRole ||
+      role.split('.').pop() === parentRole ||
+      parentRole.endsWith(`.${role}`)
+    );
+  });
 
   // Create combinations Parent.Child
-  Object.keys(parent.roles).forEach((parentRole) => {
-    specificChildRoles.forEach((childRole) => {
-      child.roles[`${parentRole}.${childRole}`] ??= true;
-    });
+  parentRoles.forEach((role) => {
+    child.roles[`${role}.${childRole}`] ??= true;
   });
 }

--- a/tests/assets/layers/template_test/roles_template.json
+++ b/tests/assets/layers/template_test/roles_template.json
@@ -1,7 +1,7 @@
 {
   "roles": {
-    "super": null,
-    "standard": null,
+    "Super": null,
+    "Standard": null,
     "A": {
       "filter": {
         "default": {

--- a/tests/assets/layers/template_test/roles_template.json
+++ b/tests/assets/layers/template_test/roles_template.json
@@ -1,17 +1,15 @@
 {
-    "roles": {
-        "super": null,
-        "standard": null,
-        "A": {
-            "filter": {
-                "default": {
-                    "franchisee_name": {
-                        "in": [
-                            "A"
-                        ]
-                    }
-                }
-            }
+  "roles": {
+    "super": null,
+    "standard": null,
+    "A": {
+      "filter": {
+        "default": {
+          "franchisee_name": {
+            "in": ["A"]
+          }
         }
+      }
     }
+  }
 }

--- a/tests/assets/layers/template_test/roles_template.json
+++ b/tests/assets/layers/template_test/roles_template.json
@@ -1,0 +1,17 @@
+{
+    "roles": {
+        "super": null,
+        "standard": null,
+        "A": {
+            "filter": {
+                "default": {
+                    "franchisee_name": {
+                        "in": [
+                            "A"
+                        ]
+                    }
+                }
+            }
+        }
+    }
+}

--- a/tests/assets/roles_object_workspace.json
+++ b/tests/assets/roles_object_workspace.json
@@ -1,0 +1,50 @@
+{
+  "templates": {
+    "roles_template": {
+      "src": "file:./tests/assets/layers/template_test/roles_template.json"
+    },
+    "uk_locale": {
+      "name": "United Kingdom",
+      "roles": {
+        "uk": true
+      }
+    },
+    "pol_locale": {
+      "name": "Poland",
+      "roles": {
+        "pol": true
+      }
+    },
+    "geocoffee_locale": {
+      "name": "GeoCoffee",
+      "roles": {
+        "GeoCoffee": true
+      }
+    },
+    "geoburger_locale": {
+      "name": "GeoBurger",
+      "roles": {
+        "GeoBurger": true
+      }
+    }
+  },
+  "locale": {},
+  "locales": {
+    "uk": {
+      "template": "uk_locale",
+      "locales": ["geocoffee_locale", "geoburger_locale"]
+    },
+    "pol": {
+      "template": "pol_locale",
+      "locales": ["geocoffee_locale"]
+    },
+    "roles_locale": {
+      "roles": {
+        "Super": null,
+        "Standard": null,
+        "A": null
+      },
+      "template": "roles_template"
+    }
+  }
+}

--- a/tests/mod/utils/roles.test.mjs
+++ b/tests/mod/utils/roles.test.mjs
@@ -432,20 +432,20 @@ describe('Roles Module', () => {
   });
 
   describe('combine()', () => {
-    it('should combine parent roles with child roles', () => {
+    it('should not combine roles object keys', () => {
       const child = { roles: { Child: true } };
       const parent = { roles: { Parent: true } };
       combine(child, parent);
       expect(child.roles.Child).toBeTruthy();
-      expect(child.roles['Parent.Child']).toBeTruthy();
+      expect(!!child.roles['Parent.Child']).toBeFalsy();
     });
 
     it('should handle string role properties', () => {
-      const child = { role: 'Child' };
-      const parent = { role: 'Parent' };
+      const child = { role: 'child_role' };
+      const parent = { role: 'parent_role' };
       combine(child, parent);
-      expect(child.roles.Child).toBeTruthy();
-      expect(child.roles['Parent.Child']).toBeTruthy();
+      expect(child.roles.child_role).toBeTruthy();
+      expect(child.roles['parent_role.child_role']).toBeTruthy();
     });
 
     it('should not combine if parent role is same as child role', () => {

--- a/tests/mod/workspace/_workspace.test.mjs
+++ b/tests/mod/workspace/_workspace.test.mjs
@@ -243,9 +243,9 @@ describe('workspace: Roles Object Templates', () => {
       'A',
       'GeoBurger',
       'GeoCoffee',
+      'pol',
       'Standard',
       'Super',
-      'pol',
       'uk',
     ]);
   });

--- a/tests/mod/workspace/_workspace.test.mjs
+++ b/tests/mod/workspace/_workspace.test.mjs
@@ -65,8 +65,6 @@ describe('workspace: w/ Nested Locales & Roles', () => {
       'TEMPLATE_ROLE',
       'test',
       'uk',
-      'uk.brand_a',
-      'uk.brand_b',
       'uk.coremarkets',
       'uk.coremarkets.brand_a',
       'uk.coremarkets.brand_b',
@@ -216,6 +214,40 @@ describe('workspace: w/ Nested Locales & Roles', () => {
     const code = res.statusCode;
 
     expect(code).toEqual(400);
+  });
+});
+
+describe('workspace: Roles Object Templates', () => {
+  beforeAll(async () => {
+    globalThis.xyzEnv = {
+      TITLE: 'WORKSPACE TEST',
+      WORKSPACE: 'file:./tests/assets/roles_object_workspace.json',
+    };
+
+    await checkWorkspaceCache(true);
+  });
+
+  it('roles objects should not create dot notation roles', async () => {
+    const { req, res } = createMocks({
+      params: {
+        key: 'roles',
+        user: {
+          admin: true,
+        },
+      },
+    });
+
+    await getKeyMethod(req, res);
+
+    expect(res._getData()).toEqual([
+      'A',
+      'GeoBurger',
+      'GeoCoffee',
+      'Standard',
+      'Super',
+      'pol',
+      'uk',
+    ]);
   });
 });
 

--- a/tests/mod/workspace/mergeTemplates.test.mjs
+++ b/tests/mod/workspace/mergeTemplates.test.mjs
@@ -235,7 +235,7 @@ describe('mergeTemplates', async () => {
 
     const template = await mergeTemplates(obj, roles);
 
-    // Check the roles object contains nested roles.
+    // Check the roles object contains just the expected roles without dot notation.
     const expectedRoles = ['Super', 'Standard', 'A'].sort();
 
     const templateRoles = Object.keys(template.roles).sort();

--- a/tests/mod/workspace/mergeTemplates.test.mjs
+++ b/tests/mod/workspace/mergeTemplates.test.mjs
@@ -214,4 +214,33 @@ describe('mergeTemplates', async () => {
     // Check no other roles are present other than expected.
     expect(expectedRoles).toEqual(templateRoles);
   });
+
+  it('mergeTemplates using roles object should not create dot notation roles', async () => {
+    // This test is designed to ensure that backwards compatibility is maintained with templates that use the "roles" object instead of "localeRole" and "role".
+    // The test is similar to the previous one but uses "roles" object instead of dot notation roles.
+    // The expected result is that the same roles are present in the final template, but without the dot notation.
+    const obj = {
+      roles: {
+        Super: null,
+        Standard: null,
+        A: null,
+      },
+      template: {
+        src: 'file:./tests/assets/layers/template_test/roles_template.json',
+      },
+    };
+
+    // Call the template as if i have role "A".
+    const roles = ['A'];
+
+    const template = await mergeTemplates(obj, roles);
+
+    // Check the roles object contains nested roles.
+    const expectedRoles = ['Super', 'Standard', 'A'].sort();
+
+    const templateRoles = Object.keys(template.roles).sort();
+
+    // Check no other roles are present other than expected.
+    expect(expectedRoles).toEqual(templateRoles);
+  });
 });


### PR DESCRIPTION
## Description

Please include a summary of the changes, and the motivation for the change.


## Type of Change

Please delete options that are not relevant, and select all options that apply.

- ✅ Bug fix (non-breaking change which fixes an issue)
- ✅ Testing

## How have you tested this?
Failing test provided for the problem.

## Testing Checklist
- ✅ Updated Existing Tests
- ✅ New Tests Added
- ✅ Ran locally on my machine
