### PR TITLE
Use globalThis and includes

### DIFF
--- a/lib/hooks.mjs
+++ b/lib/hooks.mjs
@@ -43,7 +43,7 @@ export default hooks;
 The method parses key/value pairs of URL searchParams from the document window.location.href.
 */
 function parse() {
-  const url = new URL(window.location.href);
+  const url = new URL(globalThis.location.href);
 
   // Iterate over the search parameters
   for (const [key, value] of url.searchParams.entries()) {
@@ -71,7 +71,7 @@ function parse() {
   // Strip token from url
   if (hooks.current.token) {
     url.searchParams.delete('token');
-    window.history.replaceState({}, document.title, url.toString());
+    globalThis.history.replaceState({}, document.title, url.toString());
     delete hooks.current.token;
   }
 }
@@ -132,7 +132,9 @@ Assigns the val param to the hooks.current[key] property.
 */
 function push(key, val) {
   if (hooks.current[key]) {
-    if (hooks.current[key].indexOf(val) < 0) hooks.current[key].push(val);
+    if (!hooks.current[key].includes(val)) {
+      hooks.current[key].push(val);
+    }
   } else {
     hooks.current[key] = [val];
   }
@@ -167,7 +169,7 @@ Pushes changes in the hooks.current to the window URL.
 */
 function pushState() {
   try {
-    window.history.pushState(
+    globalThis.history.pushState(
       {},
       document.title,
       `?${mapp.utils.paramString(hooks.current)}`,


### PR DESCRIPTION
The lib/hooks module script should use globalThis instead of window.

globalThis is the standardized way to access the global object across all JavaScript environments. Before globalThis, developers had to use different global references depending on the environment:

window in browsers
global in Node.js
self in Web Workers
This created compatibility issues when code needed to run in multiple environments. Using environment-specific globals makes code less portable and harder to maintain.

globalThis was introduced in ES2020 as a unified solution that works consistently across all JavaScript environments. It provides the same global object reference regardless of whether your code runs in a browser, Node.js, or Web Worker.

Using globalThis makes your code more future-proof and eliminates the need for environment detection when accessing global properties.

The array.includes method should be used instead of indexOf in the push condition.

Using .indexOf() or .lastIndexOf() with comparison operators like !== -1 or >= 0 to check if an element exists is less readable and semantic than using .includes(). The intent is not immediately clear - you need to understand that -1 means "not found" and remember the comparison logic.

The .includes() method was specifically designed for existence checks. It clearly expresses the intent: "does this array/string include this element?" This makes code more readable and self-documenting.

Similarly, using Array#some() for simple equality checks is overkill. The some() method is designed for complex conditions and predicates. When you only need to check if an element exists, .includes() is more appropriate and can be more performant since it doesn’t need to execute a callback function.

Using the right method for the right purpose makes code more maintainable and easier to understand for other developers.