### PR TITLE
Enable versioning of userIndexedDB to create additional stores

### DIFF
--- a/lib/plugins/dark_mode.mjs
+++ b/lib/plugins/dark_mode.mjs
@@ -66,7 +66,7 @@ async function updateUser() {
   await mapp.utils.userIndexedDB.put({
     store: 'user',
     name: mapp.user.email,
-    obj: sanitizedUser,
+    obj: mapp.user,
   });
 }
 

--- a/lib/plugins/dark_mode.mjs
+++ b/lib/plugins/dark_mode.mjs
@@ -62,13 +62,6 @@ This function updates the user object in the IndexedDB.
 Removes roles, admin and, blocked flag from the user to prevent these properties being overwritten.
 */
 async function updateUser() {
-  // Remove roles, admin and, blocked from mapp.user.
-  // Prevents overwriting values from the user table
-  const sanitizedUser = { ...mapp.user };
-  delete sanitizedUser.roles;
-  delete sanitizedUser.admin;
-  delete sanitizedUser.blocked;
-
   // Store the user object in the IndexedDB
   await mapp.utils.userIndexedDB.put({
     store: 'user',

--- a/lib/utils/userIndexedDB.mjs
+++ b/lib/utils/userIndexedDB.mjs
@@ -30,7 +30,7 @@ export async function openDB(params, version = 3) {
 
   const db = dbs.find((db) => db.name === params.indexedDB);
 
-  if (db?.version > version) {
+  if (db) {
     // The version must not exceed the current version of the database, otherwise an error will be thrown and the database will not be opened.
     version = db.version;
   }
@@ -55,7 +55,7 @@ export async function openDB(params, version = 3) {
       }
     };
 
-    // will be called on database versioning.
+    // will be called on database versioning. 10941 user
     IDBRequest.onupgradeneeded = (event) => {
       // onsuccess method will be called after the object store is created.
       event.target.result.createObjectStore(params.store);
@@ -106,7 +106,7 @@ export async function add(params) {
 @function get
 @description
 The get method will retrieve records from the userIndexedDB.
-@param {Object} params
+@param {Object} params 10941 user
 @property {string} params.store Identifier for the object store in the userIndexedDB.
 @property {object} params.name The key of the record to retrieve.
 @returns {Promise} getPromise
@@ -189,7 +189,9 @@ export async function put(params) {
   if (params.store === 'user') {
     delete params.obj.admin;
     delete params.obj.roles;
+    delete params.obj.blocked;
   }
+
   const IDB = await openDB(params);
 
   const updatePromise = new Promise((resolve, reject) => {

--- a/lib/utils/userIndexedDB.mjs
+++ b/lib/utils/userIndexedDB.mjs
@@ -18,12 +18,12 @@ The name for the userIndexedDB database can be set with the `indexedDB` paramete
 A new store will be created when a new DB is upgraded [on creation].
 
 @param {object} params 
-@param {integer} [version=1] The version number for the userIndexedDB. Incremented when a new store needs to be created.
+@param {integer} [version=3] The version number for the userIndexedDB. Incremented when a new store needs to be created.
 @property {string} params.store The name of the object store to interact with.
 @property {string} [params.indexedDB="MAPP"] The name of the userIndexedDB database to open.
 @returns {Promise} OpenDBPromise
 */
-export async function openDB(params, version = 1) {
+export async function openDB(params, version = 3) {
   params.indexedDB ??= mapp.user?.title || 'MAPP';
 
   const dbs = await indexedDB.databases();

--- a/lib/utils/userIndexedDB.mjs
+++ b/lib/utils/userIndexedDB.mjs
@@ -24,10 +24,18 @@ A new store will be created when a new DB is upgraded [on creation].
 @returns {Promise} OpenDBPromise
 */
 export async function openDB(params, version = 1) {
+  params.indexedDB ??= mapp.user?.title || 'MAPP';
+
   const dbs = await indexedDB.databases();
 
-  const OpenDBPromise = new Promise((resolve, reject) => {
-    params.indexedDB ??= mapp.user?.title || 'MAPP';
+  const db = dbs.find((db) => db.name === params.indexedDB);
+
+  if (db) {
+    // The version must not exceed the current version of the database, otherwise an error will be thrown and the database will not be opened.
+    version = db.version;
+  }
+
+  const OpenDBPromise = new Promise(async (resolve, reject) => {
     // will create a new database if db/version doesn't exist.
     const IDBRequest = indexedDB.open(params.indexedDB, version);
 
@@ -41,8 +49,6 @@ export async function openDB(params, version = 1) {
         console.warn(
           `UserIDB '${params.indexedDB}' doesn't contain "${params.store}" objectStore.`,
         );
-
-        const db = dbs.find((db) => db.name === params.indexedDB);
 
         // Increment the version number to trigger onupgradeneeded and create the new store.
         return openDB(params, db.version + 1);

--- a/lib/utils/userIndexedDB.mjs
+++ b/lib/utils/userIndexedDB.mjs
@@ -1,7 +1,7 @@
 /** 
-### mapp.utils.userIndexedDB
+### /utils/userIndexedDB
 
-The module exports method to store and retrieve objects from a userIndexedDB.
+The module exports methods to store and retrieve objects from a userIndexedDB.
 
 @module /utils/userIndexedDB
 */
@@ -13,19 +13,23 @@ The method is called from any transaction method to interact with the userIndexe
 
 A new database will be created when attempting to open a DB which does not exist.
 
+The name for the userIndexedDB database can be set with the `indexedDB` parameter or will default to the `mapp.user.title` property or "MAPP" if the user title is not defined. This is to ensure that different XYZ environments running on the same host will have separate userIndexedDB databases.
+
 A new store will be created when a new DB is upgraded [on creation].
 
 @param {object} params 
-@property {string} params.store
-@property {string} params.user
-@property {string} params.workspace
+@param {integer} [version=1] The version number for the userIndexedDB. Incremented when a new store needs to be created.
+@property {string} params.store The name of the object store to interact with.
+@property {string} [params.indexedDB="MAPP"] The name of the userIndexedDB database to open.
 @returns {Promise} OpenDBPromise
 */
-export async function openDB(params) {
+export async function openDB(params, version = 1) {
+  const dbs = await indexedDB.databases();
+
   const OpenDBPromise = new Promise((resolve, reject) => {
-    params.indexedDB ??= 'MAPP';
+    params.indexedDB ??= mapp.user?.title || 'MAPP';
     // will create a new database if db/version doesn't exist.
-    const IDBRequest = indexedDB.open(params.indexedDB, 3);
+    const IDBRequest = indexedDB.open(params.indexedDB, version);
 
     IDBRequest.onerror = (event) => {
       console.error(IDBRequest.error);
@@ -38,10 +42,15 @@ export async function openDB(params) {
           `UserIDB '${params.indexedDB}' doesn't contain "${params.store}" objectStore.`,
         );
 
-        resolve(null);
-      }
+        const db = dbs.find((db) => db.name === params.indexedDB);
 
-      resolve(event.target.result);
+        // Increment the version number to trigger onupgradeneeded and create the new store.
+        return openDB(params, db.version + 1);
+
+        // event.target.result.createObjectStore(params.store);
+      } else {
+        resolve(event.target.result);
+      }
     };
 
     // will be called on database versioning.
@@ -58,11 +67,12 @@ export async function openDB(params) {
 
 /**
 @function add
+@description
+The add method will add new records to the userIndexedDB.
+
 @param {Object} params 
-@property {string} params.user 
-@property {string} params.db 
-@property {string} params.store 
-@property {object} params.key 
+@property {string} params.store Identifier for the object store in the userIndexedDB.
+@property {object} params.obj Object to be stored in the userIndexedDB store.
 @returns {Promise} addPromise
 */
 export async function add(params) {
@@ -92,11 +102,11 @@ export async function add(params) {
 
 /**
 @function get
+@description
+The get method will retrieve records from the userIndexedDB.
 @param {Object} params 
-@property {string} params.user 
-@property {string} params.workspace 
-@property {string} params.store 
-@property {object} params.name 
+@property {string} params.store Identifier for the object store in the userIndexedDB.
+@property {object} params.name The key of the record to retrieve.
 @returns {Promise} getPromise
 */
 export async function get(params) {
@@ -124,6 +134,15 @@ export async function get(params) {
   return getPromise;
 }
 
+/**
+@function list
+@description
+The list method will retrieve all records from the userIndexedDB store.
+
+@param {Object} params 
+@property {string} params.store Identifier for the object store in the userIndexedDB.
+@returns {Promise} getPromise
+*/
 export async function list(params) {
   const IDB = await openDB(params);
 
@@ -140,11 +159,11 @@ export async function list(params) {
     };
 
     IDBRequest.onsuccess = (event) => {
-      const locales = IDBRequest.result.map((locale) => ({
-        key: locale.key,
-        name: locale.name,
+      const records = IDBRequest.result.map((record) => ({
+        key: record.key,
+        name: record.name,
       }));
-      resolve(locales);
+      resolve(records);
     };
   });
 
@@ -155,14 +174,20 @@ export async function list(params) {
 
 /**
 @function put
+@description
+The put method will update existing records or add new records to the userIndexedDB.
+
 @param {Object} params 
-@property {string} params.user 
-@property {string} params.db 
-@property {string} params.store 
-@property {object} params.obj 
+@property {string} params.name The key of the record to update or add.
+@property {string} params.store The name of the object store in the userIndexedDB.
+@property {object} params.obj The object to be stored in the userIndexedDB store.
 @returns {Promise} updatePromise
 */
 export async function put(params) {
+  if (params.store === 'user') {
+    delete params.obj.admin;
+    delete params.obj.roles;
+  }
   const IDB = await openDB(params);
 
   const updatePromise = new Promise((resolve, reject) => {
@@ -187,6 +212,16 @@ export async function put(params) {
   return updatePromise;
 }
 
+/**
+@function remove
+@description
+The remove method will delete records from the userIndexedDB.
+
+@param {Object} params 
+@property {string} params.name The key of the record to remove.
+@property {string} params.store The name of the object store in the userIndexedDB.
+@returns {Promise} removePromise
+*/
 export async function remove(params) {
   const IDB = await openDB(params);
 

--- a/lib/utils/userIndexedDB.mjs
+++ b/lib/utils/userIndexedDB.mjs
@@ -30,7 +30,7 @@ export async function openDB(params, version = 3) {
 
   const db = dbs.find((db) => db.name === params.indexedDB);
 
-  if (db) {
+  if (db?.version > version) {
     // The version must not exceed the current version of the database, otherwise an error will be thrown and the database will not be opened.
     version = db.version;
   }

--- a/lib/utils/userIndexedDB.mjs
+++ b/lib/utils/userIndexedDB.mjs
@@ -1,4 +1,4 @@
-/** 
+/**
 ### /utils/userIndexedDB
 
 The module exports methods to store and retrieve objects from a userIndexedDB.
@@ -17,7 +17,7 @@ The name for the userIndexedDB database can be set with the `indexedDB` paramete
 
 A new store will be created when a new DB is upgraded [on creation].
 
-@param {object} params 
+@param {object} params
 @param {integer} [version=3] The version number for the userIndexedDB. Incremented when a new store needs to be created.
 @property {string} params.store The name of the object store to interact with.
 @property {string} [params.indexedDB="MAPP"] The name of the userIndexedDB database to open.
@@ -30,7 +30,7 @@ export async function openDB(params, version = 3) {
 
   const db = dbs.find((db) => db.name === params.indexedDB);
 
-  if (db) {
+  if (db?.version > version) {
     // The version must not exceed the current version of the database, otherwise an error will be thrown and the database will not be opened.
     version = db.version;
   }
@@ -46,10 +46,6 @@ export async function openDB(params, version = 3) {
 
     IDBRequest.onsuccess = (event) => {
       if (!event.target.result.objectStoreNames.contains(params.store)) {
-        console.warn(
-          `UserIDB '${params.indexedDB}' doesn't contain "${params.store}" objectStore.`,
-        );
-
         // Increment the version number to trigger onupgradeneeded and create the new store.
         return openDB(params, db.version + 1);
 
@@ -76,7 +72,7 @@ export async function openDB(params, version = 3) {
 @description
 The add method will add new records to the userIndexedDB.
 
-@param {Object} params 
+@param {Object} params
 @property {string} params.store Identifier for the object store in the userIndexedDB.
 @property {object} params.obj Object to be stored in the userIndexedDB store.
 @returns {Promise} addPromise
@@ -110,7 +106,7 @@ export async function add(params) {
 @function get
 @description
 The get method will retrieve records from the userIndexedDB.
-@param {Object} params 
+@param {Object} params
 @property {string} params.store Identifier for the object store in the userIndexedDB.
 @property {object} params.name The key of the record to retrieve.
 @returns {Promise} getPromise
@@ -145,7 +141,7 @@ export async function get(params) {
 @description
 The list method will retrieve all records from the userIndexedDB store.
 
-@param {Object} params 
+@param {Object} params
 @property {string} params.store Identifier for the object store in the userIndexedDB.
 @returns {Promise} getPromise
 */
@@ -183,7 +179,7 @@ export async function list(params) {
 @description
 The put method will update existing records or add new records to the userIndexedDB.
 
-@param {Object} params 
+@param {Object} params
 @property {string} params.name The key of the record to update or add.
 @property {string} params.store The name of the object store in the userIndexedDB.
 @property {object} params.obj The object to be stored in the userIndexedDB store.
@@ -223,7 +219,7 @@ export async function put(params) {
 @description
 The remove method will delete records from the userIndexedDB.
 
-@param {Object} params 
+@param {Object} params
 @property {string} params.name The key of the record to remove.
 @property {string} params.store The name of the object store in the userIndexedDB.
 @returns {Promise} removePromise


### PR DESCRIPTION
It must be possible to have different userindexedDB for different instances. The title from the user object will be used as name for the database.

A store can only be added to a database if the version is increased to trigger the onupgradeneeded event method.

The admin flag and roles should be deleted from the [user] object for a put transaction on the 'user' store.

The userindexedDB module was poorly documented.