### PR TITLE
Replace AUTHORIZATION_PROVIDER environment variable with authorization_provider property of user object [ENG-89]

### DIFF
--- a/apps/xyz/mod/query.js
+++ b/apps/xyz/mod/query.js
@@ -68,7 +68,7 @@ export default async function query(req, res) {
   // Must be run after the layerQuery method since the query template could be defined within the layer [template].
   const template = await composeObj(
     { template: req.params.template },
-    req.params.user?.roles,
+    req.params.user,
   );
 
   if (template instanceof Error) {

--- a/apps/xyz/mod/user/cookie.js
+++ b/apps/xyz/mod/user/cookie.js
@@ -118,6 +118,11 @@ export default async function cookie(req, res) {
         user.session = payload.session;
       }
 
+      // The authorization_provider property is assigned by a composing host and is not stored in the ACL. The property must be carried over from the current token.
+      if (payload.authorization_provider) {
+        user.authorization_provider = payload.authorization_provider;
+      }
+
       //If we have a sessionIndex from a SAML IdP then we need to pass it from the
       //already created cookie as this is not stored in the acl.
       if (decodedCookie.sessionIndex) {

--- a/apps/xyz/mod/user/key.js
+++ b/apps/xyz/mod/user/key.js
@@ -69,6 +69,11 @@ export default async function apiKey(req, res) {
     roles: user.roles,
   };
 
+  // The authorization_provider property is assigned by a composing host and is not stored in the ACL. The property must be carried over from the requesting user.
+  if (req.params.user.authorization_provider) {
+    api_user.authorization_provider = req.params.user.authorization_provider;
+  }
+
   const key = jwt.sign(api_user, xyzEnv.SECRET, {
     algorithm: xyzEnv.SECRET_ALGORITHM,
   });

--- a/apps/xyz/mod/utils/processEnv.js
+++ b/apps/xyz/mod/utils/processEnv.js
@@ -110,7 +110,6 @@ The process.ENV object holds configuration provided to the node process from the
 @property {String} [SAML_PROVIDER_NAME] Display name for your service
 @property {String} [SLO_CALLBACK] URL for handling logout callbacks
 @property {Boolean} [LEGACY_ROLES] Enable legacy role checks
-@property {Boolean} [AUTHORIZATION_PROVIDER] Route workspace composition scope checks through the [authorization]{@link module:/workspace/authorization} provider registered by the composing host.
 */
 
 const defaults = {

--- a/apps/xyz/mod/workspace/authorization.js
+++ b/apps/xyz/mod/workspace/authorization.js
@@ -3,9 +3,9 @@
 
 The authorization module exports the seam through which workspace composition routes template scope access decisions.
 
-A composing host may register an asynchronous authorization provider to answer scope decisions from an external policy store, eg. OpenFGA.
+A composing host may register asynchronous authorization providers to answer scope decisions from an external policy store, eg. OpenFGA. Each provider is registered with a key.
 
-The provider is only consulted when the AUTHORIZATION_PROVIDER flag is enabled in the xyzEnv. Without the flag the authorizeScope method returns the synchronous checkScope semantics for the user.roles array, matching the LEGACY_ROLES flag pattern.
+A provider is only consulted for a user with a matching authorization_provider property. Without the property the authorizeScope method returns the synchronous checkScope semantics for the user.roles array.
 
 @requires /workspace/scopes
 
@@ -16,11 +16,19 @@ import { checkScope } from './scopes.js';
 
 /**
 @global
+@typedef {Object} User
+@property {Array<string>|boolean} [user.roles] The user roles.
+@property {string} [user.authorization_provider] The key of the authorization provider which decides scope access for the user.
+*/
+
+/**
+@global
 @typedef {Object} AuthorizationContext
 @property {Array<string>} scope The templateScope chain of the object being composed.
 @property {string} scopeKey The joined scope chain. The scopeKey matches the identifiers recorded in workspace.scopes.
 @property {Object} obj The object being composed.
-@property {array|boolean} [roles] The user roles from request params.
+@property {User} [user] The requesting user from request params.
+
 */
 
 /**
@@ -29,20 +37,26 @@ import { checkScope } from './scopes.js';
 @property {function(AuthorizationContext):Promise<boolean>} checkScope Resolves whether the user has access to the scope.
 */
 
-let provider;
+const providers = new Map();
 
 /**
 @function setAuthorizationProvider
 
 @description
-The method registers an authorization provider for workspace composition. The provider is only consulted with the AUTHORIZATION_PROVIDER flag enabled in the xyzEnv.
+The method registers an authorization provider for workspace composition. The provider is only consulted for a user with an authorization_provider property matching the key.
 
-Calling the method without a provider argument clears the registration.
+Calling the method without a provider argument clears the registration for the key.
 
-@param {AuthorizationProvider} [nextProvider] The provider to register.
+@param {string} key The provider key matched against the user.authorization_provider property.
+@param {AuthorizationProvider} [provider] The provider to register.
 */
-export function setAuthorizationProvider(nextProvider) {
-  provider = nextProvider;
+export function setAuthorizationProvider(key, provider) {
+  if (provider === undefined) {
+    providers.delete(key);
+    return;
+  }
+
+  providers.set(key, provider);
 }
 
 /**
@@ -52,23 +66,26 @@ export function setAuthorizationProvider(nextProvider) {
 @description
 The method resolves a scope access decision for workspace composition.
 
-The checkScope semantics for the user.roles array apply unless the
-AUTHORIZATION_PROVIDER flag is enabled in the xyzEnv.
+The checkScope semantics for the user.roles array apply unless the user has an
+authorization_provider property.
 
-With the flag enabled the decision is routed through the registered provider.
-The provider must resolve true for the scope access to be granted. A missing
-provider or a provider error fails closed and access is denied.
+With the property the decision is routed through the provider registered for
+the user.authorization_provider key. The provider must resolve true for the
+scope access to be granted. A missing provider or a provider error fails closed
+and access is denied.
 
 @param {AuthorizationContext} context The scope decision context.
 @returns {Promise<boolean>} Whether the user has access to the scope.
 */
 export async function authorizeScope(context) {
-  if (!xyzEnv.AUTHORIZATION_PROVIDER) {
-    return checkScope(context.scope, context.roles);
+  const providerKey = context.user?.authorization_provider;
+
+  if (!providerKey) {
+    return checkScope(context.scope, context.user?.roles);
   }
 
   try {
-    return (await provider?.checkScope(context)) === true;
+    return (await providers.get(providerKey)?.checkScope(context)) === true;
   } catch (error) {
     console.error(error);
     return false;

--- a/apps/xyz/mod/workspace/composeObj.js
+++ b/apps/xyz/mod/workspace/composeObj.js
@@ -187,45 +187,63 @@ async function parseTemplates(obj, user, templateScope) {
   if (obj === null) return;
 
   for (const key of Object.keys(obj)) {
-    // The value must be read fresh on each iteration rather than destructured from a snapshot. Earlier keys in this same loop (eg. a templates array) can merge into and reassign a not-yet-processed property (eg. infoj), and a stale val would overwrite that merge when this key is reached.
-    const val = obj[key];
+    const parseKeyCheck = await parseKey(key, obj, user, templateScope);
 
-    // Locale object layers should never be processed. Layers will be processed in the getLayer method. The layers property will be removed from the locale object after processing.
-    if (key === 'layers') continue;
-    if (queryTemplate(key, val, obj, user, templateScope)) {
-      continue;
+    if (parseKeyCheck instanceof Error) {
+      return parseKeyCheck;
     }
+  }
+}
 
-    if (await templatesArray(key, val, obj, user, templateScope)) {
-      continue;
-    }
+/**
+@function parseKey
+@async
 
-    const rolesTemplatesCheck = await rolesTemplates(
-      key,
-      val,
-      obj,
-      user,
-      templateScope,
-    );
+@description
+The parseKey method processes a single key of an object parsed by the parseTemplates method.
 
-    if (rolesTemplatesCheck === true) {
-      continue;
-    }
+The key value is checked against the queryTemplate, templatesArray, rolesTemplates, and arrayProperty methods in order. The first method to process the key value will short circuit the remaining checks. A key value which is not processed by any of these methods will be traversed recursively by the parseTemplates method.
 
-    if (rolesTemplatesCheck instanceof Error) {
-      return rolesTemplatesCheck;
-    }
+@param {string} key
+@param {Object} obj
+@param {User} [user] The requesting user from request params.
+@param {array} templateScope
 
-    // Recursively process each item in an array property of the object.
-    if (await arrayProperty(key, val, obj, user, templateScope)) {
-      continue;
-    }
+@returns {Promise<Error|undefined>} Returns an Error if the roles check for the obj fails.
+*/
+async function parseKey(key, obj, user, templateScope) {
+  // The value must be read fresh on each iteration rather than destructured from a snapshot. Earlier keys in the parseTemplates loop (eg. a templates array) can merge into and reassign a not-yet-processed property (eg. infoj), and a stale val would overwrite that merge when this key is reached.
+  const val = obj[key];
 
-    // Recursively process nested objects
-    const parseTemplatesCheck = await parseTemplates(val, user, templateScope);
-    if (parseTemplatesCheck instanceof Error) {
-      delete obj[key];
-    }
+  // Locale object layers should never be processed. Layers will be processed in the getLayer method. The layers property will be removed from the locale object after processing.
+  if (key === 'layers') return;
+
+  if (queryTemplate(key, val, obj, user, templateScope)) return;
+
+  if (await templatesArray(key, val, obj, user, templateScope)) return;
+
+  const rolesTemplatesCheck = await rolesTemplates(
+    key,
+    val,
+    obj,
+    user,
+    templateScope,
+  );
+
+  if (rolesTemplatesCheck === true) return;
+
+  if (rolesTemplatesCheck instanceof Error) {
+    return rolesTemplatesCheck;
+  }
+
+  // Recursively process each item in an array property of the object.
+  if (await arrayProperty(key, val, obj, user, templateScope)) return;
+
+  // Recursively process nested objects
+  const parseTemplatesCheck = await parseTemplates(val, user, templateScope);
+
+  if (parseTemplatesCheck instanceof Error) {
+    delete obj[key];
   }
 }
 

--- a/apps/xyz/mod/workspace/composeObj.js
+++ b/apps/xyz/mod/workspace/composeObj.js
@@ -24,12 +24,13 @@ let workspace;
 The composeObj method is the main entry point for composing an object with templates and roles. It will recursively traverse the provided object and its nested objects to identify and process template definitions.
 
 @param {Object} obj
-@param {array} [roles] An array of user roles from request params.
+@param {User} [user] The requesting user from request params.
 
 @property {string} [obj.template] Key of template for the object.
 @property {array} [obj.templates] An array of template keys to be merged into the object.
+@property {array<string>|boolean} [user.roles] An array of user roles. Admin endpoints set the roles property to true to bypass role checks.
 */
-export default async function composeObj(obj, roles) {
+export default async function composeObj(obj, user) {
   // Cache workspace in module scope for template assignment.
   workspace = await workspaceCache();
 
@@ -57,9 +58,9 @@ export default async function composeObj(obj, roles) {
 
   const allowed = await authorizeScope({
     obj,
-    roles,
     scope: [...templateScope],
     scopeKey: templateScope.join('.'),
+    user,
   });
 
   if (!allowed) {
@@ -68,7 +69,7 @@ export default async function composeObj(obj, roles) {
     );
   }
 
-  const rolesCheck = await parseTemplates(obj, roles, templateScope);
+  const rolesCheck = await parseTemplates(obj, user, templateScope);
 
   if (rolesCheck instanceof Error) {
     return rolesCheck;
@@ -86,12 +87,12 @@ The mergeTemplateIntoObj method merges a template into an object. It first retri
 
 @param {Object} obj
 @param {Object} template The template maybe an object with a src property or a string.
-@param {array} [roles] An array of user roles from request params.
+@param {User} [user] The requesting user from request params.
 @param {array} [templateScope] The templateScope is an array that represents nested template roles/scope.
 
 @returns {Promise<Object>} Returns the merged obj.
 */
-async function mergeTemplateIntoObj(obj, template, roles, templateScope = []) {
+async function mergeTemplateIntoObj(obj, template, user, templateScope = []) {
   template = await getTemplate(template);
 
   if (template instanceof Error) {
@@ -109,16 +110,16 @@ async function mergeTemplateIntoObj(obj, template, roles, templateScope = []) {
 
   const allowed = await authorizeScope({
     obj: template,
-    roles,
     scope: [...templateScope],
     scopeKey: templateScope.join('.'),
+    user,
   });
 
   if (!allowed) {
     return;
   }
 
-  const rolesCheck = await parseTemplates(template, roles, templateScope);
+  const rolesCheck = await parseTemplates(template, user, templateScope);
 
   if (rolesCheck instanceof Error) {
     obj.warn ??= [];
@@ -177,10 +178,10 @@ If a template object is found, it will be added to the workspace.templates objec
 If an array of templates is found, each template will be merged into the object in the order they are defined in the array.
 
 @param {Object} obj
-@param {Object} roles
+@param {User} [user] The requesting user from request params.
 @param {array} templateScope
 */
-async function parseTemplates(obj, roles, templateScope) {
+async function parseTemplates(obj, user, templateScope) {
   if (typeof obj !== 'object') return;
 
   if (obj === null) return;
@@ -191,11 +192,11 @@ async function parseTemplates(obj, roles, templateScope) {
 
     // Locale object layers should never be processed. Layers will be processed in the getLayer method. The layers property will be removed from the locale object after processing.
     if (key === 'layers') continue;
-    if (queryTemplate(key, val, obj, roles, templateScope)) {
+    if (queryTemplate(key, val, obj, user, templateScope)) {
       continue;
     }
 
-    if (await templatesArray(key, val, obj, roles, templateScope)) {
+    if (await templatesArray(key, val, obj, user, templateScope)) {
       continue;
     }
 
@@ -203,7 +204,7 @@ async function parseTemplates(obj, roles, templateScope) {
       key,
       val,
       obj,
-      roles,
+      user,
       templateScope,
     );
 
@@ -216,12 +217,12 @@ async function parseTemplates(obj, roles, templateScope) {
     }
 
     // Recursively process each item in an array property of the object.
-    if (await arrayProperty(key, val, obj, roles, templateScope)) {
+    if (await arrayProperty(key, val, obj, user, templateScope)) {
       continue;
     }
 
     // Recursively process nested objects
-    const parseTemplatesCheck = await parseTemplates(val, roles, templateScope);
+    const parseTemplatesCheck = await parseTemplates(val, user, templateScope);
     if (parseTemplatesCheck instanceof Error) {
       delete obj[key];
     }
@@ -241,11 +242,11 @@ Access to an object is denied if the user does not have access to a prototype te
 @param {string} key
 @param {Object} val
 @param {Object} obj
-@param {array} roles
+@param {User} [user] The requesting user from request params.
 @param {array} templateScope
 @returns {boolean} Returns true if the key is 'template' and the val has a key property.
 */
-function queryTemplate(key, val, obj, roles, templateScope) {
+function queryTemplate(key, val, obj, user, templateScope) {
   if (key !== 'template') return false;
 
   if (typeof val === 'string') {
@@ -300,11 +301,11 @@ The method checks if the key is 'templates' and the val is an array. If so, it w
 @param {string} key
 @param {Object} val
 @param {Object} obj
-@param {array} roles
+@param {User} [user] The requesting user from request params.
 @param {array} templateScope
 @returns {boolean} Returns true if the key is 'templates' and the val is an array.
 */
-async function templatesArray(key, val, obj, roles, templateScope) {
+async function templatesArray(key, val, obj, user, templateScope) {
   if (key !== 'templates') return false;
 
   if (!Array.isArray(val)) {
@@ -320,7 +321,7 @@ async function templatesArray(key, val, obj, roles, templateScope) {
 
   for (const template of val) {
     // Merge template from templates array into the object. The templates will be merged in the order they are defined in the array.
-    await mergeTemplateIntoObj(obj, template, roles, templateScope);
+    await mergeTemplateIntoObj(obj, template, user, templateScope);
   }
 
   return true;
@@ -333,17 +334,20 @@ async function templatesArray(key, val, obj, roles, templateScope) {
 @description
 The rolesTemplates method processes the 'roles' property of an object. It iterates over each role and merges the corresponding template into the object if the role value is true or an object.
 
-The role as defined by the key in the roles object will be added to the accessRoles array. Access to the obj will be denied if none of the accessRoles are included in the roles array provided by the user.
+The role as defined by the key in the roles object will be added to the accessRoles array. Access to the obj will be denied if none of the accessRoles are included in the user.roles array.
 
 @param {string} key
 @param {Object} val
 @param {Object} obj
-@param {array} roles
+@param {User} [user] The requesting user from request params.
 @param {array} templateScope
+@property {array|boolean} [user.roles] An array of user roles.
 @returns {boolean}
 */
-async function rolesTemplates(key, val, obj, roles, templateScope) {
+async function rolesTemplates(key, val, obj, user, templateScope) {
   if (key !== 'roles') return false;
+
+  const roles = user?.roles;
 
   // The roles property value must be an object. If the value is true, null, or not an object, access to the obj will be denied.
   if (typeof val !== 'object' || val === true || !val) return false;
@@ -369,7 +373,7 @@ async function rolesTemplates(key, val, obj, roles, templateScope) {
       role: roleKey,
       ...roleVal,
     };
-    await mergeTemplateIntoObj(obj, template, roles, templateScope);
+    await mergeTemplateIntoObj(obj, template, user, templateScope);
     accessRoles.push(roleKey);
   }
 
@@ -377,7 +381,7 @@ async function rolesTemplates(key, val, obj, roles, templateScope) {
     accessRoles.forEach((role) => {
       workspace.scopes.add([...templateScope, role].filter(Boolean).join('.'));
     });
-    // Role check is not required for admin endpoints. The roles parameter is set to true to bypass role checks.
+    // Role check is not required for admin endpoints. The user.roles property is set to true to bypass role checks.
     return true;
   }
 
@@ -413,16 +417,16 @@ The arrayProperty method processes array properties of an object. It iterates ov
 @param {string} key
 @param {Object} val
 @param {Object} obj
-@param {array} roles
+@param {User} [user] The requesting user from request params.
 @param {array} templateScope
 @returns {boolean}
 */
-async function arrayProperty(key, val, obj, roles, templateScope) {
+async function arrayProperty(key, val, obj, user, templateScope) {
   if (!Array.isArray(val)) return false;
 
   const kept = [];
   for (const item of val) {
-    const rolesCheck = await parseTemplates(item, roles, templateScope);
+    const rolesCheck = await parseTemplates(item, user, templateScope);
     if (!(rolesCheck instanceof Error)) kept.push(item);
   }
   obj[key] = kept;

--- a/apps/xyz/mod/workspace/composeObj.js
+++ b/apps/xyz/mod/workspace/composeObj.js
@@ -354,6 +354,8 @@ The rolesTemplates method processes the 'roles' property of an object. It iterat
 
 The role as defined by the key in the roles object will be added to the accessRoles array. Access to the obj will be denied if none of the accessRoles are included in the user.roles array.
 
+The user.roles gate does not apply to a user with an authorization_provider property. Scope access for such a user is decided by the provider in the authorizeScope method.
+
 @param {string} key
 @param {Object} val
 @param {Object} obj
@@ -402,6 +404,9 @@ async function rolesTemplates(key, val, obj, user, templateScope) {
     // Role check is not required for admin endpoints. The user.roles property is set to true to bypass role checks.
     return true;
   }
+
+  // A user with an authorization_provider property is not gated by the user.roles array. Scope access for the user is decided by the provider in the authorizeScope method.
+  if (user?.authorization_provider) return true;
 
   // The roles object has no gateRoles, so the obj itself is not gated and remains visible regardless of the roles provided by the user.
   if (!gateRoles.length) return true;

--- a/apps/xyz/mod/workspace/composeObj.js
+++ b/apps/xyz/mod/workspace/composeObj.js
@@ -303,7 +303,7 @@ The method checks if the key is 'templates' and the val is an array. If so, it w
 @param {Object} obj
 @param {User} [user] The requesting user from request params.
 @param {array} templateScope
-@returns {boolean} Returns true if the key is 'templates' and the val is an array.
+@returns {Promise<boolean>} Returns true if the key is 'templates' and the val is an array.
 */
 async function templatesArray(key, val, obj, user, templateScope) {
   if (key !== 'templates') return false;
@@ -342,7 +342,7 @@ The role as defined by the key in the roles object will be added to the accessRo
 @param {User} [user] The requesting user from request params.
 @param {array} templateScope
 @property {array|boolean} [user.roles] An array of user roles.
-@returns {boolean}
+@returns {Promise<boolean>}
 */
 async function rolesTemplates(key, val, obj, user, templateScope) {
   if (key !== 'roles') return false;
@@ -419,7 +419,7 @@ The arrayProperty method processes array properties of an object. It iterates ov
 @param {Object} obj
 @param {User} [user] The requesting user from request params.
 @param {array} templateScope
-@returns {boolean}
+@returns {Promise<boolean>}
 */
 async function arrayProperty(key, val, obj, user, templateScope) {
   if (!Array.isArray(val)) return false;

--- a/apps/xyz/mod/workspace/getLayer.js
+++ b/apps/xyz/mod/workspace/getLayer.js
@@ -88,7 +88,7 @@ export default async function getLayer(params, locale) {
   layer.parentRoles = locale.parentRoles;
 
   // The roles property maybe assigned from a template. Templates must be merged prior to the role check.
-  layer = await composeObj(layer, params.user?.roles);
+  layer = await composeObj(layer, params.user);
 
   // The composeObj method returned an Error.
   if (layer instanceof Error) {

--- a/apps/xyz/mod/workspace/getLocale.js
+++ b/apps/xyz/mod/workspace/getLocale.js
@@ -83,7 +83,7 @@ export default async function getLocale(params, parentLocale) {
       : [parentLocale.role];
   }
 
-  locale = await composeObj(locale, params.user?.roles);
+  locale = await composeObj(locale, params.user);
 
   if (locale instanceof Error) {
     return locale;

--- a/apps/xyz/tests/mod/user/cookie.test.mjs
+++ b/apps/xyz/tests/mod/user/cookie.test.mjs
@@ -235,4 +235,50 @@ describe('cookie:', async () => {
 
     expect(Object.hasOwn(token, 'sessionIndex')).toBeTruthy();
   });
+
+  it('carries the authorization_provider property over to the new cookie', async () => {
+    const user = {
+      email: 'test@geolytix.co.uk',
+      roles: [],
+      admin: false,
+    };
+
+    const providerUser = {
+      ...user,
+      authorization_provider: 'openfga',
+    };
+
+    const secret = crypto.randomUUID();
+
+    globalThis.xyzEnv.SECRET = secret;
+
+    const { req, res } = createMocks({
+      headers: {
+        host: 'http://localhost:3000',
+      },
+      cookies: {
+        TEST: jwt.sign(providerUser, secret),
+      },
+      params: {},
+    });
+
+    aclFn.mockImplementation(() => {
+      return [user];
+    });
+
+    await cookie(req, res);
+
+    const header = res.getHeader('set-cookie');
+    let token = {};
+
+    header.split(';').forEach((cookie) => {
+      const [name, value] = cookie.trim().split('=');
+
+      if (name === 'TEST') {
+        token = jwt.decode(value);
+      }
+    });
+
+    expect(token.authorization_provider).toBe('openfga');
+  });
 });

--- a/apps/xyz/tests/mod/user/key.test.mjs
+++ b/apps/xyz/tests/mod/user/key.test.mjs
@@ -1,3 +1,4 @@
+import jwt from 'jsonwebtoken';
 import { createMocks } from 'node-mocks-http';
 import { describe, expect, it, vi } from 'vitest';
 
@@ -138,5 +139,23 @@ describe('key:', async () => {
 
     expect(res.statusCode === 200).toBeTruthy();
     expect(res._getData().startsWith('ey')).toBeTruthy();
+  });
+
+  it('carries the authorization_provider property over to the api key', async () => {
+    const { req, res } = createMocks({
+      params: {
+        user: { ...user, authorization_provider: 'openfga' },
+      },
+    });
+
+    aclFn.mockImplementation(async () => {
+      return [user];
+    });
+
+    await apiKey(req, res);
+
+    const token = jwt.decode(res._getData());
+
+    expect(token.authorization_provider).toBe('openfga');
   });
 });

--- a/apps/xyz/tests/mod/workspace/authorization.test.mjs
+++ b/apps/xyz/tests/mod/workspace/authorization.test.mjs
@@ -30,7 +30,10 @@ describe('basic authorization', () => {
 
     expect(denied instanceof Error).toBeTruthy();
 
-    const allowed = await composeObj({ role: 'analyst' }, { roles: ['analyst'] });
+    const allowed = await composeObj(
+      { role: 'analyst' },
+      { roles: ['analyst'] },
+    );
 
     expect(allowed instanceof Error).toBeFalsy();
   });
@@ -192,7 +195,10 @@ describe('basic authorization', () => {
     expect(denied instanceof Error).toBeTruthy();
 
     // The user.roles semantics apply for a user without the property.
-    const allowed = await composeObj({ role: 'analyst' }, { roles: ['analyst'] });
+    const allowed = await composeObj(
+      { role: 'analyst' },
+      { roles: ['analyst'] },
+    );
 
     expect(allowed instanceof Error).toBeFalsy();
   });

--- a/apps/xyz/tests/mod/workspace/authorization.test.mjs
+++ b/apps/xyz/tests/mod/workspace/authorization.test.mjs
@@ -1,13 +1,13 @@
 /**
 Basic authorization.
 
-An asynchronous authorization provider can be registered for workspace
-composition. The provider decides scope access in composeObj instead of the
+Asynchronous authorization providers can be registered for workspace
+composition. A provider decides scope access in composeObj instead of the
 user.roles array.
 
-The provider is only consulted when the AUTHORIZATION_PROVIDER flag is
-enabled in the xyzEnv, matching the LEGACY_ROLES flag pattern. Without the
-flag the user.roles semantics apply unchanged.
+A provider is only consulted for a user with an authorization_provider property
+matching the key the provider was registered with. Without the property the
+user.roles semantics apply unchanged.
 
 This is the first increment: the root composeObj decision only.
 */
@@ -22,24 +22,23 @@ globalThis.xyzEnv = {
 
 describe('basic authorization', () => {
   afterEach(() => {
-    setAuthorizationProvider();
-    delete globalThis.xyzEnv.AUTHORIZATION_PROVIDER;
+    setAuthorizationProvider('openfga');
   });
 
-  it('without the AUTHORIZATION_PROVIDER flag the user.roles semantics apply', async () => {
+  it('without the authorization_provider property the user.roles semantics apply', async () => {
     const denied = await composeObj({ role: 'analyst' });
 
     expect(denied instanceof Error).toBeTruthy();
 
-    const allowed = await composeObj({ role: 'analyst' }, ['analyst']);
+    const allowed = await composeObj({ role: 'analyst' }, { roles: ['analyst'] });
 
     expect(allowed instanceof Error).toBeFalsy();
   });
 
-  it('a registered provider is ignored without the flag', async () => {
+  it('a registered provider is ignored without the user property', async () => {
     const checkScope = vi.fn(async () => true);
 
-    setAuthorizationProvider({ checkScope });
+    setAuthorizationProvider('openfga', { checkScope });
 
     const denied = await composeObj({ role: 'analyst' });
 
@@ -48,13 +47,14 @@ describe('basic authorization', () => {
   });
 
   it('a provider allow admits a scoped object without user roles', async () => {
-    globalThis.xyzEnv.AUTHORIZATION_PROVIDER = true;
-
     const checkScope = vi.fn(async () => true);
 
-    setAuthorizationProvider({ checkScope });
+    setAuthorizationProvider('openfga', { checkScope });
 
-    const obj = await composeObj({ role: 'analyst' });
+    const obj = await composeObj(
+      { role: 'analyst' },
+      { authorization_provider: 'openfga' },
+    );
 
     expect(obj instanceof Error).toBeFalsy();
     expect(checkScope).toHaveBeenCalled();
@@ -62,55 +62,88 @@ describe('basic authorization', () => {
     expect(checkScope.mock.calls[0][0].scopeKey).toBe('analyst');
   });
 
+  it('the provider context receives the user object', async () => {
+    const checkScope = vi.fn(async () => true);
+
+    setAuthorizationProvider('openfga', { checkScope });
+
+    const user = {
+      authorization_provider: 'openfga',
+      email: 'analyst@geolytix.co.uk',
+      roles: ['analyst'],
+    };
+
+    await composeObj({ role: 'analyst' }, user);
+
+    expect(checkScope.mock.calls[0][0].user).toEqual(user);
+  });
+
+  it('a user is only routed through their own provider', async () => {
+    const openfga = vi.fn(async () => true);
+    const other = vi.fn(async () => true);
+
+    setAuthorizationProvider('openfga', { checkScope: openfga });
+    setAuthorizationProvider('other', { checkScope: other });
+
+    await composeObj({ role: 'analyst' }, { authorization_provider: 'other' });
+
+    expect(other).toHaveBeenCalled();
+    expect(openfga).not.toHaveBeenCalled();
+
+    setAuthorizationProvider('other');
+  });
+
   it('a provider deny returns an Error despite matching user roles', async () => {
-    globalThis.xyzEnv.AUTHORIZATION_PROVIDER = true;
+    setAuthorizationProvider('openfga', { checkScope: async () => false });
 
-    setAuthorizationProvider({ checkScope: async () => false });
-
-    const response = await composeObj({ role: 'analyst' }, ['analyst']);
+    const response = await composeObj(
+      { role: 'analyst' },
+      { authorization_provider: 'openfga', roles: ['analyst'] },
+    );
 
     expect(response instanceof Error).toBeTruthy();
   });
 
-  it('the enabled flag without a registered provider fails closed', async () => {
-    globalThis.xyzEnv.AUTHORIZATION_PROVIDER = true;
-
-    const response = await composeObj({ role: 'analyst' }, ['analyst']);
+  it('a user property without a registered provider fails closed', async () => {
+    const response = await composeObj(
+      { role: 'analyst' },
+      { authorization_provider: 'openfga', roles: ['analyst'] },
+    );
 
     expect(response instanceof Error).toBeTruthy();
   });
 
   it('a provider error fails closed', async () => {
-    globalThis.xyzEnv.AUTHORIZATION_PROVIDER = true;
-
-    setAuthorizationProvider({
+    setAuthorizationProvider('openfga', {
       checkScope: async () => {
         throw new Error('Authorization store unavailable.');
       },
     });
 
-    const response = await composeObj({ role: 'analyst' }, ['analyst']);
+    const response = await composeObj(
+      { role: 'analyst' },
+      { authorization_provider: 'openfga', roles: ['analyst'] },
+    );
 
     expect(response instanceof Error).toBeTruthy();
   });
 
   it('a provider allow merges a role-gated template without user roles', async () => {
-    globalThis.xyzEnv.AUTHORIZATION_PROVIDER = true;
+    setAuthorizationProvider('openfga', { checkScope: async () => true });
 
-    setAuthorizationProvider({ checkScope: async () => true });
-
-    const obj = await composeObj({
-      templates: [{ analystProp: true, role: 'analyst' }],
-    });
+    const obj = await composeObj(
+      {
+        templates: [{ analystProp: true, role: 'analyst' }],
+      },
+      { authorization_provider: 'openfga' },
+    );
 
     expect(obj instanceof Error).toBeFalsy();
     expect(obj.analystProp).toBe(true);
   });
 
   it('a provider deny silently skips the template merge despite matching user roles', async () => {
-    globalThis.xyzEnv.AUTHORIZATION_PROVIDER = true;
-
-    setAuthorizationProvider({
+    setAuthorizationProvider('openfga', {
       checkScope: async ({ scopeKey }) => scopeKey !== 'analyst',
     });
 
@@ -118,7 +151,7 @@ describe('basic authorization', () => {
       {
         templates: [{ analystProp: true, role: 'analyst' }],
       },
-      ['analyst'],
+      { authorization_provider: 'openfga', roles: ['analyst'] },
     );
 
     expect(obj instanceof Error).toBeFalsy();
@@ -126,16 +159,17 @@ describe('basic authorization', () => {
   });
 
   it('a merged template is consulted with the chained scopeKey', async () => {
-    globalThis.xyzEnv.AUTHORIZATION_PROVIDER = true;
-
     const checkScope = vi.fn(async () => true);
 
-    setAuthorizationProvider({ checkScope });
+    setAuthorizationProvider('openfga', { checkScope });
 
-    await composeObj({
-      role: 'retail',
-      templates: [{ analystProp: true, role: 'analyst' }],
-    });
+    await composeObj(
+      {
+        role: 'retail',
+        templates: [{ analystProp: true, role: 'analyst' }],
+      },
+      { authorization_provider: 'openfga' },
+    );
 
     const scopeKeys = checkScope.mock.calls.map(
       ([context]) => context.scopeKey,
@@ -145,18 +179,20 @@ describe('basic authorization', () => {
     expect(scopeKeys).toContain('retail.analyst');
   });
 
-  it('removing the flag restores the user.roles semantics', async () => {
-    globalThis.xyzEnv.AUTHORIZATION_PROVIDER = true;
+  it('clearing the provider registration fails closed', async () => {
+    setAuthorizationProvider('openfga', { checkScope: async () => true });
 
-    setAuthorizationProvider({ checkScope: async () => true });
+    setAuthorizationProvider('openfga');
 
-    delete globalThis.xyzEnv.AUTHORIZATION_PROVIDER;
-
-    const denied = await composeObj({ role: 'analyst' });
+    const denied = await composeObj(
+      { role: 'analyst' },
+      { authorization_provider: 'openfga', roles: ['analyst'] },
+    );
 
     expect(denied instanceof Error).toBeTruthy();
 
-    const allowed = await composeObj({ role: 'analyst' }, ['analyst']);
+    // The user.roles semantics apply for a user without the property.
+    const allowed = await composeObj({ role: 'analyst' }, { roles: ['analyst'] });
 
     expect(allowed instanceof Error).toBeFalsy();
   });

--- a/apps/xyz/tests/mod/workspace/authorization.test.mjs
+++ b/apps/xyz/tests/mod/workspace/authorization.test.mjs
@@ -96,6 +96,24 @@ describe('basic authorization', () => {
     setAuthorizationProvider('other');
   });
 
+  it('the roles object gate does not apply to a provider user', async () => {
+    setAuthorizationProvider('openfga', { checkScope: async () => true });
+
+    const withoutRoles = await composeObj(
+      { roles: { analyst: true } },
+      { authorization_provider: 'openfga' },
+    );
+
+    expect(withoutRoles instanceof Error).toBeFalsy();
+
+    const otherRoles = await composeObj(
+      { roles: { analyst: true } },
+      { authorization_provider: 'openfga', roles: ['other'] },
+    );
+
+    expect(otherRoles instanceof Error).toBeFalsy();
+  });
+
   it('a provider deny returns an Error despite matching user roles', async () => {
     setAuthorizationProvider('openfga', { checkScope: async () => false });
 

--- a/apps/xyz/tests/mod/workspace/composeObj.test.mjs
+++ b/apps/xyz/tests/mod/workspace/composeObj.test.mjs
@@ -173,7 +173,7 @@ describe('composeObj', async () => {
       },
     };
 
-    const with_roles = await composeObj(obj, ['foo']);
+    const with_roles = await composeObj(obj, { roles: ['foo'] });
 
     expect(with_roles.check === true).toBeTruthy();
   });
@@ -187,7 +187,7 @@ describe('composeObj', async () => {
       },
     };
 
-    const with_roles = await composeObj(obj, ['foo']);
+    const with_roles = await composeObj(obj, { roles: ['foo'] });
 
     expect(with_roles.check === true).toBeTruthy();
   });
@@ -203,7 +203,7 @@ describe('composeObj', async () => {
     };
 
     // Access to the layer should be granted because the user has the "foo" role.
-    const layer = await composeObj(obj, ['foo', 'alpha']);
+    const layer = await composeObj(obj, { roles: ['foo', 'alpha'] });
 
     expect(layer.name === 'Test Alpha').toBeTruthy();
     expect(layer.infoj.length).toEqual(2);
@@ -224,7 +224,7 @@ describe('composeObj', async () => {
       'locale.layer_a.draw_circle',
     ];
 
-    const layer = await composeObj(obj, roles);
+    const layer = await composeObj(obj, { roles });
 
     expect(layer.draw?.point).toBeTruthy();
     expect(layer.draw?.circle).toBeTruthy();
@@ -247,7 +247,7 @@ describe('composeObj', async () => {
       'locale.layer_a.draw_circle',
     ];
 
-    const layer = await composeObj(obj, roles);
+    const layer = await composeObj(obj, { roles });
 
     expect(layer.draw?.point).toBeTruthy();
     expect(layer.draw?.circle).toBeTruthy();
@@ -264,7 +264,7 @@ describe('composeObj', async () => {
     };
 
     // The user holds a role but not one of the accessRoles in the roles object.
-    const response = await composeObj(obj, ['some_other_role']);
+    const response = await composeObj(obj, { roles: ['some_other_role'] });
 
     expect(response instanceof Error).toBeTruthy();
   });
@@ -281,7 +281,7 @@ describe('composeObj', async () => {
     };
 
     // The user holds a role but not one of the accessRoles in the nested roles object.
-    const response = await composeObj(obj, ['some_other_role']);
+    const response = await composeObj(obj, { roles: ['some_other_role'] });
 
     expect(response.root).toBeTruthy();
     expect(response.nested).toBeFalsy();
@@ -314,7 +314,7 @@ describe('composeObj', async () => {
     };
 
     // The user holds a role but not one of the accessRoles in the nested roles object.
-    const response = await composeObj(obj, ['Franchisee']);
+    const response = await composeObj(obj, { roles: ['Franchisee'] });
 
     expect(response.hover.query).toEqual('oppscan_hover_franchisee');
     expect(response.hover.template).toBeFalsy();

--- a/apps/xyz/tests/mod/workspace/getTemplate.test.mjs
+++ b/apps/xyz/tests/mod/workspace/getTemplate.test.mjs
@@ -234,7 +234,7 @@ describe('getTemplate', async () => {
       const first = await getTemplate('nested_roles_template');
 
       // The roles object is merged for a user holding the restricted role.
-      const composed = await composeObj(first, ['restricted']);
+      const composed = await composeObj(first, { roles: ['restricted'] });
 
       expect(composed.nested).toMatchObject({ keep: true, merged: true });
 


### PR DESCRIPTION
The user object is now defined as a global in the authorization module.

Instead of passing the roles param to the composeObj method the user object with the roles property is passed on.

The user object has an optional authorization_provider string property which can be used to define an alternative authorization provider eg. openfga. 