### PR TITLE
Enhance debounce handling in xhr and improve tab visibility logic

### DIFF
--- a/lib/layer/format/mvt.mjs
+++ b/lib/layer/format/mvt.mjs
@@ -276,6 +276,11 @@ async function wktPropertiesLoad(layer) {
     },
   });
 
+  if (!response) return;
+
+  // The method must shortcircuit on debounce other no features would be rendered.
+  if (response.debounce) return;
+
   // The featuresObject should be reset before being populated by the featureFormats.wkt_properties method for use in the featureStyle method.
   // The featuresObject should be empty if the xhr query fails to provide an array response.
   layer.featuresObject = {};

--- a/lib/ui/Tabview.mjs
+++ b/lib/ui/Tabview.mjs
@@ -237,6 +237,9 @@ function addTab(entry) {
     // A tab without parent element cannot be in the tab bar.
     if (!entry.tab.parentElement) return;
 
+    // Data should not be queried if a tab is removed.
+    entry.display = false;
+
     // Find a sibling of the entry.
     const sibling =
       entry.tab.nextElementSibling || entry.tab.previousElementSibling;

--- a/lib/utils/xhr.mjs
+++ b/lib/utils/xhr.mjs
@@ -125,6 +125,11 @@ const debounceMap = new Map();
 function debounce(xhr, params, reject) {
   if (!params.debounce) return;
 
+  if (typeof params.debounce === 'object') {
+    params.delay = params.debounce.delay;
+    params.key = params.debounce.key;
+  }
+
   if (typeof params.debounce === 'number') {
     params.delay = params.debounce;
   }


### PR DESCRIPTION
The mvt wkt_properties uses a debounce object to handle debounce requests. This was not handled by the xhr utility method. Any wkt_properties request would default to the global key. Only a single displayed wkt_properties layer would be shown.

The wkt_properties method should return if no, or a debounced response is received. Otherwise the layer would not be shown at all. A debounced request will still show the mvt features.

The entry.display must be set to false. Otherwise a closed dataview will still request data.