### PR TITLE
Fix SSO-enabled API requests

### DIFF
--- a/api/api.js
+++ b/api/api.js
@@ -173,7 +173,7 @@ async function validateRequestAuth(req, res) {
 
   // The authentication method returns an error.
   if (user && user instanceof Error) {
-    if (req.headers.authorization || req.params?.token || req.params?.key) {
+    if (req.headers.authorization || hasKeyOrToken(req)) {
       // Request with failed authorization headers are not passed to login.
       return res.status(401).send(user.message);
     }
@@ -223,7 +223,7 @@ async function validateRequestAuth(req, res) {
 }
 
 function hasKeyOrToken(req) {
-  return req.params?.key || req.params?.token;
+  return req.query?.key || req.query?.token;
 }
 
 /**

--- a/api/api.js
+++ b/api/api.js
@@ -99,11 +99,6 @@ export default function api(req, res) {
     return res.status(302).send();
   }
 
-  // SAML request.
-  if (req.url.match(/\/saml/)) {
-    return saml(req, res);
-  }
-
   req.params = validateRequestParams(req);
 
   if (req.params instanceof Error) {
@@ -111,6 +106,11 @@ export default function api(req, res) {
       .status(400)
       .setHeader('Content-Type', 'text/plain')
       .send(req.params.message);
+  }
+
+  // SAML request. Key/token params should be authenticated and routed normally.
+  if (req.url.match(/\/saml/) && !hasKeyOrToken(req)) {
+    return saml(req, res);
   }
 
   if (req.params.logout) {
@@ -171,12 +171,9 @@ async function validateRequestAuth(req, res) {
   //Call request router if signature authentication was used.
   if (user?.signature_auth) return requestRouter(req, res);
 
-  // Remove token from params object.
-  delete req.params.token;
-
   // The authentication method returns an error.
   if (user && user instanceof Error) {
-    if (req.headers.authorization) {
+    if (req.headers.authorization || req.params?.token || req.params?.key) {
       // Request with failed authorization headers are not passed to login.
       return res.status(401).send(user.message);
     }
@@ -206,6 +203,10 @@ async function validateRequestAuth(req, res) {
 
   // PRIVATE instances require user auth for all requests.
   if (!req.params.user && xyzEnv.PRIVATE) {
+    if (hasKeyOrToken(req)) {
+      return requestRouter(req, res);
+    }
+
     // Redirect to the SAML login.
     if (xyzEnv.SAML_LOGIN) {
       // The redirect for a successful login.
@@ -219,6 +220,10 @@ async function validateRequestAuth(req, res) {
   }
 
   requestRouter(req, res);
+}
+
+function hasKeyOrToken(req) {
+  return req.params?.key || req.params?.token;
 }
 
 /**

--- a/express.js
+++ b/express.js
@@ -111,6 +111,14 @@ app.post(
 
 app.get(`${xyzEnv.DIR}/saml/metadata`, api);
 
+app.get(`${xyzEnv.DIR}/saml/logout/callback`, api);
+
+app.post(
+  `${xyzEnv.DIR}/saml/logout/callback`,
+  express.urlencoded({ extended: true }),
+  api,
+);
+
 app.get(`${xyzEnv.DIR}/saml/logout`, api);
 
 app.get(`${xyzEnv.DIR}/saml/login`, api);

--- a/mod/user/saml.js
+++ b/mod/user/saml.js
@@ -140,12 +140,11 @@ const getModule = async () => {
           readFileSync(join(__dirname, `../../${xyzEnv.SAML_SP_CRT}.crt`)),
         ),
       signatureAlgorithm: xyzEnv.SAML_SIGNATURE_ALGORITHM,
-      wantAssertionsSigned: xyzEnv.SAML_WANT_ASSERTIONS_SIGNED,
-      wantAuthnResponseSigned: xyzEnv.SAML_AUTHN_RESPONSE_SIGNED ?? false,
+      wantAssertionsSigned: booleanFromEnv(xyzEnv.SAML_WANT_ASSERTIONS_SIGNED),
+      wantAuthnResponseSigned:
+        booleanFromEnv(xyzEnv.SAML_AUTHN_RESPONSE_SIGNED) ?? false,
       disableRequestedAuthnContext:
-        xyzEnv.SAML_DISABLE_REQUESTED_AUTHN_CONTEXT !== undefined
-          ? xyzEnv.SAML_DISABLE_REQUESTED_AUTHN_CONTEXT === 'true'
-          : true,
+        booleanFromEnv(xyzEnv.SAML_DISABLE_REQUESTED_AUTHN_CONTEXT) ?? true,
     };
 
     // Create SAML strategy instance
@@ -164,6 +163,12 @@ const getModule = async () => {
     return saml_not_configured;
   }
 };
+
+function booleanFromEnv(value) {
+  if (typeof value === 'boolean') return value;
+  if (value === 'true') return true;
+  if (value === 'false') return false;
+}
 
 /**
 @function saml_not_configured

--- a/tests/mod/api.test.mjs
+++ b/tests/mod/api.test.mjs
@@ -31,7 +31,10 @@ vi.mock('../../mod/sign/_sign.js', () => ({ default: vi.fn() }));
 vi.mock('../../mod/user/_user.js', () => ({ default: vi.fn() }));
 vi.mock('../../mod/user/register.js', () => ({ default: vi.fn() }));
 vi.mock('../../mod/view.js', () => ({ default: vi.fn() }));
-vi.mock('../../mod/workspace/_workspace.js', () => ({ default: vi.fn() }));
+const workspaceFn = vi.fn();
+vi.mock('../../mod/workspace/_workspace.js', () => ({
+  default: (...args) => workspaceFn(...args),
+}));
 
 describe('api', async () => {
   const { default: api } = await import('../../api/api.js');
@@ -63,6 +66,24 @@ describe('api', async () => {
     expect(samlFn).not.toHaveBeenCalled();
     expect(setRedirectFn).not.toHaveBeenCalled();
     expect(res.getHeader('location')).toBeUndefined();
+  });
+
+  it('redirects workspace key route params without query key or token', async () => {
+    authFn.mockResolvedValueOnce(null);
+
+    const { req, res } = createMocks({
+      headers: { host: 'localhost' },
+      params: { key: 'locales' },
+      query: {},
+      url: '/api/workspace/locales',
+    });
+
+    api(req, res);
+    await vi.waitFor(() => expect(setRedirectFn).toHaveBeenCalledWith(req, res));
+
+    expect(workspaceFn).not.toHaveBeenCalled();
+    expect(res.statusCode).toEqual(302);
+    expect(res.getHeader('location')).toEqual('/app/saml/login');
   });
 
   it('does not short-circuit SAML routes when key is present', async () => {

--- a/tests/mod/api.test.mjs
+++ b/tests/mod/api.test.mjs
@@ -1,0 +1,97 @@
+import { createMocks } from 'node-mocks-http';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const authFn = vi.fn();
+vi.mock('../../mod/user/auth.js', () => ({
+  default: (...args) => authFn(...args),
+}));
+
+const loginFn = vi.fn();
+vi.mock('../../mod/user/login.js', () => ({
+  default: (...args) => loginFn(...args),
+}));
+
+const queryFn = vi.fn();
+vi.mock('../../mod/query.js', () => ({
+  default: (...args) => queryFn(...args),
+}));
+
+const samlFn = vi.fn();
+vi.mock('../../mod/user/saml.js', () => ({
+  default: (...args) => samlFn(...args),
+}));
+
+const setRedirectFn = vi.fn();
+vi.mock('../../mod/utils/redirect.js', () => ({
+  setRedirect: (...args) => setRedirectFn(...args),
+}));
+
+vi.mock('../../mod/provider/_provider.js', () => ({ default: vi.fn() }));
+vi.mock('../../mod/sign/_sign.js', () => ({ default: vi.fn() }));
+vi.mock('../../mod/user/_user.js', () => ({ default: vi.fn() }));
+vi.mock('../../mod/user/register.js', () => ({ default: vi.fn() }));
+vi.mock('../../mod/view.js', () => ({ default: vi.fn() }));
+vi.mock('../../mod/workspace/_workspace.js', () => ({ default: vi.fn() }));
+
+describe('api', async () => {
+  const { default: api } = await import('../../api/api.js');
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+
+    globalThis.xyzEnv = {
+      DIR: '/app',
+      PRIVATE: true,
+      SAML_LOGIN: true,
+      TITLE: 'TEST',
+    };
+  });
+
+  it('routes key requests instead of redirecting to SAML login', async () => {
+    authFn.mockResolvedValueOnce(null);
+
+    const { req, res } = createMocks({
+      headers: { host: 'localhost' },
+      params: {},
+      query: { key: 'xx' },
+      url: '/api/query?key=xx',
+    });
+
+    api(req, res);
+    await vi.waitFor(() => expect(queryFn).toHaveBeenCalledWith(req, res));
+
+    expect(samlFn).not.toHaveBeenCalled();
+    expect(setRedirectFn).not.toHaveBeenCalled();
+    expect(res.getHeader('location')).toBeUndefined();
+  });
+
+  it('does not short-circuit SAML routes when key is present', async () => {
+    authFn.mockResolvedValueOnce(null);
+
+    const { req, res } = createMocks({
+      headers: { host: 'localhost' },
+      params: {},
+      query: { key: 'xx' },
+      url: '/app/saml/login?key=xx',
+    });
+
+    api(req, res);
+    await vi.waitFor(() => expect(authFn).toHaveBeenCalledWith(req, res));
+
+    expect(samlFn).not.toHaveBeenCalled();
+  });
+
+  it('still routes SAML endpoints without key or token to SAML', () => {
+    const { req, res } = createMocks({
+      headers: { host: 'localhost' },
+      params: {},
+      query: {},
+      url: '/app/saml/login',
+    });
+
+    api(req, res);
+
+    expect(samlFn).toHaveBeenCalledWith(req, res);
+    expect(authFn).not.toHaveBeenCalled();
+  });
+});

--- a/tests/mod/api.test.mjs
+++ b/tests/mod/api.test.mjs
@@ -79,7 +79,9 @@ describe('api', async () => {
     });
 
     api(req, res);
-    await vi.waitFor(() => expect(setRedirectFn).toHaveBeenCalledWith(req, res));
+    await vi.waitFor(() =>
+      expect(setRedirectFn).toHaveBeenCalledWith(req, res),
+    );
 
     expect(workspaceFn).not.toHaveBeenCalled();
     expect(res.statusCode).toEqual(302);


### PR DESCRIPTION
## What's the craic?
Fixes SSO-enabled API requests with key or token query parameters being redirected to SAML login before they can execute.

### Issue?
`api.js` short-circuited any /saml URL before request params were validated or auth/routing logic could run. 
In private SSO-enabled apps, requests containing key or token should
supersede login auth and run immediately, but they were redirected to SAML login instead.

### Changes
- Move SAML route handling until after request params are validated.
- Skip the SAML short-circuit when a key or token param is present.
- Skip the private SAML login redirect for key or token requests and route them normally.
- Return 401 for failed key/token auth attempts instead of redirecting to login.
