### PR TITLE
Legendicon function return

### DIFF
--- a/lib/ui/elements/legendIcon.mjs
+++ b/lib/ui/elements/legendIcon.mjs
@@ -175,7 +175,7 @@ function svgSymbolUrl(icon) {
 
   if (!Object.hasOwn(mapp.utils.svgSymbols, icon.type)) return;
 
-  return mapp.utils.svgSymbols[icon.type](icon.type);
+  return mapp.utils.svgSymbols[icon.type](icon);
 }
 
 /**

--- a/lib/ui/elements/legendIcon.mjs
+++ b/lib/ui/elements/legendIcon.mjs
@@ -175,7 +175,7 @@ function svgSymbolUrl(icon) {
 
   if (!Object.hasOwn(mapp.utils.svgSymbols, icon.type)) return;
 
-  return mapp.utils.svgSymbols[icon.type];
+  return mapp.utils.svgSymbols[icon.type](icon.type);
 }
 
 /**

--- a/mod/query.js
+++ b/mod/query.js
@@ -359,11 +359,6 @@ async function checkFieldsParam(req, res) {
 
   objPropValueSet(req.params.layer, 'field', layerFields);
 
-  // Technical debt: The cluster label should be added as a field in the layer template to prevent direct reference here.
-  if (req.params.layer.cluster?.label) {
-    layerFields.add(req.params.layer.cluster.label);
-  }
-
   req.params.fieldsMap = new Map();
 
   for (const field of req.params.fields.split(',')) {

--- a/mod/query.js
+++ b/mod/query.js
@@ -359,6 +359,11 @@ async function checkFieldsParam(req, res) {
 
   objPropValueSet(req.params.layer, 'field', layerFields);
 
+  // Technical debt: The cluster label should be added as a field in the layer template to prevent direct reference here.
+  if (req.params.layer.cluster?.label) {
+    layerFields.add(req.params.layer.cluster.label);
+  }
+
   req.params.fieldsMap = new Map();
 
   for (const field of req.params.fields.split(',')) {


### PR DESCRIPTION
This PR fixes an issue introduced in this patch commit. https://github.com/GEOLYTIX/xyz/commit/23e16a179fbc6fbdad4d773ad00d698c313fa85d

The svgSymbolUrl method must return an SVG url, not the method which will cause a crash.