### PR TITLE
Mapview modules; this assignment, documentation, named methods

### DIFF
--- a/lib/mapview/infotip.mjs
+++ b/lib/mapview/infotip.mjs
@@ -1,16 +1,21 @@
 /**
-## Mapview.infotip()
+## /mapview/infotip
 
 @module /mapview/infotip
-
-@param {Object} content
 */
 
 const infotip = {};
 
-export default function (content) {
-  const mapview = this;
+/**
+@function Infotip
 
+@description
+The method creates an infotip element that follows the pointer location on the mapview. The content of the infotip can be a string, an HTML element, or an object. If the content is an object, a warning will be logged in the console since it cannot be rendered in the infotip. The infotip is removed when the content argument is falsy or when a new infotip is created.
+
+@param {object} params The params object is spread into the interaction defaults.
+@param {mapview} mapview The mapview object to which the interaction will be added.
+*/
+export default function Infotip(content, mapview = this) {
   // Remove infotip node element
   infotip.node?.remove();
 

--- a/lib/mapview/interactions/draw.mjs
+++ b/lib/mapview/interactions/draw.mjs
@@ -1,15 +1,21 @@
 /**
-## Mapview.interactions.draw()
+## /mapview/interactions/draw
+
+The module exports the draw interaction method which is bound to a mapview in the [decorator]{@link module:/mapview~decorate} method.
 
 @module /mapview/interactions/draw
-
-@param {Object} params
-The params object argument.
 */
 
-export default function (params) {
-  const mapview = this;
+/**
+@function draw
 
+@description
+Defines the behaviour for a draw interaction performed on the map.
+
+@param {object} params The params object is spread into the interaction defaults.
+@param {mapview} mapview The mapview object to which the interaction will be added.
+*/
+export default function draw(params, mapview = this) {
   // Finish the current interaction.
   mapview.interaction?.finish();
 

--- a/lib/mapview/interactions/highlight.mjs
+++ b/lib/mapview/interactions/highlight.mjs
@@ -40,11 +40,9 @@ The highlight interaction works by assigning mousedown, touchstart, mouseup, and
 The optional getLocation function property will be executed the [mapp.location.get()]{@link module:/location/get~get} method.
 
 @param {object} params The params object is spread into the interaction defaults.
-@property {Function} [getLocation] Will be executed after the getFeature method.
+@param {mapview} mapview The mapview object to which the interaction will be added.
 */
-export default function highlight(params) {
-  const mapview = this;
-
+export default function highlight(params, mapview = this) {
   // Finish the current interaction.
   mapview.interaction?.finish();
 
@@ -112,16 +110,6 @@ export default function highlight(params) {
     // Reset candidateKeys Set
     mapview.interaction.candidateKeys = new Set();
     clear();
-  }
-
-  /**
-  @function touchStart
-
-  @description
-  The touchStart event prevents the mouseDown event on touch input.
-  */
-  function touchStart(e) {
-    e.preventDefault();
   }
 
   /**
@@ -499,4 +487,14 @@ export default function highlight(params) {
 
     mapview.interaction.callback?.();
   }
+}
+
+/**
+@function touchStart
+
+@description
+The touchStart event prevents the mouseDown event on touch input.
+*/
+function touchStart(e) {
+  e.preventDefault();
 }

--- a/lib/mapview/interactions/modify.mjs
+++ b/lib/mapview/interactions/modify.mjs
@@ -1,13 +1,9 @@
 /**
-## Mapview.interactions.modify()
+## /mapview/interactions/modify
 
-The modify module exports the modify function. The modify function defines the behaviour of a modification performed on the map.
-
-Dictionary entries:
-- delete_vertex
+The module exports the modify interaction method which is bound to a mapview in the [decorator]{@link module:/mapview~decorate} method.
 
 @requires /dictionary
-
 @module /mapview/interactions/modify
 */
 
@@ -16,11 +12,9 @@ Dictionary entries:
 Defines the behaviour for a modification interaction performed on the map.
 
 @param {Object} params Extra parameters for the mapview.interaction.
+@param {mapview} mapview The mapview object to which the interaction will be added.
 */
-
-export default function modify(params) {
-  const mapview = this;
-
+export default function modify(params, mapview = this) {
   // Finish the current interaction.
   mapview.interaction?.finish();
 

--- a/lib/mapview/interactions/snap.mjs
+++ b/lib/mapview/interactions/snap.mjs
@@ -1,20 +1,20 @@
 /**
- * ### mapview.interactions.snap()
- * This module sets up the snap interaction for the mapview.
- * @module /mapview/interactions/snap
- */
+## /mapview/interactions/snap
+
+@module /mapview/interactions/snap
+*/
 
 /**
- * Sets up the snap interaction for the mapview.
- * @function snap
- * @param {Object} mapview - The mapview object.
- * @param {ol.Map} mapview.Map - The OpenLayers map object.
- * @param {Object} mapview.interaction - The interaction object.
- * @param {boolean|Object} mapview.interaction.snap - The snap interaction configuration.
- * @param {string} [mapview.interaction.snap.layer] - The key of the layer to snap to.
- * @param {ol.layer.Layer} mapview.interaction.layer - The interaction layer.
- * @param {Object} mapview.layers - The map layers object.
- */
+@function snap
+@description
+Sets up the snap interaction for the mapview.
+
+@param {mapview} mapview
+@property {object} mapview.layers The map layers object.
+@property {object} mapview.interaction The interaction object.
+@property {object} interaction.snap The snap interaction configuration.
+@property {string} [mapview.interaction.snap.layer] The key of the layer to snap to.
+*/
 export default function (mapview) {
   // The current draw/modify interaction doesn't snap.
   if (!mapview.interaction.snap) return;

--- a/lib/mapview/interactions/zoom.mjs
+++ b/lib/mapview/interactions/zoom.mjs
@@ -1,15 +1,21 @@
 /**
-## Mapview.interactions.zoom()
+## /mapview/interactions/zoom
+
+The module exports the zoom interaction method which is bound to a mapview in the [decorator]{@link module:/mapview~decorate} method.
 
 @module /mapview/interactions/zoom
-
-@param {Object} params
-The params object argument.
 */
 
-export default function (params) {
-  const mapview = this;
+/**
+@function zoom
 
+@description
+Defines the behaviour for a zoom interaction performed on the map.
+
+@param {object} params The params object is spread into the interaction defaults.
+@param {mapview} mapview The mapview object to which the interaction will be added.
+*/
+export default function zoom(params, mapview = this) {
   // Finish the current interaction.
   mapview.interaction?.finish();
 

--- a/lib/mapview/popup.mjs
+++ b/lib/mapview/popup.mjs
@@ -1,21 +1,25 @@
 /**
-## Mapview.popup()
+## /mapview/popup
 
 @module /mapview/popup
-
-@param {Object} params
-The params object argument.
 */
 
 const popup = {};
 
-export default function (params) {
+/**
+@function Popup
+
+@description
+The method creates a popup element that is displayed on the mapview at a specified location. The content of the popup can be an HTML element or a string. The popup is removed when the params argument is falsy or when a new popup is created.
+
+@param {object} params The params object is spread into the interaction defaults.
+@param {mapview} mapview The mapview object to which the interaction will be added.
+*/
+export default function Popup(params, mapview = this) {
   if (typeof params === 'undefined') {
     // Returns undefined / falsy if popup.node has been removed.
     return popup.node?.parentNode;
   }
-
-  const mapview = this;
 
   // Remove a current tooltip.
   mapview.infotip(null);


### PR DESCRIPTION
This PR removes the assignment of `const mapview = this` in several mapview modules.

Assigning this to a variable is an outdated JavaScript pattern that creates unnecessary complexity and reduces code readability.

In JavaScript, the value of this depends on how a function is called. Before ES6, developers commonly assigned this to a variable (like self, that, or foo) to preserve the context when calling functions where this would have a different value.

This pattern has several drawbacks:

It creates additional variables that clutter the scope
It can cause confusion about which context is being referenced
It makes the code harder to understand and maintain
It’s prone to errors if the wrong variable is used
Modern JavaScript provides better alternatives that eliminate the need for this pattern. Arrow functions automatically preserve the lexical this binding, meaning they inherit this from the enclosing scope. The Function.prototype.bind() method can also explicitly set the this value for regular functions.

The touchStart method has been unnested from the highlight interaction method.

The documentation for several modules and methods was either missing or all over the place.