### PR TITLE
Return timestamp from nonblocking query

### DIFF
--- a/mod/query.js
+++ b/mod/query.js
@@ -714,7 +714,7 @@ function sendRows(res, template, rows) {
     res
       .status(202)
       .setHeader('Content-Type', 'text/plain')
-      .send('No row returned any value.');
+      .send('No rows returned from table.');
     return;
   }
 

--- a/mod/query.js
+++ b/mod/query.js
@@ -143,23 +143,20 @@ export default async function query(req, res) {
 
   logger(query, 'query');
 
-  // Nonblocking queries will not wait for results but return immediately.
-  if (template.nonblocking) {
-    dbs_connections[template.dbs](
-      query,
-      req.params.SQL,
-      template.statement_timeout,
-    );
-
-    return res.send('Non blocking request sent.');
-  }
-
-  // Run the query
-  const rows = await dbs_connections[template.dbs](
+  const queryPromise = dbs_connections[template.dbs](
     query,
     req.params.SQL,
     template.statement_timeout,
   );
+
+  // Nonblocking queries will not wait for results but return immediately.
+  if (template.nonblocking) {
+
+    return res.send(`Non blocking request sent at ${new Date().toISOString()}.`);
+  }
+
+  // Run the query
+  const rows = await queryPromise;
 
   sendRows(res, template, rows);
 }

--- a/mod/query.js
+++ b/mod/query.js
@@ -151,8 +151,9 @@ export default async function query(req, res) {
 
   // Nonblocking queries will not wait for results but return immediately.
   if (template.nonblocking) {
-
-    return res.send(`Non blocking request sent at ${new Date().toISOString()}.`);
+    return res.send(
+      `Non blocking request sent at ${new Date().toISOString()}.`,
+    );
   }
 
   // Run the query

--- a/mod/query.js
+++ b/mod/query.js
@@ -150,7 +150,7 @@ export default async function query(req, res) {
 
   // Nonblocking queries will not wait for results but return immediately.
   if (template.nonblocking) {
-    return res.send(
+    return res.status(202).send(
       `Non blocking request sent at ${new Date().toISOString()}.`,
     );
   }

--- a/mod/query.js
+++ b/mod/query.js
@@ -150,9 +150,9 @@ export default async function query(req, res) {
 
   // Nonblocking queries will not wait for results but return immediately.
   if (template.nonblocking) {
-    return res.status(202).send(
-      `Non blocking request sent at ${new Date().toISOString()}.`,
-    );
+    return res
+      .status(202)
+      .send(`Non blocking request sent at ${new Date().toISOString()}.`);
   }
 
   // Run the query

--- a/mod/utils/dbs.js
+++ b/mod/utils/dbs.js
@@ -52,9 +52,7 @@ Object.keys(xyzEnv)
       console.error(err);
     });
 
-    // Assigning clientQuery method to dbs property.
-    dbs[id] = async (query, variables, timeout) =>
-      await clientQuery(pool, query, variables, timeout);
+    dbs[id] = clientQuery.bind(pool);
   });
 
 // Export dbs constant
@@ -64,25 +62,24 @@ export default dbs;
 @function clientQuery
 @async
 
-
 @description
 The clientQuery method creates a client connection from the provided Pool and executes a query on this pool.
 
-@param {Pool} pool The node-postgres connection Pool for a Client connection.
+@this {Pool} The connection pool to use for the query.
 @param {string} query SQL query to execute
 @param {Array} [variables] Parameters for the SQL query
 @param {number} [timeout] Statement timeout in milliseconds
 @returns {Promise<Array|Error>} Query results or error object
 @throws {Error} Database connection or query errors
 */
-async function clientQuery(pool, query, variables, timeout) {
+async function clientQuery(query, variables, timeout) {
   let retryCount = 0;
   let lastError;
   let client;
 
   while (retryCount < RETRY_LIMIT) {
     try {
-      client = await pool.connect();
+      client = await this.connect();
 
       timeout ??= xyzEnv.STATEMENT_TIMEOUT;
 

--- a/tests/mod/query.test.mjs
+++ b/tests/mod/query.test.mjs
@@ -454,7 +454,6 @@ describe('Query: Testing Query API', () => {
       await query(req, res);
 
       expect(res.statusCode).toBe(200);
-      expect(res._getData()).toBe('Non blocking request sent.');
       expect(mockDbQuery).toHaveBeenCalled();
     });
   });

--- a/tests/mod/query.test.mjs
+++ b/tests/mod/query.test.mjs
@@ -452,7 +452,7 @@ describe('Query: Testing Query API', () => {
 
       await query(req, res);
 
-      expect(res.statusCode).toBe(200);
+      expect(res.statusCode).toBe(202);
       expect(mockDbQuery).toHaveBeenCalled();
     });
   });


### PR DESCRIPTION
A nonblocking query should return the timestamp making the return differ for the same request.

Instead of awaiting a regular query but not the nonblocking query it is cleaner to store the response in a const for the same query and await if not blocking.

The dbs module does not await the clientQuery because this makes the nonblocking nonsense since we return an await to either await again or not.

The whole structure of an arrow function with an implicit await return in order to provide the pool argument is very hard to debug and wrap my head around.

I think it is much cleaner to bind the clientQuery to the pool. With the pool then being `this` in the clientQuery. The async function is returned as a promise to be awaited if not blocking.
