### PR TITLE
fix(Queryparams): Locale passed as string

### DIFF
--- a/lib/utils/queryParams.mjs
+++ b/lib/utils/queryParams.mjs
@@ -91,7 +91,9 @@ function queryParams(_this) {
 
   // Locale param is only required for layer lookups.
   const locale =
-    layer?.mapview?.locale.key || _this.location?.locale || undefined;
+  typeof _this.queryparams.locale === 'string'
+    ? _this.queryparams.locale
+    : layer?.mapview?.locale.key || _this.location?.locale || undefined;
 
   // ID will be taken if a location object is provided with the params.
   const id = _this.queryparams.id ? _this.location?.id : undefined;

--- a/lib/utils/queryParams.mjs
+++ b/lib/utils/queryParams.mjs
@@ -1,12 +1,10 @@
 /**
 ## /utils/queryParams
 
-The queryParams module exports the queryParams utility method for layer and dataview requests.
+The queryParams module exports the queryParams utility method.
 
 @module /utils/queryParams
 */
-
-export default queryParams;
 
 /**
 @function queryParams
@@ -16,39 +14,18 @@ The queryParams method returns a params object for the creation of a query URL p
 
 The utility facilitates the creation of params argument for the [mapp.utils.paramString()]{@link module:/utils/paramString~paramString} method.
 
-from the [dataview.update()]{@link module:/ui/Dataview~updateDataview} method.
-```js
-// Compile params object from dataview this.
-const params = mapp.utils.queryParams(this);
-
-// Stringify paramString from object.
-const paramString = mapp.utils.paramString(params);
-
-this.host ??= this.layer?.mapview?.host
-
-// Query data as response from query.
-const response = await mapp.utils.xhr(`${this.host || mapp.host}/api/query?${paramString}`);
-```
 The queryParams method is particularly useful for calculating the current [viewport] bounds for a data query and to determine the current table for the mapviews current zoom level.
 
 @param {Object} _this Object from which the query originates, eg. layer, dataview entry.
-@property {Object} _this.queryparams Parameter object for the query.
-@property {Boolean} [queryparams.layer] The layer associated with the requesting object _this should be provided as request param.
-@property {layer} [_this.layer] The layer associated with _this object. The layer is required to calculate a viewport, center, zoom [z], or table [if not explicit].
-@property {Boolean} [_this.viewport] Calculate the bounds for the current viewport of the mapview for _this.layer.
+@property {Object} [_this.queryparams] Parameter object for the query.
+@property {layer} [_this.layer] A dataview associated with a mapp layer will have a layer reference.
 @returns {object} A params object to create a params string.
 */
-function queryParams(_this) {
+export default function queryParams(_this) {
   // Must be an empty object if undefined.
   _this.queryparams ??= {};
 
-  // If queryparams is not an object, return.
-  if (typeof _this.queryparams !== 'object') {
-    console.warn('queryparams must be an object');
-    return;
-  }
-
-  let layer = _this.layer || _this.location?.layer;
+  const layer = _this.layer || _this.location?.layer;
 
   // Merge layer queryparams with request queryparams.
   // _this.queryparams takes precedence.
@@ -59,129 +36,183 @@ function queryParams(_this) {
     };
   }
 
-  // Assign table from layer JSON or layer.tableCurrent() method.
-  _this.queryparams.table &&=
-    typeof _this.queryparams.table === 'string'
-      ? _this.queryparams.table
-      : getTable(_this);
-
-  // Get bounds from mapview.
-  const bounds = _this.viewport && _this.layer.mapview.getBounds();
-
-  const geom =
-    typeof _this.queryparams.geom === 'string'
-      ? _this.queryparams.geom
-      : getGeom(_this);
-
-  // Get center from mapview.
-  const center =
-    _this.queryparams.center &&
-    ol.proj.transform(
-      _this.layer.mapview.Map.getView().getCenter(),
-      `EPSG:${_this.layer.mapview.srid}`,
-      `EPSG:4326`,
-    );
-
-  // Queries will fail if the template can not be accessed in workspace.
-  const template =
-    _this.queryparams.template || encodeURIComponent(_this.query);
-
-  // Layer filter can only be applied if the layer is provided as reference to a layer object in the layers list.
-  const filter = _this.queryparams.filter ? layer?.filter?.current : undefined;
-
-  // Locale param is only required for layer lookups.
-  const locale =
-    typeof _this.queryparams.locale === 'string'
-      ? _this.queryparams.locale
-      : layer?.mapview?.locale.key || _this.location?.locale || undefined;
-
-  // ID will be taken if a location object is provided with the params.
-  const id = _this.queryparams.id ? _this.location?.id : undefined;
-
-  // qID will be taken if a location object is provided with the params.
-  const qID = _this.queryparams.qID ? _this.location?.layer?.qID : undefined;
-
-  // queryparams.email is a boolean property.
-  const email = _this.queryparams.email ? mapp.user.email : undefined;
-
-  // lat lng must be explicit or the center flag param must be set.
-  const lat = center?.[1];
-  const lng = center?.[0];
-
-  // z will be generated if the z flag is set in the params.
-  const z = _this.queryparams?.z && layer.mapview.Map.getView().getZoom();
-
-  // Viewport will only be generated if the viewport flag is set on the params.
-  const viewport = bounds && [
-    bounds.west,
-    bounds.south,
-    bounds.east,
-    bounds.north,
-    layer.mapview.srid,
-  ];
-
-  // The layer maybe defined as string in the queryparams.
-  layer = layer?.key || _this.queryparams.layer || undefined;
-
   const params = {
     ..._this.queryparams,
-    email,
-    fieldValues: undefined,
-    filter,
-    geom,
-    id,
-    lat,
-    layer,
-    lng,
-    locale,
-    qID,
-    template,
-    viewport,
-    z, // The fieldValues array entries should not be part of the url params.
   };
+
+  // Queries will fail if the template can not be accessed in workspace.
+  params.template ??= encodeURIComponent(_this.query);
+
+  if (typeof params.locale !== 'string') {
+    // set locale param from mapview or location if not provided as string.
+    params.locale =
+      layer.mapview.locale.key || _this.location?.locale || undefined;
+  }
+
+  if (typeof params.layer !== 'string') {
+    // set layer param from layer key if not provided as string.
+    params.layer = layer?.key || undefined;
+  }
+
+  tableParam(_this, params);
+
+  viewortParam(_this, params);
+
+  geomParam(_this, params);
+
+  centerParam(_this, params);
+
+  if (params.filter === true) {
+    params.filter = layer?.filter?.current;
+  }
+
+  if (params.id === true) {
+    params.id = _this.location?.id;
+  }
+
+  if (params.qID === true) {
+    params.qID = _this.location?.layer?.qID;
+  }
+
+  if (params.email === true) {
+    params.email = mapp.user?.email;
+  }
+
+  if (params.z === true) {
+    params.z = layer.mapview.Map.getView().getZoom();
+  }
 
   return params;
 }
 
 /**
-@function getTable
+@function tableParam
 
 @description
-Returns the current table associated with a layer or location.layer which maybe dependent on the mapview zoom level.
+Assigns table param to params object if a table can be found on the _this object or its location or layer.
+
+The method will shortcircuit if a table param is already provided as a string if the param is nullish.
 
 @param {Object} _this Object from which the query originates, eg. layer, dataview entry.
+@param {Object} params The params object to set the table param on if found.
 @property {location} [_this.location] A mapp location associated with _this object.
 @property {layer} [location.layer] A mapp layer associated with _this.location.
 @property {layer} [_this.layer] A mapp layer associated with _this object.
-
-@returns {string} Table name
 */
-function getTable(_this) {
-  return (
-    _this.location?.layer?.table ||
-    _this.layer?.table ||
-    _this.location?.layer?.tableCurrent?.() ||
-    _this.layer?.tableCurrent?.() ||
-    _this.location?.layer?.tableCurrent?.() ||
-    (_this.layer?.tables &&
-      Object.values(_this.layer.tables).find((table) => !!table)) ||
-    (_this.location?.layer?.tables &&
-      Object.values(_this.location?.layer.tables).find((table) => !!table))
+function tableParam(_this, params) {
+  if (!params.table) return;
+
+  if (typeof params.table === 'string') return;
+
+  if (_this.location?.layer?.table) {
+    params.table = _this.location.layer.table;
+    return;
+  }
+
+  if (_this.layer?.table) {
+    params.table = _this.layer.table;
+    return;
+  }
+
+  if (_this.location?.layer?.tableCurrent) {
+    params.table = _this.location.layer.tableCurrent();
+    return;
+  }
+
+  if (_this.layer?.tableCurrent) {
+    params.table = _this.layer.tableCurrent();
+    return;
+  }
+
+  if (_this.layer?.tables) {
+    const table = Object.values(_this.layer.tables).find((table) => !!table);
+    params.table = table;
+    return;
+  }
+
+  if (_this.location?.layer?.tables) {
+    const table = Object.values(_this.location.layer.tables).find(
+      (table) => !!table,
+    );
+    params.table = table;
+    return;
+  }
+}
+
+/**
+@function viewortParam
+
+@description
+Assigns viewport param to params object if the viewport of the mapview can be found from the _this.layer.
+
+The method will shortcircuit if a viewport param is already provided as a string or if the layer or mapview is not found.
+
+@param {Object} _this Object from which the query originates, eg. layer, dataview entry.
+@param {Object} params The params object to set the viewport param on if found.
+@property {layer} [_this.layer] A mapp layer associated with _this object. The layer is required to calculate a viewport, center, zoom [z], or table [if not explicit].
+*/
+function viewortParam(_this, params) {
+  if (!params.viewport) return;
+
+  if (typeof params.viewport === 'string') return;
+
+  const mapview = _this.layer?.mapview || _this.location?.layer?.mapview;
+
+  if (!mapview) return;
+
+  const extent = mapview.getExtent();
+
+  params.viewport = ol.proj.transformExtent(
+    extent,
+    `EPSG:${mapview.srid}`,
+    `EPSG:4326`,
   );
 }
 
 /**
-@function getGeom
+@function geomParam
 
 @description
-Returns the current geometry associated with a layer or location.layer which maybe dependent on the mapview zoom level.
+Assign the geom param value from the layer object.
 
 @param {Object} _this Object from which the query originates, eg. layer, dataview entry.
-@property {location} [_this.viewport] The viewport flag is set on the params.
+@param {Object} params The params object to set the geom param on if found.
+@property {boolean} params.geom The geom param is set to true to trigger the assignment of the geom param value.
 @property {layer} [_this.layer] A mapp layer associated with _this object.
-
-@returns {string} Table name
 */
-function getGeom(_this) {
-  return _this.viewport ? _this.layer.geomCurrent() : undefined;
+function geomParam(_this, params) {
+  if (params.geom !== true) {
+    return;
+  }
+
+  params.geom = _this.layer?.geomCurrent();
+}
+
+/**
+@function centerParam
+
+@description
+Assigns center param to params object if the center of the mapview can be found from the _this.layer.
+
+The method will shortcircuit if a center param is already provided as a string or if the layer or mapview is not found.
+
+@param {Object} _this Object from which the query originates, eg. layer, dataview entry.
+@param {Object} params The params object to set the center param on if found.
+@property {layer} [_this.layer] A mapp layer associated with _this object. The layer is required to calculate a viewport, center, zoom [z], or table [if not explicit].
+*/
+function centerParam(_this, params) {
+  if (!params.center) return;
+
+  if (typeof params.center === 'string') return;
+
+  const center = _this.layer.mapview.Map.getView().getCenter();
+
+  params.center = ol.proj.transform(
+    center,
+    `EPSG:${_this.layer.mapview.srid}`,
+    `EPSG:4326`,
+  );
+
+  params.lat = center?.[1];
+  params.lng = center?.[0];
 }

--- a/lib/utils/queryParams.mjs
+++ b/lib/utils/queryParams.mjs
@@ -91,9 +91,9 @@ function queryParams(_this) {
 
   // Locale param is only required for layer lookups.
   const locale =
-  typeof _this.queryparams.locale === 'string'
-    ? _this.queryparams.locale
-    : layer?.mapview?.locale.key || _this.location?.locale || undefined;
+    typeof _this.queryparams.locale === 'string'
+      ? _this.queryparams.locale
+      : layer?.mapview?.locale.key || _this.location?.locale || undefined;
 
   // ID will be taken if a location object is provided with the params.
   const id = _this.queryparams.id ? _this.location?.id : undefined;

--- a/lib/utils/queryParams.mjs
+++ b/lib/utils/queryParams.mjs
@@ -56,7 +56,7 @@ export default function queryParams(_this) {
 
   tableParam(_this, params);
 
-  viewortParam(_this, params);
+  viewportParam(_this, params);
 
   geomParam(_this, params);
 
@@ -140,7 +140,7 @@ function tableParam(_this, params) {
 }
 
 /**
-@function viewortParam
+@function viewportParam
 
 @description
 Assigns viewport param to params object if the viewport of the mapview can be found from the _this.layer.
@@ -151,7 +151,7 @@ The method will shortcircuit if a viewport param is already provided as a string
 @param {Object} params The params object to set the viewport param on if found.
 @property {layer} [_this.layer] A mapp layer associated with _this object. The layer is required to calculate a viewport, center, zoom [z], or table [if not explicit].
 */
-function viewortParam(_this, params) {
+function viewportParam(_this, params) {
   if (!params.viewport) return;
 
   if (typeof params.viewport === 'string') return;


### PR DESCRIPTION
## Description
It should be possible to pass `locale` as a string to a query. 
Otherwise, you need to pass the `layer.mapview.locale.key` or `location.locale` which requires complex object building or the whole object being passed.