### PR TITLE
Layer cluster label field

### DIFF
--- a/mod/query.js
+++ b/mod/query.js
@@ -359,11 +359,6 @@ async function checkFieldsParam(req, res) {
 
   objPropValueSet(req.params.layer, 'field', layerFields);
 
-  // Technical debt: The cluster label should be added as a field in the layer template to prevent direct reference here.
-  if (req.params.layer.cluster?.label) {
-    layerFields.add(req.params.layer.cluster.label);
-  }
-
   req.params.fieldsMap = new Map();
 
   for (const field of req.params.fields.split(',')) {

--- a/mod/query.js
+++ b/mod/query.js
@@ -359,6 +359,11 @@ async function checkFieldsParam(req, res) {
 
   objPropValueSet(req.params.layer, 'field', layerFields);
 
+  // Technical debt: The cluster label should be added as a field in the layer template to prevent direct reference here.
+  if (req.params.layer.cluster?.label) {
+    layerFields.add(req.params.layer.cluster.label);
+  }
+
   req.params.fieldsMap = new Map();
 
   for (const field of req.params.fields.split(',')) {


### PR DESCRIPTION
The cluster.label field must be valid for requests to the WKT layer query template.

The cluster.label property value must be added to the layerFields set in the checkFieldsParam method to allow requests to pass.