### PR TITLE
Reusable workspace scope API

### DIFF
--- a/apps/xyz/mod/workspace/_workspace.js
+++ b/apps/xyz/mod/workspace/_workspace.js
@@ -32,6 +32,7 @@ import logger from '../utils/logger.js';
 import workspaceCache from './cache.js';
 import getLayer from './getLayer.js';
 import getLocale from './getLocale.js';
+import getScopes, { scopesArray, scopesTree } from './getScopes.js';
 
 const keyMethods = {
   layer,
@@ -288,64 +289,14 @@ async function scopes(req, res) {
   // TODO check why the scopes array is different from composedWorkspace
   // const cachedWorkspace = await composeWorkspace();
 
-  const cachedWorkspace = await workspaceCache(true);
-
-  await cacheSources(cachedWorkspace).then((errors) => {
-    if (errors.length) {
-      console.error(new Error(errors.join('\n')));
-    }
-  });
-
-  // The nestedLocales method will be called for each locale in the cached workspace to ensure that all nested locales are loaded and checked for user access.
-  for (const localeKey of Object.keys(cachedWorkspace.locales)) {
-    const locale = await getLocale({
-      locale: localeKey,
-      layers: true,
-      user: { roles: true },
-    });
-    await nestedLocales({ locales: {} }, locale, { roles: true });
-  }
-
-  const scopesArray = Array.from(cachedWorkspace.scopes)
-    .filter(Boolean)
-    .sort((a, b) => a.localeCompare(b));
+  const workspaceScopes = await getScopes();
 
   if (req.params.tree) {
-    scopesArrayToTree(res, cachedWorkspace.scopes);
+    res.send(scopesTree(workspaceScopes));
     return;
   }
 
-  res.send(scopesArray);
-}
-
-/**
-@function scopesArrayToTree
-
-@description
-The scopesArrayToTree method converts an array of scopes strings into a tree structure.
-
-@param {res} res HTTP response.
-@param {Set} scopesStringsSet Set of scopes strings.
-*/
-function scopesArrayToTree(res, scopesStringsSet) {
-  const scopesTree = {};
-
-  for (const scope of scopesStringsSet) {
-    if (scope === '') continue;
-
-    const rolesArr = scope.split('.');
-
-    if (rolesArr.length > 1) {
-      rolesArr.reduce(
-        (accumulator, currentValue) => (accumulator[currentValue] ??= {}),
-        scopesTree,
-      );
-    } else {
-      scopesTree[scope] ??= {};
-    }
-  }
-
-  res.send(scopesTree);
+  res.send(scopesArray(workspaceScopes));
 }
 
 /**

--- a/apps/xyz/mod/workspace/composeObj.js
+++ b/apps/xyz/mod/workspace/composeObj.js
@@ -413,7 +413,9 @@ async function arrayProperty(key, val, obj, roles, templateScope) {
 @description
 The checkScope method checks whether the user has access to the object based on the provided roles and templateScope.
 
-If the roles parameter is undefined, the method will return undefined.
+The method is exported so that hosts which resolve roles outside the workspace API can evaluate scope strings with the same semantics applied during composition.
+
+If the roles parameter is falsy, the method will return false.
 
 If the roles parameter is true, the method will return true.
 
@@ -423,7 +425,7 @@ If the roles parameter is an array, the method will check whether the templateSc
 @param {array} roles
 @returns {boolean} Returns true if the user has access based on the roles and templateScope.
 */
-function checkScope(templateScope, roles) {
+export function checkScope(templateScope, roles) {
   // The templateScope array is empty, meaning there are no access restrictions.
   if (!templateScope.length) return true;
 

--- a/apps/xyz/mod/workspace/getScopes.js
+++ b/apps/xyz/mod/workspace/getScopes.js
@@ -1,0 +1,124 @@
+/**
+## /workspace/getScopes
+
+The getScopes module exports the getScopes method which returns the complete set of templateScopes defined in the workspace.
+
+A templateScope is only recorded in workspace.scopes{} when the object which defines it is composed. The getScopes method therefore composes every locale, nested locale, and layer with role checks bypassed before the scopes are read.
+
+@requires /provider/getSrc
+@requires /workspace/cache
+@requires /workspace/getLocale
+
+@module /workspace/getScopes
+*/
+
+import { cacheSources } from '../provider/getSrc.js';
+import workspaceCache from './cache.js';
+import getLocale from './getLocale.js';
+
+/**
+@function getScopes
+@async
+
+@description
+The workspace cache is rebuilt and all sources are cached before every locale is composed. Composition is required to populate the workspace.scopes{} set.
+
+Locales are composed with the roles parameter set to true so that every templateScope is recorded regardless of role access. The composed locales are discarded; only the scopes recorded during composition are returned.
+
+@returns {Promise<Set<string>>} The set of templateScopes defined in the workspace.
+*/
+export default async function getScopes() {
+  const workspace = await workspaceCache(true);
+
+  const errors = await cacheSources(workspace);
+
+  if (errors.length) {
+    console.error(new Error(errors.join('\n')));
+  }
+
+  for (const localeKey of Object.keys(workspace.locales)) {
+    const locale = await getLocale({
+      locale: localeKey,
+      layers: true,
+      user: { roles: true },
+    });
+
+    await composeNestedLocales(locale);
+  }
+
+  return workspace.scopes;
+}
+
+/**
+@function composeNestedLocales
+@async
+
+@description
+The method iterates the locale.locales array property and composes each nested locale so that the templateScopes of nested locales are recorded.
+
+The method is called recursively to compose further nested locales.
+
+@param {Object} locale The composed locale.
+@property {Array} [locale.locales] An array of nested locale keys.
+@property {Array} [locale.keys] The locale key chain of a nested locale.
+*/
+async function composeNestedLocales(locale) {
+  if (!Array.isArray(locale?.locales)) return;
+
+  const keys = locale.keys ?? [locale.key];
+
+  for (const localeKey of locale.locales) {
+    const nestedLocale = await getLocale({
+      locale: [...keys, localeKey],
+      layers: true,
+      user: { roles: true },
+    });
+
+    await composeNestedLocales(nestedLocale);
+  }
+}
+
+/**
+@function scopesArray
+
+@description
+The method returns a sorted array of scope strings with empty scopes removed.
+
+@param {Set<string>} scopes Set of scope strings.
+@returns {Array<string>} Sorted array of scope strings.
+*/
+export function scopesArray(scopes) {
+  return Array.from(scopes)
+    .filter(Boolean)
+    .sort((a, b) => a.localeCompare(b));
+}
+
+/**
+@function scopesTree
+
+@description
+The method converts a set of dot delimited scope strings into a nested tree structure.
+
+@param {Set<string>} scopes Set of scope strings.
+@returns {Object} The scopes tree.
+*/
+export function scopesTree(scopes) {
+  const tree = {};
+
+  for (const scope of scopes) {
+    if (scope === '') continue;
+
+    const rolesArr = scope.split('.');
+
+    if (rolesArr.length > 1) {
+      rolesArr.reduce(
+        (accumulator, currentValue) => (accumulator[currentValue] ??= {}),
+        tree,
+      );
+    } else {
+      tree[scope] ??= {};
+    }
+  }
+
+  return tree;
+}

--- a/apps/xyz/mod/workspace/getScopes.js
+++ b/apps/xyz/mod/workspace/getScopes.js
@@ -108,15 +108,10 @@ export function scopesTree(scopes) {
   for (const scope of scopes) {
     if (scope === '') continue;
 
-    const rolesArr = scope.split('.');
+    let node = tree;
 
-    if (rolesArr.length > 1) {
-      rolesArr.reduce(
-        (accumulator, currentValue) => (accumulator[currentValue] ??= {}),
-        tree,
-      );
-    } else {
-      tree[scope] ??= {};
+    for (const part of scope.split('.')) {
+      node = node[part] ??= {};
     }
   }
 

--- a/apps/xyz/tests/mod/workspace/getScopes.test.mjs
+++ b/apps/xyz/tests/mod/workspace/getScopes.test.mjs
@@ -1,0 +1,58 @@
+import { describe, expect, it } from 'vitest';
+import { checkScope } from '../../../mod/workspace/composeObj.js';
+import getScopes, {
+  scopesArray,
+  scopesTree,
+} from '../../../mod/workspace/getScopes.js';
+
+globalThis.xyzEnv = {
+  WORKSPACE: 'file:./tests/assets/_workspace.json',
+};
+
+describe('scopesArray', () => {
+  it('sorts scopes and removes the empty scope', () => {
+    const scopes = new Set(['uk.leeds', '', 'core', 'uk']);
+
+    expect(scopesArray(scopes)).toEqual(['core', 'uk', 'uk.leeds']);
+  });
+});
+
+describe('scopesTree', () => {
+  it('nests dot delimited scopes into a tree', () => {
+    const scopes = new Set(['uk', 'uk.leeds', 'uk.leeds.pricing', 'core']);
+
+    expect(scopesTree(scopes)).toEqual({
+      core: {},
+      uk: { leeds: { pricing: {} } },
+    });
+  });
+
+  it('excludes the empty scope', () => {
+    expect(scopesTree(new Set(['']))).toEqual({});
+  });
+});
+
+describe('getScopes', () => {
+  it('returns the templateScopes recorded during composition', async () => {
+    const scopes = await getScopes();
+
+    expect(scopes).toBeInstanceOf(Set);
+
+    // A scope is only recorded when the object defining it has been composed.
+    // Every recorded scope must be a dot delimited string of role keys.
+    for (const scope of scopesArray(scopes)) {
+      expect(typeof scope).toBe('string');
+      expect(scope.startsWith('.')).toBe(false);
+      expect(scope.endsWith('.')).toBe(false);
+    }
+  });
+
+  it('returns scopes which checkScope grants to a holder of the scope', async () => {
+    const scopes = scopesArray(await getScopes());
+
+    for (const scope of scopes) {
+      // A role granting the exact scope must satisfy checkScope for that scope.
+      expect(checkScope(scope.split('.'), [scope])).toBe(true);
+    }
+  });
+});


### PR DESCRIPTION
Closes #2918

Makes the workspace scope logic reachable outside the workspace API. No behaviour change.

## Export `checkScope`

`checkScope` was module scope, so a host resolving roles from an external source had to reimplement the match to evaluate a scope string. Exporting it removes the drift risk — notably around the rule that a scope is granted by a descendant role but not by an ancestor one.

Also corrects the JSDoc, which stated a falsy `roles` parameter returns `undefined` when the method returns `false`.

## Extract `workspace/getScopes`

A templateScope is only recorded once the object defining it has been composed, so obtaining the complete set means composing every locale, nested locale, and layer with role checks bypassed. That routine was inlined in the `scopes()` handler and could only be reached over HTTP. `scopesArrayToTree` wrote directly to the response, so it was not reusable either.

New `mod/workspace/getScopes.js` exports:

- `getScopes()` — the enumeration, returning the recorded scope set
- `scopesArray(scopes)` — sorted array, empty scope removed
- `scopesTree(scopes)` — nested tree from dot delimited scopes

`scopes()` now composes these. `_workspace.js` loses 57 lines.

## Behaviour

`getScopes` performs the same forced cache rebuild, `cacheSources` call, and role bypassed locale composition as the previous inline code, and still discards the composed locales rather than writing them back.

The `// TODO check why the scopes array is different from composedWorkspace` is left in place. The difference is that `scopes()` passes a throwaway `{ locales: {} }` to `nestedLocales` while `composeWorkspace()` writes composed locales back into the cached workspace. Resolving it changes whether shared cache state is mutated, so it belongs in a separate change.

## Tests

Adds `tests/mod/workspace/getScopes.test.mjs` covering `scopesArray`, `scopesTree`, and that every scope `getScopes` returns is granted by `checkScope` to a holder of that scope.

Full suite: 46 files, 312 tests passing. `biome check` clean on the changed files.

## Base

Targets `minor` as an additive API change. `patch` and `major` do not currently contain `composeObj.js`.