### PR TITLE
Default entry.newValue

### DIFF
--- a/lib/ui/locations/infoj.mjs
+++ b/lib/ui/locations/infoj.mjs
@@ -315,7 +315,8 @@ function entryDefault(entry) {
 
   if (!entry.edit) return;
 
-  if (entry.value !== undefined) return;
+  // Do not apply default value if entry.value is already set to a non nullish value.
+  if (entry.value) return;
 
   entry.newValue = entry.default;
 

--- a/lib/ui/locations/infoj.mjs
+++ b/lib/ui/locations/infoj.mjs
@@ -315,6 +315,8 @@ function entryDefault(entry) {
 
   if (!entry.edit) return;
 
+  if (entry.value !== undefined) return;
+
   entry.newValue = entry.default;
 
   entry.location.view?.dispatchEvent(


### PR DESCRIPTION
The default should not be applied if the entry has a value [not nullish]. Otherwise the default would always be applied even if the entry already has a value.