### PR TITLE
Review getLocale methods and documentation

### DIFF
--- a/mod/workspace/getLocale.js
+++ b/mod/workspace/getLocale.js
@@ -98,12 +98,12 @@ TODO
 
 @param {locale} locale
 @param {workspace} workspace
-@param {string} key
+@param {string} [key='locale'] Key of locale object in the workspace.
 */
-async function loadLocale(locale, workspace, key) {
+async function loadLocale(locale, workspace, key = 'locale') {
   let locale;
 
-  if (!key || key === 'locale') {
+  if (key === 'locale') {
     locale = workspace.locale;
   } else if (Object.hasOwn(workspace.locales, key)) {
     locale = workspace.locales[key];

--- a/mod/workspace/getLocale.js
+++ b/mod/workspace/getLocale.js
@@ -70,22 +70,37 @@ export default async function getLocale(params, parentLocale) {
     ? params.locale.shift()
     : params.locale;
 
-  let locale = await loadLocale(workspace, localeKey);
+  let locale;
+
+  await loadLocale(locale, workspace, localeKey);
 
   if (locale instanceof Error) {
     return new Error(locale.message);
   }
 
-  locale = await processRoles(locale, parentLocale, params);
+  await processRoles(locale, parentLocale, params);
 
   if (locale instanceof Error) {
     return locale;
   }
 
-  return await composeLocale(locale, parentLocale, params, workspace.key);
+  await composeLocale(locale, parentLocale, params, workspace.key);
+
+  return locale;
 }
 
-async function loadLocale(workspace, key) {
+/**
+@function loadLocale
+@async
+
+@description
+TODO
+
+@param {locale} locale
+@param {workspace} workspace
+@param {string} key
+*/
+async function loadLocale(locale, workspace, key) {
   let locale;
 
   if (!key || key === 'locale') {
@@ -97,7 +112,7 @@ async function loadLocale(workspace, key) {
   }
 
   // This is to prevent that locale in the workspace is modified.
-  return structuredClone(locale);
+  locale = structuredClone(locale);
 }
 
 /**
@@ -139,19 +154,17 @@ async function processRoles(locale, parentLocale, params) {
 
   // The mergeTemplates method returned an Error.
   if (locale instanceof Error) {
-    return locale;
+    return;
   }
 
   // Strict Role Check
   if (params.ignoreRoles) {
-    return locale;
+    return;
   }
 
   if (!Roles.check(locale.roles, params.user?.roles)) {
-    return new Error('Role access denied.');
+    locale = new Error('Role access denied.');
   }
-
-  return locale;
 }
 
 /**
@@ -222,6 +235,4 @@ async function composeLocale(locale, parentLocale, params, workspaceKey) {
   delete locale.templates;
   delete locale._type;
   delete locale.localesRoleContext;
-
-  return locale;
 }


### PR DESCRIPTION
@RobAndrewHurst  Can you help me understand the loadLocale method? This was missing any form of documentation. I feel this was nested into it's own method to reduce the complexity of the getLocale method by way of increasing the overall module complexity.

The assignment of the locale variable and return of the variable, or error, or method is really hard to understand.

I believe it is easier to just always provide the locale as first parameter which can be reassigned if needed.

Nothing needs to be returned apart from the locale getLocale method. This was previously returning a method/promise which resolves to a locale.

I don't understand the part where the locale.message is returned if locale is an error after awaiting the loadLocale method but the locale is returned if the locale is an instance of an error after the processRoles method.

How can the key be nullish in the loadLocale method? [Can we not assign the default in the params](https://github.com/GEOLYTIX/xyz/pull/2873/commits/988389a6b2e80805828dd630b7bf444b9889866d). 