### PR TITLE
Delete params.viewport if no mapview

### DIFF
--- a/lib/utils/queryParams.mjs
+++ b/lib/utils/queryParams.mjs
@@ -158,7 +158,7 @@ function viewportParam(_this, params) {
 
   if (typeof params.viewport === 'string') return;
 
-  const mapview = _this?.layer?.mapview || _this?.location?.layer?.mapview;
+  const mapview = _this.layer?.mapview || _this.location?.layer?.mapview;
 
   // Delete viewport property if no mapview is found.
   // This prevents the viewport property from retaining a true flag only.

--- a/lib/utils/queryParams.mjs
+++ b/lib/utils/queryParams.mjs
@@ -148,7 +148,7 @@ function tableParam(_this, params) {
 Assigns viewport param to params object if the viewport of the mapview can be found from the _this.layer.
 
 The method will shortcircuit if a viewport param is already provided as a string or if the layer or mapview is not found.
-
+The method will also delete the viewport param if no mapview is found to prevent the viewport param from retaining a true flag only.
 @param {Object} _this Object from which the query originates, eg. layer, dataview entry.
 @param {Object} params The params object to set the viewport param on if found.
 @property {layer} [_this.layer] A mapp layer associated with _this object. The layer is required to calculate a viewport, center, zoom [z], or table [if not explicit].
@@ -158,9 +158,14 @@ function viewportParam(_this, params) {
 
   if (typeof params.viewport === 'string') return;
 
-  const mapview = _this.layer?.mapview || _this.location?.layer?.mapview;
+  const mapview = _this?.layer?.mapview || _this?.location?.layer?.mapview;
 
-  if (!mapview) return;
+  // Delete viewport property if no mapview is found.
+  // This prevents the viewport property from retaining a true flag only.
+  if (!mapview) {
+    delete params.viewport;
+    return;
+  }
 
   const extent = mapview.getBounds();
 


### PR DESCRIPTION
This PR fixes an issue whereby a `layer` without a `mapview` would mean that requests for data on that layer would persist a viewport true flag. 
Then `paramString` method would then try to use `.split` on `true` and crash the whole process.