### PR TITLE
Reset features array in vector reload

### DIFF
--- a/lib/layer/format/vector.mjs
+++ b/lib/layer/format/vector.mjs
@@ -96,6 +96,7 @@ The clusterSourceChange method is triggered for cluster layer.
 async function setSource(features) {
   // The layer datasource is empty.
   if (features === null) {
+    this.Features = [];
     this.L.setSource(null);
     mapp.layer.featureFields.reset(this);
     mapp.layer.featureFields.process(this);


### PR DESCRIPTION
The setSource method must reset the Features array if null features are returned.

The Features array length is used for the feature count display, eg in the Filter panel.