### PR TITLE
Prefix node module imports

### DIFF
--- a/mod/provider/file.js
+++ b/mod/provider/file.js
@@ -8,8 +8,8 @@ The file provider module exports a method to fetch resources from the local file
 @module /provider/file
 */
 
-import { readFileSync } from 'fs';
-import { join } from 'path';
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
 
 /**
 @function file

--- a/mod/sign/cloudfront.js
+++ b/mod/sign/cloudfront.js
@@ -10,9 +10,9 @@ The cloudfront sign module exports a method to sign requests to an AWS cloudfron
 @module /sign/cloudfront
 */
 
-import { readFileSync } from 'fs';
-import { dirname, join } from 'path';
-import { fileURLToPath } from 'url';
+import { readFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);

--- a/mod/user/fromACL.js
+++ b/mod/user/fromACL.js
@@ -16,7 +16,7 @@ This module exports the fromACL method to request and validate a user from the A
 
 import { compareSync } from 'bcrypt';
 
-import { randomBytes } from 'crypto';
+import { randomBytes } from 'node:crypto';
 import languageTemplates from '../utils/languageTemplates.js';
 import reqHost from '../utils/reqHost.js';
 import mailer from '../utils/resend.js';

--- a/mod/user/fromACL.js
+++ b/mod/user/fromACL.js
@@ -14,8 +14,6 @@ This module exports the fromACL method to request and validate a user from the A
 @module /user/fromACL
 */
 
-
-
 import { randomBytes } from 'node:crypto';
 import { compareSync } from 'bcrypt';
 import languageTemplates from '../utils/languageTemplates.js';

--- a/mod/user/fromACL.js
+++ b/mod/user/fromACL.js
@@ -14,9 +14,10 @@ This module exports the fromACL method to request and validate a user from the A
 @module /user/fromACL
 */
 
-import { compareSync } from 'bcrypt';
+
 
 import { randomBytes } from 'node:crypto';
+import { compareSync } from 'bcrypt';
 import languageTemplates from '../utils/languageTemplates.js';
 import reqHost from '../utils/reqHost.js';
 import mailer from '../utils/resend.js';

--- a/mod/user/register.js
+++ b/mod/user/register.js
@@ -17,7 +17,7 @@ Exports the [user] register method for the /api/user/register route.
 */
 
 import bcrypt from 'bcrypt';
-import crypto from 'crypto';
+import crypto from 'node:crypto';
 import languageTemplates from '../utils/languageTemplates.js';
 import reqHost from '../utils/reqHost.js';
 import mailer from '../utils/resend.js';

--- a/mod/user/register.js
+++ b/mod/user/register.js
@@ -16,8 +16,8 @@ Exports the [user] register method for the /api/user/register route.
 @module /user/register
 */
 
-import bcrypt from 'bcrypt';
 import crypto from 'node:crypto';
+import bcrypt from 'bcrypt';
 import languageTemplates from '../utils/languageTemplates.js';
 import reqHost from '../utils/reqHost.js';
 import mailer from '../utils/resend.js';

--- a/mod/user/saml.js
+++ b/mod/user/saml.js
@@ -93,10 +93,10 @@ This module handles SAML-based Single Sign-On (SSO) authentication. Here's how t
 @property {boolean} disableRequestedAuthnContext - If true, disables sending the AuthnContext in SAML authentication requests. Useful for IdPs that do not require or support AuthnContext, or for compatibility with certain SAML providers.
 **/
 
-import { readFileSync } from 'fs';
+import { readFileSync } from 'node:fs';
 // Import required dependencies
-import { dirname, join } from 'path';
-import { fileURLToPath } from 'url';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);

--- a/mod/utils/logger.js
+++ b/mod/utils/logger.js
@@ -42,7 +42,7 @@ CREATE TABLE public.dev_logs (
 @module /utils/logger
 */
 
-import crypto from 'crypto';
+import crypto from 'node:crypto';
 
 const logs = new Set(xyzEnv.LOGS?.split(',') || []);
 

--- a/mod/utils/processEnv.js
+++ b/mod/utils/processEnv.js
@@ -55,7 +55,7 @@ The process.ENV object holds configuration provided to the node process from the
 */
 
 import 'dotenv/config';
-import { readFileSync } from 'fs';
+import { readFileSync } from 'node:fs';
 
 const defaults = {
   COOKIE_TTL: 36000,

--- a/utils/sync-vercel-env.js
+++ b/utils/sync-vercel-env.js
@@ -23,9 +23,9 @@ Other arguments you can provide the script are:
 */
 
 import { config } from 'dotenv';
-import { existsSync, readFileSync } from 'fs';
+import { existsSync, readFileSync } from 'node:fs';
 import https from 'https';
-import { join } from 'path';
+import { join } from 'node:path';
 
 //get the vercel token from a separate .env file
 config({ path: '.env.vercel' });

--- a/utils/sync-vercel-env.js
+++ b/utils/sync-vercel-env.js
@@ -22,10 +22,10 @@ Other arguments you can provide the script are:
 - `--file=` - specifies the .env file location that you want to push.
 */
 
-import { config } from 'dotenv';
 import { existsSync, readFileSync } from 'node:fs';
-import https from 'https';
 import { join } from 'node:path';
+import { config } from 'dotenv';
+import https from 'https';
 
 //get the vercel token from a separate .env file
 config({ path: '.env.vercel' });

--- a/utils/version.js
+++ b/utils/version.js
@@ -11,7 +11,7 @@ To run this script you can execute `node version.js` in your terminal.
 
 import { execSync } from 'child_process'; // For executing shell commands synchronously
 // File system module for reading/writing files
-import { readFileSync, writeFileSync } from 'fs';
+import { readFileSync, writeFileSync } from 'node:fs';
 
 // Regular expression pattern to match 'hash: ' followed by any characters
 const key = 'hash:.*';

--- a/utils/version.js
+++ b/utils/version.js
@@ -9,9 +9,8 @@ To run this script you can execute `node version.js` in your terminal.
 @module version
 */
 
-import { execSync } from 'child_process'; // For executing shell commands synchronously
-// File system module for reading/writing files
 import { readFileSync, writeFileSync } from 'node:fs';
+import { execSync } from 'child_process';
 
 // Regular expression pattern to match 'hash: ' followed by any characters
 const key = 'hash:.*';


### PR DESCRIPTION
When importing Node.js built-in modules, using the node: protocol makes it explicitly clear that you’re importing a core Node.js module rather than a third-party package from npm.

Without the node: prefix, it can be ambiguous whether import fs from 'fs' refers to the built-in file system module or a potential npm package named 'fs'. This ambiguity can lead to confusion, especially for developers who are new to a codebase or when reviewing code.

The node: protocol was introduced in Node.js 12.20.0 and became the recommended approach for importing built-in modules. It provides several benefits:

Clarity: Makes it immediately obvious that the import refers to a Node.js built-in module
Security: Prevents potential confusion attacks where malicious packages could have names similar to built-in modules
Future-proofing: Aligns with Node.js best practices and ESM standards
Consistency: Creates a uniform way to reference all built-in modules
This practice is particularly important in larger codebases where the distinction between built-in modules and external dependencies needs to be clear at a glance.