### PR TITLE
Resolve workspace scopes from the cached workspace [ENG-241]

### DIFF
--- a/apps/xyz/mod/workspace/_workspace.js
+++ b/apps/xyz/mod/workspace/_workspace.js
@@ -271,12 +271,16 @@ function roles(req, res) {
 @description
 The scopes method returns an array of scopes which are the templateScopes assigned to each template in the workspace.templates{} object.
 
+The scopes are resolved from the cached workspace. The workspace cache is rebuilt with the force request param.
+
 @param {req} req HTTP request.
 @param {res} res HTTP response.
 
 @property {Object} req.params HTTP request parameter.
 @property {Object} params.user User requesting the scopes.
 @property {boolean} params.user.admin Whether user has admin privileges (required).
+@property {boolean} [params.force] Rebuild the workspace cache before the scopes are resolved.
+@property {boolean} [params.tree] Respond with the scopes as a nested tree.
 */
 async function scopes(req, res) {
   if (!req.params.user?.admin) {
@@ -289,7 +293,7 @@ async function scopes(req, res) {
   // TODO check why the scopes array is different from composedWorkspace
   // const cachedWorkspace = await composeWorkspace();
 
-  const workspaceScopes = await getScopes();
+  const workspaceScopes = await getScopes(req.params.force);
 
   if (req.params.tree) {
     res.send(scopesTree(workspaceScopes));

--- a/apps/xyz/mod/workspace/scopes.js
+++ b/apps/xyz/mod/workspace/scopes.js
@@ -5,6 +5,8 @@ The scopes module exports the getScopes method which returns the complete set of
 
 A templateScope is only recorded in workspace.scopes{} when the object which defines it is composed. The getScopes method therefore composes every locale, nested locale, and layer with role checks bypassed before the scopes are read.
 
+The composition is expensive. The composition promise is stored against the cached workspace object so repeat requests share one composition until the workspace cache is rebuilt.
+
 @requires /provider/getSrc
 @requires /workspace/cache
 @requires /workspace/getLocale
@@ -17,19 +19,54 @@ import workspaceCache from './cache.js';
 import getLocale from './getLocale.js';
 
 /**
+Module scope map of composition promises keyed by the cached workspace object. A rebuilt workspace cache is a new object which does not have an entry in the map. Entries for discarded workspace objects are garbage collected.
+*/
+const compositionMap = new WeakMap();
+
+/**
 @function getScopes
 @async
 
 @description
-The workspace cache is rebuilt and all sources are cached before every locale is composed. Composition is required to populate the workspace.scopes{} set.
+The cached workspace is retrieved from the workspace cache. The cache is only rebuilt with the force param flag or when the WORKSPACE_AGE is exceeded.
+
+All sources are cached before every locale is composed. Composition is required to populate the workspace.scopes{} set.
+
+The composition promise is stored in the compositionMap against the workspace object. Repeat requests for the same cached workspace await the stored promise and do not compose the workspace again. A failed composition is removed from the map so a subsequent request will retry the composition.
 
 Locales are composed with the roles parameter set to true so that every templateScope is recorded regardless of role access. The composed locales are discarded; only the scopes recorded during composition are returned.
 
+@param {boolean} [force] The workspace cache will be rebuilt with the force param flag.
 @returns {Promise<Set<string>>} The set of templateScopes defined in the workspace.
 */
-export async function getScopes() {
-  const workspace = await workspaceCache(true);
+export async function getScopes(force) {
+  const workspace = await workspaceCache(force);
 
+  let composition = compositionMap.get(workspace);
+
+  if (!composition) {
+    composition = composeWorkspaceScopes(workspace).catch((err) => {
+      compositionMap.delete(workspace);
+      throw err;
+    });
+
+    compositionMap.set(workspace, composition);
+  }
+
+  return await composition;
+}
+
+/**
+@function composeWorkspaceScopes
+@async
+
+@description
+All sources are cached before every locale, nested locale, and layer is composed with role checks bypassed.
+
+@param {Object} workspace The cached workspace.
+@returns {Promise<Set<string>>} The workspace.scopes{} set.
+*/
+async function composeWorkspaceScopes(workspace) {
   const errors = await cacheSources(workspace);
 
   if (errors.length) {

--- a/apps/xyz/tests/mod/workspace/scopes.test.mjs
+++ b/apps/xyz/tests/mod/workspace/scopes.test.mjs
@@ -57,4 +57,30 @@ describe('getScopes', () => {
       expect(checkScope(scope.split('.'), [scope])).toBe(true);
     }
   });
+
+  it('resolves repeat requests from the cached workspace', async () => {
+    const first = await getScopes();
+    const second = await getScopes();
+
+    // The same workspace.scopes{} set is returned without a cache rebuild.
+    expect(second).toBe(first);
+  });
+
+  it('shares one composition between concurrent requests', async () => {
+    const [first, second] = await Promise.all([getScopes(), getScopes()]);
+
+    expect(second).toBe(first);
+  });
+
+  it('rebuilds the workspace cache with the force param', async () => {
+    const cached = await getScopes();
+    const forced = await getScopes(true);
+
+    // A rebuilt workspace cache has a new workspace.scopes{} set.
+    expect(forced).not.toBe(cached);
+    expect(scopesArray(forced)).toEqual(scopesArray(cached));
+
+    // The rebuilt workspace is cached for subsequent requests.
+    expect(await getScopes()).toBe(forced);
+  });
 });

--- a/public/views/_user.html
+++ b/public/views/_user.html
@@ -147,9 +147,6 @@
   <script>
   window.onload = async () => {
 
-    // Get list of available roles from workspace.
-    const rolesList = await xhrPromise(`${document.head.dataset.dir}/api/workspace/scopes`)
-
     // List of languages key values.
     const languagesList = {
       "en": "English",
@@ -182,6 +179,10 @@
     if (params.email) {
       data.sort(function (x, y) { return x.email == params.email ? -1 : y.email == params.email ? 1 : 0; });
     }
+
+     // Get list of available roles from workspace.
+    // Once this is available, update the dropdown list of roles in the user table.
+    let rolesList = ["Loading Roles..."];
 
     const userTable = new Tabulator(document.getElementById('userTable'),
       {
@@ -293,10 +294,12 @@
             headerSort: false,
             editor: 'list',
             width: 400,
-            editorParams: {
+            // Function form so rolesList is read fresh each time the editor
+            // opens, picking up the scopes response whenever it arrives.
+            editorParams: () => ({
               values: rolesList,
               multiselect: true
-            },
+            }),
             cellEdited: rolesEdited,
             resizable: false,
             responsive: 0 // Never hide
@@ -394,6 +397,15 @@
         || user.roles.some(role => role.includes(e.target.value))))
     }
 
+    // Get the roles from the scopes endpoint and update the rolesList variable. 
+    // This will update the dropdown list of roles in the user table.
+    xhrPromise(`${document.head.dataset.dir}/api/workspace/scopes`).then(response => {
+      
+      if (response.err) return console.error(response.err);
+
+      rolesList = response.map(scope => scope);
+    });
+    
 
     function expiryEdit(cell, onRendered, success, cancel) {
 


### PR DESCRIPTION
## Summary

Requests to `/api/workspace/scopes` were slow because `getScopes()` called `workspaceCache(true)`. The forced rebuild cleared the workspace cache and the source map on every request, so every source was fetched again and every locale, nested locale, and layer was composed again. The rebuild also discarded the cache for concurrent requests to other endpoints.

## Changes

- `apps/xyz/mod/workspace/scopes.js`
  - `getScopes(force)` resolves the workspace from the cache. The cache is only rebuilt with the `force` param or when `WORKSPACE_AGE` is exceeded.
  - The composition promise is stored in a `WeakMap` keyed by the cached workspace object. Repeat and concurrent requests share one composition until the workspace cache is rebuilt. A failed composition is removed from the map so the next request retries.
- `apps/xyz/mod/workspace/_workspace.js`
  - The `scopes` handler passes `req.params.force` to `getScopes()`. `GET /api/workspace/scopes?force=true` restores the previous rebuild behaviour on demand.
- `apps/xyz/tests/mod/workspace/scopes.test.mjs`
  - Tests for repeat requests, concurrent requests, and the `force` param.

`composeWorkspace()` in `_workspace.js` still forces a rebuild and is unchanged in this PR.

## Testing

- `npx vitest run tests/mod/workspace` — 12 files, 119 tests pass.
- `npx biome check` on the changed files — clean.

Resolves ENG-241
