### PR TITLE
Correct template dbs connection

### DIFF
--- a/mod/query.js
+++ b/mod/query.js
@@ -112,8 +112,7 @@ export default async function query(req, res) {
     return;
   }
   // Use template dbs, layer dbs if defined, or workspace dbs in the query.
-  template.dbs =
-    template.dbs || req.params.layer?.dbs || req.params.workspace.dbs;
+  template.dbs ??= req.params.layer?.dbs || req.params.workspace.dbs;
 
   // Validate that the dbs string exists as a stored connection method in dbs_connections.
   if (!Object.hasOwn(dbs_connections, template.dbs)) {

--- a/mod/query.js
+++ b/mod/query.js
@@ -111,9 +111,9 @@ export default async function query(req, res) {
       .send('Role access denied for query template.');
     return;
   }
-  // Use layer dbs if defined, or workspace dbs, or provided dbs in the query.
+  // Use template dbs, layer dbs if defined, or workspace dbs in the query.
   template.dbs =
-    req.params.layer?.dbs || req.params.workspace.dbs || template.dbs;
+    template.dbs || req.params.layer?.dbs || req.params.workspace.dbs;
 
   // Validate that the dbs string exists as a stored connection method in dbs_connections.
   if (!Object.hasOwn(dbs_connections, template.dbs)) {

--- a/tests/mod/query.test.mjs
+++ b/tests/mod/query.test.mjs
@@ -175,11 +175,12 @@ describe('Query: Testing Query API', () => {
       expect(mockDbQuery).not.toHaveBeenCalled();
     });
 
-    it('should use template.dbs when layer, workspace, and req dbs are NOT defined', async () => {
+    it('should use template.dbs when provided', async () => {
       const { req, res } = createMocks({
         params: {
           template: 'mock_template',
           user: { roles: ['admin'], admin: true },
+          dbs: 'template_db',
         },
       });
 
@@ -197,11 +198,10 @@ describe('Query: Testing Query API', () => {
       expect(mockLayerDb).not.toHaveBeenCalled();
     });
 
-    it('should use workspace.dbs when defined, overriding req.params and template dbs', async () => {
+    it('should use workspace.dbs as template dbs not provided', async () => {
       const { req, res } = createMocks({
         params: {
           template: 'mock_template',
-          dbs: 'req_db',
           user: { roles: ['admin'], admin: true },
         },
       });
@@ -209,7 +209,7 @@ describe('Query: Testing Query API', () => {
       checkWorkspaceCache.mockResolvedValueOnce({ dbs: 'workspace_db' });
       getTemplate.mockResolvedValueOnce({
         template: 'SELECT * FROM mock_table',
-        dbs: 'template_db',
+        dbs: 'workspace_db',
       });
 
       await query(req, res);
@@ -220,11 +220,10 @@ describe('Query: Testing Query API', () => {
       expect(mockLayerDb).not.toHaveBeenCalled();
     });
 
-    it('should use layer.dbs when defined, overriding workspace, req, and template dbs', async () => {
+    it('should use layer.dbs when defined, overriding workspace dbs as template dbs not provided', async () => {
       const { req, res } = createMocks({
         params: {
           template: 'mock_template',
-          dbs: 'req_db',
           user: { roles: ['admin'], admin: true },
           // Inject layer directly into req.params to bypass getLayer lookup
           layer: {
@@ -239,7 +238,7 @@ describe('Query: Testing Query API', () => {
       checkWorkspaceCache.mockResolvedValueOnce({ dbs: 'workspace_db' });
       getTemplate.mockResolvedValueOnce({
         template: 'SELECT * FROM mock_table',
-        dbs: 'template_db',
+        dbs: 'layer_db',
         layer: true, // Requires layer
       });
 


### PR DESCRIPTION
This PR fixes an issue with a query template having a template `dbs` property and it not being used. 

The order of `dbs` should be template, layer, workspace. 
Tests have been updated to fix this issue.