### PR TITLE
Bump esbuild to 28.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "clean-jsdoc-theme": "^4.3.2",
     "concurrently": "^9.2.1",
     "cookie-parser": "^1.4.7",
-    "esbuild": "^0.25.12",
+    "esbuild": "^0.28.1",
     "express": "5.2.0",
     "express-rate-limit": "^7.5.1",
     "node-mocks-http": "^1.17.2",


### PR DESCRIPTION
esbuild will be retired in v5. it is still worth bumping this to the current version 0.28.1