### PR TITLE
fix(queryparams): Fix Changes in queryparams

### DIFF
--- a/lib/utils/queryParams.mjs
+++ b/lib/utils/queryParams.mjs
@@ -46,7 +46,7 @@ export default function queryParams(_this) {
   if (typeof params.locale !== 'string') {
     // set locale param from mapview or location if not provided as string.
     params.locale =
-      layer.mapview.locale.key || _this.location?.locale || undefined;
+      layer?.mapview?.locale?.key || _this.location?.locale || undefined;
   }
 
   if (typeof params.layer !== 'string') {
@@ -79,7 +79,7 @@ export default function queryParams(_this) {
   }
 
   if (params.z === true) {
-    params.z = layer.mapview.Map.getView().getZoom();
+    params.z = layer?.mapview?.Map?.getView()?.getZoom();
   }
 
   return params;
@@ -160,7 +160,7 @@ function viewportParam(_this, params) {
 
   if (!mapview) return;
 
-  const extent = mapview.getExtent();
+  const extent = mapview.getBounds();
 
   params.viewport = ol.proj.transformExtent(
     extent,


### PR DESCRIPTION
## Description
1. Conditional on layer having a mapview - it may not if layer is not provided.
2. getExtent() should be getBounds() - this was mistakenly changed.

## Type of Change
- ✅ Bug fix (non-breaking change which fixes an issue)

## How have you tested this?
Tested locally against the demo application.

## Testing Checklist
- ✅ Existing Tests still pass
- ✅ Ran locally on my machine