### PR TITLE
fix(Mapview/Modify): Deletion of MultiPolygons

### DIFF
--- a/lib/mapview/interactions/modify.mjs
+++ b/lib/mapview/interactions/modify.mjs
@@ -185,33 +185,58 @@ function deleteCondition(e, mapview) {
 
   params.coords = params.geom.getCoordinates();
 
-  // Return on point or line with 2 vertices.
-  if (params.geomType === 'LineString' && params.coords.length < 3) return;
+  // Initialize empty list for popup content
+  params.content = [];
 
-  // Return on polygon with less than 3 vertices.
-  if (params.geomType === 'Polygon' && params.coords[0].length <= 4) return;
+  // Only allow to remove vertex on linestring with more than 2.
+  if (params.geomType === 'LineString' && params.coords.length > 2) {
+    params.content.push(mapp.utils.html`<li
+      onclick=${() => removeVertex(e, mapview)}>
+      ${mapp.dictionary.delete_vertex}`)
+  };
 
-  if (params.geomType !== 'MultiPolygon') {
-    // Set popup to remove vertex.
-    mapview.popup({
-      content: mapp.utils.html.node`<ul><li
-      onclick=${() => {
-        mapview.interaction.interaction.removePoint();
-        mapview.interaction.vertices.push(
-          mapview.interaction.Feature.getGeometry().getClosestPoint(
-            e.coordinate,
-          ),
-        );
-      }}>${mapp.dictionary.delete_vertex}`,
-      coords: params.geom.getClosestPoint(e.coordinate),
-    });
-    return;
+  // Only allow to delete vertex on polygon with more than 3.
+  if (params.geomType === 'Polygon' && params.coords[0].length > 3) {
+    params.content.push(mapp.utils.html`<li
+      onclick=${() => removeVertex(e, mapview)}>
+      ${mapp.dictionary.delete_vertex}`)
   }
 
-  params.ringLength =
-    params.geomType === 'Polygon' ? params.coords[0].length : 0;
-  params.clickedPolyIndex = -1;
+  multipolygon(e, mapview, params)
 
+  // Set popup
+  mapview.popup({
+    content: mapp.utils.html.node`<ul>${params.content}`,
+    coords: params.geom.getClosestPoint(e.coordinate),
+  });
+}
+
+function removeVertex(e, mapview) {
+  mapview.interaction.interaction.removePoint();
+  mapview.interaction.vertices.push(
+    mapview.interaction.Feature.getGeometry().getClosestPoint(e.coordinate),
+  );
+  mapview.popup(null);
+
+  // Display save/cancel popup.
+  mapview.interaction.interaction.dispatchEvent({
+    type: 'modifyend',
+    features: new ol.Collection([mapview.interaction.Feature]),
+  });
+}
+
+/**
+@function multipolygon
+@description 
+
+@param {Object} mapview The mapview object.
+@param {Object} e The event object.
+@param {Object} params The parameters object containing geometry information.
+*/
+function multipolygon(e, mapview, params) {
+  if (params.geomType !== 'MultiPolygon') return;
+
+  params.clickedPolyIndex = -1;
   params.minDist = Infinity;
   params.polygons = params.geom.getPolygons();
 
@@ -228,71 +253,16 @@ function deleteCondition(e, mapview) {
     }
   });
 
-  // Initialize empty list for popup content
-  params.content = mapp.utils.html.node`<ul></ul>`;
-
-  // Call the vertexRemoval function to handle standard vertex removal
-  vertexRemoval(mapview, e, params);
-
-  // Call the multipolygonPartRemoval function to handle MultiPolygon part removal
-  multipolygonPartRemoval(mapview, e, params);
-
-  // Set popup
-  mapview.popup({
-    content: params.content,
-    coords: params.geom.getClosestPoint(e.coordinate),
-  });
-}
-
-/**
-@function vertexRemoval
-@description 
-Adds the option to delete a vertex to the popup content if the geometry has more than 3 vertices.
-@param {Object} mapview The mapview object.
-@param {Object} e The event object.
-@param {Object} params The parameters object containing geometry information.
-*/
-function vertexRemoval(mapview, e, params) {
-  // Return if the shape has less than 4 vertices as you cannot remove a vertex from a triangle or line.
-  if (params.ringLength < 4) return;
-
-  params.content.appendChild(mapp.utils.html.node`<li
-            onclick=${() => {
-              mapview.interaction.interaction.removePoint();
-              mapview.interaction.vertices.push(
-                mapview.interaction.Feature.getGeometry().getClosestPoint(
-                  e.coordinate,
-                ),
-              );
-              mapview.popup(null);
-
-              mapview.interaction.interaction.dispatchEvent({
-                type: 'modifyend',
-                features: new ol.Collection([mapview.interaction.Feature]),
-              });
-            }}>${mapp.dictionary.delete_vertex}</li>`);
-
-  return params.content;
-}
-
-/**
-@function multipolygonPartRemoval
-@description 
-Adds the option to delete a polygon part to the popup content if the geometry is a MultiPolygon.
-
-@param {Object} mapview The mapview object.
-@param {Object} e The event object.
-@param {Object} params The parameters object containing geometry information.
-*/
-function multipolygonPartRemoval(mapview, e, params) {
-  if (params.geomType !== 'MultiPolygon') return;
+  if (params.ringLength > 4) {
+    params.content.push(mapp.utils.html`<li
+    onclick=${() => removeVertex(e, mapview)}>
+    ${mapp.dictionary.delete_vertex}`);
+  }
 
   // Add the option to delete the polygon part to the popup content
-  params.content.append(mapp.utils.html.node`<li
+  params.content.push(mapp.utils.html`<li
     onclick=${onclick}>
     ${mapp.dictionary.delete_polygon_part}`);
-
-  return params.content;
 
   function onclick() {
     mapview.popup(null);

--- a/lib/mapview/interactions/modify.mjs
+++ b/lib/mapview/interactions/modify.mjs
@@ -136,7 +136,7 @@ export default function modify(params, mapview = this) {
 
   /**
   @function finish
-  @description 
+  @description
   Ends the modification interaction, cleans up event listeners, and removes the interaction from the map.
   @param {Object} feature The modified feature to be passed to the callback function.
   */
@@ -168,7 +168,7 @@ export default function modify(params, mapview = this) {
 
 /**
 @function deleteCondition
-@description 
+@description
 @param {object} e The interaction event object.
 @param {mapview} mapview
 */
@@ -188,13 +188,15 @@ function deleteCondition(e, mapview) {
     if (params.geomType === 'LineString' && params.coords.length < 3) return;
 
     params.ringLength =
-      params.geomType === 'Polygon' ? params.coords[0].length : 0;
+      params.geomType === 'Polygon'
+        ? params.coords[0].length
+        : params.coords.length;
     params.clickedPolyIndex = -1;
 
     params.minDist = Infinity;
-    params.polygons = params.geom.getPolygons();
+    params.polygons = params.geom.getPolygons?.() || {};
 
-    params.polygons.forEach((poly, idx) => {
+    for (const [idx, poly] of Object.entries(params.polygons)) {
       const closest = poly.getClosestPoint(e.coordinate);
       const dx = closest[0] - e.coordinate[0];
       const dy = closest[1] - e.coordinate[1];
@@ -205,7 +207,7 @@ function deleteCondition(e, mapview) {
         params.clickedPolyIndex = idx;
         params.ringLength = poly.getCoordinates()[0].length;
       }
-    });
+    }
 
     // Initialize empty list for popup content
     params.content = mapp.utils.html.node`<ul></ul>`;
@@ -226,7 +228,7 @@ function deleteCondition(e, mapview) {
 
 /**
   @function vertexRemoval
-  @description 
+  @description
   Adds the option to delete a vertex to the popup content if the geometry has more than 3 vertices.
   @param {Object} mapview The mapview object.
   @param {Object} e The event object.
@@ -257,7 +259,7 @@ function vertexRemoval(mapview, e, params) {
 
 /**
   @function multipolygonPartRemoval
-  @description 
+  @description
   Adds the option to delete a polygon part to the popup content if the geometry is a MultiPolygon.
   @param {Object} mapview The mapview object.
   @param {Object} e The event object.

--- a/lib/mapview/interactions/modify.mjs
+++ b/lib/mapview/interactions/modify.mjs
@@ -192,17 +192,17 @@ function deleteCondition(e, mapview) {
   if (params.geomType === 'LineString' && params.coords.length > 2) {
     params.content.push(mapp.utils.html`<li
       onclick=${() => removeVertex(e, mapview)}>
-      ${mapp.dictionary.delete_vertex}`)
-  };
+      ${mapp.dictionary.delete_vertex}`);
+  }
 
   // Only allow to delete vertex on polygon with more than 3.
   if (params.geomType === 'Polygon' && params.coords[0].length > 3) {
     params.content.push(mapp.utils.html`<li
       onclick=${() => removeVertex(e, mapview)}>
-      ${mapp.dictionary.delete_vertex}`)
+      ${mapp.dictionary.delete_vertex}`);
   }
 
-  multipolygon(e, mapview, params)
+  multipolygon(e, mapview, params);
 
   // Set popup
   mapview.popup({

--- a/lib/mapview/interactions/modify.mjs
+++ b/lib/mapview/interactions/modify.mjs
@@ -21,33 +21,53 @@ export default function modify(params, mapview = this) {
   mapview.interaction = {
     deleteCondition: (e) => {
       if (e.type === 'singleclick') {
-        const geom = mapview.interaction.Feature.getGeometry();
+        const params = {};
 
-        const geomType = geom.getType();
+        params.geom = mapview.interaction.Feature.getGeometry();
 
-        if (geomType === 'Point') return;
+        params.geomType = params.geom.getType();
 
-        const coords = geom.getCoordinates();
+        if (params.geomType === 'Point') return;
+
+        params.coords = params.geom.getCoordinates();
 
         // Return on point or line with 2 vertices.
-        if (geomType === 'LineString' && coords.length < 3) return;
+        if (params.geomType === 'LineString' && params.coords.length < 3)
+          return;
 
-        // Return on polygon with less than 3 vertices.
-        if (geomType === 'Polygon' && coords[0].length <= 4) return;
+        params.ringLength =
+          params.geomType === 'Polygon' ? params.coords[0].length : 0;
+        params.clickedPolyIndex = -1;
 
-        // Set popup to remove vertex.
+        params.minDist = Infinity;
+        params.polygons = params.geom.getPolygons();
+
+        params.polygons.forEach((poly, idx) => {
+          const closest = poly.getClosestPoint(e.coordinate);
+          const dx = closest[0] - e.coordinate[0];
+          const dy = closest[1] - e.coordinate[1];
+          const dist = dx * dx + dy * dy;
+
+          if (dist < params.minDist) {
+            params.minDist = dist;
+            params.clickedPolyIndex = idx;
+            params.ringLength = poly.getCoordinates()[0].length;
+          }
+        });
+
+        // Initialize empty list for popup content
+        params.content = mapp.utils.html.node`<ul></ul>`;
+
+        // Call the vertexRemoval function to handle standard vertex removal
+        vertexRemoval(mapview, e, params);
+
+        // Call the multipolygonPartRemoval function to handle MultiPolygon part removal
+        multipolygonPartRemoval(mapview, e, params);
+
+        // Set popup
         mapview.popup({
-          content: mapp.utils.html.node`<ul>
-            <li
-              onclick=${() => {
-                mapview.interaction.interaction.removePoint();
-                mapview.interaction.vertices.push(
-                  mapview.interaction.Feature.getGeometry().getClosestPoint(
-                    e.coordinate,
-                  ),
-                );
-              }}>${mapp.dictionary.delete_vertex}`,
-          coords: geom.getClosestPoint(e.coordinate),
+          content: params.content,
+          coords: params.geom.getClosestPoint(e.coordinate),
         });
       }
     },
@@ -119,6 +139,88 @@ export default function modify(params, mapview = this) {
   //End the modification on escape key.
   document.addEventListener('keyup', escape);
 
+  /**
+   * @function vertexRemoval
+   * @description Adds the option to delete a vertex to the popup content if the geometry has more than 3 vertices.
+   * @param {Object} mapview The mapview object.
+   * @param {Object} e The event object.
+   * @param {Object} params The parameters object containing geometry information.
+   */
+  function vertexRemoval(mapview, e, params) {
+    // Return if the shape has less than 4 vertices as you cannot remove a vertex from a triangle or line.
+    if (params.ringLength < 4) return;
+
+    params.content.appendChild(mapp.utils.html.node`<li
+            onclick=${() => {
+              mapview.interaction.interaction.removePoint();
+              mapview.interaction.vertices.push(
+                mapview.interaction.Feature.getGeometry().getClosestPoint(
+                  e.coordinate,
+                ),
+              );
+              mapview.popup(null);
+
+              mapview.interaction.interaction.dispatchEvent({
+                type: 'modifyend',
+                features: new ol.Collection([mapview.interaction.Feature]),
+              });
+            }}>${mapp.dictionary.delete_vertex}</li>`);
+
+    return params.content;
+  }
+
+  /**
+   * @function multipolygonPartRemoval
+   * @description Adds the option to delete a polygon part to the popup content if the geometry is a MultiPolygon.
+   * @param {Object} mapview The mapview object.
+   * @param {Object} e The event object.
+   * @param {Object} params The parameters object containing geometry information.
+   */
+  function multipolygonPartRemoval(mapview, e, params) {
+    if (params.geomType !== 'MultiPolygon') return;
+
+    // Add the option to delete the polygon part to the popup content
+    params.content.appendChild(mapp.utils.html.node`<li
+            onclick=${() => {
+              mapview.popup(null);
+
+              const polygons = params.geom.getPolygons();
+              const remaining = polygons.filter(
+                (_, idx) => idx !== params.clickedPolyIndex,
+              );
+
+              if (remaining.length === 0) {
+                // If they deleted the last part, end the interaction and nullify
+                mapview.interaction.finish();
+                mapview.interaction.callback?.(null);
+              } else {
+                // Apply the filtered coordinates back to the geometry
+                params.geom.setCoordinates(
+                  remaining.map((p) => p.getCoordinates()),
+                );
+
+                // Refresh the visual display
+                mapview.interaction.source.clear();
+                mapview.interaction.source.addFeature(
+                  mapview.interaction.Feature,
+                );
+
+                mapview.interaction.interaction.dispatchEvent({
+                  type: 'modifyend',
+                  features: new ol.Collection([mapview.interaction.Feature]),
+                });
+              }
+            }}>
+        ${mapp.dictionary.delete_polygon_part}</li>`);
+
+    return params.content;
+  }
+
+  /**
+   * @function escape
+   * @description Ends the modification interaction when the Escape key is pressed.
+   * @param {Object} e The event object.
+   */
   function escape(e) {
     e.key === 'Escape' && mapview.interaction.finish();
   }
@@ -145,6 +247,11 @@ export default function modify(params, mapview = this) {
   // Assign snap interaction.
   mapview.interactions.snap(mapview);
 
+  /**
+   * @function getFeature
+   * @description Returns the modified feature as a GeoJSON object.
+   * @returns {Object} The modified feature in GeoJSON format.
+   */
   function getFeature() {
     return JSON.parse(
       mapview.interaction.format.writeFeature(mapview.interaction.Feature, {
@@ -154,6 +261,11 @@ export default function modify(params, mapview = this) {
     );
   }
 
+  /**
+   * @function finish
+   * @description Ends the modification interaction, cleans up event listeners, and removes the interaction from the map.
+   * @param {Object} feature The modified feature to be passed to the callback function.
+   */
   function finish(feature) {
     //Remove the escape key event listener
     document.removeEventListener('keyup', escape);

--- a/lib/mapview/interactions/modify.mjs
+++ b/lib/mapview/interactions/modify.mjs
@@ -90,85 +90,6 @@ export default function modify(params, mapview = this) {
   document.addEventListener('keyup', escape);
 
   /**
-  @function vertexRemoval
-  @description 
-  Adds the option to delete a vertex to the popup content if the geometry has more than 3 vertices.
-  @param {Object} mapview The mapview object.
-  @param {Object} e The event object.
-  @param {Object} params The parameters object containing geometry information.
-  */
-  function vertexRemoval(mapview, e, params) {
-    // Return if the shape has less than 4 vertices as you cannot remove a vertex from a triangle or line.
-    if (params.ringLength < 4) return;
-
-    params.content.appendChild(mapp.utils.html.node`<li
-            onclick=${() => {
-              mapview.interaction.interaction.removePoint();
-              mapview.interaction.vertices.push(
-                mapview.interaction.Feature.getGeometry().getClosestPoint(
-                  e.coordinate,
-                ),
-              );
-              mapview.popup(null);
-
-              mapview.interaction.interaction.dispatchEvent({
-                type: 'modifyend',
-                features: new ol.Collection([mapview.interaction.Feature]),
-              });
-            }}>${mapp.dictionary.delete_vertex}</li>`);
-
-    return params.content;
-  }
-
-  /**
-  @function multipolygonPartRemoval
-  @description 
-  Adds the option to delete a polygon part to the popup content if the geometry is a MultiPolygon.
-  @param {Object} mapview The mapview object.
-  @param {Object} e The event object.
-  @param {Object} params The parameters object containing geometry information.
-  */
-  function multipolygonPartRemoval(mapview, e, params) {
-    if (params.geomType !== 'MultiPolygon') return;
-
-    // Add the option to delete the polygon part to the popup content
-    params.content.appendChild(mapp.utils.html.node`<li
-            onclick=${() => {
-              mapview.popup(null);
-
-              const polygons = params.geom.getPolygons();
-              const remaining = polygons.filter(
-                (_, idx) => idx !== params.clickedPolyIndex,
-              );
-
-              if (remaining.length === 0) {
-                // If they deleted the last part, end the interaction and nullify
-                mapview.interaction.finish();
-                mapview.interaction.callback?.(null);
-              } else {
-                // Apply the filtered coordinates back to the geometry
-                params.geom.setCoordinates(
-                  remaining.map((p) => p.getCoordinates()),
-                );
-
-                // Refresh the visual display
-                mapview.interaction.source.clear();
-                mapview.interaction.source.addFeature(
-                  mapview.interaction.Feature,
-                );
-
-                mapview.interaction.interaction.dispatchEvent({
-                  type: 'modifyend',
-                  features: new ol.Collection([mapview.interaction.Feature]),
-                });
-              }
-            }}>
-        ${mapp.dictionary.delete_polygon_part}</li>`);
-
-    return params.content;
-  }
-
-  /**
   @function escape
   @description Ends the modification interaction when the Escape key is pressed.
   @param {Object} e The event object.
@@ -302,3 +223,82 @@ function deleteCondition(e, mapview) {
     });
   }
 }
+
+  /**
+  @function vertexRemoval
+  @description 
+  Adds the option to delete a vertex to the popup content if the geometry has more than 3 vertices.
+  @param {Object} mapview The mapview object.
+  @param {Object} e The event object.
+  @param {Object} params The parameters object containing geometry information.
+  */
+  function vertexRemoval(mapview, e, params) {
+    // Return if the shape has less than 4 vertices as you cannot remove a vertex from a triangle or line.
+    if (params.ringLength < 4) return;
+
+    params.content.appendChild(mapp.utils.html.node`<li
+            onclick=${() => {
+              mapview.interaction.interaction.removePoint();
+              mapview.interaction.vertices.push(
+                mapview.interaction.Feature.getGeometry().getClosestPoint(
+                  e.coordinate,
+                ),
+              );
+              mapview.popup(null);
+
+              mapview.interaction.interaction.dispatchEvent({
+                type: 'modifyend',
+                features: new ol.Collection([mapview.interaction.Feature]),
+              });
+            }}>${mapp.dictionary.delete_vertex}</li>`);
+
+    return params.content;
+  }
+
+    /**
+  @function multipolygonPartRemoval
+  @description 
+  Adds the option to delete a polygon part to the popup content if the geometry is a MultiPolygon.
+  @param {Object} mapview The mapview object.
+  @param {Object} e The event object.
+  @param {Object} params The parameters object containing geometry information.
+  */
+  function multipolygonPartRemoval(mapview, e, params) {
+    if (params.geomType !== 'MultiPolygon') return;
+
+    // Add the option to delete the polygon part to the popup content
+    params.content.appendChild(mapp.utils.html.node`<li
+            onclick=${() => {
+              mapview.popup(null);
+
+              const polygons = params.geom.getPolygons();
+              const remaining = polygons.filter(
+                (_, idx) => idx !== params.clickedPolyIndex,
+              );
+
+              if (remaining.length === 0) {
+                // If they deleted the last part, end the interaction and nullify
+                mapview.interaction.finish();
+                mapview.interaction.callback?.(null);
+              } else {
+                // Apply the filtered coordinates back to the geometry
+                params.geom.setCoordinates(
+                  remaining.map((p) => p.getCoordinates()),
+                );
+
+                // Refresh the visual display
+                mapview.interaction.source.clear();
+                mapview.interaction.source.addFeature(
+                  mapview.interaction.Feature,
+                );
+
+                mapview.interaction.interaction.dispatchEvent({
+                  type: 'modifyend',
+                  features: new ol.Collection([mapview.interaction.Feature]),
+                });
+              }
+            }}>
+        ${mapp.dictionary.delete_polygon_part}</li>`);
+
+    return params.content;
+  }

--- a/lib/mapview/interactions/modify.mjs
+++ b/lib/mapview/interactions/modify.mjs
@@ -224,7 +224,7 @@ function deleteCondition(e, mapview) {
   }
 }
 
-  /**
+/**
   @function vertexRemoval
   @description 
   Adds the option to delete a vertex to the popup content if the geometry has more than 3 vertices.
@@ -232,11 +232,11 @@ function deleteCondition(e, mapview) {
   @param {Object} e The event object.
   @param {Object} params The parameters object containing geometry information.
   */
-  function vertexRemoval(mapview, e, params) {
-    // Return if the shape has less than 4 vertices as you cannot remove a vertex from a triangle or line.
-    if (params.ringLength < 4) return;
+function vertexRemoval(mapview, e, params) {
+  // Return if the shape has less than 4 vertices as you cannot remove a vertex from a triangle or line.
+  if (params.ringLength < 4) return;
 
-    params.content.appendChild(mapp.utils.html.node`<li
+  params.content.appendChild(mapp.utils.html.node`<li
             onclick=${() => {
               mapview.interaction.interaction.removePoint();
               mapview.interaction.vertices.push(
@@ -252,10 +252,10 @@ function deleteCondition(e, mapview) {
               });
             }}>${mapp.dictionary.delete_vertex}</li>`);
 
-    return params.content;
-  }
+  return params.content;
+}
 
-    /**
+/**
   @function multipolygonPartRemoval
   @description 
   Adds the option to delete a polygon part to the popup content if the geometry is a MultiPolygon.
@@ -263,11 +263,11 @@ function deleteCondition(e, mapview) {
   @param {Object} e The event object.
   @param {Object} params The parameters object containing geometry information.
   */
-  function multipolygonPartRemoval(mapview, e, params) {
-    if (params.geomType !== 'MultiPolygon') return;
+function multipolygonPartRemoval(mapview, e, params) {
+  if (params.geomType !== 'MultiPolygon') return;
 
-    // Add the option to delete the polygon part to the popup content
-    params.content.appendChild(mapp.utils.html.node`<li
+  // Add the option to delete the polygon part to the popup content
+  params.content.appendChild(mapp.utils.html.node`<li
             onclick=${() => {
               mapview.popup(null);
 
@@ -300,5 +300,5 @@ function deleteCondition(e, mapview) {
             }}>
         ${mapp.dictionary.delete_polygon_part}</li>`);
 
-    return params.content;
-  }
+  return params.content;
+}

--- a/lib/mapview/interactions/modify.mjs
+++ b/lib/mapview/interactions/modify.mjs
@@ -14,63 +14,13 @@ Defines the behaviour for a modification interaction performed on the map.
 @param {Object} params Extra parameters for the mapview.interaction.
 @param {mapview} mapview The mapview object to which the interaction will be added.
 */
+
 export default function modify(params, mapview = this) {
   // Finish the current interaction.
   mapview.interaction?.finish();
 
   mapview.interaction = {
-    deleteCondition: (e) => {
-      if (e.type === 'singleclick') {
-        const params = {};
-
-        params.geom = mapview.interaction.Feature.getGeometry();
-
-        params.geomType = params.geom.getType();
-
-        if (params.geomType === 'Point') return;
-
-        params.coords = params.geom.getCoordinates();
-
-        // Return on point or line with 2 vertices.
-        if (params.geomType === 'LineString' && params.coords.length < 3)
-          return;
-
-        params.ringLength =
-          params.geomType === 'Polygon' ? params.coords[0].length : 0;
-        params.clickedPolyIndex = -1;
-
-        params.minDist = Infinity;
-        params.polygons = params.geom.getPolygons();
-
-        params.polygons.forEach((poly, idx) => {
-          const closest = poly.getClosestPoint(e.coordinate);
-          const dx = closest[0] - e.coordinate[0];
-          const dy = closest[1] - e.coordinate[1];
-          const dist = dx * dx + dy * dy;
-
-          if (dist < params.minDist) {
-            params.minDist = dist;
-            params.clickedPolyIndex = idx;
-            params.ringLength = poly.getCoordinates()[0].length;
-          }
-        });
-
-        // Initialize empty list for popup content
-        params.content = mapp.utils.html.node`<ul></ul>`;
-
-        // Call the vertexRemoval function to handle standard vertex removal
-        vertexRemoval(mapview, e, params);
-
-        // Call the multipolygonPartRemoval function to handle MultiPolygon part removal
-        multipolygonPartRemoval(mapview, e, params);
-
-        // Set popup
-        mapview.popup({
-          content: params.content,
-          coords: params.geom.getClosestPoint(e.coordinate),
-        });
-      }
-    },
+    deleteCondition: (e) => deleteCondition(e, mapview),
 
     finish,
 
@@ -140,12 +90,13 @@ export default function modify(params, mapview = this) {
   document.addEventListener('keyup', escape);
 
   /**
-   * @function vertexRemoval
-   * @description Adds the option to delete a vertex to the popup content if the geometry has more than 3 vertices.
-   * @param {Object} mapview The mapview object.
-   * @param {Object} e The event object.
-   * @param {Object} params The parameters object containing geometry information.
-   */
+  @function vertexRemoval
+  @description 
+  Adds the option to delete a vertex to the popup content if the geometry has more than 3 vertices.
+  @param {Object} mapview The mapview object.
+  @param {Object} e The event object.
+  @param {Object} params The parameters object containing geometry information.
+  */
   function vertexRemoval(mapview, e, params) {
     // Return if the shape has less than 4 vertices as you cannot remove a vertex from a triangle or line.
     if (params.ringLength < 4) return;
@@ -170,12 +121,13 @@ export default function modify(params, mapview = this) {
   }
 
   /**
-   * @function multipolygonPartRemoval
-   * @description Adds the option to delete a polygon part to the popup content if the geometry is a MultiPolygon.
-   * @param {Object} mapview The mapview object.
-   * @param {Object} e The event object.
-   * @param {Object} params The parameters object containing geometry information.
-   */
+  @function multipolygonPartRemoval
+  @description 
+  Adds the option to delete a polygon part to the popup content if the geometry is a MultiPolygon.
+  @param {Object} mapview The mapview object.
+  @param {Object} e The event object.
+  @param {Object} params The parameters object containing geometry information.
+  */
   function multipolygonPartRemoval(mapview, e, params) {
     if (params.geomType !== 'MultiPolygon') return;
 
@@ -217,10 +169,10 @@ export default function modify(params, mapview = this) {
   }
 
   /**
-   * @function escape
-   * @description Ends the modification interaction when the Escape key is pressed.
-   * @param {Object} e The event object.
-   */
+  @function escape
+  @description Ends the modification interaction when the Escape key is pressed.
+  @param {Object} e The event object.
+  */
   function escape(e) {
     e.key === 'Escape' && mapview.interaction.finish();
   }
@@ -248,10 +200,10 @@ export default function modify(params, mapview = this) {
   mapview.interactions.snap(mapview);
 
   /**
-   * @function getFeature
-   * @description Returns the modified feature as a GeoJSON object.
-   * @returns {Object} The modified feature in GeoJSON format.
-   */
+  @function getFeature
+  @description Returns the modified feature as a GeoJSON object.
+  @returns {Object} The modified feature in GeoJSON format.
+  */
   function getFeature() {
     return JSON.parse(
       mapview.interaction.format.writeFeature(mapview.interaction.Feature, {
@@ -262,10 +214,11 @@ export default function modify(params, mapview = this) {
   }
 
   /**
-   * @function finish
-   * @description Ends the modification interaction, cleans up event listeners, and removes the interaction from the map.
-   * @param {Object} feature The modified feature to be passed to the callback function.
-   */
+  @function finish
+  @description 
+  Ends the modification interaction, cleans up event listeners, and removes the interaction from the map.
+  @param {Object} feature The modified feature to be passed to the callback function.
+  */
   function finish(feature) {
     //Remove the escape key event listener
     document.removeEventListener('keyup', escape);
@@ -289,5 +242,63 @@ export default function modify(params, mapview = this) {
     mapview.Map.removeLayer(mapview.interaction.Layer);
 
     mapview.interaction.callback?.(feature);
+  }
+}
+
+/**
+@function deleteCondition
+@description 
+@param {object} e The interaction event object.
+@param {mapview} mapview
+*/
+function deleteCondition(e, mapview) {
+  if (e.type === 'singleclick') {
+    const params = {};
+
+    params.geom = mapview.interaction.Feature.getGeometry();
+
+    params.geomType = params.geom.getType();
+
+    if (params.geomType === 'Point') return;
+
+    params.coords = params.geom.getCoordinates();
+
+    // Return on point or line with 2 vertices.
+    if (params.geomType === 'LineString' && params.coords.length < 3) return;
+
+    params.ringLength =
+      params.geomType === 'Polygon' ? params.coords[0].length : 0;
+    params.clickedPolyIndex = -1;
+
+    params.minDist = Infinity;
+    params.polygons = params.geom.getPolygons();
+
+    params.polygons.forEach((poly, idx) => {
+      const closest = poly.getClosestPoint(e.coordinate);
+      const dx = closest[0] - e.coordinate[0];
+      const dy = closest[1] - e.coordinate[1];
+      const dist = dx * dx + dy * dy;
+
+      if (dist < params.minDist) {
+        params.minDist = dist;
+        params.clickedPolyIndex = idx;
+        params.ringLength = poly.getCoordinates()[0].length;
+      }
+    });
+
+    // Initialize empty list for popup content
+    params.content = mapp.utils.html.node`<ul></ul>`;
+
+    // Call the vertexRemoval function to handle standard vertex removal
+    vertexRemoval(mapview, e, params);
+
+    // Call the multipolygonPartRemoval function to handle MultiPolygon part removal
+    multipolygonPartRemoval(mapview, e, params);
+
+    // Set popup
+    mapview.popup({
+      content: params.content,
+      coords: params.geom.getClosestPoint(e.coordinate),
+    });
   }
 }

--- a/lib/mapview/interactions/modify.mjs
+++ b/lib/mapview/interactions/modify.mjs
@@ -189,20 +189,20 @@ function deleteCondition(e, mapview) {
   if (params.geomType === 'LineString' && params.coords.length < 3) return;
 
   // Return on polygon with less than 3 vertices.
-  if (params.geomType === 'Polygon' && coords[0].length <= 4) return;
+  if (params.geomType === 'Polygon' && params.coords[0].length <= 4) return;
 
   if (params.geomType !== 'MultiPolygon') {
     // Set popup to remove vertex.
     mapview.popup({
       content: mapp.utils.html.node`<ul><li
       onclick=${() => {
-          mapview.interaction.interaction.removePoint();
-          mapview.interaction.vertices.push(
-            mapview.interaction.Feature.getGeometry().getClosestPoint(
-              e.coordinate,
-            ));
-        }}>${mapp.dictionary.delete_vertex}`,
-      coords: geom.getClosestPoint(e.coordinate),
+        mapview.interaction.interaction.removePoint();
+        mapview.interaction.vertices.push(
+        mapview.interaction.Feature.getGeometry().getClosestPoint(
+        e.coordinate,
+      ));
+      }}>${mapp.dictionary.delete_vertex}`,
+      coords: params.geom.getClosestPoint(e.coordinate),
     });
     return;
   }

--- a/lib/mapview/interactions/modify.mjs
+++ b/lib/mapview/interactions/modify.mjs
@@ -22,17 +22,17 @@ export default function modify(params, mapview = this) {
   mapview.interaction = {
     deleteCondition: (e) => deleteCondition(e, mapview),
 
-    finish,
+    finish: finish.bind(mapview),
 
     format: new ol.format.GeoJSON(),
 
-    getFeature,
+    getFeature: getFeature.bind(mapview),
 
     Layer: new ol.layer.Vector({
       zIndex: Infinity,
     }),
 
-    modifyend: mapp.ui?.elements.contextMenu.modify.bind(this),
+    modifyend: mapp.ui?.elements.contextMenu.modify.bind(mapview),
 
     Style: [
       new ol.style.Style({
@@ -86,17 +86,18 @@ export default function modify(params, mapview = this) {
   // Add mapview.interaction.Layer to mapview.
   mapview.Map.addLayer(mapview.interaction.Layer);
 
-  //End the modification on escape key.
-  document.addEventListener('keyup', escape);
-
   /**
   @function escape
-  @description Ends the modification interaction when the Escape key is pressed.
+  @description 
+  Ends the modification interaction when the Escape key is pressed.
   @param {Object} e The event object.
   */
   function escape(e) {
     e.key === 'Escape' && mapview.interaction.finish();
-  }
+  }  
+
+  //End the modification on escape key.
+  document.addEventListener('keyup', escape);
 
   mapview.interaction.interaction = new ol.interaction.Modify(
     mapview.interaction,
@@ -120,50 +121,52 @@ export default function modify(params, mapview = this) {
   // Assign snap interaction.
   mapview.interactions.snap(mapview);
 
-  /**
-  @function getFeature
-  @description Returns the modified feature as a GeoJSON object.
-  @returns {Object} The modified feature in GeoJSON format.
-  */
-  function getFeature() {
-    return JSON.parse(
-      mapview.interaction.format.writeFeature(mapview.interaction.Feature, {
-        dataProjection: 'EPSG:' + mapview.interaction.srid || mapview.srid,
-        featureProjection: 'EPSG:' + mapview.srid,
-      }),
-    );
-  }
 
-  /**
-  @function finish
-  @description
-  Ends the modification interaction, cleans up event listeners, and removes the interaction from the map.
-  @param {Object} feature The modified feature to be passed to the callback function.
-  */
-  function finish(feature) {
-    //Remove the escape key event listener
-    document.removeEventListener('keyup', escape);
+}
 
-    // Remove snap interaction.
-    mapview.interaction.snap?.remove?.();
+/**
+@function finish
+@description
+Ends the modification interaction, cleans up event listeners, and removes the interaction from the map.
+@param {Object} feature The modified feature to be passed to the callback function.
+*/
+function finish(feature) {
+  //Remove the escape key event listener
+  document.removeEventListener('keyup', escape);
 
-    // Reset the cursor style.
-    mapview.Map.getTargetElement().style.cursor = 'default';
+  // Remove snap interaction.
+  this.interaction.snap?.remove?.();
 
-    // Remove popup from mapview.
-    mapview.popup(null);
+  // Reset the cursor style.
+  this.Map.getTargetElement().style.cursor = 'default';
 
-    // Remove interaction from mapview.Map.
-    mapview.Map.removeInteraction(mapview.interaction.interaction);
+  // Remove popup from mapview.
+  this.popup(null);
 
-    // Clear the modify source.
-    mapview.interaction.source.clear();
+  // Remove interaction from mapview.Map.
+  this.Map.removeInteraction(this.interaction.interaction);
 
-    // Remove draw Layer from mapview.Map.
-    mapview.Map.removeLayer(mapview.interaction.Layer);
+  // Clear the modify source.
+  this.interaction.source.clear();
 
-    mapview.interaction.callback?.(feature);
-  }
+  // Remove draw Layer from mapview.Map.
+  this.Map.removeLayer(this.interaction.Layer);
+
+  this.interaction.callback?.(feature);
+}
+
+/**
+@function getFeature
+@description Returns the modified feature as a GeoJSON object.
+@returns {Object} The modified feature in GeoJSON format.
+*/
+function getFeature() {
+  return JSON.parse(
+    this.interaction.format.writeFeature(this.interaction.Feature, {
+      dataProjection: 'EPSG:' + this.interaction.srid || this.srid,
+      featureProjection: 'EPSG:' + this.srid,
+    }),
+  );
 }
 
 /**
@@ -196,12 +199,12 @@ function deleteCondition(e, mapview) {
     mapview.popup({
       content: mapp.utils.html.node`<ul><li
       onclick=${() => {
-        mapview.interaction.interaction.removePoint();
-        mapview.interaction.vertices.push(
-        mapview.interaction.Feature.getGeometry().getClosestPoint(
-        e.coordinate,
-      ));
-      }}>${mapp.dictionary.delete_vertex}`,
+          mapview.interaction.interaction.removePoint();
+          mapview.interaction.vertices.push(
+            mapview.interaction.Feature.getGeometry().getClosestPoint(
+              e.coordinate,
+            ));
+        }}>${mapp.dictionary.delete_vertex}`,
       coords: params.geom.getClosestPoint(e.coordinate),
     });
     return;

--- a/lib/mapview/interactions/modify.mjs
+++ b/lib/mapview/interactions/modify.mjs
@@ -14,7 +14,6 @@ Defines the behaviour for a modification interaction performed on the map.
 @param {Object} params Extra parameters for the mapview.interaction.
 @param {mapview} mapview The mapview object to which the interaction will be added.
 */
-
 export default function modify(params, mapview = this) {
   // Finish the current interaction.
   mapview.interaction?.finish();
@@ -94,7 +93,7 @@ export default function modify(params, mapview = this) {
   */
   function escape(e) {
     e.key === 'Escape' && mapview.interaction.finish();
-  }  
+  }
 
   //End the modification on escape key.
   document.addEventListener('keyup', escape);
@@ -120,8 +119,6 @@ export default function modify(params, mapview = this) {
 
   // Assign snap interaction.
   mapview.interactions.snap(mapview);
-
-
 }
 
 /**
@@ -199,12 +196,13 @@ function deleteCondition(e, mapview) {
     mapview.popup({
       content: mapp.utils.html.node`<ul><li
       onclick=${() => {
-          mapview.interaction.interaction.removePoint();
-          mapview.interaction.vertices.push(
-            mapview.interaction.Feature.getGeometry().getClosestPoint(
-              e.coordinate,
-            ));
-        }}>${mapp.dictionary.delete_vertex}`,
+        mapview.interaction.interaction.removePoint();
+        mapview.interaction.vertices.push(
+          mapview.interaction.Feature.getGeometry().getClosestPoint(
+            e.coordinate,
+          ),
+        );
+      }}>${mapp.dictionary.delete_vertex}`,
       coords: params.geom.getClosestPoint(e.coordinate),
     });
     return;
@@ -260,19 +258,19 @@ function vertexRemoval(mapview, e, params) {
 
   params.content.appendChild(mapp.utils.html.node`<li
             onclick=${() => {
-      mapview.interaction.interaction.removePoint();
-      mapview.interaction.vertices.push(
-        mapview.interaction.Feature.getGeometry().getClosestPoint(
-          e.coordinate,
-        ),
-      );
-      mapview.popup(null);
+              mapview.interaction.interaction.removePoint();
+              mapview.interaction.vertices.push(
+                mapview.interaction.Feature.getGeometry().getClosestPoint(
+                  e.coordinate,
+                ),
+              );
+              mapview.popup(null);
 
-      mapview.interaction.interaction.dispatchEvent({
-        type: 'modifyend',
-        features: new ol.Collection([mapview.interaction.Feature]),
-      });
-    }}>${mapp.dictionary.delete_vertex}</li>`);
+              mapview.interaction.interaction.dispatchEvent({
+                type: 'modifyend',
+                features: new ol.Collection([mapview.interaction.Feature]),
+              });
+            }}>${mapp.dictionary.delete_vertex}</li>`);
 
   return params.content;
 }
@@ -310,15 +308,11 @@ function multipolygonPartRemoval(mapview, e, params) {
       mapview.interaction.callback?.(null);
     } else {
       // Apply the filtered coordinates back to the geometry
-      params.geom.setCoordinates(
-        remaining.map((p) => p.getCoordinates()),
-      );
+      params.geom.setCoordinates(remaining.map((p) => p.getCoordinates()));
 
       // Refresh the visual display
       mapview.interaction.source.clear();
-      mapview.interaction.source.addFeature(
-        mapview.interaction.Feature,
-      );
+      mapview.interaction.source.addFeature(mapview.interaction.Feature);
 
       mapview.interaction.interaction.dispatchEvent({
         type: 'modifyend',

--- a/lib/mapview/interactions/modify.mjs
+++ b/lib/mapview/interactions/modify.mjs
@@ -173,132 +173,154 @@ export default function modify(params, mapview = this) {
 @param {mapview} mapview
 */
 function deleteCondition(e, mapview) {
-  if (e.type === 'singleclick') {
-    const params = {};
+  if (e.type !== 'singleclick') return;
 
-    params.geom = mapview.interaction.Feature.getGeometry();
+  const params = {};
 
-    params.geomType = params.geom.getType();
+  params.geom = mapview.interaction.Feature.getGeometry();
 
-    if (params.geomType === 'Point') return;
+  params.geomType = params.geom.getType();
 
-    params.coords = params.geom.getCoordinates();
+  if (params.geomType === 'Point') return;
 
-    // Return on point or line with 2 vertices.
-    if (params.geomType === 'LineString' && params.coords.length < 3) return;
+  params.coords = params.geom.getCoordinates();
 
-    params.ringLength =
-      params.geomType === 'Polygon' ? params.coords[0].length : 0;
-    params.clickedPolyIndex = -1;
+  // Return on point or line with 2 vertices.
+  if (params.geomType === 'LineString' && params.coords.length < 3) return;
 
-    params.minDist = Infinity;
-    params.polygons = params.geom.getPolygons();
+  // Return on polygon with less than 3 vertices.
+  if (params.geomType === 'Polygon' && coords[0].length <= 4) return;
 
-    params.polygons.forEach((poly, idx) => {
-      const closest = poly.getClosestPoint(e.coordinate);
-      const dx = closest[0] - e.coordinate[0];
-      const dy = closest[1] - e.coordinate[1];
-      const dist = dx * dx + dy * dy;
-
-      if (dist < params.minDist) {
-        params.minDist = dist;
-        params.clickedPolyIndex = idx;
-        params.ringLength = poly.getCoordinates()[0].length;
-      }
-    });
-
-    // Initialize empty list for popup content
-    params.content = mapp.utils.html.node`<ul></ul>`;
-
-    // Call the vertexRemoval function to handle standard vertex removal
-    vertexRemoval(mapview, e, params);
-
-    // Call the multipolygonPartRemoval function to handle MultiPolygon part removal
-    multipolygonPartRemoval(mapview, e, params);
-
-    // Set popup
+  if (params.geomType !== 'MultiPolygon') {
+    // Set popup to remove vertex.
     mapview.popup({
-      content: params.content,
-      coords: params.geom.getClosestPoint(e.coordinate),
+      content: mapp.utils.html.node`<ul><li
+      onclick=${() => {
+          mapview.interaction.interaction.removePoint();
+          mapview.interaction.vertices.push(
+            mapview.interaction.Feature.getGeometry().getClosestPoint(
+              e.coordinate,
+            ));
+        }}>${mapp.dictionary.delete_vertex}`,
+      coords: geom.getClosestPoint(e.coordinate),
     });
+    return;
   }
+
+  params.ringLength =
+    params.geomType === 'Polygon' ? params.coords[0].length : 0;
+  params.clickedPolyIndex = -1;
+
+  params.minDist = Infinity;
+  params.polygons = params.geom.getPolygons();
+
+  params.polygons.forEach((poly, idx) => {
+    const closest = poly.getClosestPoint(e.coordinate);
+    const dx = closest[0] - e.coordinate[0];
+    const dy = closest[1] - e.coordinate[1];
+    const dist = dx * dx + dy * dy;
+
+    if (dist < params.minDist) {
+      params.minDist = dist;
+      params.clickedPolyIndex = idx;
+      params.ringLength = poly.getCoordinates()[0].length;
+    }
+  });
+
+  // Initialize empty list for popup content
+  params.content = mapp.utils.html.node`<ul></ul>`;
+
+  // Call the vertexRemoval function to handle standard vertex removal
+  vertexRemoval(mapview, e, params);
+
+  // Call the multipolygonPartRemoval function to handle MultiPolygon part removal
+  multipolygonPartRemoval(mapview, e, params);
+
+  // Set popup
+  mapview.popup({
+    content: params.content,
+    coords: params.geom.getClosestPoint(e.coordinate),
+  });
 }
 
 /**
-  @function vertexRemoval
-  @description 
-  Adds the option to delete a vertex to the popup content if the geometry has more than 3 vertices.
-  @param {Object} mapview The mapview object.
-  @param {Object} e The event object.
-  @param {Object} params The parameters object containing geometry information.
-  */
+@function vertexRemoval
+@description 
+Adds the option to delete a vertex to the popup content if the geometry has more than 3 vertices.
+@param {Object} mapview The mapview object.
+@param {Object} e The event object.
+@param {Object} params The parameters object containing geometry information.
+*/
 function vertexRemoval(mapview, e, params) {
   // Return if the shape has less than 4 vertices as you cannot remove a vertex from a triangle or line.
   if (params.ringLength < 4) return;
 
   params.content.appendChild(mapp.utils.html.node`<li
             onclick=${() => {
-              mapview.interaction.interaction.removePoint();
-              mapview.interaction.vertices.push(
-                mapview.interaction.Feature.getGeometry().getClosestPoint(
-                  e.coordinate,
-                ),
-              );
-              mapview.popup(null);
+      mapview.interaction.interaction.removePoint();
+      mapview.interaction.vertices.push(
+        mapview.interaction.Feature.getGeometry().getClosestPoint(
+          e.coordinate,
+        ),
+      );
+      mapview.popup(null);
 
-              mapview.interaction.interaction.dispatchEvent({
-                type: 'modifyend',
-                features: new ol.Collection([mapview.interaction.Feature]),
-              });
-            }}>${mapp.dictionary.delete_vertex}</li>`);
+      mapview.interaction.interaction.dispatchEvent({
+        type: 'modifyend',
+        features: new ol.Collection([mapview.interaction.Feature]),
+      });
+    }}>${mapp.dictionary.delete_vertex}</li>`);
 
   return params.content;
 }
 
 /**
-  @function multipolygonPartRemoval
-  @description 
-  Adds the option to delete a polygon part to the popup content if the geometry is a MultiPolygon.
-  @param {Object} mapview The mapview object.
-  @param {Object} e The event object.
-  @param {Object} params The parameters object containing geometry information.
-  */
+@function multipolygonPartRemoval
+@description 
+Adds the option to delete a polygon part to the popup content if the geometry is a MultiPolygon.
+
+@param {Object} mapview The mapview object.
+@param {Object} e The event object.
+@param {Object} params The parameters object containing geometry information.
+*/
 function multipolygonPartRemoval(mapview, e, params) {
   if (params.geomType !== 'MultiPolygon') return;
 
   // Add the option to delete the polygon part to the popup content
-  params.content.appendChild(mapp.utils.html.node`<li
-            onclick=${() => {
-              mapview.popup(null);
-
-              const polygons = params.geom.getPolygons();
-              const remaining = polygons.filter(
-                (_, idx) => idx !== params.clickedPolyIndex,
-              );
-
-              if (remaining.length === 0) {
-                // If they deleted the last part, end the interaction and nullify
-                mapview.interaction.finish();
-                mapview.interaction.callback?.(null);
-              } else {
-                // Apply the filtered coordinates back to the geometry
-                params.geom.setCoordinates(
-                  remaining.map((p) => p.getCoordinates()),
-                );
-
-                // Refresh the visual display
-                mapview.interaction.source.clear();
-                mapview.interaction.source.addFeature(
-                  mapview.interaction.Feature,
-                );
-
-                mapview.interaction.interaction.dispatchEvent({
-                  type: 'modifyend',
-                  features: new ol.Collection([mapview.interaction.Feature]),
-                });
-              }
-            }}>
-        ${mapp.dictionary.delete_polygon_part}</li>`);
+  params.content.append(mapp.utils.html.node`<li
+    onclick=${onclick}>
+    ${mapp.dictionary.delete_polygon_part}`);
 
   return params.content;
+
+  function onclick() {
+    mapview.popup(null);
+
+    const polygons = params.geom.getPolygons();
+    const remaining = polygons.filter(
+      (_, idx) => idx !== params.clickedPolyIndex,
+    );
+
+    if (remaining.length === 0) {
+      // If they deleted the last part, end the interaction and nullify
+      mapview.interaction.finish();
+      mapview.interaction.callback?.(null);
+    } else {
+      // Apply the filtered coordinates back to the geometry
+      params.geom.setCoordinates(
+        remaining.map((p) => p.getCoordinates()),
+      );
+
+      // Refresh the visual display
+      mapview.interaction.source.clear();
+      mapview.interaction.source.addFeature(
+        mapview.interaction.Feature,
+      );
+
+      mapview.interaction.interaction.dispatchEvent({
+        type: 'modifyend',
+        features: new ol.Collection([mapview.interaction.Feature]),
+      });
+    }
+  }
 }

--- a/public/dictionaries/en.mjs
+++ b/public/dictionaries/en.mjs
@@ -17,6 +17,7 @@ export default {
   delete: 'Delete',
   delete_geometry: 'Delete Geometry',
   delete_vertex: 'Remove vertex',
+  delete_polygon_part: 'Delete polygon part',
   document_upload_failed: 'Document upload failed.',
   drag_and_drop_doc: 'Drag and drop or add document',
   drag_and_drop_image: 'Drag and drop or add image',


### PR DESCRIPTION
## Description
Previously, accidentally creating overlapping MultiPolygon geometries left users stuck, as the modify interaction prevented removing parts or vertices once a sub-shape reached three nodes. 
This PR resolves the issue by extracting the click logic into a structured params object and introducing dedicated vertexRemoval and multipolygonPartRemoval functions to accurately target specific polygon rings. 
Users can now successfully delete entire polygon sub-parts directly from the map popup to clean up accidental or complex shapes. 

**Commit Changes**
1. Add Delete Polygon Part Dictionary Term
2. Add vertexRemoval function to unnest code
3. Add new multipolygonPartRemoval function
4. Documentation on functions

<img width="631" height="616" alt="image" src="https://github.com/user-attachments/assets/d5a78454-0593-4833-9b9f-ef3b53e86030" />

## Type of Change
- ✅ Bug fix (non-breaking change which fixes an issue)

## How have you tested this?
Tested locally by messing with a polygon until I create holes and islands in it. 
Then trying to remove those holes is not possible. 
Clients have flagged this as a problem - the only solution at the moment is to start again or run queries on the back-end to resolve it.