### PR TITLE
Replace instanceof function with typeof function

### DIFF
--- a/lib/layer/decorate.mjs
+++ b/lib/layer/decorate.mjs
@@ -199,13 +199,13 @@ function show() {
   }
 
   // Reload layer data if available.
-  this.reload instanceof Function && this.reload();
+  typeof this.reload === 'function' && this.reload();
 
   // Add layer attribution to mapview attribution.
   this.mapview.attribution?.check();
 
   // Execute showCallbacks
-  this.showCallbacks?.forEach((fn) => fn instanceof Function && fn(this));
+  this.showCallbacks?.forEach((fn) => typeof fn === 'function' && fn(this));
 }
 
 /**
@@ -255,7 +255,7 @@ function hide() {
   }
 
   // Execute hideCallbacks
-  this.hideCallbacks?.forEach((fn) => fn instanceof Function && fn(this));
+  this.hideCallbacks?.forEach((fn) => typeof fn === 'function' && fn(this));
 }
 
 /**

--- a/lib/location/decorate.mjs
+++ b/lib/location/decorate.mjs
@@ -282,7 +282,7 @@ async function update(callback) {
   // Ensure that modify/draw interactions are finished.
   this.layer.mapview.interactions.highlight();
 
-  if (callback instanceof Function) {
+  if (typeof callback === 'function') {
     callback(this);
     return;
   }

--- a/lib/location/get.mjs
+++ b/lib/location/get.mjs
@@ -39,7 +39,7 @@ export async function get(location, list = location.layer.mapview.locations) {
   const mapview = location.layer.mapview;
 
   // A getLocation function has been assigned to the current mapview.interaction.
-  if (mapview.interaction?.getLocation instanceof Function) {
+  if (typeof mapview.interaction?.getLocation === 'function') {
     mapview.interaction?.getLocation(location);
     return;
   }

--- a/lib/ui/Dataview.mjs
+++ b/lib/ui/Dataview.mjs
@@ -71,12 +71,12 @@ The mapp.ui.utils.dataview.mapChange() method will be called after the dataview 
 */
 export default async function Dataview(_this) {
   // Only dynamic dataviews should be recreated.
-  if (!_this.dynamic && _this.create instanceof Function) {
+  if (!_this.dynamic && typeof _this.create === 'function') {
     return;
   }
 
   // A dataview create method has already been assigned by the checkDataview method.
-  if (_this.create instanceof Function) {
+  if (typeof _this.create === 'function') {
     _this.create();
     return;
   }

--- a/lib/ui/Tabview.mjs
+++ b/lib/ui/Tabview.mjs
@@ -213,7 +213,7 @@ function addTab(entry) {
 
     tabview.timer = window.setTimeout(() => entry.activate(), 500);
 
-    if (tabview.showTab instanceof Function) {
+    if (typeof tabview.showTab === 'function') {
       // Execute tabview method to show a tab.
       tabview.showTab();
     }

--- a/lib/ui/elements/dialog.mjs
+++ b/lib/ui/elements/dialog.mjs
@@ -75,7 +75,7 @@ export default function dialog(dialog) {
     }}>`;
 
   function closeDialog(e) {
-    if (dialog.onClose instanceof Function) {
+    if (typeof dialog.onClose === 'function') {
       dialog.onClose(e);
     }
     dialog.node.remove();

--- a/lib/ui/elements/searchbox.mjs
+++ b/lib/ui/elements/searchbox.mjs
@@ -24,7 +24,7 @@ The decorated component object.
 */
 
 export default function searchbox(component = {}) {
-  if (!(component.searchFunction instanceof Function)) {
+  if (typeof component.searchFunction !== 'function') {
     console.warn(
       `A searchFunction must be provided for the construction of a searchbox component.`,
     );

--- a/lib/ui/elements/toast.mjs
+++ b/lib/ui/elements/toast.mjs
@@ -112,7 +112,7 @@ export default function toast(params = {}) {
         container.remove();
       }, 1200);
 
-      if (action?.callback instanceof Function) action.callback(e);
+      if (typeof action?.callback === 'function') action.callback(e);
 
       resolve(e?.target.value);
     }

--- a/lib/ui/locations/entries/layer.mjs
+++ b/lib/ui/locations/entries/layer.mjs
@@ -226,7 +226,7 @@ async function decorateLayer(entry) {
   entry.style.panel && entry.panel.append(entry.style.panel);
 
   entry.location.removeCallbacks.push(() => {
-    entry.remove();
+    typeof entry.remove === 'function' && entry.remove();
   });
 
   entry.display && entry.show();
@@ -277,10 +277,12 @@ async function showLayer() {
   }
 
   // Reload layer data if available.
-  entry.reload instanceof Function && entry.reload();
+  if (typeof entry.reload === 'function') {
+    entry.reload();
+  }
 
   // Execute showCallbacks
-  entry.showCallbacks?.forEach((fn) => fn instanceof Function && fn(entry));
+  entry.showCallbacks?.forEach((fn) => typeof fn === 'function' && fn(entry));
 }
 
 /**
@@ -334,5 +336,5 @@ function hideLayer() {
   this.mapview.Map.removeLayer(this.L);
 
   // Execute hideCallbacks
-  this.hideCallbacks?.forEach((fn) => fn instanceof Function && fn(this));
+  this.hideCallbacks?.forEach((fn) => typeof fn === 'function' && fn(this));
 }

--- a/lib/ui/locations/view.mjs
+++ b/lib/ui/locations/view.mjs
@@ -260,7 +260,7 @@ function valChange(e) {
   // Get location from entry
   const location = entry.location;
 
-  if (entry.valChangeMethod instanceof Function) {
+  if (typeof entry.valChangeMethod === 'function') {
     // Execute a custom valChangeMethod.
     entry.valChangeMethod(entry);
     return;

--- a/lib/utils/ping.mjs
+++ b/lib/utils/ping.mjs
@@ -88,7 +88,7 @@ function pingQuery(params) {
         return reject(response);
       }
 
-      if (params.callback instanceof Function) {
+      if (typeof params.callback === 'function') {
         params.callback(response, params);
       }
 

--- a/tests/lib/mapview/addLayer.test.mjs
+++ b/tests/lib/mapview/addLayer.test.mjs
@@ -34,7 +34,7 @@ export async function addLayer(mapview) {
             'We expect to see 1 layer being returned from getLayers method.',
           );
           codi.assertTrue(
-            layers[0].show instanceof Function,
+            typeof layers[0].show === 'function',
             'The decorated layer has a show method.',
           );
           codi.assertTrue(
@@ -74,7 +74,7 @@ export async function addLayer(mapview) {
             'We expect to see 2 layer being returned from getLayers method.',
           );
           codi.assertTrue(
-            layers[0].show instanceof Function,
+            typeof layers[0].show === 'function',
             'The first decorated layer has a show method.',
           );
           codi.assertTrue(

--- a/tests/lib/ui/Dataview.test.mjs
+++ b/tests/lib/ui/Dataview.test.mjs
@@ -16,7 +16,7 @@ export async function DataviewTest(mapview) {
 
     await codi.it('dataview should have a show method', async () => {
       codi.assertTrue(
-        entry.show instanceof Function,
+        typeof entry.show === 'function',
         'The dataview entry has a show method.',
       );
     });
@@ -34,7 +34,7 @@ export async function DataviewTest(mapview) {
 
     await codi.it('dataview should have a hide method', async () => {
       codi.assertTrue(
-        entry.hide instanceof Function,
+        typeof entry.hide === 'function',
         'The dataview entry has a hide method.',
       );
     });


### PR DESCRIPTION
Using instanceof to check built-in object types has significant limitations that can cause your code to behave unexpectedly.
