### PR TITLE
Refactor wktPropertiesLoad logic to always call function

### DIFF
--- a/lib/layer/format/mvt.mjs
+++ b/lib/layer/format/mvt.mjs
@@ -67,10 +67,7 @@ export default function MVT(layer) {
   Otherwise the source and featureSource [Openlayers VectorTile]{@link https://openlayers.org/en/latest/apidoc/module-ol_source_VectorTile.html} sources are cleared and refreshed.
   */
   function reload() {
-    if (layer.wkt_properties) {
-      wktPropertiesLoad(layer);
-      return;
-    }
+    wktPropertiesLoad(layer);
 
     layer.source.clear();
     layer.source.refresh();
@@ -225,8 +222,11 @@ The wktPropertiesLoad method send a query to the wkt template. The response is p
 Finally the layer.L.changed() method is called to trigger the [layer.featureStyle]{@link module:/layer/featureStyle~featureProperties} method which assigns feature properties from the layer.featuresObject.
 
 @param {layer} layer A decorated format:mvt mapp layer.
+@property {boolean} [layer.wkt_properties] A flag whether feature properties should be loaded independent from MVT geometries.
 */
 async function wktPropertiesLoad(layer) {
+  if (!layer.wkt_properties) return;
+
   const table = layer.tableCurrent();
 
   if (!table || !layer.display) {


### PR DESCRIPTION
The condition for the wktproperties load should be inside the method. This should short circuit if not given.