### PR TITLE
fix(Dataviews): Store target property to _target so it can be reinstated post jsonParser [ENG-72]

### DIFF
--- a/apps/mapp/lib/ui/layers/panels/dataviews.mjs
+++ b/apps/mapp/lib/ui/layers/panels/dataviews.mjs
@@ -42,6 +42,12 @@ export default function dataviews(layer) {
       layer,
     });
 
+    // Reinstate target from the snapshot if it was lost (eg. saved as an HTMLElement and stripped by jsonParser).
+    dataview.target ??= dataview._target;
+
+    // Snapshot the original target before it is overwritten with a render element below.
+    dataview._target ??= dataview.target;
+
     // Find tabview element from data-id attribute.
     populateTabview(dataview);
 


### PR DESCRIPTION
## Description
This PR fixes a bug whereby if you had a layer with a dataview that was set to "target": "tabview". 
The target is mutated to the HTML Element in the dataview.mjs module. 
However, when you store this locale used the Saved Views functionality, the target is then wiped as its HTML which is stripped by the `jsonParser` module. 
This results in "target": "undefined" which then causes the dataview to render in the layer panel not the tabview where it should. 

This PR adds the `_target` property to hold the actual string representation of the target always, meaning it can be reinstated and is never lost post `jsonParser`. 
This means that dataviews are always displayed in the location they should be, pre and post Saved Views. 


## Type of Change
- ✅ Bug fix (non-breaking change which fixes an issue)

## How have you tested this?
Tested locally by having a layer with a display true, target tabview dataview. 
Saved this view and come back to it, off this PR the table will render in the layer panel, on this PR it should remain in the tabview - exactly as it is off the PR. 