### PR TITLE
Several fixes for the docs tree build from the jsdocs mapp modules.

### DIFF
--- a/lib/mapp.mjs
+++ b/lib/mapp.mjs
@@ -14,7 +14,7 @@ The MAPP library requires Openlayers. The mapp module will check whether the Ope
 @requires /dictionary
 @requires /dictionaries
 
-@module mapp
+@module /
 */
 
 import { dictionaries, dictionary } from './dictionary.mjs';

--- a/lib/plugins/layer_order.mjs
+++ b/lib/plugins/layer_order.mjs
@@ -12,7 +12,7 @@ Layer with keys not referenced in the layer order will be on top.
   "retail_places"
 ]
 ```
-@module plugins/layer_order
+@module /plugins/layer_order
 */
 
 /**

--- a/lib/ui.mjs
+++ b/lib/ui.mjs
@@ -12,7 +12,7 @@ The `ui.mjs` module is used as entry point for the esbuild process to bundle the
 @requires /ui/layers
 @requires /ui/utils
 
-@module ui
+@module /ui
 */
 
 import Dataview from './ui/Dataview.mjs';

--- a/lib/ui/elements/contextMenu.mjs
+++ b/lib/ui/elements/contextMenu.mjs
@@ -9,12 +9,12 @@ export default {
   modify,
 };
 
-/** 
+/**
 @function modify
-@description 
+@description
 This is a context menu for the modify interaction.
 It pushes the save and cancel options to the context menu.
-@params {Object} e The event object.
+@param {Object} e The event object.
 @returns {void}
 */
 function modify(e) {
@@ -46,7 +46,7 @@ function modify(e) {
 @description
 This is a context menu for the draw interaction.
 It pushes the save and cancel options to the context menu.
-@params {Object} e The event object.
+@param {Object} e The event object.
 @returns {void}
 */
 function draw(e) {

--- a/lib/ui/elements/contextMenu.mjs
+++ b/lib/ui/elements/contextMenu.mjs
@@ -1,29 +1,22 @@
+/**
+### /ui/elements/contextMenu
+
+@module /ui/elements/contextMenu
+*/
+
 export default {
   draw,
   modify,
 };
 
-/**
-## /ui/elements/contextMenu
-Dictionary entries:
-- save
-- cancel
-
-@requires /dictionary
-
-@module /ui/elements/contextMenu
-Exports the modify and draw context menu methods as mapp.ui.elements.contextMenu()
-
-
 /** 
- * @function modify
- * @description 
- * This is a context menu for the modify interaction.
- * It pushes the save and cancel options to the context menu.
- * @params {Object} e The event object.
- * @returns {void}
- */
-
+@function modify
+@description 
+This is a context menu for the modify interaction.
+It pushes the save and cancel options to the context menu.
+@params {Object} e The event object.
+@returns {void}
+*/
 function modify(e) {
   e?.preventDefault?.();
 
@@ -49,14 +42,13 @@ function modify(e) {
 }
 
 /**
- * @function draw
- * @description
- * This is a context menu for the draw interaction.
- * It pushes the save and cancel options to the context menu.
- * @params {Object} e The event object.
- * @returns {void}
- */
-
+@function draw
+@description
+This is a context menu for the draw interaction.
+It pushes the save and cancel options to the context menu.
+@params {Object} e The event object.
+@returns {void}
+*/
 function draw(e) {
   if (this.interaction.vertices.length === 0) return;
 

--- a/lib/ui/elements/locales.mjs
+++ b/lib/ui/elements/locales.mjs
@@ -1,7 +1,9 @@
 /**
-@module @ui/elements/locales
+### /ui/elements/locales
 
 The module exports method to create an interface with dropdown to select locales and nested locales.
+
+@module /ui/elements/locales
 */
 
 /**

--- a/lib/ui/elements/loginForm.mjs
+++ b/lib/ui/elements/loginForm.mjs
@@ -1,5 +1,6 @@
 /**
-@module ui/elements/loginForm
+### /ui/elements/loginForm
+@module /ui/elements/loginForm
 */
 
 /**

--- a/lib/ui/elements/registerForm.mjs
+++ b/lib/ui/elements/registerForm.mjs
@@ -1,5 +1,6 @@
 /**
-@module ui/elements/registerForm
+### /ui/elements/registerForm
+@module /ui/elements/registerForm
 */
 
 /**

--- a/lib/ui/elements/reportLink.mjs
+++ b/lib/ui/elements/reportLink.mjs
@@ -1,5 +1,6 @@
 /**
-@module ui/elements/reportLink
+### /ui/elements/reportLink
+@module /ui/elements/reportLink
 */
 
 /**

--- a/lib/ui/elements/tooltip.mjs
+++ b/lib/ui/elements/tooltip.mjs
@@ -1,13 +1,12 @@
 /**
-## ui/elements/tooltip
+### /ui/elements/tooltip
 Exports tooltip HTML document fragment.
 
-@function ui/elements/tooltip
+@module /ui/elements/tooltip
 */
 
 /**
-mapp.ui.elements.tooltip(params)
-
+@function tooltip
 @description
 Adds an inline "help" symbol to indicate that the closest sibling has a tooltip information.
 
@@ -17,9 +16,6 @@ const tooltip = mapp.ui.elements.tooltip({
 });
 
 In order to use tooltip symbol on entries, set `entry.tooltip = <text>` to display.
-```
-
-@function tooltip
 @param {Object} params Params for the tooltip element.
 @property {string} [params.data_id='ui-elements-tooltip'] The data-id attribute value for the element, optional.
 @property {string} [params.content] Text to display on mouseover. Required, if undefined tooltip creation will be skipped.

--- a/lib/ui/elements/tooltip.mjs
+++ b/lib/ui/elements/tooltip.mjs
@@ -14,6 +14,7 @@ Adds an inline "help" symbol to indicate that the closest sibling has a tooltip 
 const tooltip = mapp.ui.elements.tooltip({
    content: "My tooltip text"
 });
+```
 
 In order to use tooltip symbol on entries, set `entry.tooltip = <text>` to display.
 @param {Object} params Params for the tooltip element.

--- a/lib/ui/elements/userLocale.mjs
+++ b/lib/ui/elements/userLocale.mjs
@@ -1,7 +1,9 @@
 /**
-Exports the default userLocale element method as mapp.ui.elements.userLocale().
+### /ui/elements/userLocale
 
-@module ui/elements/userLocale
+The module exports a method to create an interface for managing user locales, allowing users to save, list, and delete their custom locales.
+
+@module /ui/elements/userLocale
 */
 
 /**

--- a/lib/ui/utils/locationCount.mjs
+++ b/lib/ui/utils/locationCount.mjs
@@ -1,7 +1,8 @@
 /**
+### /ui/utils/locationCount
 Exports the default locationCount utility method as mapp.ui.utils.locationCount().
 
-@module ui/utils/locationCount
+@module /ui/utils/locationCount
 */
 
 /**


### PR DESCRIPTION
The tree structure of the mapp modules should now correctly display.

<img width="389" height="571" alt="image" src="https://github.com/user-attachments/assets/c5add364-b808-4b26-96ee-4e0479d380be" />

<img width="1245" height="889" alt="image" src="https://github.com/user-attachments/assets/923311ec-a526-4e50-959f-251b9455c1de" />
