### PR TITLE
Cop out on layer key condition

### DIFF
--- a/lib/plugins/_plugins.mjs
+++ b/lib/plugins/_plugins.mjs
@@ -44,7 +44,6 @@ import { zoomToArea } from './zoomToArea.mjs';
 @property {function} feature_info Show feature properties in popup.
 @property {function} fullscreen The fullscreen plugin module.
 @property {function} layer_order The layer_order plugin module.
-@property {function} keyvalue_dictionary The keyvalue_dictionary plugin module.
 @property {function} locator The locator plugin module.
 @property {function} login The login plugin module.
 @property {function} svgTemplates The svg_templates plugin module.

--- a/lib/utils/keyvalue_dictionary.mjs
+++ b/lib/utils/keyvalue_dictionary.mjs
@@ -52,6 +52,7 @@ Parses an object and replaces its string values with dictionary entries.
 function parseObject(obj, dictionary) {
   for (const [key, value] of Object.entries(obj)) {
     if (key === 'mapview') continue;
+    if (key === 'layer') continue;
     if (isArrayObject(value, dictionary)) continue;
     if (typeof value === 'string') replaceKeyValue(obj, key, value, dictionary);
   }


### PR DESCRIPTION
The keyvalue utility is run on the mapview and layer object from the respective decorator methods.

The parseObject method should therefore continue when the key is 'layer', just like the array iteration shortcircuits if the key is mapview to prevent an infinite iteration.