### PR TITLE
Filter out user locale layer entries in addLayer function and update …

### DIFF
--- a/lib/mapview/addLayer.mjs
+++ b/lib/mapview/addLayer.mjs
@@ -35,7 +35,7 @@ export default async function addLayer(layers = []) {
   }
 
   // infoj layer entries stored in a user locale should be filtered out.
-  layers = layers.filter(layer => layer.type !== 'layer')
+  layers = layers.filter((layer) => layer.type !== 'layer');
 
   // A set of the layers is required in order to control the display based on URL params [hooks]
   const currentLayers = this.hooks && new Set(mapp.hooks.current.layers);
@@ -46,7 +46,6 @@ export default async function addLayer(layers = []) {
   this.zIndex ??= 1;
 
   for (const layer of layers) {
-
     // The layer.err is an array of errors from failing to retrieve templates asscoiated with a layer.
     layer.err && console.error(layer.err);
 

--- a/lib/mapview/addLayer.mjs
+++ b/lib/mapview/addLayer.mjs
@@ -34,6 +34,9 @@ export default async function addLayer(layers = []) {
     layers = [layers];
   }
 
+  // infoj layer entries stored in a user locale should be filtered out.
+  layers = layers.filter(layer => layer.type !== 'layer')
+
   // A set of the layers is required in order to control the display based on URL params [hooks]
   const currentLayers = this.hooks && new Set(mapp.hooks.current.layers);
 
@@ -43,6 +46,7 @@ export default async function addLayer(layers = []) {
   this.zIndex ??= 1;
 
   for (const layer of layers) {
+
     // The layer.err is an array of errors from failing to retrieve templates asscoiated with a layer.
     layer.err && console.error(layer.err);
 

--- a/lib/plugins/userLocale.mjs
+++ b/lib/plugins/userLocale.mjs
@@ -1,27 +1,50 @@
 /**
 ### /plugins/userLocale
 
-The userLocale plugin appends the userLocale utility interface to the layer panel.
+The userLocale plugin allows to open a dialog for the userLocale element.
 
 @module /plugins/userLocale
 */
 
 /**
 @function userLocale
-An input allows to define the userlocale name with buttons to either put (create or overwrite) a stored userlocale or delete a stored userlocale.
-The panel will be disabled during the transaction to save or remove a user locale.
+The method assigns a button to the btnColumn which allows to toggle a dialog for the userLocale element.
 
 @param {Object} plugin The userLocale config from the locale.
 @param {Object} mapview The mapview object.
 */
 export function userLocale(plugin, mapview) {
-  const layersNode = document.getElementById('ctrls');
+  if (!mapp.user) return;
 
-  if (!layersNode) return;
+  const btnColumn = mapview.mapButton;
 
-  // Call the utility method to create the userLocale interface.
-  plugin.content = mapp.ui.elements.userLocale(plugin, mapview);
+  // The btnColumn element only exists in the default mapp view.
+  if (!btnColumn) return;
 
-  // Append the content to the layersNode.
-  layersNode.append(plugin.content);
+  plugin = {};
+
+  const content = mapp.ui.elements.userLocale(plugin, mapview);
+
+  const dialog = {
+    closeBtn: true,
+    content,
+    header: 'User Locale',
+    onClose: (e) => {
+      btn.classList.remove('active');
+    },
+    target: document.getElementById('Map'),
+  };
+
+  const btn = mapp.utils.html.node`
+    <button
+      data-id="user-locale"
+      onclick=${() => {
+        if (btn.classList.toggle('active')) {
+          mapp.ui.elements.dialog(dialog);
+        } else {
+          dialog.close();
+        }
+      }}><span class="notranslate material-symbols-outlined">save_as`;
+
+  btnColumn.append(btn);
 }

--- a/lib/plugins/userLocale.mjs
+++ b/lib/plugins/userLocale.mjs
@@ -15,7 +15,7 @@ The panel will be disabled during the transaction to save or remove a user local
 @param {Object} mapview The mapview object.
 */
 export function userLocale(plugin, mapview) {
-  const layersNode = document.getElementById('layers');
+  const layersNode = document.getElementById('ctrls');
 
   if (!layersNode) return;
 

--- a/lib/ui/elements/drawing.mjs
+++ b/lib/ui/elements/drawing.mjs
@@ -130,9 +130,9 @@ function point(layer) {
   layer.draw.point = {
     helpDialog,
     label: mapp.dictionary.draw_point,
-    layer,
     type: 'Point',
     ...layer.draw.point,
+    layer,
   };
 
   // Create the button
@@ -164,9 +164,9 @@ function line(layer) {
   layer.draw.line = {
     helpDialog,
     label: mapp.dictionary.draw_line,
-    layer,
     type: 'LineString',
     ...layer.draw.line,
+    layer,
   };
 
   // Create the button
@@ -199,9 +199,9 @@ function polygon(layer) {
   layer.draw.polygon = {
     helpDialog,
     label: mapp.dictionary.draw_polygon,
-    layer,
     type: 'Polygon',
     ...layer.draw.polygon,
+    layer,
   };
 
   // Create the button
@@ -233,9 +233,9 @@ function rectangle(layer) {
     geometryFunction: ol.interaction.Draw.createBox(),
     helpDialog,
     label: mapp.dictionary.draw_rectangle,
-    layer,
     type: 'Circle',
     ...layer.draw.rectangle,
+    layer,
   };
 
   // Create the button
@@ -267,9 +267,9 @@ function circle_2pt(layer) {
     geometryFunction: ol.interaction.Draw.createRegularPolygon(33),
     helpDialog,
     label: mapp.dictionary.draw_circle_2pt,
-    layer,
     type: 'Circle',
     ...layer.draw.circle_2pt,
+    layer,
   };
 
   // Create the button
@@ -301,7 +301,6 @@ function circle(layer) {
   const circle = {
     helpDialog,
     label: mapp.dictionary.draw_circle,
-    layer,
     type: 'Point',
     units: 'meter',
     unitsConfig: {
@@ -339,6 +338,7 @@ function circle(layer) {
       miles: (v) => v * 1609.34,
     },
     ...layer.draw.circle,
+    layer,
   };
 
   layer.draw.circle = circle;
@@ -471,9 +471,9 @@ function setUnits(circle, option) {
 function locator(layer) {
   layer.draw.locator = {
     label: mapp.dictionary.draw_position,
-    layer,
     type: 'Point',
     ...layer.draw.locator,
+    layer,
   };
 
   layer.draw.locator.btn = mapp.utils.html.node`

--- a/lib/utils/jsonParser.mjs
+++ b/lib/utils/jsonParser.mjs
@@ -75,6 +75,9 @@ function propertyParser(target, source) {
       continue;
     }
 
+    // value objects created not from a default Object prototype should not be parsed.
+    if (typeof value.hasOwnProperty !== 'function') continue;
+
     if (value.hasOwnProperty('__parsed')) {
       if (value.key) {
         target[key] = value.key;


### PR DESCRIPTION
infoj layer type entries must be filtered out from a user locale.

The userLocale plugin now attaches a button which opens the userLocale element in a dialog.

This PR also addresses the issue with the layer property being stored in drawing/draw config objects.

The layer provided as a param must be assigned to the object after the spread of the existing object.