### PR TITLE
fix(Theme/Graduated): Return when clustered features

### DIFF
--- a/lib/layer/themes/graduated.mjs
+++ b/lib/layer/themes/graduated.mjs
@@ -28,6 +28,9 @@ export default function graduated(theme, feature) {
   // The graduated theme requires feature.properties.
   if (!feature.properties) return;
 
+  // If the feature has an array of features, only process if there is one feature.
+  if (Array.isArray(feature.properties.features) && feature.properties.features.length > 1) return;
+
   const catValue = Array.isArray(feature.properties.features)
     ? // Reduce array of features to sum catValue
       feature.properties.features.reduce(

--- a/lib/layer/themes/graduated.mjs
+++ b/lib/layer/themes/graduated.mjs
@@ -29,16 +29,13 @@ export default function graduated(theme, feature) {
   if (!feature.properties) return;
 
   // If the feature has an array of features, only process if there is one feature.
-  if (Array.isArray(feature.properties.features) && feature.properties.features.length > 1) return;
+  if (feature.properties.features?.length > 1) {
+    return;
+  }
 
   const catValue = Array.isArray(feature.properties.features)
-    ? // Reduce array of features to sum catValue
-      feature.properties.features.reduce(
-        (total, F) => total + Number(F.getProperties()[theme.field]),
-        0,
-      )
-    : // Get catValue from cat or field property.
-      Number.parseFloat(feature.properties[theme.field]);
+    ? feature.properties.features[0].getProperties()[theme.field]
+    : Number.parseFloat(feature.properties[theme.field]);
 
   if (!Number.isNaN(Number(catValue)) && catValue !== null) {
     const index = theme.categories.findIndex(


### PR DESCRIPTION
## Description

Return when feature length more than 1 to prevent clusters being removed. This prevents an issue whereby clustered features are simply summing up values. When using a graduated thematic, all the clusters at a high zoom level end up above the highest theme option. E.g. each feature has an average value of 10, the top theme option is >100. You only need 10 features to cluster before they exceed the top theme and thus get removed when you filter it out using the theme legend.

## Type of Change
- ✅ Bug fix (non-breaking change which fixes an issue)