### PR TITLE
Location view - group to inherit padding from parent. [ENG-22]

### DIFF
--- a/public/css/layout/_locationview.css
+++ b/public/css/layout/_locationview.css
@@ -79,6 +79,7 @@
       color: var(--color-font-contrast);
       border-radius: 3px;
       padding: 0 5px;
+      margin: -1px; /* evens out the border width offset of the outer container */
 
       & > .material-symbols-outlined.caret::after {
         color: var(--color-font-contrast);

--- a/public/css/layout/_locationview.css
+++ b/public/css/layout/_locationview.css
@@ -85,15 +85,8 @@
       }
     }
 
-    & .label,
-    & .val,
-    label {
+    .contents > * {
       margin-left: 1em;
-    }
-
-    /* all values on the right side with the same margin */
-    .val,
-    .legend-icon {
       margin-right: 0.5em;
     }
   }

--- a/public/css/layout/_locationview.css
+++ b/public/css/layout/_locationview.css
@@ -60,6 +60,10 @@
     grid-template-columns: 1fr 1fr;
     grid-gap: inherit;
     padding: 0;
+    transition: 
+    height 0.3s ease, 
+    padding-top 0.3s ease, 
+    padding-bottom 0.3s ease;
 
     &.expanded {
       padding: 5px;
@@ -72,7 +76,7 @@
       border-radius: 3px;
       padding: 0 0.5em;
 
-      & > .caret::after {
+      & > .material-symbols-outlined.caret::after {
         color: var(--color-font-contrast);
       }
     }

--- a/public/css/layout/_locationview.css
+++ b/public/css/layout/_locationview.css
@@ -86,12 +86,14 @@
     }
 
     & .label,
-    & .val {
+    & .val,
+    label {
       margin-left: 1em;
     }
 
     /* all values on the right side with the same margin */
-    .val, .legend-icon {
+    .val,
+    .legend-icon {
       margin-right: 0.5em;
     }
   }

--- a/public/css/layout/_locationview.css
+++ b/public/css/layout/_locationview.css
@@ -59,7 +59,11 @@
     display: grid;
     grid-template-columns: 1fr 1fr;
     grid-gap: inherit;
-    padding: inherit;
+    padding: 0;
+
+    &.expanded {
+      padding: 5px;
+    }
 
     & > .header {
       grid-column: 1 / 3;

--- a/public/css/layout/_locationview.css
+++ b/public/css/layout/_locationview.css
@@ -58,9 +58,8 @@
     grid-column: 1 / 3;
     display: grid;
     grid-template-columns: 1fr 1fr;
-    grid-gap: 5px 10px;
-    border-bottom: 1px solid var(--color-border);
-    padding: 0;
+    grid-gap: inherit;
+    padding: inherit;
 
     & > .header {
       grid-column: 1 / 3;

--- a/public/css/layout/_locationview.css
+++ b/public/css/layout/_locationview.css
@@ -87,7 +87,7 @@
     }
 
     .contents > * {
-      margin-left: 1em;
+      margin-left: 0.5em;
       margin-right: 0.5em;
     }
   }

--- a/public/css/layout/_locationview.css
+++ b/public/css/layout/_locationview.css
@@ -60,10 +60,10 @@
     grid-template-columns: 1fr 1fr;
     grid-gap: inherit;
     padding: 0;
-    transition: 
-    height 0.3s ease, 
-    padding-top 0.3s ease, 
-    padding-bottom 0.3s ease;
+    transition:
+      height 0.3s ease,
+      padding-top 0.3s ease,
+      padding-bottom 0.3s ease;
 
     &.expanded {
       padding: 5px;

--- a/public/css/layout/_locationview.css
+++ b/public/css/layout/_locationview.css
@@ -66,7 +66,11 @@
       padding-bottom 0.3s ease;
 
     &.expanded {
-      padding: 5px;
+      padding: 0 0 5px;
+
+      & > .header {
+        border-radius: 3px 3px 1px 1px;
+      }
     }
 
     & > .header {
@@ -74,7 +78,7 @@
       background-color: var(--color-primary);
       color: var(--color-font-contrast);
       border-radius: 3px;
-      padding: 0 0.5em;
+      padding: 0 5px;
 
       & > .material-symbols-outlined.caret::after {
         color: var(--color-font-contrast);
@@ -84,6 +88,10 @@
     & .label,
     & .val {
       margin-left: 1em;
+    }
+
+    .val {
+      margin-right: 0.5em;
     }
   }
 

--- a/public/css/layout/_locationview.css
+++ b/public/css/layout/_locationview.css
@@ -90,7 +90,8 @@
       margin-left: 1em;
     }
 
-    .val {
+    /* all values on the right side with the same margin */
+    .val, .legend-icon {
       margin-right: 0.5em;
     }
   }

--- a/public/css/mapp.css
+++ b/public/css/mapp.css
@@ -4,6 +4,7 @@
   --color-base: #f2f2f2;
   --color-base-secondary: #f7f7f7;
   --color-base-tertiary: #fafafa;
+  --color-base-quartenary: #f7f7f7;
   --color-border: #dddddd;
   --color-font: #3f3f3f;
   --color-font-mid: #858585;

--- a/public/css/ui.css
+++ b/public/css/ui.css
@@ -1475,6 +1475,10 @@ label.radio {
     grid-template-columns: 1fr 1fr;
     grid-gap: inherit;
     padding: 0;
+    transition:
+      height 0.3s ease,
+      padding-top 0.3s ease,
+      padding-bottom 0.3s ease;
     &.expanded {
       padding: 5px;
     }
@@ -1484,7 +1488,7 @@ label.radio {
       color: var(--color-font-contrast);
       border-radius: 3px;
       padding: 0 0.5em;
-      & > .caret::after {
+      & > .material-symbols-outlined.caret::after {
         color: var(--color-font-contrast);
       }
     }

--- a/public/css/ui.css
+++ b/public/css/ui.css
@@ -1491,6 +1491,7 @@ label.radio {
       color: var(--color-font-contrast);
       border-radius: 3px;
       padding: 0 5px;
+      margin: -1px;
       & > .material-symbols-outlined.caret::after {
         color: var(--color-font-contrast);
       }

--- a/public/css/ui.css
+++ b/public/css/ui.css
@@ -1473,9 +1473,8 @@ label.radio {
     grid-column: 1 / 3;
     display: grid;
     grid-template-columns: 1fr 1fr;
-    grid-gap: 5px 10px;
-    border-bottom: 1px solid var(--color-border);
-    padding: 0;
+    grid-gap: inherit;
+    padding: inherit;
     & > .header {
       grid-column: 1 / 3;
       background-color: var(--color-primary);

--- a/public/css/ui.css
+++ b/public/css/ui.css
@@ -1497,7 +1497,7 @@ label.radio {
       }
     }
     .contents > * {
-      margin-left: 1em;
+      margin-left: 0.5em;
       margin-right: 0.5em;
     }
   }

--- a/public/css/ui.css
+++ b/public/css/ui.css
@@ -1474,7 +1474,10 @@ label.radio {
     display: grid;
     grid-template-columns: 1fr 1fr;
     grid-gap: inherit;
-    padding: inherit;
+    padding: 0;
+    &.expanded {
+      padding: 5px;
+    }
     & > .header {
       grid-column: 1 / 3;
       background-color: var(--color-primary);

--- a/public/css/ui.css
+++ b/public/css/ui.css
@@ -1495,13 +1495,8 @@ label.radio {
         color: var(--color-font-contrast);
       }
     }
-    & .label,
-    & .val,
-    label {
+    .contents > * {
       margin-left: 1em;
-    }
-    .val,
-    .legend-icon {
       margin-right: 0.5em;
     }
   }

--- a/public/css/ui.css
+++ b/public/css/ui.css
@@ -1499,7 +1499,8 @@ label.radio {
     & .val {
       margin-left: 1em;
     }
-    .val {
+    .val,
+    .legend-icon {
       margin-right: 0.5em;
     }
   }

--- a/public/css/ui.css
+++ b/public/css/ui.css
@@ -1496,7 +1496,8 @@ label.radio {
       }
     }
     & .label,
-    & .val {
+    & .val,
+    label {
       margin-left: 1em;
     }
     .val,

--- a/public/css/ui.css
+++ b/public/css/ui.css
@@ -1480,14 +1480,17 @@ label.radio {
       padding-top 0.3s ease,
       padding-bottom 0.3s ease;
     &.expanded {
-      padding: 5px;
+      padding: 0 0 5px;
+      & > .header {
+        border-radius: 3px 3px 1px 1px;
+      }
     }
     & > .header {
       grid-column: 1 / 3;
       background-color: var(--color-primary);
       color: var(--color-font-contrast);
       border-radius: 3px;
-      padding: 0 0.5em;
+      padding: 0 5px;
       & > .material-symbols-outlined.caret::after {
         color: var(--color-font-contrast);
       }
@@ -1495,6 +1498,9 @@ label.radio {
     & .label,
     & .val {
       margin-left: 1em;
+    }
+    .val {
+      margin-right: 0.5em;
     }
   }
   & .layer-key {


### PR DESCRIPTION
The padding was previously forced as `0` on a container which serves an a group in the location view.
For group container padding and grid-gap are now inherited from the parent location view container for consistency.

+ rebuilt stylesheets.