### PR TITLE
fix(.vercelignore): Remove lock files [ENG-6]

### DIFF
--- a/.vercelignore
+++ b/.vercelignore
@@ -4,8 +4,6 @@
 .DS_Store
 
 env
-package-lock.json
-pnpm-lock.yaml
 node_modules/*
 
 *.md


### PR DESCRIPTION
## Description
Trying to deploy `v4.23.5` yields this error on vercel:
<img width="1401" height="98" alt="screenshot-2026-07-29_16-44-52" src="https://github.com/user-attachments/assets/a875af18-13cd-4178-b37e-6831fac9a72c" />

Removing these lock files from the `.vercelignore` fixes the issue. 

## GitHub Issue
closes #2906

[Linear Issue](https://linear.app/geolytix/issue/ENG-6/unable-to-deploy-v4235-to-vercel)

## Type of Change

Please delete options that are not relevant, and select all options that apply.
- ✅ Bug fix (non-breaking change which fixes an issue)

## How have you tested this?
Tested by deploying a dev instance to using this branch.

## Testing Checklist
- ✅ Existing Tests still pass
- ✅ Ran locally on my machine

## Code Quality Checklist
- ✅ My code follows the guidelines of XYZ
- ✅ My code has been commented
- ✅ Documentation has been updated
- ✅ New and existing unit tests pass locally with my changes
- ✅ Main has been merged into this PR
