### PR TITLE
module templates must have a typeof string response

### DIFF
--- a/mod/workspace/getTemplate.js
+++ b/mod/workspace/getTemplate.js
@@ -103,7 +103,7 @@ export default async function getTemplate(template) {
     return new Error(`Unable to getFrom src: ${template.src}`);
   }
 
-  if (template.module) {
+  if (template.module && typeof response === 'string') {
     // Module templates must not be cached.
     return await moduleTemplate(template, response);
   }


### PR DESCRIPTION
SonarQube has issued a security warning in regards to user controlled imports.

<img width="707" height="970" alt="image" src="https://github.com/user-attachments/assets/71421a5d-7bd3-4e9b-a744-2c48801dc1f8" />

This should not be valid since a module response for the import must be string type.

A condition should be added in this regard to the check for the module property flag.
