### PR TITLE
fix(csv_upload): Assign 'null' where data is not supplied in the field 

### DIFF
--- a/lib/utils/csvUpload.mjs
+++ b/lib/utils/csvUpload.mjs
@@ -127,8 +127,9 @@ export default async function csvUpload(file, params = {}) {
       // Split text file into rows on carriage return / new line.
       const rows = e.target.result.trim().split(/\r?\n/);
 
+      let matrix;
       try {
-        const matrix = rows.map((row) => splitRowIntoFields(row));
+        matrix = rows.map((row) => splitRowIntoFields(row));
       } catch (error) {
         resolve([error]);
         return;

--- a/lib/utils/csvUpload.mjs
+++ b/lib/utils/csvUpload.mjs
@@ -73,7 +73,7 @@ This function replaces single quotes in a string with double single quotes for S
 */
 function stringQuotes(val) {
   if (val === 'null') return null;
-  val = val.replaceAll("'", "''")
+  val = val.replaceAll("'", "''");
   return val;
 }
 
@@ -182,7 +182,6 @@ function chunkRows(matrix, params) {
   let chunk = {};
 
   matrix.forEach((fields) => {
-
     for (const indx in fields) {
       const field = Object.keys(params.fields)[indx];
       const type = params.fields[field];
@@ -260,7 +259,7 @@ function splitRowIntoFields(row) {
     expectedFieldCount = fields.length;
   } else if (fields.length !== expectedFieldCount) {
     throw new Error(
-      `Inconsistent number of fields. Expected ${expectedFieldCount}, but got ${fields.length}.`
+      `Inconsistent number of fields. Expected ${expectedFieldCount}, but got ${fields.length}.`,
     );
   }
   return fields;

--- a/lib/utils/csvUpload.mjs
+++ b/lib/utils/csvUpload.mjs
@@ -59,8 +59,18 @@ The methods are used in the chunkRows method to convert the field values to the 
 const schemaMethods = {
   int: (val) => Number.parseInt(val.replace(/[^\d.-]/g, '')) || null,
   numeric: (val) => Number.parseFloat(val.replace(/[^\d.-]/g, '')) || null,
-  text: (val) => `${val.replace(/'/g, "''")}`,
-  varchar: (val) => `${val.replace(/'/g, "''")}`,
+  text: (val) => {
+    val = `${val.replace(/'/g, "''")}`;
+    //set the value to null if it is 'null'
+    if (val === 'null') return null;
+    return val;
+  },
+  varchar: (val) => {
+    val = `${val.replace(/'/g, "''")}`;
+    //set the value to null if it is 'null'
+    if (val === 'null') return null;
+    return val;
+  },
 };
 
 /**
@@ -113,15 +123,19 @@ export default async function csvUpload(file, params = {}) {
       // Split text file into rows on carriage return / new line.
       const rows = e.target.result.trim().split(/\r?\n/);
 
-      // Check the number of columns in the csv across all rows and return the highest count.
+      // Check the number of columns in the csv across all rows and return the average count.
       const columnCounts = rows.map((row) => splitRowIntoFields(row).length);
-      const columnCount = Math.max(...columnCounts);
+      const maxColumnCount = Math.max(...columnCounts);
+      const minColumnCount = Math.min(...columnCounts);
 
-      if (columnCount !== Object.keys(params.fields).length) {
+      if (
+        maxColumnCount !== Object.keys(params.fields).length ||
+        minColumnCount !== Object.keys(params.fields).length
+      ) {
         // Return an error if the number of columns in the CSV file does not match the number of fields supplied.
         resolve([
           new Error(
-            `The number of columns in the CSV file (${columnCount}) does not match the number of fields supplied (${
+            `The number of columns in the CSV file (longest row: ${maxColumnCount}, shortest row: ${minColumnCount}) does not match the number of fields supplied (${
               Object.keys(params.fields).length
             }). Please check your CSV file and try again.`,
           ),
@@ -227,6 +241,12 @@ function splitRowIntoFields(row) {
   let currentField = '';
 
   let insideQuotes = false;
+
+  //Ensure rows with missing data become null
+  row = row
+    .split(',')
+    .map((value) => (value === '' ? 'null' : value))
+    .join(',');
 
   // Loop through each character in the row.
   for (const character of row) {

--- a/lib/utils/csvUpload.mjs
+++ b/lib/utils/csvUpload.mjs
@@ -123,19 +123,19 @@ export default async function csvUpload(file, params = {}) {
       // Split text file into rows on carriage return / new line.
       const rows = e.target.result.trim().split(/\r?\n/);
 
-      // Check the number of columns in the csv across all rows and return the average count.
+      // Check the number of columns in the csv across all rows and return the max or min count.
+      // assign the one thats different
       const columnCounts = rows.map((row) => splitRowIntoFields(row).length);
-      const maxColumnCount = Math.max(...columnCounts);
-      const minColumnCount = Math.min(...columnCounts);
+      const columnCount =
+        Math.max(...columnCounts) != Object.keys(params.fields).length
+          ? Math.max(...columnCounts)
+          : Math.min(...columnCounts);
 
-      if (
-        maxColumnCount !== Object.keys(params.fields).length ||
-        minColumnCount !== Object.keys(params.fields).length
-      ) {
+      if (columnCount !== Object.keys(params.fields).length) {
         // Return an error if the number of columns in the CSV file does not match the number of fields supplied.
         resolve([
           new Error(
-            `The number of columns in the CSV file (longest row: ${maxColumnCount}, shortest row: ${minColumnCount}) does not match the number of fields supplied (${
+            `The number of columns in the CSV file (${columnCount}) does not match the number of fields supplied (${
               Object.keys(params.fields).length
             }). Please check your CSV file and try again.`,
           ),

--- a/lib/utils/csvUpload.mjs
+++ b/lib/utils/csvUpload.mjs
@@ -59,19 +59,23 @@ The methods are used in the chunkRows method to convert the field values to the 
 const schemaMethods = {
   int: (val) => Number.parseInt(val.replace(/[^\d.-]/g, '')) || null,
   numeric: (val) => Number.parseFloat(val.replace(/[^\d.-]/g, '')) || null,
-  text: (val) => {
-    val = `${val.replace(/'/g, "''")}`;
-    //set the value to null if it is 'null'
-    if (val === 'null') return null;
-    return val;
-  },
-  varchar: (val) => {
-    val = `${val.replace(/'/g, "''")}`;
-    //set the value to null if it is 'null'
-    if (val === 'null') return null;
-    return val;
-  },
+  text: stringQuotes,
+  varchar: stringQuotes,
 };
+
+/**
+@function stringQuotes
+@description
+This function replaces single quotes in a string with double single quotes for SQL compatibility.
+
+@param {String} val The string value to process.
+@returns {String|null} The processed string with quotes replaced, or null if the input is 'null'.
+*/
+function stringQuotes(val) {
+    if (val === 'null') return null;
+    val = val.replaceAll("'","''")
+    return val;
+}
 
 /**
 @function csvUpload
@@ -124,7 +128,6 @@ export default async function csvUpload(file, params = {}) {
       const rows = e.target.result.trim().split(/\r?\n/);
 
       // Check the number of columns in the csv across all rows and return the max or min count.
-      // assign the one thats different
       const columnCounts = rows.map((row) => splitRowIntoFields(row).length);
       const columnCount =
         Math.max(...columnCounts) != Object.keys(params.fields).length

--- a/lib/utils/csvUpload.mjs
+++ b/lib/utils/csvUpload.mjs
@@ -72,9 +72,9 @@ This function replaces single quotes in a string with double single quotes for S
 @returns {String|null} The processed string with quotes replaced, or null if the input is 'null'.
 */
 function stringQuotes(val) {
-    if (val === 'null') return null;
-    val = val.replaceAll("'","''")
-    return val;
+  if (val === 'null') return null;
+  val = val.replaceAll("'", "''")
+  return val;
 }
 
 /**
@@ -127,29 +127,17 @@ export default async function csvUpload(file, params = {}) {
       // Split text file into rows on carriage return / new line.
       const rows = e.target.result.trim().split(/\r?\n/);
 
-      // Check the number of columns in the csv across all rows and return the max or min count.
-      const columnCounts = rows.map((row) => splitRowIntoFields(row).length);
-      const columnCount =
-        Math.max(...columnCounts) != Object.keys(params.fields).length
-          ? Math.max(...columnCounts)
-          : Math.min(...columnCounts);
-
-      if (columnCount !== Object.keys(params.fields).length) {
-        // Return an error if the number of columns in the CSV file does not match the number of fields supplied.
-        resolve([
-          new Error(
-            `The number of columns in the CSV file (${columnCount}) does not match the number of fields supplied (${
-              Object.keys(params.fields).length
-            }). Please check your CSV file and try again.`,
-          ),
-        ]);
+      try {
+        const matrix = rows.map((row) => splitRowIntoFields(row));
+      } catch (error) {
+        resolve([error]);
         return;
       }
 
       // The file has a header row.
       if (params.header) rows.shift();
 
-      const chunks = chunkRows(rows, params);
+      const chunks = chunkRows(matrix, params);
 
       let responses = [];
 
@@ -178,14 +166,14 @@ export default async function csvUpload(file, params = {}) {
 @description
 The method iterates over each row in the rows param. And returns an array of chunks according to max payload size for the POST request.
 
-@param {array} rows An array of rows extracted from the CSV file.
+@param {array} matrix An array of field arrays extracted from the CSV file.
 @param {object} params Parameter for chunking the rows array.
 @property {Object} params.fields The definition of the columns being inserted e.g. {field: field_type}.
 @property {Number} [params.chunkSize] The chunk size in bytes to upload the data in. Defaults to 4MB.
 @property {Array} [params.schema] The schema array of column types.
 @returns {Array} An array of field arrays chunked to size.
 */
-function chunkRows(rows, params) {
+function chunkRows(matrix, params) {
   const chunks = [];
 
   // Set default chunksize in bytes.
@@ -193,9 +181,7 @@ function chunkRows(rows, params) {
   let chunkSize = 0;
   let chunk = {};
 
-  rows.forEach((row) => {
-    // Split row into fields array.
-    const fields = splitRowIntoFields(row);
+  matrix.forEach((fields) => {
 
     for (const indx in fields) {
       const field = Object.keys(params.fields)[indx];
@@ -236,6 +222,7 @@ The method splits a CSV row string into fields.
 @param {String} row The row to split.
 @returns {Array} The fields array.
 */
+let expectedFieldCount = null; // Variable to store the expected number of fields
 function splitRowIntoFields(row) {
   // Create an array to store the fields.
   const fields = [];
@@ -244,12 +231,6 @@ function splitRowIntoFields(row) {
   let currentField = '';
 
   let insideQuotes = false;
-
-  //Ensure rows with missing data become null
-  row = row
-    .split(',')
-    .map((value) => (value === '' ? 'null' : value))
-    .join(',');
 
   // Loop through each character in the row.
   for (const character of row) {
@@ -271,11 +252,17 @@ function splitRowIntoFields(row) {
     }
   }
 
-  // Push the last field (if any) after the loop to the fields array.
-  if (currentField) {
-    fields.push(currentField.trim());
-  }
+  // Push the last row field in to the fields array.
+  fields.push(currentField.trim());
 
+  // Check if the number of fields matches the expected field count.
+  if (expectedFieldCount === null) {
+    expectedFieldCount = fields.length;
+  } else if (fields.length !== expectedFieldCount) {
+    throw new Error(
+      `Inconsistent number of fields. Expected ${expectedFieldCount}, but got ${fields.length}.`
+    );
+  }
   return fields;
 }
 


### PR DESCRIPTION
## Description
Fields in a csv are sometimes null, in this pr the missing data is replaced with 'null' to maintain the row length upon insert. 
```csv
A,,C,D,
A,B,C,D,E
,,C,D,
```
On the current patch these rows would get assigned to wrong columns as the empty fields would not be parsed at all 

On this PR the above would become
```csv
A,null,C,D,null
A,B,C,D,E
null,null,C,D,null
```
In the case of `varchar` and `text` the 'null' is set to null.
The nulls are handled by the casting in the query i.e null:numeric, null::text, etc. 

## GitHub Issue
#2899

## Type of Change
- ✅ Bug fix (non-breaking change which fixes an issue)
- ✅ Documentation

## How have you tested this?
Tested Locally
> [!IMPORTANT]
> `bugs_testing/dataviews/csvupload.json` with `places.csv`

## Testing Checklist
- ✅ Existing Tests still pass
- ✅ Ran locally on my machine

## Code Quality Checklist
- ✅ My code follows the guidelines of XYZ
- ✅ My code has been commented
- ✅ Documentation has been updated
- ✅ New and existing unit tests pass locally with my changes
- ✅ Main has been merged into this PR
