### PR TITLE
fix(ui/elements/locale): Restore Back button [ENG-212]

### DIFF
--- a/apps/mapp/lib/ui/elements/locales.mjs
+++ b/apps/mapp/lib/ui/elements/locales.mjs
@@ -78,7 +78,7 @@ async function buildDropdown(elements, locale, level, locales) {
     entries: locales.map((l) => {
       const keys = l.key.split(',');
       const names = l.name.split('/');
-      const title = `${keys.length === level ? '<- Back' : ''}${names.slice(level).join('/')}`;
+      const title = `${keys.length === level ? mapp.dictionary.locale_back_option : ''}${names.slice(level).join('/')}`;
 
       // Build string for selected from slicing keys[] array with current level.
       const selectedLv =

--- a/apps/mapp/lib/ui/elements/locales.mjs
+++ b/apps/mapp/lib/ui/elements/locales.mjs
@@ -78,7 +78,7 @@ async function buildDropdown(elements, locale, level, locales) {
     entries: locales.map((l) => {
       const keys = l.key.split(',');
       const names = l.name.split('/');
-      const title = names.slice(level).join('/');
+      const title = `${keys.length === level ? '<- Back' : ''}${names.slice(level).join('/')}`;
 
       // Build string for selected from slicing keys[] array with current level.
       const selectedLv =

--- a/public/dictionaries/en.mjs
+++ b/public/dictionaries/en.mjs
@@ -90,6 +90,7 @@ export default {
   layers: 'Layers',
   link: 'Link',
   loading: 'Loading',
+  locale_back_option: '<- Back',
   location_clear_all: 'Clear locations',
   location_new_failed: 'Creating new location has failed.',
   location_no_location_selected: 'No Locations selected',


### PR DESCRIPTION
## Description
Previously there was a back option in the locale dropdown, this was erroneously removed here:
[#2883](https://github.com/GEOLYTIX/xyz/pull/2883)

This PR simply restores it.

## Type of Change
- ✅ Bug fix (non-breaking change which fixes an issue)

## How have you tested this?
tested using `mapp-demo`

## Testing Checklist
- ✅ Existing Tests still pass
- ✅ Ran locally on my machine

## Code Quality Checklist
- ✅ My code follows the guidelines of XYZ
- ✅ My code has been commented
- ✅ Documentation has been updated
- ✅ New and existing unit tests pass locally with my changes
- ✅ Main has been merged into this PR
