### PR TITLE
fix(filter.numeric_filter): Prefer filter.type in the spread operation

### DIFF
--- a/lib/ui/layers/filters.mjs
+++ b/lib/ui/layers/filters.mjs
@@ -316,20 +316,18 @@ Numeric layer filter are a combination of an LTE (less-than-[or]equal) and GTE (
 @param {layer} layer MAPP layer typedef object.
 @param {Object} filter Filter object.
 @property {string} filter.field Field to filter.
+@property {string} filter.type Filter type [numeric, integer].
 @property {numeric} [filter.min] Min bounds.
 @property {numeric} [filter.max] Max bounds.
-@property {numeric} [filter.step] Step for renage slider.
+@property {numeric} [filter.step] Step for range slider.
 
-@returns {Promise<HTMLElement>}
-The filter UI elements.
+@returns {Promise<HTMLElement>} The filter UI elements.
 */
-
 async function filter_numeric(layer, filter) {
   // Find infoj entry and merge into the filter object.
   const entry = layer.infoj.find((entry) => entry.field === filter.field);
 
-  //Assign the filter to the entry.
-  //Ensures filter.type is used.
+  // Use entry defaults but spread filter to override entry values. This allows for filter object to override entry values.
   filter = { ...entry, ...filter };
 
   delete filter.val_a;

--- a/lib/ui/layers/filters.mjs
+++ b/lib/ui/layers/filters.mjs
@@ -330,7 +330,7 @@ async function filter_numeric(layer, filter) {
 
   //Assign the filter to the entry.
   //Ensures filter.type is used.
-  filter = Object.assign(entry, filter);
+  filter = { ...entry, ...filter };
 
   delete filter.val_a;
   delete filter.val_b;

--- a/lib/ui/layers/filters.mjs
+++ b/lib/ui/layers/filters.mjs
@@ -328,7 +328,9 @@ async function filter_numeric(layer, filter) {
   // Find infoj entry and merge into the filter object.
   const entry = layer.infoj.find((entry) => entry.field === filter.field);
 
-  Object.assign(filter, entry);
+  //Assign the filter to the entry.
+  //Ensures filter.type is used.
+  filter = Object.assign(entry, filter);
 
   delete filter.val_a;
   delete filter.val_b;


### PR DESCRIPTION
## Description

Filter types were being overwritten by the type of the entry due to this line:

<img width="344" height="28" alt="screenshot-2026-07-16_16-02-11" src="https://github.com/user-attachments/assets/a5de011e-37b1-4c1f-afa1-b0fbbdfdefa4" />

in lib/ui/layers/filters.mjs. This meant that setting the filter type to numeric or integer would always use numeric steps e.g. 0.01
as the type of the filter would the same as the entry, text for example, and steps would default:
<img width="552" height="22" alt="screenshot-2026-07-16_16-03-52" src="https://github.com/user-attachments/assets/2413bbf1-1ca7-4de0-acd7-f003b8bef1cc" />

This PR uses a spread operation filter to entry to maintain the filters' type. 

## GitHub Issue
#2895

## Type of Change
- ✅ Bug fix (non-breaking change which fixes an issue)
- ✅ Documentation

## How have you tested this?
Tested locally
> [!IMPORTANT]
> `bugs_testing/filter/all_filters.json`
> The numeric filter should use decimal steps and the integer filter should use integer steps

## Testing Checklist
- ✅ Existing Tests still pass
- ✅ Ran locally on my machine

## Code Quality Checklist
- ✅ My code follows the guidelines of XYZ
- ✅ My code has been commented
- ✅ Documentation has been updated
- ✅ New and existing unit tests pass locally with my changes
- ✅ Main has been merged into this PR
