### PR TITLE
fix(filter): Use includes/includeAll correctly [ENG-5]

### DIFF
--- a/lib/ui/layers/panels/filter.mjs
+++ b/lib/ui/layers/panels/filter.mjs
@@ -241,30 +241,31 @@ function listFilter(layer) {
     ) {
       entry.type ??= 'text';
 
-      if (!Object.hasOwn(filterByType, entry.type)) continue;
-
       if (!Object.keys(entry.filter || {}).length)
         entry.filter = filterByType[entry.type];
+
+      // The filter is defined as a string e.g. "like"
+      if (typeof entry.filter === 'string') {
+        entry.filter = {
+          type: entry.filter,
+        };
+      }
+
+      if (
+        !entry.filter?.type ||
+        !Object.hasOwn(mapp.ui.layers.filters, entry.filter.type)
+      ) {
+        entry.filter ??= { type: entry.type };
+        console.warn(`${entry.filter.type} is not a valid filter type`);
+        continue;
+      }
+
+      entry.filter.title ??= entry.title;
+
+      entry.filter.field ??= entry.field;
+
+      list.push(structuredClone(entry.filter));
     }
-
-    // The filter is defined as a string e.g. "like"
-    if (typeof entry.filter === 'string') {
-      entry.filter = {
-        type: entry.filter,
-      };
-    }
-
-    if (
-      !entry.filter?.type ||
-      !Object.hasOwn(mapp.ui.layers.filters, entry.filter.type)
-    )
-      continue;
-
-    entry.filter.title ??= entry.title;
-
-    entry.filter.field ??= entry.field;
-
-    list.push(structuredClone(entry.filter));
   }
 
   return list;
@@ -342,5 +343,5 @@ function multi_filter(layer) {
 
   layer.filter.dialog = true;
   layer.filter.drawer = false;
-  layer.filter.includeAll = true;
+  layer.filter.includeAll = !layer.filter.include?.length;
 }

--- a/lib/ui/layers/panels/filter.mjs
+++ b/lib/ui/layers/panels/filter.mjs
@@ -227,10 +227,12 @@ function listFilter(layer) {
   layer.filter.exclude ??= [];
 
   for (const entry of layer.infoj) {
+    entry.type ??= 'text';
     if (
       entry.skipEntry === true ||
       entry.field === undefined ||
-      layer.filter.exclude.includes(entry.field)
+      layer.filter.exclude.includes(entry.field) ||
+      !Object.hasOwn(filterByType, entry.type)
     )
       continue;
 


### PR DESCRIPTION
## Description
The include option was previously not working as filters defined on the entry would be included regardless.
Using the multi_filter object in config would all set includeAll to true, this is now set to false if include is used. 

## GitHub Issue
#2909 

## Type of Change
- ✅ Bug fix (non-breaking change which fixes an issue)

## How have you tested this?
> [!IMPORTANT]
> Tested on `bugs_testing/filter/all_filters.json`

## Testing Checklist
- ✅ Existing Tests still pass
- ✅ Ran locally on my machine

## Code Quality Checklist
- ✅ My code follows the guidelines of XYZ
- ✅ My code has been commented
- ✅ Documentation has been updated
- ✅ New and existing unit tests pass locally with my changes
- ✅ Main has been merged into this PR
