### PR TITLE
Only show legend from showcallback method [ENG-66] [ENG-92]

### DIFF
--- a/lib/ui/elements/layerStyle.mjs
+++ b/lib/ui/elements/layerStyle.mjs
@@ -349,7 +349,7 @@ function theme(layer) {
     });
 
     // The legend methods replace the children of the layer.style.legend node with the legend content.
-    layer.style.legend = mapp.utils.html.node`<div>`;
+    layer.style.legend = mapp.utils.html.node`<div class="legend">`;
 
     layer.style.legend && content.push(layer.style.legend);
   }

--- a/lib/ui/elements/layerStyle.mjs
+++ b/lib/ui/elements/layerStyle.mjs
@@ -344,7 +344,12 @@ function theme(layer) {
   }
 
   if (Object.hasOwn(mapp.ui.layers.legends, layer.style.theme?.type)) {
-    mapp.ui.layers.legends[layer.style.theme.type](layer);
+    layer.showCallbacks.push(() => {
+      mapp.ui.layers.legends[layer.style.theme.type](layer);
+    });
+
+    // The legend methods replace the children of the layer.style.legend node with the legend content.
+    layer.style.legend = mapp.utils.html.node`<div>`;
 
     layer.style.legend && content.push(layer.style.legend);
   }


### PR DESCRIPTION
The theme layerStyle module method creates an empty div node for the legend and assigns the legends method to the layer.showCallbacks array.

The legend method eg categorized will replace the children in this legend node with the legend when called from the showCallbacks methods on show.