### PR TITLE
fix(utils/CSV Upload): CSV Upload Fixes

### DIFF
--- a/lib/utils/csvUpload.mjs
+++ b/lib/utils/csvUpload.mjs
@@ -127,18 +127,24 @@ export default async function csvUpload(file, params = {}) {
       // Split text file into rows on carriage return / new line.
       const rows = e.target.result.trim().split(/\r?\n/);
 
+      // The file has a header row.
+      if (params.header) rows.shift();
+
       let matrix;
       try {
-        matrix = rows.map((row) => splitRowIntoFields(row));
+        matrix = rows.map((row) => splitRowIntoFields(row, params));
       } catch (error) {
         resolve([error]);
         return;
       }
 
-      // The file has a header row.
-      if (params.header) rows.shift();
-
-      const chunks = chunkRows(matrix, params);
+      let chunks;
+      try {
+        chunks = chunkRows(matrix, params);
+      } catch (error) {
+        resolve([error]);
+        return;
+      }
 
       let responses = [];
 
@@ -184,7 +190,14 @@ function chunkRows(matrix, params) {
 
   matrix.forEach((fields) => {
     for (const indx in fields) {
-      const field = Object.keys(params.fields)[indx];
+      const field = Object.keys(params.fields)?.[indx];
+
+      if (!field) {
+        throw new Error(
+          `Unexpected field. Please ensure the CSV file has the correct number of fields.`,
+        );
+      }
+
       const type = params.fields[field];
 
       //assign field definition to its type with a `::` separator e.g. field::field_type
@@ -220,10 +233,10 @@ function chunkRows(matrix, params) {
 The method splits a CSV row string into fields.
 
 @param {String} row The row to split.
+@param {Object} params The parameters object.
 @returns {Array} The fields array.
 */
-let expectedFieldCount = null; // Variable to store the expected number of fields
-function splitRowIntoFields(row) {
+function splitRowIntoFields(row, params) {
   // Create an array to store the fields.
   const fields = [];
 
@@ -256,9 +269,8 @@ function splitRowIntoFields(row) {
   fields.push(currentField.trim());
 
   // Check if the number of fields matches the expected field count.
-  if (expectedFieldCount === null) {
-    expectedFieldCount = fields.length;
-  } else if (fields.length !== expectedFieldCount) {
+  const expectedFieldCount = Object.keys(params.fields).length;
+  if (fields.length !== expectedFieldCount) {
     throw new Error(
       `Inconsistent number of fields. Expected ${expectedFieldCount}, but got ${fields.length}.`,
     );


### PR DESCRIPTION
## Description
1. Move params.header check to before matrix using rows
2. Wrap chunkRows in try catch
3. Add check in chunkRows that the field actually exists
4. expectedFieldCount should be the length of params.fields

## Type of Change
- ✅ Bug fix (non-breaking change which fixes an issue)

## How have you tested this?
Tested locally against a CSV which is longer than the params.fields expects. 
Tested with a header row on the data.