### PR TITLE
fix provider urls

### DIFF
--- a/mod/provider/getFrom.js
+++ b/mod/provider/getFrom.js
@@ -21,6 +21,7 @@ import file from './file.js';
 const getFromModules = {
   cloudfront: Cloudfront,
   file: File,
+  http: Https,
   https: Https,
 };
 
@@ -86,11 +87,21 @@ function File(ref) {
 
 async function Https(url) {
   try {
-    const response = await fetch(url);
+    const requestUrl = new URL(url);
+
+    const isLoopbackHttp =
+      requestUrl.protocol === 'http:' &&
+      ['localhost', '127.0.0.1', '[::1]'].includes(requestUrl.hostname);
+
+    if (requestUrl.protocol !== 'https:' && !isLoopbackHttp) {
+      throw new Error('Invalid HTTPS URL');
+    }
+
+    const response = await fetch(requestUrl);
 
     logger(`${response.status} - ${response.url}`, 'fetch');
 
-    if (url.match(/\.json$/i)) {
+    if (requestUrl.href.match(/\.json$/i)) {
       return await response.json();
     }
 

--- a/tests/mod/provider/getFrom.test.mjs
+++ b/tests/mod/provider/getFrom.test.mjs
@@ -41,6 +41,44 @@ describe('getFrom:', () => {
     );
   });
 
+  it('http accepts loopback urls', async () => {
+    const resBody = JSON.stringify(
+      '{ "templates": {}, "locale": { "layers": {}, }, }',
+    );
+
+    const mockPool = mockAgent.get('http://localhost:3000');
+
+    mockPool.intercept({ path: '/config/workspace.json' }).reply(200, resBody);
+
+    const url = 'http://localhost:3000/config/workspace.json';
+
+    const results = await getFrom['http'](url);
+
+    expect(results).toEqual(
+      '{ "templates": {}, "locale": { "layers": {}, }, }',
+    );
+  });
+
+  it('https rejects unsafe urls', async () => {
+    const consoleError = vi
+      .spyOn(console, 'error')
+      .mockImplementation(() => {});
+
+    try {
+      for (const url of [
+        'http://geolytix.com/config/workspace.json',
+        'file:///etc/passwd',
+        'not-a-url',
+      ]) {
+        const results = await getFrom['https'](url);
+
+        expect(results).toBeInstanceOf(Error);
+      }
+    } finally {
+      consoleError.mockRestore();
+    }
+  });
+
   it('file', async () => {
     const filePath = 'file:../../workspaces/workspace.json';
 


### PR DESCRIPTION
This PR validates URLs before they are passed to `fetch` in the `getFrom` provider.

Changes include:

- Parse incoming request URLs with `new URL()` before use.
- Allow remote resources only over `https:`.
- Add `http` provider support for local development.
- Allow plain `http:` only for loopback hosts: `localhost`, `127.0.0.1`, and `[::1]`.
- Reject malformed URLs, `file://` URLs, and non-local `http://` URLs.
- Add tests covering valid HTTPS, local HTTP, and unsafe URL rejection.

## Why

This addresses the SonarQube security finding:

> Ensure that tainted data is validated before being used to construct a client-side request URL.

The validation prevents untrusted input from being used directly in `fetch`, while preserving local development workflows that use `http://localhost`.