### PR TITLE
Check layer key in template method. Ignore templates object.

### DIFF
--- a/mod/provider/getFrom.js
+++ b/mod/provider/getFrom.js
@@ -101,7 +101,7 @@ async function Https(url) {
 
     logger(`${response.status} - ${response.url}`, 'fetch');
 
-    if (requestUrl.href.match(/\.json$/i)) {
+    if (requestUrl.href.endsWith('.json')) {
       return await response.json();
     }
 

--- a/mod/workspace/getLayer.js
+++ b/mod/workspace/getLayer.js
@@ -44,7 +44,7 @@ Template properties will be removed as these are not required by the MAPP API bu
 @param {Object} params
 @param {locale} [locale] An optional workspace locale can be provided to prevent a roundtrip to the getLocale method.
 @property {string} [params.locale] Locale key.
-@property {string} [params.layer] Layer key.
+@property {string} params.layer Layer key.
 @property {Object} [params.user] Requesting user.
 @property {Boolean} [params.ignoreRoles] Whether role check should be performed.
 @property {Array} [user.roles] User roles.
@@ -52,6 +52,18 @@ Template properties will be removed as these are not required by the MAPP API bu
 @returns {Promise<Object|Error>} JSON Layer.
 */
 export default async function getLayer(params, locale) {
+  if (typeof params.layer !== 'string') {
+    return new Error(
+      'The layer [key] params must be provided as a string property.',
+    );
+  }
+
+  if (/[^a-zA-Z0-9 :_-]/.exec(params.layer)) {
+    return new Error(
+      'The layer [key] property may only contain whitelisted character [^a-zA-Z0-9 :_-]',
+    );
+  }
+
   if (!locale) {
     locale = await getLocale(params);
   }

--- a/mod/workspace/getTemplate.js
+++ b/mod/workspace/getTemplate.js
@@ -97,6 +97,7 @@ export default async function getTemplate(template) {
     return new Error(`Unknown getFrom method: ${template.src}`);
   }
 
+  // module templates must be returned as string.
   const response = await getFrom[method](template.src);
 
   if (response instanceof Error) {

--- a/mod/workspace/mergeTemplates.js
+++ b/mod/workspace/mergeTemplates.js
@@ -64,11 +64,6 @@ export default async function mergeTemplates(obj, roles) {
     for (const _template of obj.templates) {
       obj = await objTemplate(obj, _template, roles, context);
     }
-  } else if (obj.templates instanceof Object) {
-    const err = `${obj.key} Object must be a templates Array.`;
-    obj.err ??= [];
-    obj.err.push(err);
-    console.warn(err);
   }
 
   // Substitute ${SRC_*} in object string.


### PR DESCRIPTION
This PR resolves some issues in regards to user controlled data.

A layer.key must only contain whitelisted character. The layer [key] as params.layer property in the getLayer method is not optional. An error should be returned on either invalidation.

Imported modules must be from string. The response.json condition should never be met on importing the a response string for a module. The check for the json href ending has been simplified to use endsWith instead of a regex.

We can ignore the warning should sonarqube cloud not pick up these safeguards.