### PR TITLE
fix viewport assignment

### DIFF
--- a/lib/utils/queryParams.mjs
+++ b/lib/utils/queryParams.mjs
@@ -40,6 +40,8 @@ export default function queryParams(_this) {
     ..._this.queryparams,
   };
 
+  params.viewport ??= _this.viewport;
+
   // Queries will fail if the template can not be accessed in workspace.
   params.template ??= encodeURIComponent(_this.query);
 
@@ -162,11 +164,14 @@ function viewportParam(_this, params) {
 
   const extent = mapview.getBounds();
 
-  params.viewport = ol.proj.transformExtent(
-    extent,
-    `EPSG:${mapview.srid}`,
-    `EPSG:4326`,
-  );
+  // Convert extent to an array and add the mapview.srid to the end of the array to create a viewport param value.
+  params.viewport = [
+    extent.west,
+    extent.south,
+    extent.east,
+    extent.north,
+    mapview.srid,
+  ];
 }
 
 /**


### PR DESCRIPTION
## Description
Nullish assign viewport flag from _this
Calling transformExtent with an object was returning NaNs.
Build the viewport array using the extent and srid

## Type of Change
- ✅ Bug fix (non-breaking change which fixes an issue)

## How have you tested this?
Tested locally with a dataview with `viewport:true` flag. 
